### PR TITLE
Pass resolved VIP from Network.IP() to NewIPVSLB

### DIFF
--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -78,7 +78,7 @@ func (cluster *Cluster) vipService(ctxArp, ctxDNS context.Context, c *kubevip.Co
 
 		log.Infof("Starting IPVS LoadBalancer")
 
-		lb, err := loadbalancer.NewIPVSLB(c.VIP, c.LoadBalancerPort)
+		lb, err := loadbalancer.NewIPVSLB(cluster.Network.IP(), c.LoadBalancerPort)
 		if err != nil {
 			log.Errorf("Error creating IPVS LoadBalancer [%s]", err)
 		}


### PR DESCRIPTION
After deploying a manifest created from
```sh
docker run --rm ghcr.io/kube-vip/kube-vip:v0.4.0 \
    manifest \
    daemonset \
    --address 192.168.1.50 \
    --inCluster \
    --controlplane \
    --services \
    --arp \
    --leaderElection \
    --taint \
    --enableLoadBalancer
```
the containers would enter a CrashLoopBackoff. The logs included the following panic:

```
 time="2021-11-26T20:28:32Z" level=info msg="Starting IPVS LoadBalancer"
panic: runtime error: slice bounds out of range [:12] with capacity 0

goroutine 52 [running]:
github.com/cloudflare/ipvs.NewIP(...)
        /go/pkg/mod/github.com/cloudflare/ipvs@v0.0.0-20210114211356-96b2597859b3/ip.go:25
github.com/kube-vip/kube-vip/pkg/loadbalancer.NewIPVSLB(0x0, 0x0, 0x192b, 0x1a, 0x0, 0x0)
        /src/pkg/loadbalancer/ipvs.go:53 +0x580
github.com/kube-vip/kube-vip/pkg/cluster.(*Cluster).vipService(0x400003a040, 0x171d870, 0x40002960c0, 0x171d870, 0x4000296100, 0x2279fe0, 0x4000300360, 0x0, 0x0, 0x0, ...)
        /src/pkg/cluster/service.go:81 +0x344
github.com/kube-vip/kube-vip/pkg/cluster.(*Cluster).StartCluster.func3(0x171d870, 0x4000296680)
        /src/pkg/cluster/clusterLeaderElection.go:194 +0x74
created by k8s.io/client-go/tools/leaderelection.(*LeaderElector).Run
        /go/pkg/mod/k8s.io/client-go@v0.22.2/tools/leaderelection/leaderelection.go:211 +0xec
```
This is caused by passing the `nil` returned from parsing the empty VIP to `ipvs.NewIP()`.

Based on other code in the general area, it looks like the Network.IP() should have been passed instead of the (possibly empty) VIP from the configuration. After making this change, the panic is resolved and the load balancer seems to function correctly.