### PR TITLE
Monitor default VIP interface

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -224,6 +224,12 @@ var kubeVipManager = &cobra.Command{
 			}
 			initConfig.Interface = defaultIF.Name
 			log.Infof("kube-vip will bind to interface [%s]", initConfig.Interface)
+
+			go func() {
+				if err := vip.MonitorDefaultInterface(context.TODO(), defaultIF); err != nil {
+					log.Fatalf("crash: %s", err.Error())
+				}
+			}()
 		}
 
 		go servePrometheusHTTPServer(cmd.Context(), PrometheusHTTPServerConfig{

--- a/pkg/vip/util.go
+++ b/pkg/vip/util.go
@@ -1,12 +1,14 @@
 package vip
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
 	"syscall"
 
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
 
@@ -84,4 +86,24 @@ func GetDefaultGatewayInterface() (*net.Interface, error) {
 	}
 
 	return nil, errors.New("Unable to find default route")
+}
+
+// MonitorDefaultInterface monitor the default interface and catch the event of the default route
+func MonitorDefaultInterface(ctx context.Context, defaultIF *net.Interface) error {
+	routeCh := make(chan netlink.RouteUpdate)
+	if err := netlink.RouteSubscribe(routeCh, ctx.Done()); err != nil {
+		return fmt.Errorf("subscribe route failed, error: %w", err)
+	}
+
+	for {
+		select {
+		case r := <-routeCh:
+			log.Infof("route event: %+v", r)
+			if r.Type == syscall.RTM_DELROUTE && (r.Dst == nil || r.Dst.String() == "0.0.0.0/0") && r.LinkIndex == defaultIF.Index {
+				return fmt.Errorf("default route deleted and the default interface may be invalid")
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
 }


### PR DESCRIPTION
The kube-vip chooses the default interface based on the default route. Once the default route changes, the default interface is very likely invalid. In this case, it would be better to crash the process. The pod will restart immediately if the kube-vip is deployed as a daemonset.

Signed-off-by: yaocw2020 <yaocanwu@gmail.com>