### PR TITLE
BGP mode spelling

### DIFF
--- a/cmd/kube-vip-start.go
+++ b/cmd/kube-vip-start.go
@@ -96,7 +96,7 @@ var kubeVipStart = &cobra.Command{
 				}
 
 				if startConfig.EnableBGP {
-					log.Info("Starting the BGP server to adverise VIP routes to VGP peers")
+					log.Info("Starting the BGP server to advertise VIP routes to VGP peers")
 					bgpServer, err = bgp.NewBGPServer(&startConfig.BGPConfig)
 					if err != nil {
 						log.Fatalf("%v", err)

--- a/pkg/cluster/clusterLeader.go
+++ b/pkg/cluster/clusterLeader.go
@@ -170,7 +170,7 @@ func (cluster *Cluster) StartLeaderCluster(c *kubevip.Config, sm *Manager, bgpSe
 
 	if c.EnableBGP {
 		// Lets start BGP
-		log.Info("Starting the BGP server to adverise VIP routes to VGP peers")
+		log.Info("Starting the BGP server to advertise VIP routes to VGP peers")
 		bgpServer, err = bgp.NewBGPServer(&c.BGPConfig)
 		if err != nil {
 			log.Error(err)

--- a/pkg/manager/manager_bgp.go
+++ b/pkg/manager/manager_bgp.go
@@ -48,7 +48,7 @@ func (sm *Manager) startBGP() error {
 		}
 	}
 
-	log.Info("Starting the BGP server to adverise VIP routes to BGP peers")
+	log.Info("Starting the BGP server to advertise VIP routes to BGP peers")
 	sm.bgpServer, err = bgp.NewBGPServer(&sm.config.BGPConfig)
 	if err != nil {
 		return err

--- a/pkg/service/manager_arp.go
+++ b/pkg/service/manager_arp.go
@@ -45,7 +45,7 @@ func (sm *Manager) startARP() error {
 	// // If BGP is enabled then we start the server that will broadcast VIPs
 	// if sm.config.EnableBGP {
 	// 	// Lets start BGP
-	// 	log.Info("Starting the BGP server to adverise VIP routes to VGP peers")
+	// 	log.Info("Starting the BGP server to advertise VIP routes to VGP peers")
 	// 	sm.bgpServer, err = bgp.NewBGPServer(&sm.config.BGPConfig)
 	// 	if err != nil {
 	// 		log.Error(err)

--- a/pkg/service/manager_bgp.go
+++ b/pkg/service/manager_bgp.go
@@ -34,7 +34,7 @@ func (sm *Manager) startBGP() error {
 		}
 	}
 
-	log.Info("Starting the BGP server to adverise VIP routes to VGP peers")
+	log.Info("Starting the BGP server to advertise VIP routes to VGP peers")
 	sm.bgpServer, err = bgp.NewBGPServer(&sm.config.BGPConfig)
 	if err != nil {
 		return err


### PR DESCRIPTION
in BGP mode this message appears with a typo

`time="2021-08-16T23:30:23Z" level=info msg="Starting the BGP server to adverise VIP routes to BGP peers"`
