### PR TITLE
Enable kube-vip to only respond to svc with kube-vip's lb class

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -128,6 +128,7 @@ func init() {
 
 	// Extended behaviour flags
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableServicesElection, "servicesElection", false, "Enable leader election per kubernetes service")
+	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.LoadBalancerClassOnly, "lbClassOnly", false, "Enable load balancing only for services with LoadBalancerClass \"kube-vip.io/kube-vip-class\"")
 
 	// Prometheus HTTP Server
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.PrometheusHTTPServer, "prometheusHTTPServer", ":2112", "Host and port used to expose Prometheus metrics via an HTTP server")

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -148,6 +148,16 @@ func ParseEnvironment(c *Config) error {
 			}
 			c.EnableServicesElection = b
 		}
+
+		// Find load-balancer class only
+		env = os.Getenv(lbClassOnly)
+		if env != "" {
+			b, err := strconv.ParseBool(env)
+			if err != nil {
+				return err
+			}
+			c.LoadBalancerClassOnly = b
+		}
 	}
 
 	// Find vip address cidr range

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -112,6 +112,9 @@ const (
 	//svcElection enables election per Kubernetes service
 	svcElection = "svc_election"
 
+	//lbClassOnly enables load-balancer for class "kube-vip.io/kube-vip-class" only
+	lbClassOnly = "lb_class_only"
+
 	//lbEnable defines if the load-balancer should be enabled
 	lbEnable = "lb_enable"
 

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -99,6 +99,15 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 			}
 			newEnvironment = append(newEnvironment, svcElection...)
 		}
+		if c.LoadBalancerClassOnly {
+			lbClassOnlyVar := []corev1.EnvVar{
+				{
+					Name:  lbClassOnly,
+					Value: strconv.FormatBool(c.LoadBalancerClassOnly),
+				},
+			}
+			newEnvironment = append(newEnvironment, lbClassOnlyVar...)
+		}
 	}
 
 	// If Leader election is enabled then add the configuration to the manifest

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -30,6 +30,9 @@ type Config struct {
 	// EnableServicesElection, will enable leaderElection per service
 	EnableServicesElection bool `yaml:"enableServicesElection"`
 
+	// LoadBalancerClassOnly, will enable load balancing only for services with LoadBalancerClass set to "kube-vip.io/kube-vip-class"
+	LoadBalancerClassOnly bool `yaml:"lbClassOnly"`
+
 	// Annotations will define if we're going to wait and lookup configuration from Kubernetes node annotations
 	Annotations string
 

--- a/pkg/manager/watch_services.go
+++ b/pkg/manager/watch_services.go
@@ -96,6 +96,10 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 					log.Infof("service [%s] specified the loadBalancer class [%s], ignoring", svc.Name, *svc.Spec.LoadBalancerClass)
 					break
 				}
+			} else if sm.config.LoadBalancerClassOnly {
+				// if kube-vip is configured to only recognize services with kube-vip's lb class, then ignore the services without any lb class
+				log.Infof("kube-vip configured to only recognize services with kube-vip's lb class but the service [%s] didn't specify any loadBalancer class, ignoring", svc.Name)
+				break
 			}
 
 			// Check if we ignore this service


### PR DESCRIPTION
Currently, there's no way to restrict `kube-vip` to only acknowledge services with kube-vip's LB class `kube-vip.io/kube-vip-class`.

For example, if you have two services A and B:
- service A has lb class set to `kube-vip.io/kube-vip-class`
- service B no has lb class set

`kube-vip` will currently advertise IPs for both services A and B

With this change, if a user passes the `--lbClassOnly` flag, `kube-vip` will only advertise IPs for service A since it has `kube-vip`'s LB class but will ignore service B

If a user does not pass the `--lbClassOnly`, there will no change from the current behavior