### PR TITLE
Allow fixed virtual MAC for DHCP VIPs

### DIFF
--- a/pkg/manager/instance.go
+++ b/pkg/manager/instance.go
@@ -168,7 +168,7 @@ func (i *Instance) startDHCP() (chan string, error) {
 	}
 
 	var initRebootFlag bool
-	if i.dhcpInterfaceHwaddr != "" {
+	if i.dhcpInterfaceIP != "" {
 		initRebootFlag = true
 	}
 

--- a/pkg/service/services_dhcp.go
+++ b/pkg/service/services_dhcp.go
@@ -65,7 +65,7 @@ func (sm *Manager) createDHCPService(newServiceUID string, newVip *kubevip.Confi
 	}
 
 	var initRebootFlag bool
-	if newService.dhcpInterfaceHwaddr != "" {
+	if newService.dhcpInterfaceIP != "" {
 		initRebootFlag = true
 	}
 


### PR DESCRIPTION
Use IP instead of MAC address to determine if the virtual interface was already previously configured. This makes it possible to pre-define `kube-vip.io/hwaddr` annotation on a `LoadBalancer` and therefore allows defining a static DHCP lease for it.

You can test this by using `valtzu/kube-vip:v0.5.0` instead of `ghcr.io/kube-vip/kube-vip:v0.5.0`.

Closes #354
