### PR TITLE
fix --table flag should add vip_routingtable env var not vip_wireguard

### DIFF
--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -210,7 +210,7 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 	if c.EnableRoutingTable {
 		routingtable := []corev1.EnvVar{
 			{
-				Name:  vipWireguard,
+				Name:  vipRoutingTable,
 				Value: strconv.FormatBool(c.EnableRoutingTable),
 			},
 		}


### PR DESCRIPTION
Hi :) 

When generating manifest using the `--table` it adds the `vip_wireguard` env var to the pod manifest instead of the `vip_routingtable`. This PR fixes this issue.

Signed-off-by: Alexandre Vilain <alexandre.vilain@me.com>