### PR TITLE
Implements a secondary interface just for services

### DIFF
--- a/cmd/kube-vip-config.go
+++ b/cmd/kube-vip-config.go
@@ -141,6 +141,6 @@ var kubeVipSampleManifest = &cobra.Command{
 		}
 
 		b, _ := yaml.Marshal(p)
-		fmt.Printf(string(b))
+		fmt.Print(string(b))
 	},
 }

--- a/cmd/kube-vip-kubeadm.go
+++ b/cmd/kube-vip-kubeadm.go
@@ -101,7 +101,9 @@ var kubeKubeadmJoin = &cobra.Command{
 		opts := metav1.ListOptions{}
 		opts.LabelSelector = "node-role.kubernetes.io/master"
 		nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), opts)
-
+		if err != nil {
+			log.Fatal(err.Error())
+		}
 		// Iterate over all nodes that are masters and find the details to build a peer list
 		for x := range nodes.Items {
 			// Get hostname and address
@@ -150,7 +152,7 @@ func autoGenLocalPeer() (*kubevip.RaftPeer, error) {
 		}
 	}
 	if a == "" {
-		return nil, fmt.Errorf("Unable to find local address")
+		return nil, fmt.Errorf("nable to find local address")
 	}
 	return &kubevip.RaftPeer{
 		ID:      h,

--- a/cmd/kube-vip-kubeadm.go
+++ b/cmd/kube-vip-kubeadm.go
@@ -152,7 +152,7 @@ func autoGenLocalPeer() (*kubevip.RaftPeer, error) {
 		}
 	}
 	if a == "" {
-		return nil, fmt.Errorf("nable to find local address")
+		return nil, fmt.Errorf("unable to find local address")
 	}
 	return &kubevip.RaftPeer{
 		ID:      h,

--- a/cmd/kube-vip-manifests.go
+++ b/cmd/kube-vip-manifests.go
@@ -49,7 +49,7 @@ var kubeManifestPod = &cobra.Command{
 		}
 
 		// The control plane has a requirement for a VIP being specified
-		if initConfig.EnableControlPane && (initConfig.VIP == "" && initConfig.Address == "" && initConfig.DDNS == false) {
+		if initConfig.EnableControlPane && (initConfig.VIP == "" && initConfig.Address == "" && !initConfig.DDNS) {
 			cmd.Help()
 			log.Fatalln("No address is specified for kube-vip to expose services on")
 		}
@@ -75,7 +75,7 @@ var kubeManifestDaemon = &cobra.Command{
 		}
 
 		// The control plane has a requirement for a VIP being specified
-		if initConfig.EnableControlPane && (initConfig.VIP == "" && initConfig.Address == "" && initConfig.DDNS == false) {
+		if initConfig.EnableControlPane && (initConfig.VIP == "" && initConfig.Address == "" && !initConfig.DDNS) {
 			cmd.Help()
 			log.Fatalln("No address is specified for kube-vip to expose services on")
 		}

--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -67,6 +67,8 @@ func init() {
 	initConfig.LocalPeer = *localpeer
 	//initConfig.Peers = append(initConfig.Peers, *localpeer)
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.Interface, "interface", "", "Name of the interface to bind to")
+	kubeVipCmd.PersistentFlags().StringVar(&initConfig.ServicesInterface, "serviceInterface", "", "Name of the interface to bind to (for services)")
+
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.VIP, "vip", "", "The Virtual IP address")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.Address, "address", "", "an address (IP or DNS name) to use as a VIP")
 	kubeVipCmd.PersistentFlags().IntVar(&initConfig.Port, "port", 6443, "listen port for the VIP")

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -24,6 +24,9 @@ const (
 	//vipInterface - defines the interface that the vip should bind too
 	vipInterface = "vip_interface"
 
+	//vipInterface - defines the interface that the vip should bind too
+	vipServicesInterface = "vip_servicesinterface"
+
 	//vipCidr - defines the cidr that the vip will use
 	vipCidr = "vip_cidr"
 

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -24,7 +24,7 @@ const (
 	//vipInterface - defines the interface that the vip should bind too
 	vipInterface = "vip_interface"
 
-	//vipInterface - defines the interface that the vip should bind too
+	//vipServicesInterface - defines the interface that the service vips should bind too
 	vipServicesInterface = "vip_servicesinterface"
 
 	//vipCidr - defines the cidr that the vip will use

--- a/pkg/kubevip/config_generator_test.go
+++ b/pkg/kubevip/config_generator_test.go
@@ -1,0 +1,23 @@
+package kubevip
+
+import "testing"
+
+func TestParseEnvironment(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		c       *Config
+		wantErr bool
+	}{
+		{"", nil, false},
+		{"", &Config{Interface: "eth0", ServicesInterface: "eth1"}, false},
+	}
+	for _, tt := range tests {
+		t.Logf("%v", tt.c)
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ParseEnvironment(tt.c); (err != nil) != tt.wantErr {
+				t.Errorf("ParseEnvironment() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -63,6 +63,9 @@ type Config struct {
 	// Interface is the network interface to bind to (default: First Adapter)
 	Interface string `yaml:"interface,omitempty"`
 
+	// Interface is the network interface to bind to (default: First Adapter)
+	ServicesInterface string `yaml:"servicesInterface,omitempty"`
+
 	// EnableLoadBalancer, provides the flexibility to make the load-balancer optional
 	EnableLoadBalancer bool `yaml:"enableLoadBalancer"`
 

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -63,7 +63,7 @@ type Config struct {
 	// Interface is the network interface to bind to (default: First Adapter)
 	Interface string `yaml:"interface,omitempty"`
 
-	// Interface is the network interface to bind to (default: First Adapter)
+	// ServicesInterface is the network interface to bind to for services (optional)
 	ServicesInterface string `yaml:"servicesInterface,omitempty"`
 
 	// EnableLoadBalancer, provides the flexibility to make the load-balancer optional

--- a/pkg/manager/services.go
+++ b/pkg/manager/services.go
@@ -28,8 +28,8 @@ func (sm *Manager) stopService(uid string) error {
 			sm.serviceInstances[x].cluster.Stop()
 		}
 	}
-	if found == false {
-		return fmt.Errorf("Unable to find/stop service [%s]", uid)
+	if !found {
+		return fmt.Errorf("unable to find/stop service [%s]", uid)
 	}
 	return nil
 }
@@ -90,10 +90,18 @@ func (sm *Manager) syncServices(service *v1.Service, wg *sync.WaitGroup) error {
 
 	}
 
+	// Detect if we're using a specific interface for services
+	var serciceInterface string
+	if sm.config.ServicesInterface != "" {
+		serciceInterface = sm.config.ServicesInterface
+	} else {
+		serciceInterface = sm.config.Interface
+	}
+
 	// Generate new Virtual IP configuration
 	newVip := kubevip.Config{
 		VIP:        newServiceAddress, //TODO support more than one vip?
-		Interface:  sm.config.Interface,
+		Interface:  serciceInterface,
 		SingleNode: true,
 		EnableARP:  sm.config.EnableARP,
 		EnableBGP:  sm.config.EnableBGP,
@@ -101,7 +109,7 @@ func (sm *Manager) syncServices(service *v1.Service, wg *sync.WaitGroup) error {
 	}
 
 	// This instance wasn't found, we need to add it to the manager
-	if foundInstance == false {
+	if !foundInstance {
 		// Create new service
 		var newService Instance
 		newService.UID = newServiceUID

--- a/pkg/manager/services.go
+++ b/pkg/manager/services.go
@@ -91,17 +91,17 @@ func (sm *Manager) syncServices(service *v1.Service, wg *sync.WaitGroup) error {
 	}
 
 	// Detect if we're using a specific interface for services
-	var serciceInterface string
+	var serviceInterface string
 	if sm.config.ServicesInterface != "" {
-		serciceInterface = sm.config.ServicesInterface
+		serviceInterface = sm.config.ServicesInterface
 	} else {
-		serciceInterface = sm.config.Interface
+		serviceInterface = sm.config.Interface
 	}
 
 	// Generate new Virtual IP configuration
 	newVip := kubevip.Config{
 		VIP:        newServiceAddress, //TODO support more than one vip?
-		Interface:  serciceInterface,
+		Interface:  serviceInterface,
 		SingleNode: true,
 		EnableARP:  sm.config.EnableARP,
 		EnableBGP:  sm.config.EnableBGP,


### PR DESCRIPTION
This allows an end user to specify a secondary interface that is used purely for services.

```
--interface eth0
--serviceInterface eth1
```

Or within the environment variables!

```
    name: vip_serviceinterface
    value: eth1
```