### PR TITLE
logging and fixed an issue with multiple elections

### DIFF
--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -268,7 +268,7 @@ func (sm *Manager) NodeWatcher(lb *loadbalancer.IPVSLoadBalancer, port int) erro
 		case watch.Added, watch.Modified:
 			node, ok := event.Object.(*v1.Node)
 			if !ok {
-				return fmt.Errorf("Unable to parse Kubernetes Node from Annotation watcher")
+				return fmt.Errorf("unable to parse Kubernetes Node from Annotation watcher")
 			}
 			//Find the node IP address (this isn't foolproof)
 			for x := range node.Status.Addresses {
@@ -276,14 +276,14 @@ func (sm *Manager) NodeWatcher(lb *loadbalancer.IPVSLoadBalancer, port int) erro
 				if node.Status.Addresses[x].Type == v1.NodeInternalIP {
 					err = lb.AddBackend(node.Status.Addresses[x].Address, port)
 					if err != nil {
-						log.Errorf("Add IPVS backend [%v]", err)
+						log.Errorf("add IPVS backend [%v]", err)
 					}
 				}
 			}
 		case watch.Deleted:
 			node, ok := event.Object.(*v1.Node)
 			if !ok {
-				return fmt.Errorf("Unable to parse Kubernetes Node from Annotation watcher")
+				return fmt.Errorf("unable to parse Kubernetes Node from Annotation watcher")
 			}
 
 			//Find the node IP address (this isn't foolproof)

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -210,7 +210,7 @@ func ParseEnvironment(c *Config) error {
 		c.StartAsLeader = b
 	}
 
-	// Find ARP
+	// Find if ARP is enabled
 	env = os.Getenv(vipArp)
 	if env != "" {
 		b, err := strconv.ParseBool(env)
@@ -218,6 +218,19 @@ func ParseEnvironment(c *Config) error {
 			return err
 		}
 		c.EnableARP = b
+	}
+
+	// Find if ARP is enabled
+	env = os.Getenv(vipArpRate)
+	if env != "" {
+		i64, err := strconv.ParseInt(env, 10, 32)
+		if err != nil {
+			return err
+		}
+		c.ArpBroadcastRate = i64
+	} else {
+		// default to three seconds
+		c.ArpBroadcastRate = 3000
 	}
 
 	// Wireguard Mode

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -6,6 +6,9 @@ const (
 	//vipArp - defines if the arp broadcast should be enabled
 	vipArp = "vip_arp"
 
+	//vip_arpRate - defines the rate of gARP broadcasts
+	vipArpRate = "vip_arpRate"
+
 	//vipLeaderElection - defines if the kubernetes algorithm should be used
 	vipLeaderElection = "vip_leaderelection"
 

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -36,6 +36,9 @@ type Config struct {
 	// LoadBalancerClassOnly, will enable load balancing only for services with LoadBalancerClass set to "kube-vip.io/kube-vip-class"
 	LoadBalancerClassOnly bool `yaml:"lbClassOnly"`
 
+	// ArpBroadcastRate, defines how often kube-vip will update the network about updates to the network
+	ArpBroadcastRate int64 `yaml:"arpBroadcastRate"`
+
 	// Annotations will define if we're going to wait and lookup configuration from Kubernetes node annotations
 	Annotations string
 

--- a/pkg/manager/instance.go
+++ b/pkg/manager/instance.go
@@ -64,6 +64,7 @@ func NewInstance(service *v1.Service, config *kubevip.Config) (*Instance, error)
 		VIPSubnet:          config.VIPSubnet,
 		EnableRoutingTable: config.EnableRoutingTable,
 		RoutingTableID:     config.RoutingTableID,
+		ArpBroadcastRate:   config.ArpBroadcastRate,
 	}
 
 	// Create new service

--- a/pkg/manager/services.go
+++ b/pkg/manager/services.go
@@ -128,7 +128,7 @@ func (sm *Manager) addService(service *v1.Service) error {
 		return err
 	}
 
-	log.Infof("adding VIP [%s] for [%s/%s] ", newService.Vip, newService.serviceSnapshot.Namespace, newService.serviceSnapshot.Name)
+	log.Infof("[service] adding VIP [%s] for [%s/%s] ", newService.Vip, newService.serviceSnapshot.Namespace, newService.serviceSnapshot.Name)
 
 	newService.cluster.StartLoadBalancerService(newService.vipConfig, sm.bgpServer)
 
@@ -173,10 +173,10 @@ func (sm *Manager) upnpMap(s *Instance) {
 	if sm.upnp != nil {
 		log.Infof("[UPNP] Adding map to [%s:%d - %s]", s.Vip, s.Port, s.serviceSnapshot.Name)
 		if err := sm.upnp.AddPortMapping(int(s.Port), int(s.Port), 0, s.Vip, strings.ToUpper(s.Type), s.serviceSnapshot.Name); err == nil {
-			log.Infof("Service should be accessible externally on port [%d]", s.Port)
+			log.Infof("service should be accessible externally on port [%d]", s.Port)
 		} else {
 			sm.upnp.Reclaim()
-			log.Errorf("Unable to map port to gateway [%s]", err.Error())
+			log.Errorf("unable to map port to gateway [%s]", err.Error())
 		}
 	}
 }

--- a/pkg/manager/watch_endpoints.go
+++ b/pkg/manager/watch_endpoints.go
@@ -17,7 +17,7 @@ import (
 )
 
 func (sm *Manager) watchEndpoint(ctx context.Context, id string, service *v1.Service, wg *sync.WaitGroup) error {
-	log.Infof("watching endpoints for service [%s]", service.Name)
+	log.Infof("[endpoint] watching for service [%s] in namespace [%s]", service.Name, service.Namespace)
 	// Use a restartable watcher, as this should help in the event of etcd or timeout issues
 	var cancel context.CancelFunc
 	var endpointContext context.Context
@@ -116,7 +116,7 @@ func (sm *Manager) watchEndpoint(ctx context.Context, id string, service *v1.Ser
 			log.Errorf("%v", statusErr)
 		}
 	}
-	log.Infof("stopping watching endpoints for [%s]", service.Name)
+	log.Infof("[endpoints] stopping watching for [%s] in namespace [%s]", service.Name, service.Namespace)
 	return nil //nolint:govet
 }
 

--- a/pkg/vip/arp.go
+++ b/pkg/vip/arp.go
@@ -12,8 +12,6 @@ import (
 	"net"
 	"syscall"
 	"unsafe"
-
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -169,7 +167,6 @@ func ARPSendGratuitous(address, ifaceName string) error {
 	}
 
 	// This is a debug message, enable debugging to ensure that the gratuitous arp is repeating
-	log.Debugf("Broadcasting ARP update for %s (%s) via %s", address, iface.HardwareAddr, iface.Name)
 	m, err := gratuitousARP(ip, iface.HardwareAddr)
 	if err != nil {
 		return err

--- a/pkg/vip/egress.go
+++ b/pkg/vip/egress.go
@@ -40,7 +40,7 @@ func CreateIptablesClient() (*Egress, error) {
 }
 
 func (e *Egress) CheckMangleChain(name string) (bool, error) {
-	log.Infof("[egress] Cheching for Chain [%s]", name)
+	log.Infof("[egress] Checking for Chain [%s]", name)
 	return e.ipTablesClient.ChainExists("mangle", name)
 }
 


### PR DESCRIPTION
This fixes an issue where services that weren't part of endpoint watches would generate another watcher whenever a service would "change" ... Also a lot of changes to debugging messages making output a lot clearer.. finally the capability to set the rate of ARP updates through the environment variable `vip_arpRate` in milliseconds.

Signed-off-by: Dan Finneran <daniel.finneran@gmail.com>