### PR TITLE
Fixes and testing for endpoints

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -210,7 +210,6 @@ var kubeVipManager = &cobra.Command{
 	Short: "Start the kube-vip manager",
 	Run: func(cmd *cobra.Command, args []string) {
 
-		log.Infof("Starting kube-vip.io [%s]", Release.Version)
 		// parse environment variables, these will overwrite anything loaded or flags
 		err := kubevip.ParseEnvironment(&initConfig)
 		if err != nil {
@@ -219,6 +218,10 @@ var kubeVipManager = &cobra.Command{
 
 		// Set the logging level for all subsequent functions
 		log.SetLevel(log.Level(initConfig.Logging))
+
+		// Welome messages
+		log.Infof("Starting kube-vip.io [%s]", Release.Version)
+		log.Debugf("Build kube-vip.io [%s]", Release.Build)
 
 		// start prometheus server
 		if initConfig.PrometheusHTTPServer != "" {


### PR DESCRIPTION
Signed-off-by: Dan Finneran <daniel.finneran@gmail.com>

Fixes a rare event where an endpoint would be recreated on the same node as the other one was still regarded as existing.. this would leave the endpoint updates in an inconclusive state.. now if the existing endpoint is deleted then the correct logic path will ensure a new leaderElection.

