### PR TITLE
Support use Equinix Metal credentials from config

### DIFF
--- a/pkg/cluster/clusterLeader.go
+++ b/pkg/cluster/clusterLeader.go
@@ -153,6 +153,17 @@ func (cluster *Cluster) StartLeaderCluster(c *kubevip.Config, sm *Manager, bgpSe
 	// If Packet is enabled then we can begin our preperation work
 	var packetClient *packngo.Client
 	if c.EnableMetal {
+		if c.ProviderConfig != "" {
+			key, project, err := packet.GetPacketConfig(c.ProviderConfig)
+			if err != nil {
+				log.Error(err)
+			} else {
+				// Set the environment variable with the key for the project
+				os.Setenv("PACKET_AUTH_TOKEN", key)
+				// Update the configuration with the project key
+				c.MetalProjectID = project
+			}
+		}
 		packetClient, err = packngo.NewClient()
 		if err != nil {
 			log.Error(err)


### PR DESCRIPTION
Use Equinix Metal credentials when available with EIP configuration
not just BGP configuration.

Signed-off-by: Jason DeTiberus <detiber@users.noreply.github.com>