### PR TITLE
Auto detect default interface for VIP

### DIFF
--- a/cmd/kube-vip-manifests.go
+++ b/cmd/kube-vip-manifests.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
-	"github.com/kube-vip/kube-vip/pkg/vip"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -43,20 +42,6 @@ var kubeManifestPod = &cobra.Command{
 		initConfig.LoadBalancers = append(initConfig.LoadBalancers, initLoadBalancer)
 		// TODO - A load of text detailing what's actually happening
 		kubevip.ParseEnvironment(&initConfig)
-		// TODO - check for certain things VIP/interfaces
-
-		if initConfig.AutoInterface {
-			defaultIF, err := vip.GetDefaultGatewayInterface()
-			if err != nil {
-				log.Fatalf("unable to set default interface -> [%v]", err)
-			}
-			initConfig.Interface = defaultIF.Name
-		}
-
-		if initConfig.Interface == "" {
-			cmd.Help()
-			log.Fatalln("No interface is specified for kube-vip to bind to")
-		}
 
 		// The control plane has a requirement for a VIP being specified
 		if initConfig.EnableControlPane && (initConfig.VIP == "" && initConfig.Address == "" && !initConfig.DDNS) {
@@ -79,19 +64,6 @@ var kubeManifestDaemon = &cobra.Command{
 		// TODO - A load of text detailing what's actually happening
 		kubevip.ParseEnvironment(&initConfig)
 		// TODO - check for certain things VIP/interfaces
-
-		if initConfig.AutoInterface {
-			defaultIF, err := vip.GetDefaultGatewayInterface()
-			if err != nil {
-				log.Fatalf("unable to set default interface -> [%v]", err)
-			}
-			initConfig.Interface = defaultIF.Name
-		}
-
-		if initConfig.Interface == "" {
-			cmd.Help()
-			log.Fatalln("No interface is specified for kube-vip to bind to")
-		}
 
 		// The control plane has a requirement for a VIP being specified
 		if initConfig.EnableControlPane && (initConfig.VIP == "" && initConfig.Address == "" && !initConfig.DDNS) {

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -24,9 +24,6 @@ const (
 	//vipInterface - defines the interface that the vip should bind too
 	vipInterface = "vip_interface"
 
-	//vipAutoInterface - defines the interface that the vip should bind too
-	vipAutoInterface = "vip_autointerface"
-
 	//vipServicesInterface - defines the interface that the service vips should bind too
 	vipServicesInterface = "vip_servicesinterface"
 

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -34,16 +34,6 @@ func ParseEnvironment(c *Config) error {
 		c.Interface = env
 	}
 
-	// Find interface
-	env = os.Getenv(vipAutoInterface)
-	if env != "" {
-		b, err := strconv.ParseBool(env)
-		if err != nil {
-			return err
-		}
-		c.AutoInterface = b
-	}
-
 	// Find (services) interface
 	env = os.Getenv(vipServicesInterface)
 	if env != "" {
@@ -472,16 +462,8 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 		},
 	}
 
-	if c.AutoInterface {
-		// build environment variables
-		autoInterface := []corev1.EnvVar{
-			{
-				Name:  vipAutoInterface,
-				Value: strconv.FormatBool(c.AutoInterface),
-			},
-		}
-		newEnvironment = append(newEnvironment, autoInterface...)
-	} else {
+	// If we're specifically saying which interface to use then add it to the manifest
+	if c.Interface != "" {
 		iface := []corev1.EnvVar{
 			{
 				Name:  vipInterface,
@@ -490,6 +472,7 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 		}
 		newEnvironment = append(newEnvironment, iface...)
 	}
+
 	// Detect if we should be using a seperate interface for sercices
 	if c.ServicesInterface != "" {
 		// build environment variables

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -63,9 +63,6 @@ type Config struct {
 	// Interface is the network interface to bind to (default: First Adapter)
 	Interface string `yaml:"interface,omitempty"`
 
-	// AutoInterface is the network interface to bind to (Adapter is determined from Default Gateway)
-	AutoInterface bool `yaml:"interface,omitempty"`
-
 	// ServicesInterface is the network interface to bind to for services (optional)
 	ServicesInterface string `yaml:"servicesInterface,omitempty"`
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -113,7 +113,7 @@ func New(configMap string, config *kubevip.Config) (*Manager, error) {
 	// VIP up before trying to connect to the API server, we set the API endpoint to this machine to
 	// ensure connectivity.
 	if config.EnableControlPane {
-		log.Debugf("Modifying address of Kubernetes server to localhost")
+		log.Debugf("Modifying address of Kubernetes server to \"kubernetes\" (internal hostname)")
 		cfg.Host = fmt.Sprintf("kubernetes:%v", config.Port)
 		clientset, err = kubernetes.NewForConfig(cfg)
 	}

--- a/pkg/manager/watcher.go
+++ b/pkg/manager/watcher.go
@@ -58,6 +58,7 @@ func (sm *Manager) servicesWatcher(ctx context.Context) error {
 			if !ok {
 				return fmt.Errorf("Unable to parse Kubernetes services from API watcher")
 			}
+			
 			if svc.Spec.LoadBalancerIP == "" {
 				log.Infof("Service [%s] has been addded/modified, it has no assigned external addresses", svc.Name)
 			} else {


### PR DESCRIPTION
This adds a `--autoInterface` cmdline that is used to generate manifests and to start kube-vip, when this is used it will look at the default Gateway and use that interface for VIPs moving forward. 