### PR TITLE
set kubernetes:6443 as default hostname

### DIFF
--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -47,9 +47,10 @@ func NewManager(path string, inCluster bool, port int) (*Manager, error) {
 	// VIP up before trying to connect to the API server, we set the API endpoint to this machine to
 	// ensure connectivity. Else if the path passed is empty and not running in the cluster,
 	// attempt to look for a kubeconfig in the default HOME dir.
-	if inCluster {
-		hostname = fmt.Sprintf("kubernetes:%v", port)
-	} else if len(path) == 0 && !inCluster {
+
+	hostname = fmt.Sprintf("kubernetes:%v", port)
+
+	if len(path) == 0 && !inCluster {
 		path = filepath.Join(os.Getenv("HOME"), ".kube", "config")
 
 		// We modify the config so that we can always speak to the correct host


### PR DESCRIPTION
Signed-off-by: AxiomSamarth <sdeyagond@microsoft.com>

This is an update to the previous fix raised for issue #394 via PR #395 to make user consumption of inCluster `kube-vip start` command more seamless and easier.