### PR TITLE
Treat interfaces with unknown state as valid

### DIFF
--- a/pkg/kubevip/config_manager.go
+++ b/pkg/kubevip/config_manager.go
@@ -210,7 +210,10 @@ func isValidInterface(iface string) error {
 	// userspace has set operational state. Interface must be considered for user
 	// data as setting operational state has not been implemented in every driver."
 	if attrs.OperState == netlink.OperUnknown {
-		log.Warningf("the status of the interface %s is unknown. Ensure your interface is ready to accept traffic, if so you can safely ignore this message")
+		log.Warningf(
+			"the status of the interface %s is unknown. Ensure your interface is ready to accept traffic, if so you can safely ignore this message",
+			iface,
+		)
 	} else if attrs.OperState != netlink.OperUp {
 		return fmt.Errorf("%s is not up", iface)
 	}


### PR DESCRIPTION
Previous commits addressed the issue of interface being incorrectly marked as
down for loopback (1a4465e) and point-to-point (051bb1f) interfaces by directly
passing the test when the interface is identified as any of those types. Both
commits failed to address the core issue, those interfaces (and many others) do
not publish their operational state resulting in the state UNKOWN. With this
commit, now interfaces with unknown status are accepted but the user is warned as
he needs to manually ensure that the interface is ready to handle traffic.
Fix #385.