### PR TITLE
Add hostAliases to kube-vip-arp-ds.yaml on v0.3.9

### DIFF
--- a/docs/manifests/v0.3.9/kube-vip-arp-ds.yaml
+++ b/docs/manifests/v0.3.9/kube-vip-arp-ds.yaml
@@ -54,6 +54,10 @@ spec:
             - NET_ADMIN
             - NET_RAW
             - SYS_TIME
+      hostAliases:
+      - hostnames:
+        - kubernetes
+        ip: 127.0.0.1
       hostNetwork: true
       serviceAccountName: kube-vip
   updateStrategy: {}


### PR DESCRIPTION
Add hostAliases to kube-vip-arp-ds.yaml on v0.3.9.
Resolves issue where kubernetes name can not be resolved.