### PR TITLE
Table mode is now added to kube-vip

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -40,10 +40,11 @@ func startNetworking(c *kubevip.Config) (vip.Network, error) {
 		address = c.Address
 	}
 
-	network, err := vip.NewConfig(address, c.Interface, c.DDNS)
+	network, err := vip.NewConfig(address, c.Interface, c.VIPSubnet, c.DDNS, c.RoutingTableID)
 	if err != nil {
 		return nil, err
 	}
+
 	return network, nil
 }
 

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -174,12 +174,17 @@ func (cluster *Cluster) StartLoadBalancerService(c *kubevip.Config, bgp *bgp.Ser
 	if err != nil {
 		log.Warnf("Attempted to clean existing VIP => %v", err)
 	}
-
-	err = cluster.Network.AddIP()
-	if err != nil {
-		log.Warnf("%v", err)
+	if c.EnableRoutingTable {
+		err = cluster.Network.AddRoute()
+		if err != nil {
+			log.Warnf("%v", err)
+		}
+	} else {
+		err = cluster.Network.AddIP()
+		if err != nil {
+			log.Warnf("%v", err)
+		}
 	}
-
 	if c.EnableARP {
 		//ctxArp, cancelArp = context.WithCancel(context.Background())
 

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -138,6 +138,16 @@ func ParseEnvironment(c *Config) error {
 			return err
 		}
 		c.EnableServices = b
+
+		// Find Services leader Election
+		env = os.Getenv(svcElection)
+		if env != "" {
+			b, err := strconv.ParseBool(env)
+			if err != nil {
+				return err
+			}
+			c.EnableServicesElection = b
+		}
 	}
 
 	// Find vip address cidr range

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -184,6 +184,26 @@ func ParseEnvironment(c *Config) error {
 		c.EnableARP = b
 	}
 
+	// Wireguard Mode
+	env = os.Getenv(vipWireguard)
+	if env != "" {
+		b, err := strconv.ParseBool(env)
+		if err != nil {
+			return err
+		}
+		c.EnableWireguard = b
+	}
+
+	// Routing Table Mode
+	env = os.Getenv(vipRoutingTable)
+	if env != "" {
+		b, err := strconv.ParseBool(env)
+		if err != nil {
+			return err
+		}
+		c.EnableRoutingTable = b
+	}
+
 	// BGP Server options
 	env = os.Getenv(bgpEnable)
 	if env != "" {
@@ -192,16 +212,6 @@ func ParseEnvironment(c *Config) error {
 			return err
 		}
 		c.EnableBGP = b
-	}
-
-	// BGP Server options
-	env = os.Getenv(vipWireguard)
-	if env != "" {
-		b, err := strconv.ParseBool(env)
-		if err != nil {
-			return err
-		}
-		c.EnableWireguard = b
 	}
 
 	// BGP Router interface determines an interface that we can use to find an address for

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -103,11 +103,14 @@ const (
 	//cpNamespace defines the namespace the control plane pods will run in
 	cpNamespace = "cp_namespace"
 
-	//cpEnable starts kube-vip in the hybrid mode
+	//cpEnable enables the control plane feature
 	cpEnable = "cp_enable"
 
-	//cpEnable starts kube-vip in the hybrid mode
+	//svcEnable enables the Kubernetes service feature
 	svcEnable = "svc_enable"
+
+	//svcElection enables election per Kubernetes service
+	svcElection = "svc_election"
 
 	//lbEnable defines if the load-balancer should be enabled
 	lbEnable = "lb_enable"

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -97,6 +97,9 @@ const (
 	//vipWireguard - defines if wireguard will be used for vips
 	vipWireguard = "vip_wireguard" //nolint
 
+	//vipRoutingTable - defines if table mode will be used for vips
+	vipRoutingTable = "vip_routingtable" //nolint
+
 	//cpNamespace defines the namespace the control plane pods will run in
 	cpNamespace = "cp_namespace"
 

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -177,18 +177,29 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 		newEnvironment = append(newEnvironment, packet...)
 	}
 
-	// If BGP, but we're not using packet
+	// Detect and enable wireguard mode
 	if c.EnableWireguard {
-		bgp := []corev1.EnvVar{
+		wireguard := []corev1.EnvVar{
 			{
 				Name:  vipWireguard,
 				Value: strconv.FormatBool(c.EnableWireguard),
 			},
 		}
-		newEnvironment = append(newEnvironment, bgp...)
+		newEnvironment = append(newEnvironment, wireguard...)
 	}
 
-	// If BGP, but we're not using packet
+	// Detect and enable routing table mode
+	if c.EnableRoutingTable {
+		routingtable := []corev1.EnvVar{
+			{
+				Name:  vipWireguard,
+				Value: strconv.FormatBool(c.EnableRoutingTable),
+			},
+		}
+		newEnvironment = append(newEnvironment, routingtable...)
+	}
+
+	// If BGP, but we're not using Equinix Metal
 	if c.EnableBGP {
 		bgp := []corev1.EnvVar{
 			{
@@ -198,7 +209,7 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 		}
 		newEnvironment = append(newEnvironment, bgp...)
 	}
-	// If BGP, but we're not using packet
+	// If BGP, but we're not using Equinix Metal
 	if c.EnableBGP && !c.EnableMetal {
 		bgpConfig := []corev1.EnvVar{
 			{

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -83,13 +83,22 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 
 	// If we're doing the hybrid mode
 	if c.EnableServices {
-		cp := []corev1.EnvVar{
+		svc := []corev1.EnvVar{
 			{
 				Name:  svcEnable,
 				Value: strconv.FormatBool(c.EnableServices),
 			},
 		}
-		newEnvironment = append(newEnvironment, cp...)
+		newEnvironment = append(newEnvironment, svc...)
+		if c.EnableServicesElection {
+			svcElection := []corev1.EnvVar{
+				{
+					Name:  svcElection,
+					Value: strconv.FormatBool(c.EnableServicesElection),
+				},
+			}
+			newEnvironment = append(newEnvironment, svcElection...)
+		}
 	}
 
 	// If Leader election is enabled then add the configuration to the manifest

--- a/pkg/kubevip/config_manager.go
+++ b/pkg/kubevip/config_manager.go
@@ -25,19 +25,6 @@ func ParseBackendConfig(ep string) (*BackEnd, error) {
 	return &BackEnd{Address: endpoint[0], Port: p}, nil
 }
 
-//ParsePeerConfig -
-func ParsePeerConfig(ep string) (*RaftPeer, error) {
-	endpoint := strings.Split(ep, ":")
-	if len(endpoint) != 3 {
-		return nil, fmt.Errorf("ensure a peer is in in the format id:address:port, e.g. server1:10.0.0.1:8080")
-	}
-	p, err := strconv.Atoi(endpoint[2])
-	if err != nil {
-		return nil, err
-	}
-	return &RaftPeer{ID: endpoint[0], Address: endpoint[1], Port: p}, nil
-}
-
 //OpenConfig will attempt to read a file and parse it's contents into a configuration
 func OpenConfig(path string) (*Config, error) {
 	if path == "" {
@@ -73,61 +60,12 @@ func (c *Config) PrintConfig() {
 	fmt.Print(string(b))
 }
 
-//ParseFlags will write the current configuration to a specified [path]
-func (c *Config) ParseFlags(localPeer string, remotePeers, backends []string) error {
-	// Parse localPeer
-	p, err := ParsePeerConfig(localPeer)
-	if err != nil {
-		return err
-	}
-	c.LocalPeer = *p
-
-	// Parse remotePeers
-	//Iterate backends
-	for i := range remotePeers {
-		p, err := ParsePeerConfig(remotePeers[i])
-		if err != nil {
-			return err
-
-		}
-		c.RemotePeers = append(c.RemotePeers, *p)
-	}
-
-	//Iterate backends
-	for i := range backends {
-		b, err := ParseBackendConfig(backends[i])
-		if err != nil {
-			return err
-		}
-		c.LoadBalancers[0].Backends = append(c.LoadBalancers[0].Backends, *b)
-	}
-
-	return nil
-}
-
 //SampleConfig will create an example configuration and write it to the specified [path]
 func SampleConfig() {
 
 	// Generate Sample configuration
 	c := &Config{
-		// Generate sample peers
-		RemotePeers: []RaftPeer{
-			{
-				ID:      "server2",
-				Address: "192.168.0.2",
-				Port:    10000,
-			},
-			{
-				ID:      "server3",
-				Address: "192.168.0.3",
-				Port:    10000,
-			},
-		},
-		LocalPeer: RaftPeer{
-			ID:      "server1",
-			Address: "192.168.0.1",
-			Port:    10000,
-		},
+
 		// Virtual IP address
 		VIP: "192.168.0.100",
 		// Interface to bind to

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -18,6 +18,9 @@ type Config struct {
 	// EnableWireguard, will use wireguard to advertise the VIP address
 	EnableWireguard bool `yaml:"enableWireguard"`
 
+	// EnableRoutingTable, will use the routing table to advertise the VIP address
+	EnableRoutingTable bool `yaml:"enableRoutingTable"`
+
 	// EnableControlPane, will enable the control plane functionality (used for hybrid behaviour)
 	EnableControlPane bool `yaml:"enableControlPane"`
 
@@ -33,17 +36,14 @@ type Config struct {
 	// LeaderElection defines the settings around Kubernetes LeaderElection
 	LeaderElection
 
-	// LocalPeer is the configuration of this host
-	LocalPeer RaftPeer `yaml:"localPeer"`
-
-	// Peers are all of the peers within the RAFT cluster
-	RemotePeers []RaftPeer `yaml:"remotePeers"`
-
 	// AddPeersAsBackends, this will automatically add RAFT peers as backends to a loadbalancer
 	AddPeersAsBackends bool `yaml:"addPeersAsBackends"`
 
 	// VIP is the Virtual IP address exposed for the cluster (TODO: deprecate)
 	VIP string `yaml:"vip"`
+
+	// VipSubnet is the Subnet that is applied to the VIP
+	VIPSubnet string `yaml:"vipSubnet"`
 
 	// VIPCIDR is cidr range for the VIP (primarily needed for BGP)
 	VIPCIDR string `yaml:"vipCidr"`
@@ -80,6 +80,9 @@ type Config struct {
 
 	// Forwarding method for the IPVS Service
 	LoadBalancerForwardingMethod string `yaml:"lbForwardingMethod"`
+
+	// Routing Table ID for when using routing table mode
+	RoutingTableID int `yaml:"routingTableID"`
 
 	// BGP Configuration
 	BGPConfig     bgp.Config
@@ -122,18 +125,6 @@ type LeaderElection struct {
 
 	// RetryPerion - Number of times the host will retry to hold a lease
 	RetryPeriod int
-}
-
-// RaftPeer details the configuration of all cluster peers
-type RaftPeer struct {
-	// ID is the unique identifier a peer instance
-	ID string `yaml:"id"`
-
-	// IP Address of a peer instance
-	Address string `yaml:"address"`
-
-	// Listening port of this peer instance
-	Port int `yaml:"port"`
 }
 
 // LoadBalancer contains the configuration of a load balancing instance

--- a/pkg/manager/instance.go
+++ b/pkg/manager/instance.go
@@ -56,12 +56,15 @@ func NewInstance(service *v1.Service, config *kubevip.Config) (*Instance, error)
 
 	// Generate new Virtual IP configuration
 	newVip := &kubevip.Config{
-		VIP:        instanceAddress, //TODO support more than one vip?
-		Interface:  serviceInterface,
-		SingleNode: true,
-		EnableARP:  config.EnableARP,
-		EnableBGP:  config.EnableBGP,
-		VIPCIDR:    config.VIPCIDR,
+		VIP:                instanceAddress, //TODO support more than one vip?
+		Interface:          serviceInterface,
+		SingleNode:         true,
+		EnableARP:          config.EnableARP,
+		EnableBGP:          config.EnableBGP,
+		VIPCIDR:            config.VIPCIDR,
+		VIPSubnet:          config.VIPSubnet,
+		EnableRoutingTable: config.EnableRoutingTable,
+		RoutingTableID:     config.RoutingTableID,
 	}
 
 	// Create new service

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -137,6 +137,11 @@ func (sm *Manager) Start() error {
 		return sm.startWireguard()
 	}
 
+	if sm.config.EnableRoutingTable {
+		log.Infoln("Starting Kube-vip Manager with the Routing Table engine")
+		return sm.startTableMode()
+	}
+
 	log.Errorln("prematurely exiting Load-balancer as no modes [ARP/BGP/Wireguard] are enabled")
 	return nil
 }

--- a/pkg/manager/manager_arp.go
+++ b/pkg/manager/manager_arp.go
@@ -71,7 +71,7 @@ func (sm *Manager) startARP() error {
 	} else {
 		ns, err = returnNameSpace()
 		if err != nil {
-			log.Errorf("Unable to auto-detect namespace, dropping to [%s]", sm.config.Namespace)
+			log.Warnf("unable to auto-detect namespace, dropping to [%s]", sm.config.Namespace)
 			ns = sm.config.Namespace
 		}
 	}

--- a/pkg/manager/servicesLeader.go
+++ b/pkg/manager/servicesLeader.go
@@ -27,6 +27,10 @@ func (sm *Manager) startServicesWatchForLeaderElection(ctx context.Context) erro
 		return err
 	}
 
+	for x := range sm.serviceInstances {
+		sm.serviceInstances[x].cluster.Stop()
+	}
+
 	log.Infof("Shutting down kube-Vip")
 
 	return nil

--- a/testing/kubeadm/create.sh
+++ b/testing/kubeadm/create.sh
@@ -20,11 +20,11 @@ first_node() {
   logr "INFO" "Creating First node!" 
   #ssh $NODE01  "sudo modprobe ip_vs_rr"
   #ssh $NODE01  "sudo modprobe nf_conntrack"
-  logr "INFO" "$(ssh $NODE01  "docker rmi plndr/kube-vip:$kube_vip_version" 2>&1)"
+  logr "INFO" "$(ssh $NODE01  "docker rmi ghcr.io/kube-vip/kube-vip:$kube_vip_version" 2>&1)"
 
   # echo "echo "ip_vs | tee -a /etc/modules"
   logr "INFO" "Creating Kube-vip.io Manifest" 
-  ssh $NODE01 "sudo docker run --network host --rm plndr/kube-vip:$kube_vip_version manifest pod  --interface ens160 --vip $kube_vip_vip --arp --leaderElection --enableLoadBalancer $kube_vip_mode | sed  \"s/image:.*/image: plndr\/kube-vip:$kube_vip_version/\" | sudo tee /etc/kubernetes/manifests/vip.yaml" >> $logfile
+  ssh $NODE01 "sudo docker run --network host --rm ghcr.io/kube-vip/kube-vip:$kube_vip_version manifest pod  --interface ens160 --vip $kube_vip_vip --arp --leaderElection --enableLoadBalancer $kube_vip_mode | sed  \"s/image:.*/image: plndr\/kube-vip:$kube_vip_version/\" | sudo tee /etc/kubernetes/manifests/vip.yaml" >> $logfile
   logr "INFO" "Deploying first Kubernetes node $NODE01"
   FIRST_NODE=$(ssh $NODE01 "sudo kubeadm init --kubernetes-version $kubernetes_version --control-plane-endpoint $kube_vip_vip --upload-certs --pod-network-cidr=10.0.0.0/16")
   echo "$FIRST_NODE" >> $logfile
@@ -48,11 +48,11 @@ additional_controlplane() {
   logr "INFO" "Adding $NODE02"
   ssh $NODE02 "sudo $JOIN_CMD $CONTROLPLANE_CMD" >> $logfile
   sleep 1
-  ssh $NODE02 "sudo docker run --network host --rm plndr/kube-vip:$kube_vip_version manifest pod --interface ens160 --vip $kube_vip_vip --arp --leaderElection --enableLoadBalancer $kube_vip_mode | sed  \"s/image:.*/image: plndr\/kube-vip:$kube_vip_version/\"| sudo tee /etc/kubernetes/manifests/vip.yaml" >> $logfile
+  ssh $NODE02 "sudo docker run --network host --rm ghcr.io/kube-vip/kube-vip:$kube_vip_version manifest pod --interface ens160 --vip $kube_vip_vip --arp --leaderElection --enableLoadBalancer $kube_vip_mode | sed  \"s/image:.*/image: plndr\/kube-vip:$kube_vip_version/\"| sudo tee /etc/kubernetes/manifests/vip.yaml" >> $logfile
   logr "INFO" "Adding $NODE03"
   ssh $NODE03 "sudo $JOIN_CMD $CONTROLPLANE_CMD" >> $logfile
   sleep 1
-  ssh $NODE03 "sudo docker run --network host --rm plndr/kube-vip:$kube_vip_version manifest pod --interface ens160 --vip $kube_vip_vip --arp --leaderElection --enableLoadBalancer $kube_vip_mode | sed  \"s/image:.*/image: plndr\/kube-vip:$kube_vip_version/\"| sudo tee /etc/kubernetes/manifests/vip.yaml" >> $logfile
+  ssh $NODE03 "sudo docker run --network host --rm ghcr.io/kube-vip/kube-vip:$kube_vip_version manifest pod --interface ens160 --vip $kube_vip_vip --arp --leaderElection --enableLoadBalancer $kube_vip_mode | sed  \"s/image:.*/image: plndr\/kube-vip:$kube_vip_version/\"| sudo tee /etc/kubernetes/manifests/vip.yaml" >> $logfile
 }
 
 ## Main() 
@@ -96,7 +96,7 @@ esac
 
 if [[ -z "$DEPS" ]]; then
   logr "INFO" "Installing specific version of Kubernetes Dependancies"
-  install_deps
+#  install_deps
 fi
 
 first_node


### PR DESCRIPTION
```
$ sudo ./kube-vip manager --table --services --interface lo
INFO[0000] Starting kube-vip.io [v0.4.4]                
INFO[0000] namespace [kube-system], Mode: [Routing Table], Features(s): Control Plane:[false], Services:[true] 
WARN[0000] the status of the interface lo is unknown. Ensure your interface is ready to accept traffic, if so you can safely ignore this message 
INFO[0000] prometheus HTTP server started               
INFO[0000] Starting Kube-vip Manager with the Routing Table engine 
INFO[0000] all routing table entries will exist in table [198] 
WARN[0000] unable to auto-detect namespace, dropping to [kube-system] 
INFO[0000] beginning services leadership, namespace [kube-system], lock name [plndr-svcs-lock], id [k8s04] 
I0629 16:05:00.381858     757 leaderelection.go:248] attempting to acquire leader lease kube-system/plndr-svcs-lock...
I0629 16:05:00.391275     757 leaderelection.go:258] successfully acquired lease kube-system/plndr-svcs-lock
INFO[0000] service [nginx1] has been added/modified it has an assigned external addresses [192.168.0.221] 
INFO[0000] add the service [default/nginx1] with external address [192.168.0.221] 
INFO[0000] new VIP [192.168.0.221] for [default/nginx1]  
INFO[0000] Starting advertising address [192.168.0.221] with kube-vip 
INFO[0000] Started Load Balancer and Virtual IP         
INFO[0000] service [nginx-wireguard] has been added/modified it has an assigned external addresses [10.0.0.2] 
INFO[0000] add the service [default/nginx-wireguard] with external address [10.0.0.2] 
INFO[0000] new VIP [10.0.0.2] for [default/nginx-wireguard]  
INFO[0000] Starting advertising address [10.0.0.2] with kube-vip 
INFO[0000] Started Load Balancer and Virtual IP    
```

Route table:

```
$ ip r s table all | grep 198
10.0.0.2 dev lo table 198 
192.168.0.221 dev lo table 198 
```

Addresses:
```
$ ip a show dev lo
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
```