### PR TITLE
Fix watching for endpoints RBAC rule

### DIFF
--- a/docs/manifests/rbac.yaml
+++ b/docs/manifests/rbac.yaml
@@ -12,7 +12,7 @@ metadata:
   name: system:kube-vip-role
 rules:
   - apiGroups: [""]
-    resources: ["services", "services/status", "nodes"]
+    resources: ["services", "services/status", "nodes", "endpoints"]
     verbs: ["list","get","watch", "update"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]


### PR DESCRIPTION
Without this specific ClusterRole rule, kube-vip would not be able to listen for `endpoints` changes when deployed as a DaemonSet, thus causing the IP addresses not being announced and the following error message every second:

```
E1227 20:37:20.290479       1 retrywatcher.go:130] "Watch failed" err="unknown (get endpoints)"
```