### PR TITLE
chore: use ghcr default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TARGET := kube-vip
 
 # These will be provided to the target
 VERSION := $(git tag -l | sort -r | head -n1)
-BUILD := `git rev-parse HEAD`
+BUILD := $(git rev-parse HEAD)
 
 # Operating System Default (LINUX)
 TARGETOS=linux

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ TARGET := kube-vip
 .DEFAULT_GOAL: $(TARGET)
 
 # These will be provided to the target
-VERSION := $(git tag -l | sort -r | head -n1)
-BUILD := $(git rev-parse HEAD)
+VERSION := v0.3.7
+BUILD := `git rev-parse HEAD`
 
 # Operating System Default (LINUX)
 TARGETOS=linux

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TARGET := kube-vip
 .DEFAULT_GOAL: $(TARGET)
 
 # These will be provided to the target
-VERSION := v0.3.7
+VERSION := $(git tag -l | sort -r | head -n1)
 BUILD := `git rev-parse HEAD`
 
 # Operating System Default (LINUX)

--- a/cmd/kube-vip-config.go
+++ b/cmd/kube-vip-config.go
@@ -104,7 +104,7 @@ var kubeVipSampleManifest = &cobra.Command{
 				Containers: []appv1.Container{
 					{
 						Name:  "kube-vip",
-						Image: fmt.Sprintf("docker.io/plndr/kube-vip:%s", Release.Version),
+						Image: fmt.Sprintf("ghcr.io/kube-vip/kube-vip:%s", Release.Version),
 						SecurityContext: &appv1.SecurityContext{
 							Capabilities: &appv1.Capabilities{
 								Add: []appv1.Capability{

--- a/docs/control-plane/index.md
+++ b/docs/control-plane/index.md
@@ -20,7 +20,7 @@ Below are examples of the steps required:
 
 ```
 # First Node
-sudo docker run --network host --rm plndr/kube-vip:0.2.1 manifest pod \
+sudo docker run --network host --rm ghcr.io/kube-vip/kube-vip:0.3.7 manifest pod \
 --interface ens192 \
 --vip 192.168.0.75 \
 --arp \
@@ -32,7 +32,7 @@ sudo kubeadm init --kubernetes-version 1.17.0 --control-plane-endpoint 192.168.0
 
 sudo kubeadm join 192.168.0.75:6443 --token w5atsr.blahblahblah --control-plane --certificate-key abc123
 
-sudo docker run --network host --rm plndr/kube-vip:0.2.1 manifest pod \
+sudo docker run --network host --rm ghcr.io/kube-vip/kube-vip:0.3.7 manifest pod \
 --interface ens192 \
 --vip 192.168.0.75 \
 --arp \
@@ -59,7 +59,7 @@ All nodes are running Ubuntu 18.04, Docker CE and will use Kubernetes 1.17.0.
 
 ```
 sudo docker run --network host \
-	--rm plndr/kube-vip:0.2.1 \
+	--rm ghcr.io/kube-vip/kube-vip:0.3.7 \
 	manifest pod \
 	--interface ens192 \
 	--vip 192.168.0.75 \
@@ -108,7 +108,7 @@ spec:
       value: "1"
     - name: vip_address
       value: 192.168.0.75
-    image: plndr/kube-vip:0.2.1
+    image: ghcr.io/kube-vip/kube-vip:0.3.7
     imagePullPolicy: Always
     name: kube-vip
     resources: {}
@@ -129,7 +129,7 @@ Make sure that the manifest directory exists: `sudo mkdir -p /etc/kubernetes/man
 
 ```
 sudo docker run --network host \
-	--rm plndr/kube-vip:0.2.1 \
+	--rm ghcr.io/kube-vip/kube-vip:0.3.7 \
 	manifest pod \
 	--interface ens192 \
 	--vip 192.168.0.75 \
@@ -137,7 +137,7 @@ sudo docker run --network host \
 	--leaderElection | sudo tee /etc/kubernetes/manifests/vip.yaml
 ```
 
-Ensure that `image: plndr/kube-vip:<x>` is modified to point to a specific version (`0.1.8` at the time of writing), refer to [docker hub](https://hub.docker.com/r/plndr/kube-vip/tags) for details. 
+Ensure that `image: ghcr.io/kube-vip/kube-vip:<x>` is modified to point to a specific version (`0.3.7` at the time of writing), refer to [GitHyb](https://github.com/kube-vip/kube-vip/pkgs/container/kube-vip) for details. 
 
 The **vip** is set to `192.168.0.75` and this first node will elect itself as leader, and as part of the `kubeadm init` it will use the VIP in order to speak back to the initialising api-server.
 
@@ -168,7 +168,7 @@ At this point **DON’T** generate the manifests, this is due to some bizarre `k
 
 ```
 sudo docker run --network host \
-	--rm plndr/kube-vip:0.2.1 \
+	--rm ghcr.io/kube-vip/kube-vip:0.3.7 \
 	manifest pod \
 	--interface ens192 \
 	--vip 192.168.0.75 \
@@ -243,7 +243,7 @@ export PACKET_AUTH_TOKEN=XYZ
 ```
 # Generate the manifest
 
-sudo docker run --network host --rm plndr/kube-vip:0.2.1 manifest pod \
+sudo docker run --network host --rm ghcr.io/kube-vip/kube-vip:0.3.7 manifest pod \
 --arp=false \
 --interface lo \
 --vip $EIP \
@@ -265,7 +265,7 @@ kubeadm join $EIP:6443 --token BLAH --control-plane --certificate-key BLAH --dis
 
 # Generate Manifest
 
-sudo docker run --network host --rm plndr/kube-vip:0.2.1 manifest pod \
+sudo docker run --network host --rm ghcr.io/kube-vip/kube-vip:0.3.7 manifest pod \
 --arp=false \
 --interface lo \
 --vip $EIP \

--- a/docs/hybrid/daemonset/index.md
+++ b/docs/hybrid/daemonset/index.md
@@ -36,10 +36,10 @@ This section only covers generating a simple *BGP* configuration, as the main fo
 The easiest method to generate a manifest is using the container itself, below will create an alias for different container runtimes.
 
 #### containerd
-`alias kube-vip="ctr run --rm --net-host docker.io/plndr/kube-vip:0.3.1 vip"`
+`alias kube-vip="ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:0.3.7 vip"`
 
 #### Docker
-`alias kube-vip="docker run --network host --rm plndr/kube-vip:0.3.1"`
+`alias kube-vip="docker run --network host --rm ghcr.io/kube-vip/kube-vip:0.3.7"`
 
 ### BGP Example
 
@@ -108,7 +108,7 @@ spec:
           value: "192.168.0.10:65000::false,192.168.0.11:65000::false"
         - name: vip_address
           value: 192.168.0.40
-        image: plndr/kube-vip:0.2.3
+        image: ghcr.io/kube-vip/kube-vip:0.3.7
         imagePullPolicy: Always
         name: kube-vip
         resources: {}

--- a/docs/hybrid/static/index.md
+++ b/docs/hybrid/static/index.md
@@ -19,10 +19,10 @@ This section details creating a number of manifests for various use cases
 The easiest method to generate a manifest is using the container itself, below will create an alias for different container runtimes.
 
 #### containerd
-`alias kube-vip="ctr run --rm --net-host docker.io/plndr/kube-vip:0.3.1 vip /kube-vip"`
+`alias kube-vip="ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:0.3.7 vip /kube-vip"`
 
 #### Docker
-`alias kube-vip="docker run --network host --rm plndr/kube-vip:0.3.1"`
+`alias kube-vip="docker run --network host --rm ghcr.io/kube-vip/kube-vip:0.3.7"`
 
 
 ### ARP

--- a/docs/install_daemonset/index.md
+++ b/docs/install_daemonset/index.md
@@ -41,10 +41,10 @@ This section only covers generating a simple *BGP* configuration, as the main fo
 The easiest method to generate a manifest is using the container itself, below will create an alias for different container runtimes.
 
 #### containerd
-`alias kube-vip="ctr run --rm --net-host docker.io/plndr/kube-vip:0.3.1 vip"`
+`alias kube-vip="ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:0.3.7 vip"`
 
 #### Docker
-`alias kube-vip="docker run --network host --rm plndr/kube-vip:0.3.1"`
+`alias kube-vip="docker run --network host --rm ghcr.io/kube-vip/kube-vip:0.3.7"`
 
 ### BGP Example
 
@@ -122,7 +122,7 @@ spec:
           value: 192.168.0.10:65000::false,192.168.0.11:65000::false
         - name: vip_address
           value: 192.168.0.40
-        image: 'plndr/kube-vip:'
+        image: 'ghcr.io/kube-vip/kube-vip:'
         imagePullPolicy: Always
         name: kube-vip
         resources: {}

--- a/docs/install_static/index.md
+++ b/docs/install_static/index.md
@@ -32,10 +32,10 @@ This section details creating a number of manifests for various use cases
 The easiest method to generate a manifest is using the container itself, below will create an alias for different container runtimes.
 
 ### containerd
-`alias kube-vip="ctr run --rm --net-host docker.io/plndr/kube-vip:0.3.1 vip /kube-vip"`
+`alias kube-vip="ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:0.3.7 vip /kube-vip"`
 
 ### Docker
-`alias kube-vip="docker run --network host --rm plndr/kube-vip:0.3.1"`
+`alias kube-vip="docker run --network host --rm ghcr.io/kube-vip/kube-vip:0.3.7"`
 
 
 ## ARP

--- a/docs/k3s
+++ b/docs/k3s
@@ -36,7 +36,7 @@ spec:
           value: \"false\"
         - name: vip_address
           value: $vipAddress
-        image: plndr/kube-vip:v0.3.5
+        image: ghcr.io/kube-vip/kube-vip:v0.3.7
         imagePullPolicy: Always
         name: kube-vip
         resources: {}

--- a/docs/manifests/kube-vip-arp.yaml
+++ b/docs/manifests/kube-vip-arp.yaml
@@ -62,7 +62,7 @@ spec:
                   - kube-vip-workers
             topologyKey: "kubernetes.io/hostname"
       containers:
-      - image: plndr/kube-vip:0.2.2
+      - image: ghcr.io/kube-vip/kube-vip:0.3.7
         imagePullPolicy: Always
         name: kube-vip
         command:

--- a/docs/manifests/kube-vip-bgp.yaml
+++ b/docs/manifests/kube-vip-bgp.yaml
@@ -59,7 +59,7 @@ spec:
                   - kube-vip-workers
             topologyKey: "kubernetes.io/hostname"
       containers:
-      - image: plndr/kube-vip:0.2.2
+      - image: ghcr.io/kube-vip/kube-vip:0.3.7
         imagePullPolicy: Always
         name: kube-vip
         command:

--- a/docs/manifests/kube-vip-em.yaml
+++ b/docs/manifests/kube-vip-em.yaml
@@ -64,7 +64,7 @@ spec:
           value: "true"
         - name: bgp_enable
           value: "true"
-        image: plndr/kube-vip:0.2.3
+        image: ghcr.io/kube-vip/kube-vip:0.3.7
         imagePullPolicy: Always
         name: kube-vip
         resources: {}

--- a/docs/manifests/kube-vip.yaml
+++ b/docs/manifests/kube-vip.yaml
@@ -58,7 +58,7 @@ spec:
                   - kube-vip-cluster
             topologyKey: "kubernetes.io/hostname"
       containers:
-      - image: plndr/kube-vip:0.1.3
+      - image: ghcr.io/kube-vip/kube-vip:0.3.7
         imagePullPolicy: Always
         name: kube-vip
         command:

--- a/docs/usage/k3s/index.md
+++ b/docs/usage/k3s/index.md
@@ -45,10 +45,10 @@ curl -sL kube-vip.io/k3s | vipAddress=$VIP vipInterface=$INTERFACE sh | sudo tee
 ## Step 3.2 Genereate from container image
 
 ### containerd
-`alias kube-vip="ctr run --rm --net-host docker.io/plndr/kube-vip:0.3.1 vip /kube-vip"`
+`alias kube-vip="ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:0.3.7 vip /kube-vip"`
 
 ### Docker
-`alias kube-vip="docker run --network host --rm plndr/kube-vip:0.3.1"`
+`alias kube-vip="docker run --network host --rm ghcr.io/kube-vip/kube-vip:0.3.7"`
 
 
 ```

--- a/docs/usage/kind/index.md
+++ b/docs/usage/kind/index.md
@@ -30,7 +30,7 @@ kubectl create configmap --namespace kube-system kubevip --from-literal range-gl
 
 Set the correct `alias` for `kube-vip`
 ```
-alias kube-vip="docker run --network host --rm plndr/kube-vip:v0.3.5"
+alias kube-vip="docker run --network host --rm ghcr.io/kube-vip/kube-vip:v0.3.7"
 ```
 
 Install Kube-vip deamonset inside of KIND

--- a/example/deploy/0.1.2.yaml
+++ b/example/deploy/0.1.2.yaml
@@ -28,7 +28,7 @@ spec:
                   - kube-vip-cluster
             topologyKey: "kubernetes.io/hostname"
       containers:
-      - image: plndr/kube-vip:0.1.2
+      - image: ghcr.io/kube-vip/kube-vip:0.3.7
         imagePullPolicy: Always
         name: kube-vip
         command:

--- a/example/deploy/0.1.3.yaml
+++ b/example/deploy/0.1.3.yaml
@@ -58,7 +58,7 @@ spec:
                   - kube-vip-cluster
             topologyKey: "kubernetes.io/hostname"
       containers:
-      - image: plndr/kube-vip:0.1.3
+      - image: ghcr.io/kube-vip/kube-vip:0.3.7
         imagePullPolicy: Always
         name: kube-vip
         command:

--- a/kubernetes-control-plane.md
+++ b/kubernetes-control-plane.md
@@ -26,7 +26,7 @@ All nodes are running Ubuntu 18.04, Docker CE and will use Kubernetes 1.17.0.
 Make sure that the config directory exists: `sudo mkdir -p /etc/kube-vip/`, this directory can be any directory however the `hostPath` in the manifest will need modifying to point to the correct path.
 
 ```
-sudo docker run -it --rm plndr/kube-vip:0.1.5 sample config | sudo tee /etc/kube-vip/config.yaml
+sudo docker run -it --rm ghcr.io/kube-vip/kube-vip:0.3.7 sample config | sudo tee /etc/kube-vip/config.yaml
 ```
 
 ### Modify the configuration
@@ -90,10 +90,10 @@ To generate the basic Kubernetes static pod `yaml` configuration:
 Make sure that the manifest directory exists: `sudo mkdir -p /etc/kubernetes/manifests/`
 
 ```
-sudo docker run -it --rm plndr/kube-vip:0.1.5 sample manifest | sudo tee /etc/kubernetes/manifests/kube-vip.yaml
+sudo docker run -it --rm ghcr.io/kube-vip/kube-vip:0.3.7 sample manifest | sudo tee /etc/kubernetes/manifests/kube-vip.yaml
 ```
 
-Ensure that `image: plndr/kube-vip:<x>` is modified to point to a specific version (`0.1.5` at the time of writing), refer to [docker hub](https://hub.docker.com/r/plndr/kube-vip/tags) for details. Also ensure that the `hostPath` points to the correct `kube-vip` configuration, if it isn’t the above path.
+Ensure that `image: ghcr.io/kube-vip/kube-vip:<x>` is modified to point to a specific version (`0.3.7` at the time of writing), refer to [GitHub](https://github.com/kube-vip/kube-vip/pkgs/container/kube-vip) for details. Also ensure that the `hostPath` points to the correct `kube-vip` configuration, if it isn’t the above path.
 
 The **vip** is set to `192.168.0.75` and this first node will elect itself as leader, and as part of the `kubeadm init` it will use the VIP in order to speak back to the initialising api-server.
 
@@ -124,7 +124,7 @@ At this point **DON’T** generate the manifests, this is due to some bizarre `k
 **After** this node has been added to the cluster, we can add the manifest to also add this node as a `kube-vip` member. (Adding the manifest afterwards doesn’t interfere with `kubeadm`). 
 
 ```
-sudo docker run -it --rm plndr/kube-vip:0.1.5 sample manifest | sudo tee /etc/kubernetes/manifests/kube-vip.yaml
+sudo docker run -it --rm ghcr.io/kube-vip/kube-vip:0.3.7 sample manifest | sudo tee /etc/kubernetes/manifests/kube-vip.yaml
 ```
 
 Once this node is added we will be able to see that the `kube-vip` pod is up and running as expected:

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -720,7 +720,7 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 			Containers: []corev1.Container{
 				{
 					Name:            "kube-vip",
-					Image:           fmt.Sprintf("plndr/kube-vip:%s", imageVersion),
+					Image:           fmt.Sprintf("ghcr.io/kube-vip/kube-vip:%s", imageVersion),
 					ImagePullPolicy: corev1.PullAlways,
 					SecurityContext: &corev1.SecurityContext{
 						Capabilities: &corev1.Capabilities{


### PR DESCRIPTION
I've updated the unversioned docs and the config generation to use GHCR instead of docker.io, due to the rate limiting enforced by docker.io

I've made an assumption that by publishing the ghcr image that the project would perhaps be moving this way, feel free to close if I am mistaken.

NB: I got docker.io rate limited today and inspired to update this 🤣