### PR TITLE
Add random MAC address generation for DHCP

### DIFF
--- a/pkg/manager/instance.go
+++ b/pkg/manager/instance.go
@@ -139,8 +139,14 @@ func (i *Instance) startDHCP() (chan string, error) {
 		hwaddr, err := net.ParseMAC(i.dhcpInterfaceHwaddr)
 		if i.dhcpInterfaceHwaddr != "" && err != nil {
 			return nil, err
+		} else if hwaddr == nil {
+			hwaddr, err = net.ParseMAC(vip.GenerateMac())
+			if err != nil {
+				return nil, err
+			}
 		}
 
+		log.Infof("New interface [%s] mac is %s", interfaceName, hwaddr)
 		mac := &netlink.Macvlan{
 			LinkAttrs: netlink.LinkAttrs{
 				Name:         interfaceName,
@@ -159,6 +165,7 @@ func (i *Instance) startDHCP() (chan string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("could not bring up interface [%s] : %v", interfaceName, err)
 		}
+
 		iface, err = net.InterfaceByName(interfaceName)
 		if err != nil {
 			return nil, fmt.Errorf("error finding new DHCP interface by name [%v]", err)

--- a/pkg/vip/util.go
+++ b/pkg/vip/util.go
@@ -2,6 +2,7 @@ package vip
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	"net"
 	"strings"
@@ -106,4 +107,22 @@ func MonitorDefaultInterface(ctx context.Context, defaultIF *net.Interface) erro
 			return nil
 		}
 	}
+}
+
+func GenerateMac() (mac string) {
+	buf := make([]byte, 3)
+	_, err := rand.Read(buf)
+	if err != nil {
+		return
+	}
+
+	/**
+	 * The first 3 bytes need to match a real manufacturer
+	 * you can refer to the following lists for examples:
+	 * - https://gist.github.com/aallan/b4bb86db86079509e6159810ae9bd3e4
+	 * - https://macaddress.io/database-download
+	 */
+	mac = fmt.Sprintf("%s:%s:%s:%02x:%02x:%02x", "00", "00", "6C", buf[0], buf[1], buf[2])
+	log.Infof("Generated mac: %s", mac)
+	return mac
 }


### PR DESCRIPTION
I was facing an issue when a new macvlan link was added as it was added with `nil` mac; letting the underlying software generate it. Therefore the DHCP request was being made with a non existent MAC and responses were never catched.

This PR adds one randomly generated MAC address when it's empty.