### PR TITLE
Don't check status on Point-To-Point interfaces

### DIFF
--- a/pkg/kubevip/config_manager.go
+++ b/pkg/kubevip/config_manager.go
@@ -208,6 +208,10 @@ func isValidInterface(iface string) error {
 		return nil
 	}
 
+	if l.Attrs().Flags&net.FlagPointToPoint == net.FlagPointToPoint {
+		return nil
+	}
+
 	if l.Attrs().OperState != netlink.OperUp {
 		return fmt.Errorf("%s is not up", iface)
 	}


### PR DESCRIPTION
If I remember correctly, point-to-point interfaces will stay in UNKNOWN as well and never go to UP.
(Currently trying to use kube-vip to expose a Kubernetes API server on a wireguard network)