### PR TITLE
Initial design of leaderElection per service

### DIFF
--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -18,8 +18,11 @@ type Config struct {
 	// EnableControlPane, will enable the control plane functionality (used for hybrid behaviour)
 	EnableControlPane bool `yaml:"enableControlPane"`
 
-	// EnableControlPane, will enable the control plane functionality (used for hybrid behaviour)
+	// EnableControlPane, will enable the services functionality (used for hybrid behaviour)
 	EnableServices bool `yaml:"enableServices"`
+
+	// EnableServicesElection, will enable leaderElection per service
+	EnableServicesElection bool `yaml:"enableServicesElection"`
 
 	// Annotations will define if we're going to wait and lookup configuration from Kubernetes node annotations
 	Annotations string

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -124,14 +124,12 @@ func (sm *Manager) Start() error {
 		}
 
 		log.Infoln("Starting Kube-vip Manager with the BGP engine")
-		log.Infof("Namespace [%s], Hybrid mode [%t]", sm.config.Namespace, sm.config.EnableControlPane && sm.config.EnableServices)
 		return sm.startBGP()
 	}
 
 	// If ARP is enabled then we start a LeaderElection that will use ARP to advertise VIPs
 	if sm.config.EnableARP {
 		log.Infoln("Starting Kube-vip Manager with the ARP engine")
-		log.Infof("Namespace [%s], Hybrid mode [%t]", sm.config.Namespace, sm.config.EnableControlPane && sm.config.EnableServices)
 		return sm.startARP()
 	}
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -111,8 +111,7 @@ func (sm *Manager) Start() error {
 	signal.Notify(sm.signalChan, syscall.SIGTERM)
 
 	// Add Notification for SIGKILL (sent from Kubernetes)
-	//nolint
-	signal.Notify(sm.signalChan, syscall.SIGKILL)
+	signal.Notify(sm.signalChan, syscall.SIGKILL) //nolint
 
 	// If BGP is enabled then we start a server instance that will broadcast VIPs
 	if sm.config.EnableBGP {

--- a/pkg/manager/manager_arp.go
+++ b/pkg/manager/manager_arp.go
@@ -96,59 +96,69 @@ func (sm *Manager) startARP() error {
 		}
 	}
 
-	log.Infof("Beginning cluster membership, namespace [%s], lock name [%s], id [%s]", ns, plunderLock, id)
-	// we use the Lease lock type since edits to Leases are less common
-	// and fewer objects in the cluster watch "all Leases".
-	lock := &resourcelock.LeaseLock{
-		LeaseMeta: metav1.ObjectMeta{
-			Name:      plunderLock,
-			Namespace: ns,
-		},
-		Client: sm.clientSet.CoordinationV1(),
-		LockConfig: resourcelock.ResourceLockConfig{
-			Identity: id,
-		},
+	// Start a services watcher (all kube-vip pods will watch services), upon a new service
+	// a lock based upon that service is created that they will all leaderElection on
+	if sm.config.EnableServicesElection {
+		log.Infof("Beginning watching services, leaderelection will happen for every service")
+		err = sm.startServicesWatchForLeaderElection(ctx)
+		if err != nil {
+			return err
+		}
+	} else {
+
+		log.Infof("Beginning services leadership, namespace [%s], lock name [%s], id [%s]", ns, plunderLock, id)
+		// we use the Lease lock type since edits to Leases are less common
+		// and fewer objects in the cluster watch "all Leases".
+		lock := &resourcelock.LeaseLock{
+			LeaseMeta: metav1.ObjectMeta{
+				Name:      plunderLock,
+				Namespace: ns,
+			},
+			Client: sm.clientSet.CoordinationV1(),
+			LockConfig: resourcelock.ResourceLockConfig{
+				Identity: id,
+			},
+		}
+
+		// start the leader election code loop
+		leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+			Lock: lock,
+			// IMPORTANT: you MUST ensure that any code you have that
+			// is protected by the lease must terminate **before**
+			// you call cancel. Otherwise, you could have a background
+			// loop still running and another process could
+			// get elected before your background loop finished, violating
+			// the stated goal of the lease.
+			ReleaseOnCancel: true,
+			LeaseDuration:   10 * time.Second,
+			RenewDeadline:   5 * time.Second,
+			RetryPeriod:     1 * time.Second,
+			Callbacks: leaderelection.LeaderCallbacks{
+				OnStartedLeading: func(ctx context.Context) {
+					err = sm.servicesWatcher(ctx, sm.syncServices)
+					if err != nil {
+						log.Error(err)
+					}
+				},
+				OnStoppedLeading: func() {
+					// we can do cleanup here
+					log.Infof("leader lost: %s", id)
+					for x := range sm.serviceInstances {
+						sm.serviceInstances[x].cluster.Stop()
+					}
+
+					log.Fatal("lost leadership, restarting kube-vip")
+				},
+				OnNewLeader: func(identity string) {
+					// we're notified when new leader elected
+					if identity == id {
+						// I just got the lock
+						return
+					}
+					log.Infof("new leader elected: %s", identity)
+				},
+			},
+		})
 	}
-
-	// start the leader election code loop
-	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
-		Lock: lock,
-		// IMPORTANT: you MUST ensure that any code you have that
-		// is protected by the lease must terminate **before**
-		// you call cancel. Otherwise, you could have a background
-		// loop still running and another process could
-		// get elected before your background loop finished, violating
-		// the stated goal of the lease.
-		ReleaseOnCancel: true,
-		LeaseDuration:   10 * time.Second,
-		RenewDeadline:   5 * time.Second,
-		RetryPeriod:     1 * time.Second,
-		Callbacks: leaderelection.LeaderCallbacks{
-			OnStartedLeading: func(ctx context.Context) {
-				err = sm.servicesWatcher(ctx)
-				if err != nil {
-					log.Error(err)
-				}
-			},
-			OnStoppedLeading: func() {
-				// we can do cleanup here
-				log.Infof("leader lost: %s", id)
-				for x := range sm.serviceInstances {
-					sm.serviceInstances[x].cluster.Stop()
-				}
-
-				log.Fatal("lost leadership, restarting kube-vip")
-			},
-			OnNewLeader: func(identity string) {
-				// we're notified when new leader elected
-				if identity == id {
-					// I just got the lock
-					return
-				}
-				log.Infof("new leader elected: %s", identity)
-			},
-		},
-	})
-
 	return nil
 }

--- a/pkg/manager/manager_arp.go
+++ b/pkg/manager/manager_arp.go
@@ -99,14 +99,14 @@ func (sm *Manager) startARP() error {
 	// Start a services watcher (all kube-vip pods will watch services), upon a new service
 	// a lock based upon that service is created that they will all leaderElection on
 	if sm.config.EnableServicesElection {
-		log.Infof("Beginning watching services, leaderelection will happen for every service")
+		log.Infof("beginning watching services, leaderelection will happen for every service")
 		err = sm.startServicesWatchForLeaderElection(ctx)
 		if err != nil {
 			return err
 		}
 	} else {
 
-		log.Infof("Beginning services leadership, namespace [%s], lock name [%s], id [%s]", ns, plunderLock, id)
+		log.Infof("beginning services leadership, namespace [%s], lock name [%s], id [%s]", ns, plunderLock, id)
 		// we use the Lease lock type since edits to Leases are less common
 		// and fewer objects in the cluster watch "all Leases".
 		lock := &resourcelock.LeaseLock{

--- a/pkg/manager/manager_bgp.go
+++ b/pkg/manager/manager_bgp.go
@@ -52,6 +52,7 @@ func (sm *Manager) startBGP() error {
 	if err != nil {
 		return err
 	}
+	
 	// use a Go context so we can tell the leaderelection code when we
 	// want to step down
 	ctx, cancel := context.WithCancel(context.Background())
@@ -107,7 +108,7 @@ func (sm *Manager) startBGP() error {
 		}
 	}
 
-	err = sm.servicesWatcher(ctx)
+	err = sm.servicesWatcher(ctx, sm.syncServices)
 	if err != nil {
 		return err
 	}

--- a/pkg/manager/manager_bgp.go
+++ b/pkg/manager/manager_bgp.go
@@ -52,7 +52,7 @@ func (sm *Manager) startBGP() error {
 	if err != nil {
 		return err
 	}
-	
+
 	// use a Go context so we can tell the leaderelection code when we
 	// want to step down
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/manager/services.go
+++ b/pkg/manager/services.go
@@ -61,7 +61,7 @@ func (sm *Manager) deleteService(uid string) error {
 	return nil
 }
 
-func (sm *Manager) syncServices(service *v1.Service, wg *sync.WaitGroup) error {
+func (sm *Manager) syncServices(ctx context.Context, service *v1.Service, wg *sync.WaitGroup) error {
 	defer wg.Done()
 
 	log.Debugf("[STARTING] Service Sync")

--- a/pkg/manager/servicesLeader.go
+++ b/pkg/manager/servicesLeader.go
@@ -1,0 +1,92 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+// The startServicesWatchForLeaderElection function will start a services watcher, the
+func (sm *Manager) startServicesWatchForLeaderElection(ctx context.Context) error {
+
+	err := sm.servicesWatcher(ctx, sm.syncServices)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Shutting down kube-Vip")
+
+	return nil
+}
+
+// The startServicesWatchForLeaderElection function will start a services watcher, the
+func (sm *Manager) startServicesLeaderElection(service *v1.Service, wg *sync.WaitGroup) error {
+	id, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+
+	serviceLease := fmt.Sprintf("kubevip-%s", service.Name)
+	log.Infof("Beginning services leadership, namespace [%s], lock name [%s], id [%s]", service.Namespace, serviceLease, id)
+	// we use the Lease lock type since edits to Leases are less common
+	// and fewer objects in the cluster watch "all Leases".
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Name:      plunderLock,
+			Namespace: service.Namespace,
+		},
+		Client: sm.clientSet.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: id,
+		},
+	}
+
+	// start the leader election code loop
+	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+		Lock: lock,
+		// IMPORTANT: you MUST ensure that any code you have that
+		// is protected by the lease must terminate **before**
+		// you call cancel. Otherwise, you could have a background
+		// loop still running and another process could
+		// get elected before your background loop finished, violating
+		// the stated goal of the lease.
+		ReleaseOnCancel: true,
+		LeaseDuration:   10 * time.Second,
+		RenewDeadline:   5 * time.Second,
+		RetryPeriod:     1 * time.Second,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) {
+				err = sm.servicesWatcher(ctx, sm.syncServices)
+				if err != nil {
+					log.Error(err)
+				}
+			},
+			OnStoppedLeading: func() {
+				// we can do cleanup here
+				log.Infof("leader lost: %s", id)
+				for x := range sm.serviceInstances {
+					sm.serviceInstances[x].cluster.Stop()
+				}
+
+				log.Fatal("lost leadership, restarting kube-vip")
+			},
+			OnNewLeader: func(identity string) {
+				// we're notified when new leader elected
+				if identity == id {
+					// I just got the lock
+					return
+				}
+				log.Infof("new leader elected: %s", identity)
+			},
+		},
+	})
+	return nil
+}

--- a/pkg/manager/servicesLeader.go
+++ b/pkg/manager/servicesLeader.go
@@ -17,7 +17,7 @@ import (
 // The startServicesWatchForLeaderElection function will start a services watcher, the
 func (sm *Manager) startServicesWatchForLeaderElection(ctx context.Context) error {
 
-	err := sm.servicesWatcher(ctx, sm.syncServices)
+	err := sm.servicesWatcher(ctx, sm.startServicesLeaderElection)
 	if err != nil {
 		return err
 	}
@@ -28,7 +28,7 @@ func (sm *Manager) startServicesWatchForLeaderElection(ctx context.Context) erro
 }
 
 // The startServicesWatchForLeaderElection function will start a services watcher, the
-func (sm *Manager) startServicesLeaderElection(service *v1.Service, wg *sync.WaitGroup) error {
+func (sm *Manager) startServicesLeaderElection(ctx context.Context, service *v1.Service, wg *sync.WaitGroup) error {
 	id, err := os.Hostname()
 	if err != nil {
 		return err

--- a/pkg/manager/watch_annotations.go
+++ b/pkg/manager/watch_annotations.go
@@ -7,10 +7,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/kube-vip/kube-vip/pkg/bgp"
-	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/davecgh/go-spew/spew"
@@ -23,103 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 )
-
-// This file handles the watching of a services endpoints and updates a load balancers endpoint configurations accordingly
-func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context.Context, *v1.Service, *sync.WaitGroup) error) error {
-	// Watch function
-	var wg sync.WaitGroup
-
-	// Use a restartable watcher, as this should help in the event of etcd or timeout issues
-	rw, err := watchtools.NewRetryWatcher("1", &cache.ListWatch{
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return sm.clientSet.CoreV1().Services(v1.NamespaceAll).Watch(ctx, metav1.ListOptions{})
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("error creating services watcher: %s", err.Error())
-	}
-	go func() {
-		<-sm.signalChan
-		// Cancel the context
-		rw.Stop()
-	}()
-	ch := rw.ResultChan()
-	//defer rw.Stop()
-	log.Infoln("Beginning watching services for type: LoadBalancer in all namespaces")
-
-	for event := range ch {
-		sm.countServiceWatchEvent.With(prometheus.Labels{"type": string(event.Type)}).Add(1)
-
-		// We need to inspect the event and get ResourceVersion out of it
-		switch event.Type {
-		case watch.Added, watch.Modified:
-			// log.Debugf("Endpoints for service [%s] have been Created or modified", s.service.ServiceName)
-			svc, ok := event.Object.(*v1.Service)
-			if !ok {
-				return fmt.Errorf("Unable to parse Kubernetes services from API watcher")
-			}
-
-			// We only care about LoadBalancer services
-			if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
-				break
-			}
-
-			// We can ignore this service
-			if svc.Annotations["kube-vip.io/ignore"] == "true" {
-				log.Infof("Service [%s] has an ignore annotation for kube-vip", svc.Name)
-				break
-			}
-			log.Infof("Service [%s] has been added/modified it has an assigned external addresses [%s]", svc.Name, svc.Spec.LoadBalancerIP)
-			wg.Add(1)
-			err = serviceFunc(ctx, svc, &wg)
-			if err != nil {
-				log.Error(err)
-			}
-			wg.Wait()
-		case watch.Deleted:
-			svc, ok := event.Object.(*v1.Service)
-			if !ok {
-				return fmt.Errorf("Unable to parse Kubernetes services from API watcher")
-			}
-
-			// We only care about LoadBalancer services
-			if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
-				break
-			}
-
-			// We can ignore this service
-			if svc.Annotations["kube-vip.io/ignore"] == "true" {
-				log.Infof("Service [%s] has an ignore annotation for kube-vip", svc.Name)
-				break
-			}
-
-			err = sm.deleteService(string(svc.UID))
-			if err != nil {
-				log.Error(err)
-			}
-			log.Infof("Service [%s/%s] has been deleted", svc.Namespace, svc.Name)
-
-		case watch.Bookmark:
-			// Un-used
-		case watch.Error:
-			log.Error("Error attempting to watch Kubernetes services")
-
-			// This round trip allows us to handle unstructured status
-			errObject := apierrors.FromObject(event.Object)
-			statusErr, ok := errObject.(*apierrors.StatusError)
-			if !ok {
-				log.Errorf(spew.Sprintf("Received an error which is not *metav1.Status but %#+v", event.Object))
-
-			}
-
-			status := statusErr.ErrStatus
-			log.Errorf("%v", status)
-		default:
-		}
-	}
-	log.Warnln("Stopping watching services for type: LoadBalancer in all namespaces")
-	return nil
-}
 
 // This file handles the watching of node annotations for configuration, it will exit once the annotations are
 // present

--- a/pkg/manager/watch_annotations.go
+++ b/pkg/manager/watch_annotations.go
@@ -194,8 +194,8 @@ func parseBgpAnnotations(node *v1.Node, prefix string) (bgp.Config, bgp.Peer, er
 		}
 	}
 
-	log.Debugf("BGPConfig: %v\n", bgpConfig)
-	log.Debugf("BGPPeerConfig: %v\n", bgpPeer)
+	//log.Debugf("BGPConfig: %v\n", bgpConfig)
+	//log.Debugf("BGPPeerConfig: %v\n", bgpPeer)
 
 	return bgpConfig, bgpPeer, nil
 }

--- a/pkg/manager/watch_annotations.go
+++ b/pkg/manager/watch_annotations.go
@@ -85,7 +85,7 @@ func (sm *Manager) annotationsWatcher() error {
 		case watch.Added, watch.Modified:
 			node, ok := event.Object.(*v1.Node)
 			if !ok {
-				return fmt.Errorf("Unable to parse Kubernetes Node from Annotation watcher")
+				return fmt.Errorf("unable to parse Kubernetes Node from Annotation watcher")
 			}
 
 			bgpConfig, bgpPeer, err := parseBgpAnnotations(node, sm.config.Annotations)
@@ -101,7 +101,7 @@ func (sm *Manager) annotationsWatcher() error {
 		case watch.Deleted:
 			node, ok := event.Object.(*v1.Node)
 			if !ok {
-				return fmt.Errorf("Unable to parse Kubernetes Node from Kubernetes watcher")
+				return fmt.Errorf("unable to parse Kubernetes Node from Kubernetes watcher")
 			}
 
 			log.Infof("Node [%s] has been deleted", node.Name)

--- a/pkg/manager/watch_services.go
+++ b/pkg/manager/watch_services.go
@@ -1,0 +1,130 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+)
+
+// This file handles the watching of a services endpoints and updates a load balancers endpoint configurations accordingly
+func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context.Context, *v1.Service, *sync.WaitGroup) error) error {
+	// Watch function
+	var wg sync.WaitGroup
+
+	// Use a restartable watcher, as this should help in the event of etcd or timeout issues
+	rw, err := watchtools.NewRetryWatcher("1", &cache.ListWatch{
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return sm.clientSet.CoreV1().Services(v1.NamespaceAll).Watch(ctx, metav1.ListOptions{})
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("error creating services watcher: %s", err.Error())
+	}
+	go func() {
+		<-sm.signalChan
+		// Cancel the context
+		rw.Stop()
+	}()
+	ch := rw.ResultChan()
+	//defer rw.Stop()
+	log.Infoln("Beginning watching services for type: LoadBalancer in all namespaces")
+
+	for event := range ch {
+		sm.countServiceWatchEvent.With(prometheus.Labels{"type": string(event.Type)}).Add(1)
+
+		// We need to inspect the event and get ResourceVersion out of it
+		switch event.Type {
+		case watch.Added, watch.Modified:
+			// log.Debugf("Endpoints for service [%s] have been Created or modified", s.service.ServiceName)
+			svc, ok := event.Object.(*v1.Service)
+			if !ok {
+				return fmt.Errorf("unable to parse Kubernetes services from API watcher")
+			}
+
+			// We only care about LoadBalancer services
+			if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
+				break
+			}
+
+			// We only care about LoadBalancer services that have been allocated an address
+			if svc.Spec.LoadBalancerIP == "" {
+				break
+			}
+
+			// We can ignore this service
+			if svc.Annotations["kube-vip.io/ignore"] == "true" {
+				log.Infof("Service [%s] has an ignore annotation for kube-vip", svc.Name)
+				break
+			}
+			log.Infof("Service [%s] has been added/modified it has an assigned external addresses [%s]", svc.Name, svc.Spec.LoadBalancerIP)
+			wg.Add(1)
+			// Background the services election
+			if sm.config.EnableServicesElection {
+				go func() {
+					err = serviceFunc(ctx, svc, &wg)
+					if err != nil {
+						log.Error(err)
+					}
+					wg.Wait()
+				}()
+			} else {
+				err = serviceFunc(ctx, svc, &wg)
+				if err != nil {
+					log.Error(err)
+				}
+				wg.Wait()
+			}
+		case watch.Deleted:
+			svc, ok := event.Object.(*v1.Service)
+			if !ok {
+				return fmt.Errorf("Unable to parse Kubernetes services from API watcher")
+			}
+
+			// We only care about LoadBalancer services
+			if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
+				break
+			}
+
+			// We can ignore this service
+			if svc.Annotations["kube-vip.io/ignore"] == "true" {
+				log.Infof("Service [%s] has an ignore annotation for kube-vip", svc.Name)
+				break
+			}
+
+			err = sm.deleteService(string(svc.UID))
+			if err != nil {
+				log.Error(err)
+			}
+			log.Infof("Service [%s/%s] has been deleted", svc.Namespace, svc.Name)
+
+		case watch.Bookmark:
+			// Un-used
+		case watch.Error:
+			log.Error("Error attempting to watch Kubernetes services")
+
+			// This round trip allows us to handle unstructured status
+			errObject := apierrors.FromObject(event.Object)
+			statusErr, ok := errObject.(*apierrors.StatusError)
+			if !ok {
+				log.Errorf(spew.Sprintf("Received an error which is not *metav1.Status but %#+v", event.Object))
+
+			}
+
+			status := statusErr.ErrStatus
+			log.Errorf("%v", status)
+		default:
+		}
+	}
+	log.Warnln("Stopping watching services for type: LoadBalancer in all namespaces")
+	return nil
+}

--- a/pkg/manager/watch_services.go
+++ b/pkg/manager/watch_services.go
@@ -37,7 +37,6 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 	}()
 	ch := rw.ResultChan()
 	//defer rw.Stop()
-	log.Infoln("Beginning watching services for type: LoadBalancer in all namespaces")
 
 	for event := range ch {
 		sm.countServiceWatchEvent.With(prometheus.Labels{"type": string(event.Type)}).Add(1)
@@ -63,10 +62,10 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 
 			// We can ignore this service
 			if svc.Annotations["kube-vip.io/ignore"] == "true" {
-				log.Infof("Service [%s] has an ignore annotation for kube-vip", svc.Name)
+				log.Infof("service [%s] has an ignore annotation for kube-vip", svc.Name)
 				break
 			}
-			log.Infof("Service [%s] has been added/modified it has an assigned external addresses [%s]", svc.Name, svc.Spec.LoadBalancerIP)
+			log.Infof("service [%s] has been added/modified it has an assigned external addresses [%s]", svc.Name, svc.Spec.LoadBalancerIP)
 			wg.Add(1)
 			// Background the services election
 			if sm.config.EnableServicesElection {
@@ -87,7 +86,7 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 		case watch.Deleted:
 			svc, ok := event.Object.(*v1.Service)
 			if !ok {
-				return fmt.Errorf("Unable to parse Kubernetes services from API watcher")
+				return fmt.Errorf("unable to parse Kubernetes services from API watcher")
 			}
 
 			// We only care about LoadBalancer services
@@ -97,7 +96,7 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 
 			// We can ignore this service
 			if svc.Annotations["kube-vip.io/ignore"] == "true" {
-				log.Infof("Service [%s] has an ignore annotation for kube-vip", svc.Name)
+				log.Infof("service [%s] has an ignore annotation for kube-vip", svc.Name)
 				break
 			}
 
@@ -105,7 +104,7 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 			if err != nil {
 				log.Error(err)
 			}
-			log.Infof("Service [%s/%s] has been deleted", svc.Namespace, svc.Name)
+			log.Infof("service [%s/%s] has been deleted", svc.Namespace, svc.Name)
 
 		case watch.Bookmark:
 			// Un-used

--- a/pkg/manager/watcher.go
+++ b/pkg/manager/watcher.go
@@ -25,7 +25,7 @@ import (
 )
 
 // This file handles the watching of a services endpoints and updates a load balancers endpoint configurations accordingly
-func (sm *Manager) servicesWatcher(ctx context.Context) error {
+func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(s *v1.Service, wg *sync.WaitGroup) error) error {
 	// Watch function
 	var wg sync.WaitGroup
 
@@ -69,10 +69,10 @@ func (sm *Manager) servicesWatcher(ctx context.Context) error {
 				log.Infof("Service [%s] has an ignore annotation for kube-vip", svc.Name)
 				break
 			}
-
 			log.Infof("Service [%s] has been added/modified it has an assigned external addresses [%s]", svc.Name, svc.Spec.LoadBalancerIP)
 			wg.Add(1)
-			err = sm.syncServices(svc, &wg)
+			err = serviceFunc(svc, &wg)
+			//err = sm.syncServices(svc, &wg)
 			if err != nil {
 				log.Error(err)
 			}

--- a/pkg/manager/watcher.go
+++ b/pkg/manager/watcher.go
@@ -25,7 +25,7 @@ import (
 )
 
 // This file handles the watching of a services endpoints and updates a load balancers endpoint configurations accordingly
-func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(s *v1.Service, wg *sync.WaitGroup) error) error {
+func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context.Context, *v1.Service, *sync.WaitGroup) error) error {
 	// Watch function
 	var wg sync.WaitGroup
 
@@ -71,8 +71,7 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(s *v1.S
 			}
 			log.Infof("Service [%s] has been added/modified it has an assigned external addresses [%s]", svc.Name, svc.Spec.LoadBalancerIP)
 			wg.Add(1)
-			err = serviceFunc(svc, &wg)
-			//err = sm.syncServices(svc, &wg)
+			err = serviceFunc(ctx, svc, &wg)
 			if err != nil {
 				log.Error(err)
 			}

--- a/pkg/vip/arp.go
+++ b/pkg/vip/arp.go
@@ -138,7 +138,6 @@ func sendARP(iface *net.Interface, m *arpMessage) error {
 	}
 	target := ethernetBroadcast
 	for i := 0; i < len(target); i++ { //nolint
-		
 		ll.Addr[i] = target[i]
 	}
 

--- a/pkg/vip/arp.go
+++ b/pkg/vip/arp.go
@@ -137,7 +137,8 @@ func sendARP(iface *net.Interface, m *arpMessage) error {
 		Halen:    m.hardwareAddressLength,
 	}
 	target := ethernetBroadcast
-	for i := 0; i < len(target); i++ {
+	for i := 0; i < len(target); i++ { //nolint
+		
 		ll.Addr[i] = target[i]
 	}
 


### PR DESCRIPTION
This will add in a new capability to create a services watcher, on a new service all nodes will participate in a leaderElection (the lease being the service name). The leader will then advertise the VIP to the network, this will enable two things:

- Spread VIPs over ARP (layer 2), not an elegant solution.. but a solution non-the-less
- Allow external mode local, allowing direct traffic to pods (leader Election will be limited to nodes where pods are running locally)