### PR TITLE
check for new equinix ccm annotations

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -314,7 +314,7 @@ var kubeVipManager = &cobra.Command{
 			configMap = envConfigMap
 		}
 
-		// If Packet is enabled and there is a provider configuration passed
+		// If Equinix Metal is enabled and there is a provider configuration passed
 		if initConfig.EnableMetal {
 			if providerConfig != "" {
 				providerAPI, providerProject, err := equinixmetal.GetPacketConfig(providerConfig)

--- a/docs/hybrid/daemonset/index.md
+++ b/docs/hybrid/daemonset/index.md
@@ -153,7 +153,23 @@ kube-vip manifest daemonset \
 
 ### Troubleshooting
 
-If `kube-vip` has been sat waiting for a long time then you may need to investigate that the annotations have been applied correctly by doing running the `describe` on the node:
+If `kube-vip` has been sat waiting for a long time then you may need to investigate that the annotations have been applied correctly by doing running the `describe` on the node.
+As of Equinix Metal's CCM v3.3.0, the annotations format was changed. This means, you should expect either of the following:
+
+1. Equinix Metal's CCM v3.3.0 onwards:
+
+```
+kubectl describe node k8s.bgp02
+...
+Annotations:        kubeadm.alpha.kubernetes.io/cri-socket: /var/run/dockershim.sock
+                    node.alpha.kubernetes.io/ttl: 0
+                    metal.equinix.com/bgp-peers-0-node-asn: 65000
+                    metal.equinix.com/bgp-peers-0-peer-asn: 65530
+                    metal.equinix.com/bgp-peers-0-peer-ip: x.x.x.x
+                    metal.equinix.com/bgp-peers-0-src-ip: x.x.x.x
+```
+
+2. Equinix Metal's CCM before v3.0.0:
 
 ```
 kubectl describe node k8s.bgp02

--- a/docs/usage/EquinixMetal/index.md
+++ b/docs/usage/EquinixMetal/index.md
@@ -123,7 +123,23 @@ kubectl expose deployment nginx-deployment --port=80 --type=LoadBalancer --name=
 
 ## Troubleshooting
 
-If `kube-vip` has been sat waiting for a long time then you may need to investigate that the annotations have been applied correctly by doing running the `describe` on the node:
+If `kube-vip` has been sat waiting for a long time then you may need to investigate that the annotations have been applied correctly by doing running the `describe` on the node.
+As of Equinix Metal's CCM v3.3.0, the annotations format was changed. This means, you should expect either of the following:
+
+1. Equinix Metal's CCM v3.3.0 onwards:
+
+```
+kubectl describe node k8s.bgp02
+...
+Annotations:        kubeadm.alpha.kubernetes.io/cri-socket: /var/run/dockershim.sock
+                    node.alpha.kubernetes.io/ttl: 0
+                    metal.equinix.com/bgp-peers-0-node-asn: 65000
+                    metal.equinix.com/bgp-peers-0-peer-asn: 65530
+                    metal.equinix.com/bgp-peers-0-peer-ip: x.x.x.x
+                    metal.equinix.com/bgp-peers-0-src-ip: x.x.x.x
+```
+
+2. Equinix Metal's CCM before v3.0.0:
 
 ```
 kubectl describe node k8s.bgp02

--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -74,7 +74,6 @@ func NewManager(path string, inCluster bool, port int) (*Manager, error) {
 
 // StartCluster - Begins a running instance of the Leader Election cluster
 func (cluster *Cluster) StartCluster(c *kubevip.Config, sm *Manager, bgpServer *bgp.Server) error {
-
 	id, err := os.Hostname()
 	if err != nil {
 		return err
@@ -141,7 +140,7 @@ func (cluster *Cluster) StartCluster(c *kubevip.Config, sm *Manager, bgpServer *
 		}
 	}()
 
-	// If Packet is enabled then we can begin our preparation work
+	// If Equinix Metal is enabled then we can begin our preparation work
 	var packetClient *packngo.Client
 	if c.EnableMetal {
 		if c.ProviderConfig != "" {
@@ -160,9 +159,9 @@ func (cluster *Cluster) StartCluster(c *kubevip.Config, sm *Manager, bgpServer *
 			log.Error(err)
 		}
 
-		// We're using Packet with BGP, popuplate the Peer information from the API
+		// We're using Equinix Metal with BGP, populate the Peer information from the API
 		if c.EnableBGP {
-			log.Infoln("Looking up the BGP configuration from packet")
+			log.Infoln("Looking up the BGP configuration from Equinix Metal")
 			err = equinixmetal.BGPLookup(packetClient, c)
 			if err != nil {
 				log.Error(err)
@@ -199,7 +198,6 @@ func (cluster *Cluster) StartCluster(c *kubevip.Config, sm *Manager, bgpServer *
 				if err != nil {
 					log.Errorf("Error starting the VIP service on the leader [%s]", err)
 				}
-
 			},
 			OnStoppedLeading: func() {
 				// we can do cleanup here
@@ -260,7 +258,7 @@ func (sm *Manager) NodeWatcher(lb *loadbalancer.IPVSLoadBalancer, port int) erro
 	}()
 
 	ch := rw.ResultChan()
-	//defer rw.Stop()
+	// defer rw.Stop()
 
 	for event := range ch {
 		// We need to inspect the event and get ResourceVersion out of it
@@ -270,9 +268,8 @@ func (sm *Manager) NodeWatcher(lb *loadbalancer.IPVSLoadBalancer, port int) erro
 			if !ok {
 				return fmt.Errorf("unable to parse Kubernetes Node from Annotation watcher")
 			}
-			//Find the node IP address (this isn't foolproof)
+			// Find the node IP address (this isn't foolproof)
 			for x := range node.Status.Addresses {
-
 				if node.Status.Addresses[x].Type == v1.NodeInternalIP {
 					err = lb.AddBackend(node.Status.Addresses[x].Address, port)
 					if err != nil {
@@ -286,9 +283,8 @@ func (sm *Manager) NodeWatcher(lb *loadbalancer.IPVSLoadBalancer, port int) erro
 				return fmt.Errorf("unable to parse Kubernetes Node from Annotation watcher")
 			}
 
-			//Find the node IP address (this isn't foolproof)
+			// Find the node IP address (this isn't foolproof)
 			for x := range node.Status.Addresses {
-
 				if node.Status.Addresses[x].Type == v1.NodeInternalIP {
 					err = lb.RemoveBackend(node.Status.Addresses[x].Address, port)
 					if err != nil {
@@ -309,7 +305,6 @@ func (sm *Manager) NodeWatcher(lb *loadbalancer.IPVSLoadBalancer, port int) erro
 			statusErr, ok := errObject.(*apierrors.StatusError)
 			if !ok {
 				log.Errorf(spew.Sprintf("Received an error which is not *metav1.Status but %#+v", event.Object))
-
 			}
 
 			status := statusErr.ErrStatus
@@ -320,5 +315,4 @@ func (sm *Manager) NodeWatcher(lb *loadbalancer.IPVSLoadBalancer, port int) erro
 
 	log.Infoln("Exiting Node watcher")
 	return nil
-
 }

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -52,10 +52,10 @@ func (cluster *Cluster) vipService(ctxArp, ctxDNS context.Context, c *kubevip.Co
 	}
 
 	if c.EnableMetal {
-		// We're not using Packet with BGP
+		// We're not using Equinix Metal with BGP
 		if !c.EnableBGP {
 			// Attempt to attach the EIP in the standard manner
-			log.Debugf("Attaching the Packet EIP through the API to this host")
+			log.Debugf("Attaching the Equinix Metal EIP through the API to this host")
 			err = equinixmetal.AttachEIP(packetClient, c, id)
 			if err != nil {
 				log.Error(err)
@@ -101,7 +101,7 @@ func (cluster *Cluster) vipService(ctxArp, ctxDNS context.Context, c *kubevip.Co
 	}
 
 	if c.EnableARP {
-		//ctxArp, cancelArp = context.WithCancel(context.Background())
+		// ctxArp, cancelArp = context.WithCancel(context.Background())
 
 		ipString := cluster.Network.IP()
 
@@ -191,7 +191,7 @@ func (cluster *Cluster) StartLoadBalancerService(c *kubevip.Config, bgp *bgp.Ser
 		}
 	}
 	if c.EnableARP {
-		//ctxArp, cancelArp = context.WithCancel(context.Background())
+		// ctxArp, cancelArp = context.WithCancel(context.Background())
 
 		ipString := cluster.Network.IP()
 

--- a/pkg/equinixmetal/bgp.go
+++ b/pkg/equinixmetal/bgp.go
@@ -22,7 +22,7 @@ func BGPLookup(c *packngo.Client, k *kubevip.Config) error {
 		thisDevice = findSelf(c, k.MetalProjectID)
 	}
 	if thisDevice == nil {
-		return fmt.Errorf("Unable to find local/this device in packet API")
+		return fmt.Errorf("Unable to find local/this device in Equinix Metal API")
 	}
 
 	fmt.Printf("Querying BGP settings for [%s]", thisDevice.Hostname)

--- a/pkg/equinixmetal/eip.go
+++ b/pkg/equinixmetal/eip.go
@@ -9,9 +9,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// AttachEIP will use the packet APIs to move an EIP and attach to a host
+// AttachEIP will use the Equinix Metal APIs to move an EIP and attach to a host
 func AttachEIP(c *packngo.Client, k *kubevip.Config, hostname string) error {
-
 	// Use MetalProjectID if it is defined
 	projID := k.MetalProjectID
 
@@ -33,7 +32,6 @@ func AttachEIP(c *packngo.Client, k *kubevip.Config, hostname string) error {
 
 	ips, _, _ := c.ProjectIPs.List(projID, &packngo.ListOptions{})
 	for _, ip := range ips {
-
 		// Find the device id for our EIP
 		if ip.Address == vip {
 			log.Infof("Found EIP ->%s ID -> %s\n", ip.Address, ip.ID)
@@ -48,10 +46,10 @@ func AttachEIP(c *packngo.Client, k *kubevip.Config, hostname string) error {
 		}
 	}
 
-	// Lookup this server through the packet API
+	// Lookup this server through the Equinix Metal API
 	thisDevice := findSelf(c, projID)
 	if thisDevice == nil {
-		return fmt.Errorf("unable to find local/this device in packet API")
+		return fmt.Errorf("unable to find local/this device in Equinix Metal API")
 	}
 
 	// Assign the EIP to this device

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -10,7 +10,6 @@ import (
 
 // ParseEnvironment - will popultate the configuration from environment variables
 func ParseEnvironment(c *Config) error {
-
 	// Ensure that logging is set through the environment variables
 	env := os.Getenv(vipLogLevel)
 	// Set default value
@@ -345,7 +344,7 @@ func ParseEnvironment(c *Config) error {
 		c.BGPConfig.Peers = append(c.BGPConfig.Peers, c.BGPPeerConfig)
 	}
 
-	// Enable the Packet API calls
+	// Enable the Equinix Metal API calls
 	env = os.Getenv(vipPacket)
 	if env != "" {
 		b, err := strconv.ParseBool(env)
@@ -355,14 +354,14 @@ func ParseEnvironment(c *Config) error {
 		c.EnableMetal = b
 	}
 
-	// Find the Packet project name
+	// Find the Equinix Metal project name
 	env = os.Getenv(vipPacketProject)
 	if env != "" {
 		// TODO - parse address net.Host()
 		c.MetalProject = env
 	}
 
-	// Find the Packet project ID
+	// Find the Equinix Metal project ID
 	env = os.Getenv(vipPacketProjectID)
 	if env != "" {
 		// TODO - parse address net.Host()

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -191,7 +191,7 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 		newEnvironment = append(newEnvironment, provider...)
 	}
 
-	// If Packet is enabled then add it to the manifest
+	// If Equinix Metal is enabled then add it to the manifest
 	if c.EnableMetal {
 		packet := []corev1.EnvVar{
 			{
@@ -343,7 +343,6 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 
 	if c.PrometheusHTTPServer != "" {
 		prometheus := []corev1.EnvVar{
-
 			{
 				Name:  prometheusServer,
 				Value: c.PrometheusHTTPServer,
@@ -434,7 +433,6 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 	}
 
 	return newManifest
-
 }
 
 // GeneratePodManifestFromConfig will take a kube-vip config and generate a manifest
@@ -446,7 +444,6 @@ func GeneratePodManifestFromConfig(c *Config, imageVersion string, inCluster boo
 
 // GenerateDaemonsetManifestFromConfig will take a kube-vip config and generate a manifest
 func GenerateDaemonsetManifestFromConfig(c *Config, imageVersion string, inCluster, taint bool) string {
-
 	// Determine where the pod should be deployed
 	var namespace string
 	if c.ServiceNamespace != "" {

--- a/pkg/manager/manager_bgp.go
+++ b/pkg/manager/manager_bgp.go
@@ -37,7 +37,7 @@ func (sm *Manager) startBGP() error {
 			log.Error(err)
 		}
 
-		// We're using Packet with BGP, popuplate the Peer information from the API
+		// We're using Packet with BGP, populate the Peer information from the API
 		if sm.config.EnableBGP {
 			log.Infoln("Looking up the BGP configuration from packet")
 			err = equinixmetal.BGPLookup(packetClient, sm.config)

--- a/pkg/manager/manager_bgp.go
+++ b/pkg/manager/manager_bgp.go
@@ -15,10 +15,10 @@ import (
 // Start will begin the Manager, which will start services and watch the configmap
 func (sm *Manager) startBGP() error {
 	var cpCluster *cluster.Cluster
-	//var ns string
+	// var ns string
 	var err error
 
-	// If Packet is enabled then we can begin our preparation work
+	// If Equinix Metal is enabled then we can begin our preparation work
 	var packetClient *packngo.Client
 	if sm.config.EnableMetal {
 		if sm.config.ProviderConfig != "" {
@@ -37,9 +37,9 @@ func (sm *Manager) startBGP() error {
 			log.Error(err)
 		}
 
-		// We're using Packet with BGP, populate the Peer information from the API
+		// We're using Equinix Metal with BGP, populate the Peer information from the API
 		if sm.config.EnableBGP {
-			log.Infoln("Looking up the BGP configuration from packet")
+			log.Infoln("Looking up the BGP configuration from Equinix Metal")
 			err = equinixmetal.BGPLookup(packetClient, sm.config)
 			if err != nil {
 				log.Error(err)

--- a/pkg/service/manager_bgp.go
+++ b/pkg/service/manager_bgp.go
@@ -14,8 +14,7 @@ import (
 
 // Start will begin the Manager, which will start services and watch the configmap
 func (sm *Manager) startBGP() error {
-
-	// If Packet is enabled then we can begin our preparation work
+	// If Equinix Metal is enabled then we can begin our preparation work
 	var packetClient *packngo.Client
 	var err error
 	if sm.config.EnableMetal {
@@ -24,7 +23,7 @@ func (sm *Manager) startBGP() error {
 			log.Error(err)
 		}
 
-		// We're using Packet with BGP, popuplate the Peer information from the API
+		// We're using Equinix Metal with BGP, populate the Peer information from the API
 		if sm.config.EnableBGP {
 			log.Infoln("Looking up the BGP configuration from packet")
 			err = equinixmetal.BGPLookup(packetClient, sm.config)


### PR DESCRIPTION
This PR aims to fix issue https://github.com/kube-vip/kube-vip/issues/393

With this solutions it should work with both legacy and new annotations format since it looks for `metal.equinix.com/bgp-peers-0-<info>` or `metal.equinix.com/<info>` an as I understand it, it only works with one neighbour, so `metal.equinix.com/bgp-peers-1-<info>` annotations are not needed

The existing test https://github.com/kube-vip/kube-vip/blob/a92c536de25683f93161819c6630b62538166f16/pkg/manager/watcher_test.go#L67-L83 might be enough to check if this change works