### PR TITLE
Fix service deletion not registering

### DIFF
--- a/pkg/manager/watch_services.go
+++ b/pkg/manager/watch_services.go
@@ -160,7 +160,7 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 					}
 					wg.Done()
 				}
-
+				activeService[string(svc.UID)] = true
 			}
 		case watch.Deleted:
 			svc, ok := event.Object.(*v1.Service)


### PR DESCRIPTION
Ever since https://github.com/kube-vip/kube-vip/commit/36f42300c4e8024e9f819a73212ec1c23d1b522b,  `kube-vip` no longer responds to service deletion events, and thus does not release the VIP assigned to the network interface.

I tested the fix in production and it seems to behave correctly now:

```
time="2023-02-02T10:31:39Z" level=info msg="[LOADBALANCER] Stopping load balancers"
time="2023-02-02T10:31:39Z" level=info msg="[VIP] Releasing the Virtual IP [172.16.254.107]"
time="2023-02-02T10:31:39Z" level=info msg="Removed [b1756287-944c-492a-8554-0b5801134f88] from manager, [17] advertised services remain"
time="2023-02-02T10:31:39Z" level=info msg="service [util/translations-upload] has been deleted"
```