### PR TITLE
Fixes re-application of VIP

### DIFF
--- a/cmd/kube-vip-config.go
+++ b/cmd/kube-vip-config.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/ghodss/yaml"
-	"github.com/plunder-app/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	appv1 "k8s.io/api/core/v1"

--- a/cmd/kube-vip-kubeadm.go
+++ b/cmd/kube-vip-kubeadm.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"os"
 
-	"github.com/plunder-app/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"

--- a/cmd/kube-vip-manifests.go
+++ b/cmd/kube-vip-manifests.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/plunder-app/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/cmd/kube-vip-start.go
+++ b/cmd/kube-vip-start.go
@@ -4,9 +4,9 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/plunder-app/kube-vip/pkg/bgp"
-	"github.com/plunder-app/kube-vip/pkg/cluster"
-	"github.com/plunder-app/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/bgp"
+	"github.com/kube-vip/kube-vip/pkg/cluster"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/plunder-app/kube-vip/pkg/kubevip"
-	"github.com/plunder-app/kube-vip/pkg/manager"
-	"github.com/plunder-app/kube-vip/pkg/packet"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/manager"
+	"github.com/kube-vip/kube-vip/pkg/packet"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"

--- a/demo/go.mod
+++ b/demo/go.mod
@@ -1,3 +1,3 @@
-module github.com/plunder-app/kube-vip/demo
+module github.com/kube-vip/kube-vip/demo
 
 go 1.13

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -103,8 +103,8 @@ Additionally the load-balancing within `kibe-vip` has two modes of operation:
 
 The `kube-vip` kubernetes load-balancer requires a number of components in order to function:
 
-- The Plunder Cloud Provider -> [https://github.com/plunder-app/plndr-cloud-provider](https://github.com/plunder-app/plndr-cloud-provider)
-- The Kube-Vip Deployment -> [https://github.com/plunder-app/kube-vip](https://github.com/plunder-app/kube-vip)
+- The Plunder Cloud Provider -> [https://github.com/kube-vip/plndr-cloud-provider](https://github.com/kube-vip/plndr-cloud-provider)
+- The Kube-Vip Deployment -> [https://github.com/kube-vip/kube-vip](https://github.com/kube-vip/kube-vip)
 
 ### Architecture overview
 

--- a/docs/kubernetes/arp/index.md
+++ b/docs/kubernetes/arp/index.md
@@ -26,7 +26,7 @@ $ kubectl describe configmap -n kube-system kube-proxy | grep ARP
 
 To deploy the [latest] then `kubectl apply -f https://kube-vip.io/manifests/kube-vip.yaml`, specific versions should be found in the repository as detailed below:
 
-From the GitHub repository [https://github.com/plunder-app/kube-vip/tree/master/example/deploy](https://github.com/plunder-app/kube-vip/tree/master/example/deploy) find the version of the `kube-vip` to deploy (although typically the highest version number will provider more functionality/stability). The [raw] option in Github will provide the url that can be applied directly with a `kubectl apply -f <url>`.
+From the GitHub repository [https://github.com/kube-vip/kube-vip/tree/master/example/deploy](https://github.com/kube-vip/kube-vip/tree/master/example/deploy) find the version of the `kube-vip` to deploy (although typically the highest version number will provider more functionality/stability). The [raw] option in Github will provide the url that can be applied directly with a `kubectl apply -f <url>`.
 
 The following output should appear when the manifest is applied: 
 ```

--- a/docs/kubernetes/bgp/index.md
+++ b/docs/kubernetes/bgp/index.md
@@ -4,7 +4,7 @@
 
 To deploy the [latest] then `kubectl apply -f https://kube-vip.io/manifests/kube-vip.yaml`, specific versions should be found in the repository as detailed below:
 
-From the GitHub repository [https://github.com/plunder-app/kube-vip/tree/master/example/deploy](https://github.com/plunder-app/kube-vip/tree/master/example/deploy) find the version of the `kube-vip` to deploy (although typically the highest version number will provider more functionality/stability). The [raw] option in Github will provide the url that can be applied directly with a `kubectl apply -f <url>`.
+From the GitHub repository [https://github.com/kube-vip/kube-vip/tree/master/example/deploy](https://github.com/kube-vip/kube-vip/tree/master/example/deploy) find the version of the `kube-vip` to deploy (although typically the highest version number will provider more functionality/stability). The [raw] option in Github will provide the url that can be applied directly with a `kubectl apply -f <url>`.
 
 The following output should appear when the manifest is applied: 
 ```

--- a/docs/kubernetes/index.md
+++ b/docs/kubernetes/index.md
@@ -33,7 +33,7 @@ Edit the `configmap` and add in the cidr ranges for those namespaces, the key in
 
 To deploy the [latest] then `kubectl apply -f https://kube-vip.io/manifests/controller.yaml`, specific versions should be found in the repository as detailed below:
 
-From the GitHub repository [https://github.com/plunder-app/plndr-cloud-provider/tree/master/example/pod](https://github.com/plunder-app/plndr-cloud-provider/tree/master/example/pod), find the version of the plunder cloud provider manifest (although typically the highest version number will provider more functionality/stability). The [raw] option in Github will provide the url that can be applied directly with a `kubectl apply -f <url>`.
+From the GitHub repository [https://github.com/kube-vip/plndr-cloud-provider/tree/master/example/pod](https://github.com/kube-vip/plndr-cloud-provider/tree/master/example/pod), find the version of the plunder cloud provider manifest (although typically the highest version number will provider more functionality/stability). The [raw] option in Github will provide the url that can be applied directly with a `kubectl apply -f <url>`.
 
 The following output should appear when the manifest is applied: 
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/plunder-app/kube-vip
+module github.com/kube-vip/kube-vip
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/plunder-app/kube-vip/cmd"
+import "github.com/kube-vip/kube-vip/cmd"
 
 // Version is populated from the Makefile and is tied to the release TAG
 var Version string

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1,8 +1,8 @@
 package cluster
 
 import (
-	"github.com/plunder-app/kube-vip/pkg/kubevip"
-	"github.com/plunder-app/kube-vip/pkg/vip"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/vip"
 )
 
 const leaderLogcount = 5

--- a/pkg/cluster/clusterDDNS.go
+++ b/pkg/cluster/clusterDDNS.go
@@ -2,7 +2,8 @@ package cluster
 
 import (
 	"context"
-	"github.com/plunder-app/kube-vip/pkg/vip"
+
+	"github.com/kube-vip/kube-vip/pkg/vip"
 )
 
 // StartDDNS should start go routine for dhclient to hold the lease for the IP

--- a/pkg/cluster/clusterLeader.go
+++ b/pkg/cluster/clusterLeader.go
@@ -9,13 +9,13 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/plunder-app/kube-vip/pkg/bgp"
-	"github.com/plunder-app/kube-vip/pkg/kubevip"
-	leaderelection "github.com/plunder-app/kube-vip/pkg/leaderElection"
-	"github.com/plunder-app/kube-vip/pkg/loadbalancer"
-	"github.com/plunder-app/kube-vip/pkg/packet"
+	"github.com/kube-vip/kube-vip/pkg/bgp"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	leaderelection "github.com/kube-vip/kube-vip/pkg/leaderElection"
+	"github.com/kube-vip/kube-vip/pkg/loadbalancer"
+	"github.com/kube-vip/kube-vip/pkg/packet"
 
-	"github.com/plunder-app/kube-vip/pkg/vip"
+	"github.com/kube-vip/kube-vip/pkg/vip"
 
 	"github.com/packethost/packngo"
 
@@ -295,24 +295,23 @@ func (cluster *Cluster) StartLeaderCluster(c *kubevip.Config, sm *Manager, bgpSe
 						}
 
 						for {
-
-							// Ensure the address exists on the interface before attempting to ARP
-							set, err := cluster.Network.IsSet()
-							if err != nil {
-								log.Warnf("%v", err)
-							}
-							if !set {
-								log.Warnf("Re-applying the VIP configuration [%s] to the interface [%s]", ipString, c.Interface)
-								err = cluster.Network.AddIP()
-								if err != nil {
-									log.Warnf("%v", err)
-								}
-							}
-
 							select {
 							case <-ctx.Done(): // if cancel() execute
 								return
 							default:
+								// Ensure the address exists on the interface before attempting to ARP
+								set, err := cluster.Network.IsSet()
+								if err != nil {
+									log.Warnf("%v", err)
+								}
+								if !set {
+									log.Warnf("Re-applying the VIP configuration [%s] to the interface [%s]", ipString, c.Interface)
+									err = cluster.Network.AddIP()
+									if err != nil {
+										log.Warnf("%v", err)
+									}
+								}
+
 								if vip.IsIPv4(ipString) {
 									// Gratuitous ARP, will broadcast to new MAC <-> IPv4 address
 									err := vip.ARPSendGratuitous(ipString, c.Interface)

--- a/pkg/cluster/clusterRaft.go
+++ b/pkg/cluster/clusterRaft.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/hashicorp/raft"
-	"github.com/plunder-app/kube-vip/pkg/kubevip"
-	"github.com/plunder-app/kube-vip/pkg/loadbalancer"
-	"github.com/plunder-app/kube-vip/pkg/vip"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/loadbalancer"
+	"github.com/kube-vip/kube-vip/pkg/vip"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	"github.com/plunder-app/kube-vip/pkg/bgp"
-	"github.com/plunder-app/kube-vip/pkg/detector"
+	"github.com/kube-vip/kube-vip/pkg/bgp"
+	"github.com/kube-vip/kube-vip/pkg/detector"
 	log "github.com/sirupsen/logrus"
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -3,7 +3,7 @@ package kubevip
 import (
 	"net/url"
 
-	"github.com/plunder-app/kube-vip/pkg/bgp"
+	"github.com/kube-vip/kube-vip/pkg/bgp"
 )
 
 // Config defines all of the settings for the Kube-Vip Pod

--- a/pkg/loadbalancer/lb_connections.go
+++ b/pkg/loadbalancer/lb_connections.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/plunder-app/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/pkg/loadbalancer/lb_http.go
+++ b/pkg/loadbalancer/lb_http.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/plunder-app/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/pkg/loadbalancer/lb_tcp.go
+++ b/pkg/loadbalancer/lb_tcp.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/plunder-app/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/pkg/loadbalancer/manager.go
+++ b/pkg/loadbalancer/manager.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/plunder-app/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -16,10 +16,10 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/plunder-app/kube-vip/pkg/bgp"
-	"github.com/plunder-app/kube-vip/pkg/cluster"
-	"github.com/plunder-app/kube-vip/pkg/kubevip"
-	"github.com/plunder-app/kube-vip/pkg/vip"
+	"github.com/kube-vip/kube-vip/pkg/bgp"
+	"github.com/kube-vip/kube-vip/pkg/cluster"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/vip"
 )
 
 const plunderLock = "plndr-svcs-lock"

--- a/pkg/manager/manager_arp.go
+++ b/pkg/manager/manager_arp.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/kamhlos/upnp"
-	"github.com/plunder-app/kube-vip/pkg/cluster"
-	"github.com/plunder-app/kube-vip/pkg/vip"
+	"github.com/kube-vip/kube-vip/pkg/cluster"
+	"github.com/kube-vip/kube-vip/pkg/vip"
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/leaderelection"

--- a/pkg/manager/manager_bgp.go
+++ b/pkg/manager/manager_bgp.go
@@ -5,11 +5,11 @@ import (
 	"os"
 	"syscall"
 
+	"github.com/kube-vip/kube-vip/pkg/bgp"
+	"github.com/kube-vip/kube-vip/pkg/cluster"
+	"github.com/kube-vip/kube-vip/pkg/packet"
+	"github.com/kube-vip/kube-vip/pkg/vip"
 	"github.com/packethost/packngo"
-	"github.com/plunder-app/kube-vip/pkg/bgp"
-	"github.com/plunder-app/kube-vip/pkg/cluster"
-	"github.com/plunder-app/kube-vip/pkg/packet"
-	"github.com/plunder-app/kube-vip/pkg/vip"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/pkg/manager/services.go
+++ b/pkg/manager/services.go
@@ -11,12 +11,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/plunder-app/kube-vip/pkg/cluster"
-	"github.com/plunder-app/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/cluster"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
 )
 
 const (
-	hwAddrKey = "kube-vip.io/hwaddr"
+	hwAddrKey   = "kube-vip.io/hwaddr"
 	requestedIP = "kube-vip.io/requestedIP"
 )
 
@@ -72,7 +72,6 @@ func (sm *Manager) deleteService(uid string) error {
 
 	return nil
 }
-
 
 func (sm *Manager) syncServices(service *v1.Service, wg *sync.WaitGroup) error {
 	defer wg.Done()

--- a/pkg/manager/services_dhcp.go
+++ b/pkg/manager/services_dhcp.go
@@ -12,9 +12,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 
-	"github.com/plunder-app/kube-vip/pkg/cluster"
-	"github.com/plunder-app/kube-vip/pkg/kubevip"
-	"github.com/plunder-app/kube-vip/pkg/vip"
+	"github.com/kube-vip/kube-vip/pkg/cluster"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/vip"
 )
 
 func (sm *Manager) createDHCPService(newServiceUID string, newVip *kubevip.Config, newService *Instance, service *v1.Service) error {

--- a/pkg/packet/bgp.go
+++ b/pkg/packet/bgp.go
@@ -3,9 +3,9 @@ package packet
 import (
 	"fmt"
 
+	"github.com/kube-vip/kube-vip/pkg/bgp"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/packethost/packngo"
-	"github.com/plunder-app/kube-vip/pkg/bgp"
-	"github.com/plunder-app/kube-vip/pkg/kubevip"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/pkg/packet/eip.go
+++ b/pkg/packet/eip.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/packethost/packngo"
-	"github.com/plunder-app/kube-vip/pkg/kubevip"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/pkg/service/manager.go
+++ b/pkg/service/manager.go
@@ -14,10 +14,10 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/plunder-app/kube-vip/pkg/bgp"
-	"github.com/plunder-app/kube-vip/pkg/cluster"
-	"github.com/plunder-app/kube-vip/pkg/kubevip"
-	"github.com/plunder-app/kube-vip/pkg/vip"
+	"github.com/kube-vip/kube-vip/pkg/bgp"
+	"github.com/kube-vip/kube-vip/pkg/cluster"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/vip"
 )
 
 const plunderLock = "plunder-lock"

--- a/pkg/service/manager_bgp.go
+++ b/pkg/service/manager_bgp.go
@@ -6,9 +6,9 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/kube-vip/kube-vip/pkg/bgp"
+	"github.com/kube-vip/kube-vip/pkg/packet"
 	"github.com/packethost/packngo"
-	"github.com/plunder-app/kube-vip/pkg/bgp"
-	"github.com/plunder-app/kube-vip/pkg/packet"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/pkg/service/services.go
+++ b/pkg/service/services.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/plunder-app/kube-vip/pkg/cluster"
-	"github.com/plunder-app/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/cluster"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	v1 "k8s.io/api/core/v1"
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	hwAddrKey = "kube-vip.io/hwaddr"
+	hwAddrKey   = "kube-vip.io/hwaddr"
 	requestedIP = "kube-vip.io/requestedIP"
 )
 

--- a/pkg/service/services_dhcp.go
+++ b/pkg/service/services_dhcp.go
@@ -12,9 +12,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 
-	"github.com/plunder-app/kube-vip/pkg/cluster"
-	"github.com/plunder-app/kube-vip/pkg/kubevip"
-	"github.com/plunder-app/kube-vip/pkg/vip"
+	"github.com/kube-vip/kube-vip/pkg/cluster"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/vip"
 )
 
 func (sm *Manager) createDHCPService(newServiceUID string, newVip *kubevip.Config, newService *Instance, service *v1.Service) error {

--- a/pkg/service/watcher.go
+++ b/pkg/service/watcher.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	watchtools "k8s.io/client-go/tools/watch"
 
-	"github.com/plunder-app/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
 )
 
 func rebuildEndpoints(eps v1.Endpoints) []kubevip.BackEnd {


### PR DESCRIPTION
Originally this code block: 
```
								// Ensure the address exists on the interface before attempting to ARP
								set, err := cluster.Network.IsSet()
								if err != nil {
									log.Warnf("%v", err)
								}
								if !set {
									log.Warnf("Re-applying the VIP configuration [%s] to the interface [%s]", ipString, c.Interface)
									err = cluster.Network.AddIP()
									if err != nil {
										log.Warnf("%v", err)
									}
								}
```
Was left in the wrong place.. meaning that after a timeout it would re-apply the VIP without realising that the service was being removed. This code block can't no longer be executed if the context has been cancelled.

Also had to fix all the imports, as the project was renamed. 