### PR TITLE
fix: ensure node annotations are checked before watch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.7.1 // indirect
+	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/vishvananda/netlink v1.1.1-0.20200221165523-c79a4b7b4066
 	github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f // indirect
 	golang.org/x/crypto v0.0.0-20210503195802-e9a32991a82e // indirect

--- a/go.sum
+++ b/go.sum
@@ -596,6 +596,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/manager/watcher.go
+++ b/pkg/manager/watcher.go
@@ -139,7 +139,7 @@ func (sm *Manager) annotationsWatcher() error {
 	// they're as needed
 	log.Warn(err)
 
-	rw, err := watchtools.NewRetryWatcher("1", &cache.ListWatch{
+	rw, err := watchtools.NewRetryWatcher(node.ResourceVersion, &cache.ListWatch{
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			return sm.clientSet.CoreV1().Nodes().Watch(context.Background(), listOptions)
 		},
@@ -167,7 +167,7 @@ func (sm *Manager) annotationsWatcher() error {
 				return fmt.Errorf("Unable to parse Kubernetes Node from Annotation watcher")
 			}
 
-			if err := sm.parseNodeAnnotations(node); err != nil {
+			if err := sm.parseBgpAnnotations(node); err != nil {
 				log.Error(err)
 				continue
 			}
@@ -209,7 +209,7 @@ func (sm *Manager) annotationsWatcher() error {
 // parseNodeAnnotations parses the annotations on the node and updates the configuration
 // returning an error if the annotations are not valid or missing; and nil if everything is OK
 // to continue
-func (sm *Manager) parseNodeAnnotations(node *v1.Node) error {
+func (sm *Manager) parseBgpAnnotations(node *v1.Node) error {
 	nodeASN := node.Annotations[fmt.Sprintf("%s/node-asn", sm.config.Annotations)]
 	if nodeASN == "" {
 		return fmt.Errorf("node-asn value missing or empty")

--- a/pkg/manager/watcher.go
+++ b/pkg/manager/watcher.go
@@ -120,6 +120,25 @@ func (sm *Manager) annotationsWatcher() error {
 		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
 	}
 
+	// First we'll check the annotations for the node and if
+	// they aren't what are expected, we'll drop into the watch until they are
+	nodeList, err := sm.clientSet.CoreV1().Nodes().List(context.Background(), listOptions)
+	if err != nil {
+		return err
+	}
+
+	// We'll assume there's only one node with the hostname annotation. If that's not true,
+	// there's probably bigger problems
+	node := nodeList.Items[0]
+	if err = sm.parseNodeAnnotations(&node); err == nil {
+		// No error, the annotations already exist.
+		return nil
+	}
+
+	// We got an error with the annotations, falling back to the watch until
+	// they're as needed
+	log.Warn(err)
+
 	rw, err := watchtools.NewRetryWatcher("1", &cache.ListWatch{
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			return sm.clientSet.CoreV1().Nodes().Watch(context.Background(), listOptions)
@@ -140,7 +159,6 @@ func (sm *Manager) annotationsWatcher() error {
 	//defer rw.Stop()
 
 	for event := range ch {
-
 		// We need to inspect the event and get ResourceVersion out of it
 		switch event.Type {
 		case watch.Added, watch.Modified:
@@ -149,62 +167,10 @@ func (sm *Manager) annotationsWatcher() error {
 				return fmt.Errorf("Unable to parse Kubernetes Node from Annotation watcher")
 			}
 
-			// BGP Local configuration
-			nodeASN := node.Annotations[fmt.Sprintf("%s/node-asn", sm.config.Annotations)]
-			if nodeASN != "" {
-				u64, err := strconv.ParseUint(nodeASN, 10, 32)
-				if err != nil {
-					return err
-				}
-				sm.config.BGPConfig.AS = uint32(u64)
-			} else {
+			if err := sm.parseNodeAnnotations(node); err != nil {
+				log.Error(err)
 				continue
 			}
-
-			srcIP := node.Annotations[fmt.Sprintf("%s/src-ip", sm.config.Annotations)]
-			if srcIP != "" {
-				sm.config.BGPConfig.RouterID = srcIP
-			} else {
-				continue
-			}
-
-			// Peer configuration [REQUIRED]
-			peerASN := node.Annotations[fmt.Sprintf("%s/peer-asn", sm.config.Annotations)]
-			if peerASN != "" {
-				u64, err := strconv.ParseUint(peerASN, 10, 32)
-				if err != nil {
-					return err
-				}
-				sm.config.BGPPeerConfig.AS = uint32(u64)
-			} else {
-				continue
-			}
-
-			peerIPString := node.Annotations[fmt.Sprintf("%s/peer-ip", sm.config.Annotations)]
-
-			peerIPs := strings.Split(peerIPString, ",")
-
-			for _, peerIP := range peerIPs {
-				ipAddr := strings.TrimSpace(peerIP)
-
-				if ipAddr != "" {
-					sm.config.BGPPeerConfig.Address = ipAddr
-					sm.config.BGPConfig.Peers = append(sm.config.BGPConfig.Peers, sm.config.BGPPeerConfig)
-				}
-			}
-
-			// BGP Password, if it doesn't find a password don't "continue" [OPTIONAL]
-			base64BGPPassword := node.Annotations[fmt.Sprintf("%s/bgp-pass", sm.config.Annotations)]
-			if base64BGPPassword != "" {
-				// Decode base64 encoded string
-				decodedPassword, err := base64.StdEncoding.DecodeString(base64BGPPassword)
-				if err != nil {
-					return err
-				}
-				sm.config.BGPPeerConfig.Password = string(decodedPassword)
-			}
-
-			log.Debugf("%s / %d / %s / %d /n", sm.config.BGPConfig.RouterID, sm.config.BGPConfig.AS, sm.config.BGPConfig.Peers[0].Address, sm.config.BGPConfig.Peers[0].AS)
 
 			rw.Stop()
 			break
@@ -238,4 +204,65 @@ func (sm *Manager) annotationsWatcher() error {
 	log.Infoln("Exiting Annotations watcher")
 	return nil
 
+}
+
+// parseNodeAnnotations parses the annotations on the node and updates the configuration
+// returning an error if the annotations are not valid or missing; and nil if everything is OK
+// to continue
+func (sm *Manager) parseNodeAnnotations(node *v1.Node) error {
+	nodeASN := node.Annotations[fmt.Sprintf("%s/node-asn", sm.config.Annotations)]
+	if nodeASN == "" {
+		return fmt.Errorf("node-asn value missing or empty")
+	}
+
+	u64, err := strconv.ParseUint(nodeASN, 10, 32)
+	if err != nil {
+		return err
+	}
+
+	sm.config.BGPConfig.AS = uint32(u64)
+
+	srcIP := node.Annotations[fmt.Sprintf("%s/src-ip", sm.config.Annotations)]
+	if srcIP == "" {
+		return fmt.Errorf("src-ip value missing or empty")
+	}
+
+	sm.config.BGPConfig.RouterID = srcIP
+
+	peerASN := node.Annotations[fmt.Sprintf("%s/peer-asn", sm.config.Annotations)]
+	if peerASN == "" {
+		return fmt.Errorf("peer-asn value missing or empty")
+	}
+
+	u64, err = strconv.ParseUint(peerASN, 10, 32)
+	if err != nil {
+		return err
+	}
+	sm.config.BGPPeerConfig.AS = uint32(u64)
+
+	peerIPString := node.Annotations[fmt.Sprintf("%s/peer-ip", sm.config.Annotations)]
+
+	peerIPs := strings.Split(peerIPString, ",")
+
+	for _, peerIP := range peerIPs {
+		ipAddr := strings.TrimSpace(peerIP)
+
+		if ipAddr != "" {
+			sm.config.BGPPeerConfig.Address = ipAddr
+			sm.config.BGPConfig.Peers = append(sm.config.BGPConfig.Peers, sm.config.BGPPeerConfig)
+		}
+	}
+
+	base64BGPPassword := node.Annotations[fmt.Sprintf("%s/bgp-pass", sm.config.Annotations)]
+	if base64BGPPassword != "" {
+		// Decode base64 encoded string
+		decodedPassword, err := base64.StdEncoding.DecodeString(base64BGPPassword)
+		if err != nil {
+			return err
+		}
+		sm.config.BGPPeerConfig.Password = string(decodedPassword)
+	}
+
+	log.Debugf("%s / %d / %s / %d /n", sm.config.BGPConfig.RouterID, sm.config.BGPConfig.AS, sm.config.BGPConfig.Peers[0].Address, sm.config.BGPConfig.Peers[0].AS)
+	return nil
 }

--- a/pkg/manager/watcher.go
+++ b/pkg/manager/watcher.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/kube-vip/kube-vip/pkg/bgp"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
@@ -130,8 +131,12 @@ func (sm *Manager) annotationsWatcher() error {
 	// We'll assume there's only one node with the hostname annotation. If that's not true,
 	// there's probably bigger problems
 	node := nodeList.Items[0]
-	if err = sm.parseNodeAnnotations(&node); err == nil {
-		// No error, the annotations already exist.
+
+	bgpConfig, bgpPeer, err := parseBgpAnnotations(&node, sm.config.Annotations)
+	if err == nil {
+		// No error, the annotations already exist
+		sm.config.BGPConfig = bgpConfig
+		sm.config.BGPPeerConfig = bgpPeer
 		return nil
 	}
 
@@ -167,10 +172,14 @@ func (sm *Manager) annotationsWatcher() error {
 				return fmt.Errorf("Unable to parse Kubernetes Node from Annotation watcher")
 			}
 
-			if err := sm.parseBgpAnnotations(node); err != nil {
+			bgpConfig, bgpPeer, err := parseBgpAnnotations(node, sm.config.Annotations)
+			if err != nil {
 				log.Error(err)
 				continue
 			}
+
+			sm.config.BGPConfig = bgpConfig
+			sm.config.BGPPeerConfig = bgpPeer
 
 			rw.Stop()
 			break
@@ -209,38 +218,42 @@ func (sm *Manager) annotationsWatcher() error {
 // parseNodeAnnotations parses the annotations on the node and updates the configuration
 // returning an error if the annotations are not valid or missing; and nil if everything is OK
 // to continue
-func (sm *Manager) parseBgpAnnotations(node *v1.Node) error {
-	nodeASN := node.Annotations[fmt.Sprintf("%s/node-asn", sm.config.Annotations)]
+func parseBgpAnnotations(node *v1.Node, prefix string) (bgp.Config, bgp.Peer, error) {
+	bgpConfig := bgp.Config{}
+	bgpPeer := bgp.Peer{}
+
+	nodeASN := node.Annotations[fmt.Sprintf("%s/node-asn", prefix)]
 	if nodeASN == "" {
-		return fmt.Errorf("node-asn value missing or empty")
+		return bgpConfig, bgpPeer, fmt.Errorf("node-asn value missing or empty")
 	}
 
 	u64, err := strconv.ParseUint(nodeASN, 10, 32)
 	if err != nil {
-		return err
+		return bgpConfig, bgpPeer, err
 	}
 
-	sm.config.BGPConfig.AS = uint32(u64)
+	bgpConfig.AS = uint32(u64)
 
-	srcIP := node.Annotations[fmt.Sprintf("%s/src-ip", sm.config.Annotations)]
+	srcIP := node.Annotations[fmt.Sprintf("%s/src-ip", prefix)]
 	if srcIP == "" {
-		return fmt.Errorf("src-ip value missing or empty")
+		return bgpConfig, bgpPeer, fmt.Errorf("src-ip value missing or empty")
 	}
 
-	sm.config.BGPConfig.RouterID = srcIP
+	bgpConfig.RouterID = srcIP
 
-	peerASN := node.Annotations[fmt.Sprintf("%s/peer-asn", sm.config.Annotations)]
+	peerASN := node.Annotations[fmt.Sprintf("%s/peer-asn", prefix)]
 	if peerASN == "" {
-		return fmt.Errorf("peer-asn value missing or empty")
+		return bgpConfig, bgpPeer, fmt.Errorf("peer-asn value missing or empty")
 	}
 
 	u64, err = strconv.ParseUint(peerASN, 10, 32)
 	if err != nil {
-		return err
+		return bgpConfig, bgpPeer, err
 	}
-	sm.config.BGPPeerConfig.AS = uint32(u64)
 
-	peerIPString := node.Annotations[fmt.Sprintf("%s/peer-ip", sm.config.Annotations)]
+	bgpPeer.AS = uint32(u64)
+
+	peerIPString := node.Annotations[fmt.Sprintf("%s/peer-ip", prefix)]
 
 	peerIPs := strings.Split(peerIPString, ",")
 
@@ -248,21 +261,23 @@ func (sm *Manager) parseBgpAnnotations(node *v1.Node) error {
 		ipAddr := strings.TrimSpace(peerIP)
 
 		if ipAddr != "" {
-			sm.config.BGPPeerConfig.Address = ipAddr
-			sm.config.BGPConfig.Peers = append(sm.config.BGPConfig.Peers, sm.config.BGPPeerConfig)
+			bgpPeer.Address = ipAddr
+			bgpConfig.Peers = append(bgpConfig.Peers, bgpPeer)
 		}
 	}
 
-	base64BGPPassword := node.Annotations[fmt.Sprintf("%s/bgp-pass", sm.config.Annotations)]
+	base64BGPPassword := node.Annotations[fmt.Sprintf("%s/bgp-pass", prefix)]
 	if base64BGPPassword != "" {
 		// Decode base64 encoded string
 		decodedPassword, err := base64.StdEncoding.DecodeString(base64BGPPassword)
 		if err != nil {
-			return err
+			return bgpConfig, bgpPeer, err
 		}
-		sm.config.BGPPeerConfig.Password = string(decodedPassword)
+		bgpPeer.Password = string(decodedPassword)
 	}
 
-	log.Debugf("%s / %d / %s / %d /n", sm.config.BGPConfig.RouterID, sm.config.BGPConfig.AS, sm.config.BGPConfig.Peers[0].Address, sm.config.BGPConfig.Peers[0].AS)
-	return nil
+	log.Debugf("BGPConfig: %v\n", bgpConfig)
+	log.Debugf("BGPPeerConfig: %v\n", bgpPeer)
+
+	return bgpConfig, bgpPeer, nil
 }

--- a/pkg/manager/watcher_test.go
+++ b/pkg/manager/watcher_test.go
@@ -1,0 +1,58 @@
+package manager
+
+import (
+	"testing"
+
+	"github.com/kube-vip/kube-vip/pkg/bgp"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestParseBgpAnnotations(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Annotations: map[string]string{}},
+	}
+
+	_, _, err := parseBgpAnnotations(node, "bgp")
+	if err == nil {
+		t.Fatal("Parsing BGP annotations should return an error when no annotations exist")
+	}
+
+	node.Annotations = map[string]string{
+		"bgp/node-asn": "1",
+		"bgp/peer-asn": "2",
+		"bgp/src-ip":   "3",
+	}
+
+	bgpConfig, bgpPeer, err := parseBgpAnnotations(node, "bgp")
+	if err != nil {
+		t.Fatal("Parsing BGP annotations should return nil when minimum config is met")
+	}
+
+	assert.Equal(t, uint32(1), bgpConfig.AS, "bgpConfig.AS parsed incorrectly")
+	assert.Equal(t, uint32(2), bgpPeer.AS, "bgpPeer.AS parsed incorrectly")
+	assert.Equal(t, "3", bgpConfig.RouterID, "bgpConfig.RouterID parsed incorrectly")
+
+	node.Annotations = map[string]string{
+		"bgp/node-asn": "1",
+		"bgp/peer-asn": "2",
+		"bgp/src-ip":   "3",
+		"bgp/peer-ip":  "1,2,3",
+		"bgp/bgp-pass": "cGFzc3dvcmQ=", // password
+	}
+
+	bgpConfig, bgpPeer, err = parseBgpAnnotations(node, "bgp")
+	if err != nil {
+		t.Fatal("Parsing BGP annotations should return nil when minimum config is met")
+	}
+
+	bgpPeers := []bgp.Peer{
+		{Address: "1", AS: uint32(2)},
+		{Address: "2", AS: uint32(2)},
+		{Address: "3", AS: uint32(2)},
+	}
+	assert.Equal(t, bgpPeers, bgpConfig.Peers, "bgpConfig.Peers parsed incorrectly")
+	assert.Equal(t, "3", bgpPeer.Address, "bgpPeer.Address parsed incorrectly")
+	assert.Equal(t, "password", bgpPeer.Password, "bgpPeer.Password parsed incorrectly")
+}


### PR DESCRIPTION
`kube-vip` gets "stuck" waiting for the Metal annotations when they already exist on the nodes.

This change allows for the annotations on the node to be checked prior to enter the watch.

I've got a new environment spinning up now to test and will report back shortly.