### PR TITLE
allow to configure the ipvs forwarding method

### DIFF
--- a/cmd/kube-vip-config.go
+++ b/cmd/kube-vip-config.go
@@ -31,6 +31,7 @@ func init() {
 	kubeVipSampleConfig.Flags().StringVar(&cliConfigLB.Name, "lbName", "Example Load Balancer", "The name of a load balancer instance")
 	kubeVipSampleConfig.Flags().IntVar(&cliConfigLB.Port, "lbPort", 8080, "Port that load balancer will expose on")
 	kubeVipSampleConfig.Flags().StringSliceVar(&cliBackends, "lbBackends", []string{"192.168.0.1:8080", "192.168.0.2:8080"}, "Comma separated backends, format: address:port")
+	kubeVipSampleConfig.Flags().StringVar(&cliConfigLB.ForwardingMethod, "lbForwardingMethod", "local", "The forwarding method of a load balancer instance")
 }
 
 var kubeVipSampleConfig = &cobra.Command{

--- a/cmd/kube-vip-start.go
+++ b/cmd/kube-vip-start.go
@@ -38,6 +38,7 @@ func init() {
 	kubeVipStart.Flags().IntVar(&startConfigLB.Port, "lbPort", 8080, "Port that load balancer will expose on")
 	kubeVipStart.Flags().IntVar(&startConfigLB.BackendPort, "lbBackEndPort", 6443, "A port that all backends may be using (optional)")
 	kubeVipStart.Flags().StringSliceVar(&startBackends, "lbBackends", []string{"192.168.0.1:8080", "192.168.0.2:8080"}, "Comma separated backends, format: address:port")
+	kubeVipStart.Flags().StringVar(&startConfigLB.ForwardingMethod, "lbForwardingMethod", "local", "The forwarding method of a load balancer instance")
 
 	// Cluster configuration
 	kubeVipStart.Flags().StringVar(&startKubeConfigPath, "kubeConfig", "/etc/kubernetes/admin.conf", "The path of a kubernetes configuration file")

--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -72,6 +72,7 @@ func init() {
 	// LoadBalancer flags
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableLoadBalancer, "enableLoadBalancer", false, "enable loadbalancing on the VIP with IPVS")
 	kubeVipCmd.PersistentFlags().IntVar(&initConfig.LoadBalancerPort, "lbPort", 6443, "loadbalancer port for the VIP")
+	kubeVipCmd.PersistentFlags().StringVar(&initConfig.LoadBalancerForwardingMethod, "lbForwardingMethod", "local", "loadbalancer forwarding method")
 
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.DDNS, "ddns", false, "use Dynamic DNS + DHCP to allocate VIP for address")
 

--- a/docs/flags/index.md
+++ b/docs/flags/index.md
@@ -20,6 +20,7 @@ These flags are typically used in the `kube-vip` manifest generation process.
 |                     | `--leaderElection`     | Enables Kubernetes LeaderElection                                  | Used by ARP, as only the leader can broadcast                                   |
 |                     | `--enableLoadBalancer` | Enables IPVS load balancer                                         | `kube-vip` ≥ 0.4.0                                                              |
 |                     | `--lbPort`             | 6443                                                               | The port that the api server will load-balanced on                              |
+|                     | `--lbForwardingMethod` | Select the forwarding method (default local)                       | The IPVS forwarding method (local, masquerade, tunnel, direct, bypass)          |
 | **Services**        |                        |                                                                    |                                                                                 |
 |                     | `--cidr`               | Defaults "32"                                                      | Used when advertising BGP addresses (typically as `x.x.x.x/32`)                 |
 | **Kubernetes**      |                        |                                                                    |                                                                                 |
@@ -70,6 +71,7 @@ More environment variables can be read through the `pkg/kubevip/config_envvar.go
 |                     | `vip_leaderelection`  | Enables Kubernetes LeaderElection                           | Used by ARP, as only the leader can broadcast                                   |
 |                     | `lb_enable`           | Enables IPVS LoadBalancer                                   | `kube-vip` ≥ 0.4.0. Adds nodes to the IPVS load balancer                        |
 |                     | `lb_port`             | 6443                                                        | The IPVS port that will be used to load-balance control plane requests          |
+|                     | `lb_fwdmethod`        | Select the forwarding method (default local)                | The IPVS forwarding method (local, masquerade, tunnel, direct, bypass)          |
 | **Services**        |                       |                                                             |                                                                                 |
 |                     | `vip_cidr`            | Defaults "32"                                               | Used when advertising BGP addresses (typically as `x.x.x.x/32`)                 |
 | **LeaderElection**  |                       |                                                             |                                                                                 |

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -78,7 +78,7 @@ func (cluster *Cluster) vipService(ctxArp, ctxDNS context.Context, c *kubevip.Co
 
 		log.Infof("Starting IPVS LoadBalancer")
 
-		lb, err := loadbalancer.NewIPVSLB(cluster.Network.IP(), c.LoadBalancerPort)
+		lb, err := loadbalancer.NewIPVSLB(cluster.Network.IP(), c.LoadBalancerPort, c.LoadBalancerForwardingMethod)
 		if err != nil {
 			log.Errorf("Error creating IPVS LoadBalancer [%s]", err)
 		}

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -109,6 +109,9 @@ const (
 	//lbPort defines the port of load-balancer
 	lbPort = "lb_port"
 
+	//lbForwardingMethod defines the forwarding method of load-balancer
+	lbForwardingMethod = "lb_fwdmethod"
+
 	//vipConfigMap defines the configmap that kube-vip will watch for service definitions
 	// vipConfigMap = "vip_configmap"
 )

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -330,6 +330,12 @@ func ParseEnvironment(c *Config) error {
 		}
 		c.LoadBalancerPort = int(i)
 	}
+
+	// Find loadbalancer forwarding method
+	env = os.Getenv(lbForwardingMethod)
+	if env != "" {
+		c.LoadBalancerForwardingMethod = env
+	}
 	return nil
 }
 
@@ -583,6 +589,10 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 			{
 				Name:  lbPort,
 				Value: fmt.Sprintf("%d", c.LoadBalancerPort),
+			},
+			{
+				Name:  lbForwardingMethod,
+				Value: c.LoadBalancerForwardingMethod,
 			},
 		}
 

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -72,6 +72,9 @@ type Config struct {
 	// Listen port for the IPVS Service
 	LoadBalancerPort int `yaml:"lbPort"`
 
+	// Forwarding method for the IPVS Service
+	LoadBalancerForwardingMethod string `yaml:"lbForwardingMethod"`
+
 	// BGP Configuration
 	BGPConfig     bgp.Config
 	BGPPeerConfig bgp.Peer
@@ -146,6 +149,9 @@ type LoadBalancer struct {
 
 	//Backends, is an array of backend servers
 	Backends []BackEnd `yaml:"backends"`
+
+	// Forwarding method of LoadBalancer, either Local, Tunnel, DirectRoute or Bypass
+	ForwardingMethod string `yaml:"forwardingMethod"`
 }
 
 // BackEnd is a server we will load balance over


### PR DESCRIPTION
Adds `lbForwardingMethod` / `lb_fwdmethod` flag so one could change it. Default to `Local`.
To give it a try: `docker pull ghcr.io/jbguerraz/kube-vip:0.4.1`