### PR TITLE
Various KIND documentation fixes

### DIFF
--- a/docs/usage/kind/index.md
+++ b/docs/usage/kind/index.md
@@ -44,12 +44,12 @@ The easiest method to generate a manifest is using the container itself, below w
 `alias kube-vip="ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$KVVERSION vip /kube-vip"`
 
 ### Docker
-`alias kube-vip="docker run --network host --rm ghcr.io/kube-vip/kube-vip:KVVERSION"`
+`alias kube-vip="docker run --network host --rm ghcr.io/kube-vip/kube-vip:$KVVERSION"`
 
 ## Deploy Kube-vip as a deamonset
 
 ```
-kube-vip manifest daemonset --services --inCluster --arp --interface eth0 | ./kubectl apply -f -
+kube-vip manifest daemonset --services --inCluster --arp --interface eth0 | kubectl apply -f -
 ```
 
 ## Test


### PR DESCRIPTION
KVVERSION needs to be preceeded with `$` for shell expansion of the variable.
`kubectl` is unlikely to be a binary in the current directory and is likely to be in `$PATH`