### PR TITLE
Allows setting an API server port

### DIFF
--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -231,7 +231,7 @@ func (cluster *Cluster) StartCluster(c *kubevip.Config, sm *Manager, bgpServer *
 	return nil
 }
 
-func (sm *Manager) NodeWatcher(lb *loadbalancer.IPVSLoadBalancer) error {
+func (sm *Manager) NodeWatcher(lb *loadbalancer.IPVSLoadBalancer, port int) error {
 	// Use a restartable watcher, as this should help in the event of etcd or timeout issues
 	log.Infof("Kube-Vip is watching nodes for control-plane labels")
 
@@ -271,7 +271,7 @@ func (sm *Manager) NodeWatcher(lb *loadbalancer.IPVSLoadBalancer) error {
 			for x := range node.Status.Addresses {
 
 				if node.Status.Addresses[x].Type == v1.NodeInternalIP {
-					err = lb.AddBackend(node.Status.Addresses[x].Address)
+					err = lb.AddBackend(node.Status.Addresses[x].Address, port)
 					if err != nil {
 						log.Errorf("Add IPVS backend [%v]", err)
 					}
@@ -287,7 +287,7 @@ func (sm *Manager) NodeWatcher(lb *loadbalancer.IPVSLoadBalancer) error {
 			for x := range node.Status.Addresses {
 
 				if node.Status.Addresses[x].Type == v1.NodeInternalIP {
-					err = lb.AddBackend(node.Status.Addresses[x].Address)
+					err = lb.RemoveBackend(node.Status.Addresses[x].Address, port)
 					if err != nil {
 						log.Errorf("Del IPVS backend [%v]", err)
 					}

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -84,7 +84,7 @@ func (cluster *Cluster) vipService(ctxArp, ctxDNS context.Context, c *kubevip.Co
 		}
 
 		go func() {
-			err = sm.NodeWatcher(lb)
+			err = sm.NodeWatcher(lb, c.Port)
 			if err != nil {
 				log.Errorf("Error watching node labels [%s]", err)
 			}

--- a/pkg/loadbalancer/ipvs.go
+++ b/pkg/loadbalancer/ipvs.go
@@ -87,10 +87,10 @@ func (lb *IPVSLoadBalancer) RemoveIPVSLB() error {
 
 }
 
-func (lb *IPVSLoadBalancer) AddBackend(address string) error {
+func (lb *IPVSLoadBalancer) AddBackend(address string, port int) error {
 	dst := ipvs.Destination{
 		Address:   ipvs.NewIP(net.ParseIP(address)),
-		Port:      6443,
+		Port:      uint16(port),
 		Family:    ipvs.INET,
 		Weight:    1,
 		FwdMethod: ipvs.Local,
@@ -105,10 +105,10 @@ func (lb *IPVSLoadBalancer) AddBackend(address string) error {
 	return nil
 }
 
-func (lb *IPVSLoadBalancer) RemoveBackend(address string) error {
+func (lb *IPVSLoadBalancer) RemoveBackend(address string, port int) error {
 	dst := ipvs.Destination{
 		Address: ipvs.NewIP(net.ParseIP(address)),
-		Port:    6443,
+		Port:    uint16(port),
 		Family:  ipvs.INET,
 		Weight:  1,
 	}


### PR DESCRIPTION
Removes the hardcoded port from `6443` to what is specified as `port` usually still `6443` but can now be changed.