### PR TITLE
provide support for backend traffic forwarding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,11 @@ RUN --mount=type=cache,sharing=locked,id=gomod,target=/go/pkg/mod/cache \
     --mount=type=cache,sharing=locked,id=goroot,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux make build
 
-FROM scratch
-# Add Certificates into the image, for anything that does API calls
-COPY --from=dev /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+FROM alpine:3.15
+RUN apk add --no-cache iproute2 net-tools ca-certificates iptables && update-ca-certificates
+COPY dist/iptables-wrapper-installer.sh /
+RUN /iptables-wrapper-installer.sh
+
 # Add kube-vip binary
 COPY --from=dev /src/kube-vip /
 ENTRYPOINT ["/kube-vip"]

--- a/cmd/kube-vip-start.go
+++ b/cmd/kube-vip-start.go
@@ -29,6 +29,8 @@ func init() {
 	kubeVipStart.Flags().BoolVar(&startConfig.SingleNode, "singleNode", false, "Start this instance as a single node")
 	kubeVipStart.Flags().BoolVar(&startConfig.StartAsLeader, "startAsLeader", false, "Start this instance as the cluster leader")
 	kubeVipStart.Flags().BoolVar(&startConfig.EnableARP, "arp", false, "Use ARP broadcasts to improve VIP re-allocations")
+	kubeVipStart.Flags().StringVar(&startConfig.BackendAddress, "backendAddress", "0.0.0.0", "The API server backend address")
+	kubeVipStart.Flags().IntVar(&startConfig.BackendPort, "backendPort", 6443, "The API server backend port")
 	kubeVipStart.Flags().StringVar(&startLocalPeer, "localPeer", "server1:192.168.0.1:10000", "Settings for this peer, format: id:address:port")
 	kubeVipStart.Flags().StringSliceVar(&startRemotePeers, "remotePeers", []string{"server2:192.168.0.2:10000", "server3:192.168.0.3:10000"}, "Comma separated remotePeers, format: id:address:port")
 	// Load Balancer flags

--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -65,14 +65,16 @@ func init() {
 	// Basic flags
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.Interface, "interface", "", "Name of the interface to bind to")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.ServicesInterface, "serviceInterface", "", "Name of the interface to bind to (for services)")
-	kubeVipCmd.PersistentFlags().StringVar(&initConfig.VIP, "vip", "", "The Virtual IP address")
+	kubeVipCmd.PersistentFlags().StringVar(&initConfig.VIP, "vip", "", "The Virtual IP address (deprecated)")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.Address, "address", "", "an address (IP or DNS name) to use as a VIP")
 	kubeVipCmd.PersistentFlags().IntVar(&initConfig.Port, "port", 6443, "Port for the VIP")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableARP, "arp", false, "Enable Arp for Vip changes")
+	kubeVipCmd.PersistentFlags().StringVar(&initConfig.BackendAddress, "backendAddress", "0.0.0.0", "The API server backend address")
+	kubeVipCmd.PersistentFlags().IntVar(&initConfig.BackendPort, "backendPort", 6443, "The API server backend port")
 
 	// LoadBalancer flags
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableLoadBalancer, "enableLoadBalancer", false, "enable loadbalancing on the VIP with IPVS")
-	kubeVipCmd.PersistentFlags().IntVar(&initConfig.LoadBalancerPort, "lbPort", 6443, "loadbalancer port for the VIP")
+	kubeVipCmd.PersistentFlags().IntVar(&initConfig.LoadBalancerPort, "lbPort", 6443, "loadbalancer port for the VIP (deprecated)")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.LoadBalancerForwardingMethod, "lbForwardingMethod", "local", "loadbalancer forwarding method")
 
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.DDNS, "ddns", false, "use Dynamic DNS + DHCP to allocate VIP for address")

--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -120,7 +120,7 @@ func init() {
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableServices, "services", false, "Enable Kubernetes services, hybrid mode")
 
 	// Prometheus HTTP Server
-	kubeVipCmd.PersistentFlags().StringVar(&initConfig.PrometheusHTTPServer, "promethuesHTTPServer", ":2112", "Host and port used to expose Prometheus metrics via an HTTP server")
+	kubeVipCmd.PersistentFlags().StringVar(&initConfig.PrometheusHTTPServer, "prometheusHTTPServer", ":2112", "Host and port used to expose Prometheus metrics via an HTTP server")
 
 	kubeVipCmd.AddCommand(kubeKubeadm)
 	kubeVipCmd.AddCommand(kubeManifest)

--- a/dist/iptables-wrapper-installer.sh
+++ b/dist/iptables-wrapper-installer.sh
@@ -1,0 +1,218 @@
+#!/bin/sh
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage:
+#
+#   iptables-wrapper-installer.sh [--no-sanity-check]
+#
+# Installs a wrapper iptables script in a container that will figure out
+# whether iptables-legacy or iptables-nft is in use on the host and then
+# replaces itself with the correct underlying iptables version.
+#
+# Unless "--no-sanity-check" is passed, it will first verify that the
+# container already contains a suitable version of iptables.
+
+# NOTE: This can only use POSIX /bin/sh features; the build container
+# might not contain bash.
+
+set -eu
+
+# Find iptables binary location
+if [ -d /usr/sbin -a -e /usr/sbin/iptables ]; then
+    sbin="/usr/sbin"
+elif [ -d /sbin -a -e /sbin/iptables ]; then
+    sbin="/sbin"
+else
+    echo "ERROR: iptables is not present in either /usr/sbin or /sbin" 1>&2
+    exit 1
+fi
+
+# Determine how the system selects between iptables-legacy and iptables-nft
+if [ -x /usr/sbin/alternatives ]; then
+    # Fedora/SUSE style alternatives
+    altstyle="fedora"
+elif [ -x /usr/sbin/update-alternatives ]; then
+    # Debian style alternatives
+    altstyle="debian"
+else
+    # No alternatives system
+    altstyle="none"
+fi
+
+if [ "${1:-}" != "--no-sanity-check" ]; then
+    # Ensure dependencies are installed
+    if ! version=$("${sbin}/iptables-nft" --version 2> /dev/null); then
+        echo "ERROR: iptables-nft is not installed" 1>&2
+        exit 1
+    fi
+    if ! "${sbin}/iptables-legacy" --version > /dev/null 2>&1; then
+        echo "ERROR: iptables-legacy is not installed" 1>&2
+        exit 1
+    fi
+
+    case "${version}" in
+    *v1.8.[012]\ *)
+        echo "ERROR: iptables 1.8.0 - 1.8.2 have compatibility bugs." 1>&2
+        echo "       Upgrade to 1.8.3 or newer." 1>&2
+        exit 1
+        ;;
+    *v1.8.3\ *)
+	# 1.8.3 mostly works but can get stuck in an infinite loop if the nft
+	# kernel modules are unavailable
+	need_timeout=1
+	;;
+    *)
+        # 1.8.4+ are OK
+        ;;
+    esac
+fi
+
+# Start creating the wrapper...
+rm -f "${sbin}/iptables-wrapper"
+cat > "${sbin}/iptables-wrapper" <<EOF
+#!/bin/sh
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: This can only use POSIX /bin/sh features; the container image
+# might not contain bash.
+
+set -eu
+
+# Detect whether the base system is using iptables-legacy or
+# iptables-nft. This assumes that some non-containerized process (eg
+# kubelet) has already created some iptables rules.
+EOF
+
+if [ "${need_timeout:-0}" = 0 ]; then
+    # Write out the simpler version of legacy-vs-nft detection
+    cat >> "${sbin}/iptables-wrapper" <<EOF
+num_legacy_lines=\$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
+num_nft_lines=\$( (iptables-nft-save || true; ip6tables-nft-save || true) 2>/dev/null | grep '^-' | wc -l)
+if [ "\${num_legacy_lines}" -ge "\${num_nft_lines}" ]; then
+    mode=legacy
+else
+    mode=nft
+fi
+EOF
+else
+    # Write out the version of legacy-vs-nft detection with an nft timeout
+    cat >> "${sbin}/iptables-wrapper" <<EOF
+# The iptables-nft binary in this image can get stuck in an infinite
+# loop if nft is not available so we need to wrap a timeout around it
+# (and to avoid that, we don't even bother calling iptables-nft if it
+# looks like iptables-legacy is going to win).
+num_legacy_lines=\$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
+if [ "\${num_legacy_lines}" -ge 10 ]; then
+    mode=legacy
+else
+    num_nft_lines=\$( (timeout 5 sh -c "iptables-nft-save; ip6tables-nft-save" || true) 2>/dev/null | grep '^-' | wc -l)
+    if [ "\${num_legacy_lines}" -ge "\${num_nft_lines}" ]; then
+        mode=legacy
+    else
+        mode=nft
+    fi
+fi
+EOF
+fi
+
+# Write out the appropriate alternatives-selection commands
+case "${altstyle}" in
+    fedora)
+cat >> "${sbin}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
+EOF
+    ;;
+
+    debian)
+cat >> "${sbin}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+update-alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
+update-alternatives --set ip6tables "/usr/sbin/ip6tables-\${mode}" > /dev/null || failed=1
+EOF
+    ;;
+
+    *)
+cat >> "${sbin}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+    rm -f "${sbin}/\${cmd}"
+    ln -s "${sbin}/xtables-\${mode}-multi" "${sbin}/\${cmd}"
+done 2>/dev/null || failed=1
+EOF
+    ;;
+esac
+
+# Write out the post-alternatives-selection error checking and final wrap-up
+cat >> "${sbin}/iptables-wrapper" <<EOF
+if [ "\${failed:-0}" = 1 ]; then
+    echo "Unable to redirect iptables binaries. (Are you running in an unprivileged pod?)" 1>&2
+    # fake it, though this will probably also fail if they aren't root
+    exec "${sbin}/xtables-\${mode}-multi" "\$0" "\$@"
+fi
+
+# Now re-exec the original command with the newly-selected alternative
+exec "\$0" "\$@"
+EOF
+chmod +x "${sbin}/iptables-wrapper"
+
+# Now back in the installer script, point the iptables binaries at our
+# wrapper
+case "${altstyle}" in
+    fedora)
+	alternatives \
+            --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables iptables /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-save iptables-save /usr/sbin/iptables-wrapper
+	;;
+
+    debian)
+	update-alternatives \
+            --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper
+	update-alternatives \
+            --install /usr/sbin/ip6tables ip6tables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/iptables-wrapper
+	;;
+
+    *)
+	for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+            rm -f "${sbin}/${cmd}"
+            ln -s "${sbin}/iptables-wrapper" "${sbin}/${cmd}"
+	done
+	;;
+esac
+
+# Cleanup
+rm -f "$0"

--- a/docs/flags/index.md
+++ b/docs/flags/index.md
@@ -16,13 +16,15 @@ These flags are typically used in the `kube-vip` manifest generation process.
 |                     | `--bgp`                | Enables BGP peering from `kube-vip`                                |                                                                                 |
 |                     | `--vip`                | `<IP Address>`                                                     | (deprecated)                                                                    |
 |                     | `--address`            | `<IP Address>` or `<DNS name>`                                     |                                                                                 |
+|                     | `--backendAddress`     | `<IP Address>`                                                     | The API server backend address (default to 0.0.0.0)                             |
+|                     | `--backendPort`        | 6443                                                               | The API server backend port (default to 6443)                                   |
 |                     | `--interface`          | Linux interface on the node                                        |                                                                                 |
 |                     | `--leaderElection`     | Enables Kubernetes LeaderElection                                  | Used by ARP, as only the leader can broadcast                                   |
 |                     | `--enableLoadBalancer` | Enables IPVS load balancer                                         | `kube-vip` ≥ 0.4.0                                                              |
 |                     | `--lbPort`             | 6443                                                               | The port that the api server will load-balanced on                              |
 |                     | `--lbForwardingMethod` | Select the forwarding method (default local)                       | The IPVS forwarding method (local, masquerade, tunnel, direct, bypass)          |
 | **Services**        |                        |                                                                    |                                                                                 |
-|                     | `--serviceInterface`   | ""                                                          | Defines an optional different interface to bind services too                    |
+|                     | `--serviceInterface`   | ""                                                                 | Defines an optional different interface to bind services too                    |
 |                     | `--cidr`               | Defaults "32"                                                      | Used when advertising BGP addresses (typically as `x.x.x.x/32`)                 |
 | **Kubernetes**      |                        |                                                                    |                                                                                 |
 |                     | `--inCluster`          | Required for `kube-vip` as DaemonSet.                              |  Runs `kube-vip` with a ServiceAccount called `kube-vip`.                       |
@@ -56,46 +58,49 @@ These environment variables are usually part of a `kube-vip` manifest and used w
 
 More environment variables can be read through the `pkg/kubevip/config_envvar.go` file.
 
-| Category            | Environment Variable   | Usage                                                       | Notes                                                                           |
-| ------------------- | ---------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| **Troubleshooting** |                        |                                                             |                                                                                 |
-|                     | `vip_loglevel`         | default 4                                                   | Set to `5` for debugging logs                                                   |
-| **Mode**            |                        |                                                             |                                                                                 |
-|                     | `cp_enable`            | Enables `kube-vip` control plane functionality              |                                                                                 |
-|                     | `svc_enable`           | Enables `kube-vip` to watch Services of type `LoadBalancer` |                                                                                 |
-| **VIP Config**      |                        |                                                             |                                                                                 |
-|                     | `vip_arp`              | Enables ARP broadcasts from Leader                          |                                                                                 |
-|                     | `bgp_enable`           | Enables BGP peering from `kube-vip`                         |                                                                                 |
-|                     | `vip_address`          | `<IP Address>`                                              | (deprecated)                                                                    |
-|                     | `address`              | `<IP Address>` or `<DNS name>`                              |                                                                                 |
-|                     | `vip_interface`        | `<linux interface>`                                         |                                                                                 |
-|                     | `vip_leaderelection`   | Enables Kubernetes LeaderElection                           | Used by ARP, as only the leader can broadcast                                   |
-|                     | `lb_enable`            | Enables IPVS LoadBalancer                                   | `kube-vip` ≥ 0.4.0. Adds nodes to the IPVS load balancer                        |
-|                     | `lb_port`              | 6443                                                        | The IPVS port that will be used to load-balance control plane requests          |
-|                     | `lb_fwdmethod`         | Select the forwarding method (default local)                | The IPVS forwarding method (local, masquerade, tunnel, direct, bypass)          |
-| **Services**        |                        |                                                             |                                                                                 |
-|                     | `vip_servicesinterface`| ""                                                          | Defines an optional different interface to bind services too                    |
-|                     | `vip_cidr`             | Defaults "32"                                               | Used when advertising BGP addresses (typically as `x.x.x.x/32`)                 |
-| **LeaderElection**  |                        |                                                             |                                                                                 |
-|                     | `vip_leaseduration`    | default 5                                                   | Seconds a lease is held for                                                     |
-|                     | `vip_renewdeadline`    | default 3                                                   | Seconds a leader can attempt to renew the lease                                 |
-|                     | `vip_retryperiod`      | default 1                                                   | Number of times the leader will hold the lease for                              |
-|                     | `cp_namespace`         | "kube-vip"                                                  | The namespace where the lease will reside                                       |
-| **BGP**             |                        |                                                             |                                                                                 |
-|                     | `bgp_routerid`         | `<IP Address>`                                              | Typically the address of the local node                                         |
-|                     | `bgp_routerinterface`  | Interface name                                              | Used to associate the `routerID` with the control plane's interface.            |
-|                     | `bgp_as`               | default 65000                                               | The AS we peer from                                                             |
-|                     | `bgp_peers`            | `<address:AS:password:multihop>`                            | Comma separated list of BGP peers                                               |
-|                     | `bgp_peeraddress`      | `<IP Address>`                                              | Address of a single BGP Peer                                                    |
-|                     | `bgp_peeras`           | default 65000                                               | AS of a single BGP Peer                                                         |
-|                     | `bgp_peerpass`         | ""                                                          | Password to work with a single BGP Peer                                         |
-|                     | `bgp_multihop`         | Enables eBGP MultiHop                                       | Enable multiHop with a single BGP Peer                                          |
-|                     | `bgp_sourceif`         | Source Interface                                            | Determines which interface BGP should peer _from_                               |
-|                     | `bgp_sourceip`         | Source Address                                              | Determines which IP address BGP should peer _from_                              |
-|                     | `annotations`          | `<provider string>`                                         | Startup will be paused until the node annotations contain the BGP configuration |
-| **Equinix Metal**   |                        |                                                             | (May be deprecated)                                                             |
-|                     | `vip_packet`           | Enables Equinix Metal API calls                             |                                                                                 |
-|                     | `PACKET_AUTH_TOKEN`    | Equinix Metal API token                                     |                                                                                 |
-|                     | `vip_packetproject`    | Equinix Metal Project (Name)                                |                                                                                 |
-|                     | `vip_packetprojectid`  | Equinix Metal Project (UUID)                                |                                                                                 |
-|                     | `provider_config`      | Path to the Equinix Metal provider configuration            | Requires the Equinix Metal CCM                                                  |
+| Category            | Environment Variable   | Usage                                                       | Notes                                                                               |
+| ------------------- | ---------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| **Troubleshooting** |                        |                                                             |                                                                                     |
+|                     | `vip_loglevel`         | default 4                                                   | Set to `5` for debugging logs                                                       |
+| **Mode**            |                        |                                                             |                                                                                     |
+|                     | `cp_enable`            | Enables `kube-vip` control plane functionality              |                                                                                     |
+|                     | `svc_enable`           | Enables `kube-vip` to watch Services of type `LoadBalancer` |                                                                                     |
+| **VIP Config**      |                        |                                                             |                                                                                     |
+|                     | `vip_arp`              | Enables ARP broadcasts from Leader                          |                                                                                     |
+|                     | `bgp_enable`           | Enables BGP peering from `kube-vip`                         |                                                                                     |
+|                     | `vip_address`          | `<IP Address>`                                              | (deprecated)                                                                        |
+|                     | `address`              | `<IP Address>` or `<DNS name>`                              |                                                                                     |
+|                     | `port`                 | 6443                                                        | The VIP port. Default to 6443                                                       |
+|                     | `vip_backend_address`  | `<IP Address>`                                              | The API server backend address (default to 0.0.0.0)                                 |
+|                     | `vip_backend_port`     | 6443                                                        | The API server backend port (default to 6443)                                       |
+|                     | `vip_interface`        | `<linux interface>`                                         |                                                                                     |
+|                     | `vip_leaderelection`   | Enables Kubernetes LeaderElection                           | Used by ARP, as only the leader can broadcast                                       |
+|                     | `lb_enable`            | Enables IPVS LoadBalancer                                   | `kube-vip` ≥ 0.4.0. Adds nodes to the IPVS load balancer                            |
+|                     | `lb_port`              | 6443                                                        | The IPVS port that will be used to load-balance control plane requests (deprecated) |
+|                     | `lb_fwdmethod`         | Select the forwarding method (default local)                | The IPVS forwarding method (local, masquerade, tunnel, direct, bypass)              |
+| **Services**        |                        |                                                             |                                                                                     |
+|                     | `vip_servicesinterface`| ""                                                          | Defines an optional different interface to bind services too                        |
+|                     | `vip_cidr`             | Defaults "32"                                               | Used when advertising BGP addresses (typically as `x.x.x.x/32`)                     |
+| **LeaderElection**  |                        |                                                             |                                                                                     |
+|                     | `vip_leaseduration`    | default 5                                                   | Seconds a lease is held for                                                         |
+|                     | `vip_renewdeadline`    | default 3                                                   | Seconds a leader can attempt to renew the lease                                     |
+|                     | `vip_retryperiod`      | default 1                                                   | Number of times the leader will hold the lease for                                  |
+|                     | `cp_namespace`         | "kube-vip"                                                  | The namespace where the lease will reside                                           |
+| **BGP**             |                        |                                                             |                                                                                     |
+|                     | `bgp_routerid`         | `<IP Address>`                                              | Typically the address of the local node                                             |
+|                     | `bgp_routerinterface`  | Interface name                                              | Used to associate the `routerID` with the control plane's interface.                |
+|                     | `bgp_as`               | default 65000                                               | The AS we peer from                                                                 |
+|                     | `bgp_peers`            | `<address:AS:password:multihop>`                            | Comma separated list of BGP peers                                                   |
+|                     | `bgp_peeraddress`      | `<IP Address>`                                              | Address of a single BGP Peer                                                        |
+|                     | `bgp_peeras`           | default 65000                                               | AS of a single BGP Peer                                                             |
+|                     | `bgp_peerpass`         | ""                                                          | Password to work with a single BGP Peer                                             |
+|                     | `bgp_multihop`         | Enables eBGP MultiHop                                       | Enable multiHop with a single BGP Peer                                              |
+|                     | `bgp_sourceif`         | Source Interface                                            | Determines which interface BGP should peer _from_                                   |
+|                     | `bgp_sourceip`         | Source Address                                              | Determines which IP address BGP should peer _from_                                  |
+|                     | `annotations`          | `<provider string>`                                         | Startup will be paused until the node annotations contain the BGP configuration     |
+| **Equinix Metal**   |                        |                                                             | (May be deprecated)                                                                 |
+|                     | `vip_packet`           | Enables Equinix Metal API calls                             |                                                                                     |
+|                     | `PACKET_AUTH_TOKEN`    | Equinix Metal API token                                     |                                                                                     |
+|                     | `vip_packetproject`    | Equinix Metal Project (Name)                                |                                                                                     |
+|                     | `vip_packetprojectid`  | Equinix Metal Project (UUID)                                |                                                                                     |
+|                     | `provider_config`      | Path to the Equinix Metal provider configuration            | Requires the Equinix Metal CCM                                                      |

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/cloudflare/ipvs v0.8.0
+	github.com/coreos/go-iptables v0.6.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211130200136-a8f946100490/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
+github.com/coreos/go-iptables v0.6.0 h1:is9qnZMPYjLd8LYqmm/qlE+wwEgJIkTYdhV3rfZo4jk=
+github.com/coreos/go-iptables v0.6.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/kube-vip/kube-vip/pkg/bgp"
+	"github.com/kube-vip/kube-vip/pkg/forwarder"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/loadbalancer"
 	"github.com/kube-vip/kube-vip/pkg/packet"
@@ -17,7 +18,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (cluster *Cluster) vipService(ctxArp, ctxDNS context.Context, c *kubevip.Config, sm *Manager, bgpServer *bgp.Server, packetClient *packngo.Client) error {
+func (cluster *Cluster) vipService(ctxArp, ctxDNS, ctxFwd context.Context, c *kubevip.Config, sm *Manager, bgpServer *bgp.Server, packetClient *packngo.Client) error {
 	id, err := os.Hostname()
 	if err != nil {
 		return err
@@ -44,6 +45,11 @@ func (cluster *Cluster) vipService(ctxArp, ctxDNS context.Context, c *kubevip.Co
 		log.Infof("starting the DNS updater for the address %s", cluster.Network.DNSName())
 		ipUpdater := vip.NewIPUpdater(cluster.Network)
 		ipUpdater.Run(ctxDNS)
+	}
+
+	fwd := forwarder.NewForwarder(c.Address, c.Port, c.BackendAddress, c.BackendPort, c.EnableLoadBalancer, c.LoadBalancerForwardingMethod)
+	if err := fwd.Start(ctxFwd); err != nil {
+		log.Errorf("Forwarder start error: %v", err)
 	}
 
 	err = cluster.Network.AddIP()
@@ -78,13 +84,13 @@ func (cluster *Cluster) vipService(ctxArp, ctxDNS context.Context, c *kubevip.Co
 
 		log.Infof("Starting IPVS LoadBalancer")
 
-		lb, err := loadbalancer.NewIPVSLB(cluster.Network.IP(), c.LoadBalancerPort, c.LoadBalancerForwardingMethod)
+		lb, err := loadbalancer.NewIPVSLB(cluster.Network.IP(), c.Port, c.LoadBalancerForwardingMethod)
 		if err != nil {
 			log.Errorf("Error creating IPVS LoadBalancer [%s]", err)
 		}
 
 		go func() {
-			err = sm.NodeWatcher(lb, c.Port)
+			err = sm.NodeWatcher(lb, c.BackendPort)
 			if err != nil {
 				log.Errorf("Error watching node labels [%s]", err)
 			}

--- a/pkg/cluster/singleNode.go
+++ b/pkg/cluster/singleNode.go
@@ -78,5 +78,10 @@ func (cluster *Cluster) StartVipService(c *kubevip.Config, sm *Manager, bgp *bgp
 	ctxDNS, cancelDNS := context.WithCancel(context.Background())
 	defer cancelDNS()
 
-	return cluster.vipService(ctxArp, ctxDNS, c, sm, bgp, packetClient)
+	// use a Go context so we can tell the forwarder loop code when we
+	// want to step down
+	ctxFwd, cancelFwd := context.WithCancel(context.Background())
+	defer cancelFwd()
+
+	return cluster.vipService(ctxArp, ctxDNS, ctxFwd, c, sm, bgp, packetClient)
 }

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -1,0 +1,65 @@
+package forwarder
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type Forwarder interface {
+	Start(context.Context) error
+}
+
+type forwarder struct {
+	srcAddress           string
+	srcPort              int
+	dstAddress           string
+	dstPort              int
+	ipvs                 bool
+	ipvsForwardingMethod string
+}
+
+func NewForwarder(srcAddress string, srcPort int, dstAddress string, dstPort int, ipvs bool, ipvsForwardingMethod string) Forwarder {
+	return &forwarder{
+		srcAddress:           srcAddress,
+		srcPort:              srcPort,
+		dstAddress:           dstAddress,
+		dstPort:              dstPort,
+		ipvs:                 ipvs,
+		ipvsForwardingMethod: ipvsForwardingMethod,
+	}
+}
+
+func (f *forwarder) Start(ctx context.Context) error {
+	log.Infoln("starting forwarder")
+	// If backend address is quad-zero route, early return
+	// (destination address is unknown, can't setup forwarding).
+	// If at some point we want to prepare forwarding none the less we would have to pick up any interface
+	// address and continue with it. If the user want to profit from different vip port and backend port
+	// it's probably easier the user define the backend address instead
+	if f.dstAddress == "0.0.0.0" {
+		return nil
+	}
+	go func(ctx context.Context, stop func() error) {
+		<-ctx.Done()
+		if err := stop(); err != nil {
+			log.Errorf("forwarder stop error: %v", err)
+		}
+	}(ctx, f.Stop)
+	if f.ipvs {
+		return startIPVS(f.srcAddress, f.srcPort, f.dstAddress, f.dstPort, f.ipvsForwardingMethod)
+	}
+	startIPTables(ctx, f.srcAddress, f.srcPort, f.dstAddress, f.dstPort)
+	return nil
+}
+
+func (f *forwarder) Stop() error {
+	log.Infof("stopping forwarder")
+	if f.dstAddress == "0.0.0.0" {
+		return nil
+	}
+	if f.ipvs {
+		return stopIPVS(f.srcAddress, f.srcPort, f.dstAddress, f.dstPort, f.ipvsForwardingMethod)
+	}
+	return stopIPTables(f.srcAddress, f.srcPort, f.dstAddress, f.dstPort)
+}

--- a/pkg/forwarder/forwarder_iptables.go
+++ b/pkg/forwarder/forwarder_iptables.go
@@ -1,0 +1,50 @@
+package forwarder
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/kube-vip/kube-vip/pkg/network"
+)
+
+func startIPTables(ctx context.Context, srcAddress string, srcPort int, destAddress string, destPort int) {
+	//TODO support IPV6. iptables library support that (need to add ip6tables binary to the container first)
+	if strings.Contains(srcAddress, ":") {
+		log.Fatal("IPV6 forwarding isn't yet supported. Feel free to contribute.")
+	}
+	// Have a routine ensuring the iptables forwarding rules each 5 seconds
+	log.Infof("Setting up iptables backend forwarding: from %s:%d to %s:%d", srcAddress, srcPort, destAddress, destPort)
+	go network.SetupAndEnsureIPTables(ctx, forwardRules(srcAddress, srcPort, destAddress, destPort), 5)
+}
+
+func stopIPTables(srcAddress string, srcPort int, destAddress string, destPort int) error {
+	log.Infof("Stopping iptables backend forwarding: from %s:%d to %s:%d", srcAddress, srcPort, destAddress, destPort)
+	return network.DeleteIPTables(forwardRules(srcAddress, srcPort, destAddress, destPort))
+}
+
+func forwardRules(srcAddress string, srcPort int, destAddress string, destPort int) []network.IPTablesRule {
+	random := false
+	ipt, err := network.NewIPTables()
+	if err == nil {
+		random = ipt.HasRandomFully()
+	}
+
+	rr := []network.IPTablesRule{
+		{Table: "nat", Chain: "PREROUTING", Rulespec: []string{"-d", srcAddress, "-p", "tcp", "-m", "tcp", "--dport", strconv.Itoa(srcPort), "-j", "DNAT", "--to-destination", destAddress + ":" + strconv.Itoa(destPort)}},
+		{Table: "nat", Chain: "POSTROUTING", Rulespec: []string{"-d", destAddress, "-p", "tcp", "-m", "tcp", "--dport", strconv.Itoa(destPort), "-j", "MASQUERADE"}},
+		{Table: "nat", Chain: "OUTPUT", Rulespec: []string{"-d", srcAddress, "-p", "tcp", "-m", "tcp", "--dport", strconv.Itoa(srcPort), "-j", "DNAT", "--to-destination", destAddress + ":" + strconv.Itoa(destPort)}},
+	}
+
+	if random {
+		rr = []network.IPTablesRule{
+			{Table: "nat", Chain: "PREROUTING", Rulespec: []string{"-d", srcAddress, "-p", "tcp", "-m", "tcp", "--dport", strconv.Itoa(srcPort), "-j", "DNAT", "--to-destination", destAddress + ":" + strconv.Itoa(destPort), "--random"}},
+			{Table: "nat", Chain: "POSTROUTING", Rulespec: []string{"-d", destAddress, "-p", "tcp", "-m", "tcp", "--dport", strconv.Itoa(destPort), "-j", "MASQUERADE", "--random-fully"}},
+			{Table: "nat", Chain: "OUTPUT", Rulespec: []string{"-d", srcAddress, "-p", "tcp", "-m", "tcp", "--dport", strconv.Itoa(srcPort), "-j", "DNAT", "--to-destination", destAddress + ":" + strconv.Itoa(destPort), "--random"}},
+		}
+	}
+
+	return rr
+}

--- a/pkg/forwarder/forwarder_ipvs.go
+++ b/pkg/forwarder/forwarder_ipvs.go
@@ -1,0 +1,25 @@
+package forwarder
+
+import (
+	log "github.com/sirupsen/logrus"
+
+	"github.com/kube-vip/kube-vip/pkg/loadbalancer"
+)
+
+func startIPVS(srcAddress string, srcPort int, destAddress string, destPort int, forwardingMethod string) error {
+	log.Infof("Setting up IPVS backend forwarding: from %s:%d to %s:%d using method %s", srcAddress, srcPort, destAddress, destPort, forwardingMethod)
+	lb, err := loadbalancer.NewIPVSLB(srcAddress, srcPort, forwardingMethod)
+	if err != nil {
+		return err
+	}
+	return lb.AddBackend(destAddress, destPort)
+}
+
+func stopIPVS(srcAddress string, srcPort int, destAddress string, destPort int, forwardingMethod string) error {
+	log.Infof("Stopping IPVS backend forwarding: from %s:%d to %s:%d using method %s", srcAddress, srcPort, destAddress, destPort, forwardingMethod)
+	lb, err := loadbalancer.NewIPVSLB(srcAddress, srcPort, forwardingMethod)
+	if err != nil {
+		return err
+	}
+	return lb.RemoveIPVSLB()
+}

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -47,6 +47,12 @@ const (
 	//port - defines the port for the VIP
 	port = "port"
 
+	// The API server backend address (default to 0.0.0.0)
+	vipBackendAddress = "vip_backend_address"
+
+	// The API server backend port (default to 6443)
+	vipBackendPort = "vip_backend_port"
+
 	// annotations
 	annotations = "annotation"
 

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -109,6 +109,22 @@ func ParseEnvironment(c *Config) error {
 		c.Port = int(i)
 	}
 
+	// Find backend address
+	env = os.Getenv(vipBackendAddress)
+	if env != "" {
+		c.BackendAddress = env
+	}
+
+	// Find backend port
+	env = os.Getenv(vipBackendPort)
+	if env != "" {
+		i, err := strconv.ParseInt(env, 10, 32)
+		if err != nil {
+			return err
+		}
+		c.BackendPort = int(i)
+	}
+
 	// Find vipDdns
 	env = os.Getenv(vipDdns)
 	if env != "" {
@@ -321,14 +337,15 @@ func ParseEnvironment(c *Config) error {
 		c.EnableLoadBalancer = b
 	}
 
-	// Find loadbalancer port
+	// Find loadbalancer port (deprecated)
 	env = os.Getenv(lbPort)
 	if env != "" {
 		i, err := strconv.ParseInt(env, 10, 32)
 		if err != nil {
 			return err
 		}
-		c.LoadBalancerPort = int(i)
+		//lbPort is deprecated. port is used by IPVS LB instead.
+		c.Port = int(i)
 	}
 
 	// Find loadbalancer forwarding method
@@ -352,6 +369,14 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 		{
 			Name:  port,
 			Value: fmt.Sprintf("%d", c.Port),
+		},
+		{
+			Name:  vipBackendAddress,
+			Value: c.BackendAddress,
+		},
+		{
+			Name:  vipBackendPort,
+			Value: fmt.Sprintf("%d", c.BackendPort),
 		},
 	}
 

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -48,6 +48,12 @@ type Config struct {
 	// Listen port for the VirtualIP
 	Port int `yaml:"port"`
 
+	// The API server backend address (default to 0.0.0.0)
+	BackendAddress string `yaml:"backendAddress"`
+
+	// The API server backend port (default to 6443)
+	BackendPort int `yaml:"backendPort"`
+
 	// Namespace will define which namespace the control plane pods will run in
 	Namespace string `yaml:"namespace"`
 

--- a/pkg/manager/services.go
+++ b/pkg/manager/services.go
@@ -104,12 +104,14 @@ func (sm *Manager) syncServices(service *v1.Service, wg *sync.WaitGroup) error {
 
 	// Generate new Virtual IP configuration
 	newVip := kubevip.Config{
-		VIP:        newServiceAddress, //TODO support more than one vip?
-		Interface:  serviceInterface,
-		SingleNode: true,
-		EnableARP:  sm.config.EnableARP,
-		EnableBGP:  sm.config.EnableBGP,
-		VIPCIDR:    sm.config.VIPCIDR,
+		VIP:            newServiceAddress, //TODO support more than one vip?
+		Interface:      serviceInterface,
+		SingleNode:     true,
+		EnableARP:      sm.config.EnableARP,
+		EnableBGP:      sm.config.EnableBGP,
+		VIPCIDR:        sm.config.VIPCIDR,
+		BackendAddress: sm.config.BackendAddress,
+		BackendPort:    sm.config.BackendPort,
 	}
 
 	// This instance wasn't found, we need to add it to the manager

--- a/pkg/network/iptables.go
+++ b/pkg/network/iptables.go
@@ -1,0 +1,143 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/coreos/go-iptables/iptables"
+	log "github.com/sirupsen/logrus"
+)
+
+// most of it is proudly found elsewhere https://github.com/flannel-io/flannel/blob/master/network/iptables.go
+
+type IPTables interface {
+	AppendUnique(table string, chain string, rulespec ...string) error
+	Delete(table string, chain string, rulespec ...string) error
+	Exists(table string, chain string, rulespec ...string) (bool, error)
+}
+
+type IPTablesError interface {
+	IsNotExist() bool
+	Error() string
+}
+
+type IPTablesRule struct {
+	Table    string
+	Chain    string
+	Rulespec []string
+}
+
+func NewIPTables() (*iptables.IPTables, error) {
+	return iptables.New()
+}
+
+func ipTablesRulesExist(ipt IPTables, rules []IPTablesRule) (bool, error) {
+	for _, rule := range rules {
+		exists, err := ipt.Exists(rule.Table, rule.Chain, rule.Rulespec...)
+		if err != nil {
+			// this shouldn't ever happen
+			return false, fmt.Errorf("failed to check rule existence: %v", err)
+		}
+		if !exists {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func SetupAndEnsureIPTables(ctx context.Context, rules []IPTablesRule, resyncPeriod int) {
+	ipt, err := iptables.New()
+	if err != nil {
+		// if we can't find iptables, give up and return
+		log.Errorf("Failed to setup IPTables. iptables binary was not found: %v", err)
+		return
+	}
+
+	ensureCtx, ensureCancel := context.WithCancel(ctx)
+	defer ensureCancel()
+
+	for {
+		select {
+		case <-ensureCtx.Done():
+			if err := teardownIPTables(ipt, rules); err != nil {
+				log.Errorf("Failed to teardown iptables rules: %v", err)
+			}
+			return
+		default:
+			// Ensure that all the iptables rules exist every resync period
+			if err := ensureIPTables(ipt, rules); err != nil {
+				log.Errorf("Failed to ensure iptables rules: %v", err)
+			}
+		}
+		time.Sleep(time.Duration(resyncPeriod) * time.Second)
+	}
+}
+
+// DeleteIPTables delete specified iptables rules
+func DeleteIPTables(rules []IPTablesRule) error {
+	ipt, err := iptables.New()
+	if err != nil {
+		// if we can't find iptables, give up and return
+		log.Errorf("Failed to setup IPTables. iptables binary was not found: %v", err)
+		return err
+	}
+	if err := teardownIPTables(ipt, rules); err != nil {
+		log.Errorf("Failed to teardown iptables rules: %v", err)
+	}
+	return nil
+}
+
+func ensureIPTables(ipt IPTables, rules []IPTablesRule) error {
+	exists, err := ipTablesRulesExist(ipt, rules)
+	if err != nil {
+		return fmt.Errorf("Error checking rule existence: %v", err)
+	}
+	if exists {
+		// if all the rules already exist, no need to do anything
+		return nil
+	}
+	// Otherwise, teardown all the rules and set them up again
+	// We do this because the order of the rules is important
+	log.Info("Some iptables rules are missing; deleting and recreating rules")
+	if err = teardownIPTables(ipt, rules); err != nil {
+		return fmt.Errorf("Error tearing down rules: %v", err)
+	}
+	if err = setupIPTables(ipt, rules); err != nil {
+		return fmt.Errorf("Error setting up rules: %v", err)
+	}
+	return nil
+}
+
+func setupIPTables(ipt IPTables, rules []IPTablesRule) error {
+	for _, rule := range rules {
+		log.Info("Adding iptables rule: ", strings.Join(rule.Rulespec, " "))
+		err := ipt.AppendUnique(rule.Table, rule.Chain, rule.Rulespec...)
+		if err != nil {
+			return fmt.Errorf("failed to insert IPTables rule: %v", err)
+		}
+	}
+	return nil
+}
+
+func teardownIPTables(ipt IPTables, rules []IPTablesRule) error {
+	for _, rule := range rules {
+		log.Info("Deleting iptables rule: ", strings.Join(rule.Rulespec, " "))
+		err := ipt.Delete(rule.Table, rule.Chain, rule.Rulespec...)
+		if err != nil {
+			e := err.(IPTablesError)
+			// If this error is because the rule is already deleted, the message from iptables will be
+			// "Bad rule (does a matching rule exist in that chain?)". These are safe to ignore.
+			// However other errors (like EAGAIN caused by other things not respecting the xtables.lock)
+			// should halt the ensure process.  Otherwise rules can get out of order when a rule we think
+			// is deleted is actually still in the chain.
+			// This will leave the rules incomplete until the next successful reconciliation loop.
+			if !e.IsNotExist() {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/service/services.go
+++ b/pkg/service/services.go
@@ -88,12 +88,14 @@ func (sm *Manager) syncServices(service *v1.Service) error {
 
 	// Generate new Virtual IP configuration
 	newVip := kubevip.Config{
-		VIP:        newServiceAddress, //TODO support more than one vip?
-		Interface:  sm.config.Interface,
-		SingleNode: true,
-		EnableARP:  sm.config.EnableARP,
-		EnableBGP:  sm.config.EnableBGP,
-		VIPCIDR:    sm.config.VIPCIDR,
+		VIP:            newServiceAddress, //TODO support more than one vip?
+		Interface:      sm.config.Interface,
+		SingleNode:     true,
+		EnableARP:      sm.config.EnableARP,
+		EnableBGP:      sm.config.EnableBGP,
+		VIPCIDR:        sm.config.VIPCIDR,
+		BackendAddress: sm.config.BackendAddress,
+		BackendPort:    sm.config.BackendPort,
 	}
 
 	// This instance wasn't found, we need to add it to the manager


### PR DESCRIPTION
This brings decoupling between vip's address/port and backend's (api server) address/port.
Coupling is setup at start using either iptables or IPVS (depends if load balancer is enabled or not) if the backend address isn't `0.0.0.0` (which is the default value and is backward compatible).

It also adds/removes backends as they become ready/not-ready (in addition to already implemented in / out)


`lbBackEndPort` looks unused and conflict/confuse with new `backendPort` that is used to define the api server port. Maybe better to remove ?

```
rg BackendPort
pkg/kubevip/config_types.go
147:	//BackendPort, is a port that all backends are listening on (To be used to simplify building a list of backends)
148:	BackendPort int `yaml:"backendPort"`

cmd/kube-vip-start.go
39:	kubeVipStart.Flags().IntVar(&startConfigLB.BackendPort, "lbBackEndPort", 6443, "A port that all backends may be using (optional)")
```

Deprecates `lbPort` since `port` is used for the loadbalancer port (and `backendPort` is used for real (api)servers port)