### PR TITLE
fix: makefile use latest git tag and be POSIX compat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TARGET := kube-vip
 
 # These will be provided to the target
 VERSION := $(git tag -l | sort -r | head -n1)
-BUILD := `git rev-parse HEAD`
+BUILD := $(git rev-parse HEAD)
 
 # Operating System Default (LINUX)
 TARGETOS=linux

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TARGET := kube-vip
 .DEFAULT_GOAL: $(TARGET)
 
 # These will be provided to the target
-VERSION := v0.3.7
+VERSION := $(git tag -l | sort -r | head -n1)
 BUILD := `git rev-parse HEAD`
 
 # Operating System Default (LINUX)


### PR DESCRIPTION
Using a subshell to get the latest version from `git tag`, to avoid further manual updates to the `Makefile`.

Also removing backticks in favour of POSIX compatability.