### PR TITLE
garbage collection for goroutines

### DIFF
--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -122,7 +122,7 @@ func (cluster *Cluster) StartCluster(c *kubevip.Config, sm *Manager, bgpServer *
 
 	go func() {
 		<-signalChan
-		log.Info("Received termination, signaling shutdown")
+		log.Info("Received termination, signaling cluster shutdown")
 		// Cancel the context, which will in turn cancel the leadership
 		cancel()
 		// Cancel the arp context, which will in turn stop any broadcasts
@@ -318,7 +318,7 @@ func (sm *Manager) NodeWatcher(lb *loadbalancer.IPVSLoadBalancer, port int) erro
 		}
 	}
 
-	log.Infoln("Exiting Annotations watcher")
+	log.Infoln("Exiting Node watcher")
 	return nil
 
 }

--- a/pkg/manager/manager_arp.go
+++ b/pkg/manager/manager_arp.go
@@ -31,10 +31,12 @@ func (sm *Manager) startARP() error {
 	// Shutdown function that will wait on this signal, unless we call it ourselves
 	go func() {
 		<-sm.signalChan
-		log.Info("Received termination, signaling shutdown")
+		log.Info("Received kube-vip termination, signaling shutdown")
 		if sm.config.EnableControlPlane {
 			cpCluster.Stop()
 		}
+		// Close all go routines
+		close(sm.shutdownChan)
 		// Cancel the context, which will in turn cancel the leadership
 		cancel()
 	}()


### PR DESCRIPTION
Signed-off-by: Dan Finneran <daniel.finneran@gmail.com>

This adds the following:
- A separate shutdown channel that when closed will ensure all goroutines that hold various contexts or retrywatcher shutdowns is triggered.
- Fixes an issue with slow shutdowns when kubernetes deletes a pod.