### PR TITLE
Adds retry to status update

### DIFF
--- a/pkg/manager/watcher_test.go
+++ b/pkg/manager/watcher_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/bgp"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -61,7 +60,7 @@ func TestParseBgpAnnotations(t *testing.T) {
 
 func Test_parseBgpAnnotations(t *testing.T) {
 	type args struct {
-		node   *v1.Node
+		node   *corev1.Node
 		prefix string
 	}
 	tests := []struct {


### PR DESCRIPTION
This changes the `.status` update to use the retry, this should ensure we don't incur:

```
time="2022-02-17T14:31:06Z" level=error msg="Error updating Service [w4] Status: Put \"https://10.96.0.1:443/api/v1/namespaces/default/services/w4/status\": read tcp 192.168.0.44:35556->10.96.0.1:443: read: connection reset by peer"
```