### PR TITLE
Fixes the hang on BGP password

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM golang:1.15-alpine as dev
+FROM golang:1.16.5-alpine3.13 as dev
 RUN apk add --no-cache git ca-certificates make
 RUN adduser -D appuser
 COPY . /src/


### PR DESCRIPTION
This is a fix for #226, the logic around parsing annotations would never end if a BGP password wasn't supplied. The password is now optional.

This also fixes a debug message.

```
root@k8s:~# k logs -n kube-system   kube-vip-ds-8m9qk
time="2021-07-05T12:37:45Z" level=info msg="server started"
time="2021-07-05T12:37:45Z" level=debug msg="Using the internal Kubernetes token"
time="2021-07-05T12:37:45Z" level=info msg="Kube-Vip is waiting for annotation prefix [metal.equinix.com] to be present on this node"
time="2021-07-05T12:37:45Z" level=debug msg="10.80.96.25 / 65000 / 10.80.96.24 / 65530 \n"
time="2021-07-05T12:37:45Z" level=info msg="Exiting Annotations watcher"
time="2021-07-05T12:37:45Z" level=info msg="Starting Kube-vip Manager with the BGP engine"
```