### PR TITLE
Update label selector for control-plane nodes

### DIFF
--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -22,7 +22,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -235,9 +234,8 @@ func (sm *Manager) NodeWatcher(lb *loadbalancer.IPVSLoadBalancer, port int) erro
 	// Use a restartable watcher, as this should help in the event of etcd or timeout issues
 	log.Infof("Kube-Vip is watching nodes for control-plane labels")
 
-	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"node-role.kubernetes.io/control-plane": ""}}
 	listOptions := metav1.ListOptions{
-		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
+		LabelSelector: "node-role.kubernetes.io/control-plane",
 	}
 
 	rw, err := watchtools.NewRetryWatcher("1", &cache.ListWatch{


### PR DESCRIPTION
The current node watcher uses a label selector of the form `node-role.kubernetes.io/control-plane=`; this does not work correctly.

The label selector should be `node-role.kubernetes.io/control-plane` or `node-role.kubernetes.io/control-plane=true` to select the control-plane nodes.

Without these changes, the IPVS tables are never updated with the control plane nodes and clients making requests to the VIP will fail with a "connection refused" error.

```
$ kubectl get nodes -l node-role.kubernetes.io/control-plane=
No resources found

$ kubectl get nodes -l node-role.kubernetes.io/control-plane=true
NAME     STATUS   ROLES                       AGE   VERSION
pi4-00   Ready    control-plane,etcd,master   21h   v1.22.3+k3s1
pi4-01   Ready    control-plane,etcd,master   20h   v1.22.3+k3s1
pi4-02   Ready    control-plane,etcd,master   20h   v1.22.3+k3s1

$ kubectl get nodes -l node-role.kubernetes.io/control-plane
NAME     STATUS   ROLES                       AGE   VERSION
pi4-00   Ready    control-plane,etcd,master   21h   v1.22.3+k3s1
pi4-01   Ready    control-plane,etcd,master   20h   v1.22.3+k3s1
pi4-02   Ready    control-plane,etcd,master   20h   v1.22.3+k3s1
```
