### PR TITLE
Enable IPv6 peering and VIP advertisement and improve BGP support.

### DIFF
--- a/docs/flags/index.md
+++ b/docs/flags/index.md
@@ -57,7 +57,7 @@ These environment variables are usually part of a `kube-vip` manifest and used w
 More environment variables can be read through the `pkg/kubevip/config_envvar.go` file.
 
 | Category            | Environment Variable   | Usage                                                       | Notes                                                                           |
-| ------------------- | ---------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| ------------------- | ---------------------- |-------------------------------------------------------------|---------------------------------------------------------------------------------|
 | **Troubleshooting** |                        |                                                             |                                                                                 |
 |                     | `vip_loglevel`         | default 4                                                   | Set to `5` for debugging logs                                                   |
 | **Mode**            |                        |                                                             |                                                                                 |
@@ -85,7 +85,7 @@ More environment variables can be read through the `pkg/kubevip/config_envvar.go
 |                     | `bgp_routerid`         | `<IP Address>`                                              | Typically the address of the local node                                         |
 |                     | `bgp_routerinterface`  | Interface name                                              | Used to associate the `routerID` with the control plane's interface.            |
 |                     | `bgp_as`               | default 65000                                               | The AS we peer from                                                             |
-|                     | `bgp_peers`            | `<address:AS:password:multihop>`                            | Comma separated list of BGP peers                                               |
+|                     | `bgp_peers`            | `<address:AS[:password[:multihop]]>`                        | Comma separated list of BGP peers (IPv6 addresses should be enclosed with `[]`) |
 |                     | `bgp_peeraddress`      | `<IP Address>`                                              | Address of a single BGP Peer                                                    |
 |                     | `bgp_peeras`           | default 65000                                               | AS of a single BGP Peer                                                         |
 |                     | `bgp_peerpass`         | ""                                                          | Password to work with a single BGP Peer                                         |

--- a/pkg/bgp/peers.go
+++ b/pkg/bgp/peers.go
@@ -134,27 +134,36 @@ func ParseBGPPeerConfig(config string) (bgpPeers []Peer, err error) {
 		}
 
 		peer := strings.Split(peerStr, ":")
-		if len(peer) != 4 {
-			return nil, fmt.Errorf("BGP Peer configuration format error <host>:<AS>:<password>:<multihop>")
+		if len(peer) < 2 {
+			return nil, fmt.Errorf("mandatory peering params <host>:<AS> incomplete")
 		}
+
 		if !isV6Peer {
 			address = peer[0]
 		}
 
-		ASNumber, err := strconv.Atoi(peer[1])
+		ASNumber, err := strconv.ParseUint(peer[1], 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("BGP Peer AS format error [%s]", peer[1])
-
 		}
-		multiHop, err := strconv.ParseBool(peer[3])
-		if err != nil {
-			return nil, fmt.Errorf("BGP MultiHop format error (true/false) [%s]", peer[1])
+
+		password := ""
+		if len(peer) >= 3 {
+			password = peer[2]
+		}
+
+		multiHop := false
+		if len(peer) >= 4 {
+			multiHop, err = strconv.ParseBool(peer[3])
+			if err != nil {
+				return nil, fmt.Errorf("BGP MultiHop format error (true/false) [%s]", peer[1])
+			}
 		}
 
 		peerConfig := Peer{
 			Address:  address,
 			AS:       uint32(ASNumber),
-			Password: peer[2],
+			Password: password,
 			MultiHop: multiHop,
 		}
 

--- a/pkg/bgp/peers.go
+++ b/pkg/bgp/peers.go
@@ -84,18 +84,9 @@ func (b *Server) getPath(ip net.IP) *api.Path {
 		Origin: 0,
 	})
 
-	var nh string
-	if b.c.NextHop != "" {
-		nh = b.c.NextHop
-	} else if b.c.SourceIP != "" {
-		nh = b.c.SourceIP
-	} else {
-		nh = b.c.RouterID
-	}
-
 	//nolint
 	a2, _ := ptypes.MarshalAny(&api.NextHopAttribute{
-		NextHop: nh,
+		NextHop: "0.0.0.0", // gobgp will fill this
 	})
 
 	return &api.Path{

--- a/pkg/bgp/types.go
+++ b/pkg/bgp/types.go
@@ -14,12 +14,10 @@ type Peer struct {
 type Config struct {
 	AS       uint32
 	RouterID string
-	NextHop  string
 	SourceIP string
 	SourceIF string
 
 	Peers []Peer
-	IPv6  bool
 }
 
 // Server manages a server object


### PR DESCRIPTION
This series of patches allow kube-vip to advertise IPv6 VIPs and setup IPv6 peers. Also improve BGP support slightly.

See commit messages for detailed description.