### PR TITLE
Fixes the broken logic in password parsing

### DIFF
--- a/pkg/manager/watcher.go
+++ b/pkg/manager/watcher.go
@@ -262,18 +262,19 @@ func parseBgpAnnotations(node *v1.Node, prefix string) (bgp.Config, bgp.Peer, er
 
 		if ipAddr != "" {
 			bgpPeer.Address = ipAddr
+			// Check if we're also expecting a password for this peer
+			base64BGPPassword := node.Annotations[fmt.Sprintf("%s/bgp-pass", prefix)]
+			if base64BGPPassword != "" {
+				// Decode base64 encoded string
+				decodedPassword, err := base64.StdEncoding.DecodeString(base64BGPPassword)
+				if err != nil {
+					return bgpConfig, bgpPeer, err
+				}
+				// Set the password for each peer
+				bgpPeer.Password = string(decodedPassword)
+			}
 			bgpConfig.Peers = append(bgpConfig.Peers, bgpPeer)
 		}
-	}
-
-	base64BGPPassword := node.Annotations[fmt.Sprintf("%s/bgp-pass", prefix)]
-	if base64BGPPassword != "" {
-		// Decode base64 encoded string
-		decodedPassword, err := base64.StdEncoding.DecodeString(base64BGPPassword)
-		if err != nil {
-			return bgpConfig, bgpPeer, err
-		}
-		bgpPeer.Password = string(decodedPassword)
 	}
 
 	log.Debugf("BGPConfig: %v\n", bgpConfig)

--- a/pkg/manager/watcher_test.go
+++ b/pkg/manager/watcher_test.go
@@ -50,13 +50,13 @@ func TestParseBgpAnnotations(t *testing.T) {
 	}
 
 	bgpPeers := []bgp.Peer{
-		{Address: "10.0.0.1", AS: uint32(64000)},
-		{Address: "10.0.0.2", AS: uint32(64000)},
-		{Address: "10.0.0.3", AS: uint32(64000)},
+		{Address: "10.0.0.1", AS: uint32(64000), Password: "password"},
+		{Address: "10.0.0.2", AS: uint32(64000), Password: "password"},
+		{Address: "10.0.0.3", AS: uint32(64000), Password: "password"},
 	}
 	assert.Equal(t, bgpPeers, bgpConfig.Peers, "bgpConfig.Peers parsed incorrectly")
 	assert.Equal(t, "10.0.0.3", bgpPeer.Address, "bgpPeer.Address parsed incorrectly")
-	//assert.Equal(t, "password", bgpPeer.Password, "bgpPeer.Password parsed incorrectly")
+	assert.Equal(t, "password", bgpPeer.Password, "bgpPeer.Password parsed incorrectly")
 }
 
 func Test_parseBgpAnnotations(t *testing.T) {


### PR DESCRIPTION
Turns out I was never actually adding the password into the BGP configuration as the `append` happened **before** the password was added to the struct.


😢  computers... fixes #256 