### PR TITLE
Readd VIP if address has dadfailed flag

### DIFF
--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -104,9 +104,10 @@ func (cluster *Cluster) vipService(ctxArp, ctxDNS context.Context, c *kubevip.Co
 		//ctxArp, cancelArp = context.WithCancel(context.Background())
 
 		ipString := cluster.Network.IP()
+		isIPv6 := vip.IsIPv6(ipString)
 
 		var ndp *vip.NdpResponder
-		if vip.IsIPv6(ipString) {
+		if isIPv6 {
 			ndp, err = vip.NewNDPResponder(c.Interface)
 			if err != nil {
 				log.Fatalf("failed to create new NDP Responder")
@@ -123,32 +124,7 @@ func (cluster *Cluster) vipService(ctxArp, ctxDNS context.Context, c *kubevip.Co
 				case <-ctx.Done(): // if cancel() execute
 					return
 				default:
-					// Ensure the address exists on the interface before attempting to ARP
-					set, err := cluster.Network.IsSet()
-					if err != nil {
-						log.Warnf("%v", err)
-					}
-					if !set {
-						log.Warnf("Re-applying the VIP configuration [%s] to the interface [%s]", ipString, c.Interface)
-						err = cluster.Network.AddIP()
-						if err != nil {
-							log.Warnf("%v", err)
-						}
-					}
-
-					if vip.IsIPv4(ipString) {
-						// Gratuitous ARP, will broadcast to new MAC <-> IPv4 address
-						err := vip.ARPSendGratuitous(ipString, c.Interface)
-						if err != nil {
-							log.Warnf("%v", err)
-						}
-					} else {
-						// Gratuitous NDP, will broadcast new MAC <-> IPv6 address
-						err := ndp.SendGratuitous(ipString)
-						if err != nil {
-							log.Warnf("%v", err)
-						}
-					}
+					cluster.ensureIPAndSendGratuitous(c.Interface, ndp)
 				}
 				time.Sleep(3 * time.Second)
 			}
@@ -213,32 +189,7 @@ func (cluster *Cluster) StartLoadBalancerService(c *kubevip.Config, bgp *bgp.Ser
 				case <-ctx.Done(): // if cancel() execute
 					return
 				default:
-					// Ensure the address exists on the interface before attempting to ARP
-					set, err := cluster.Network.IsSet()
-					if err != nil {
-						log.Warnf("%v", err)
-					}
-					if !set {
-						log.Warnf("Re-applying the VIP configuration [%s] to the interface [%s]", ipString, c.Interface)
-						err = cluster.Network.AddIP()
-						if err != nil {
-							log.Warnf("%v", err)
-						}
-					}
-
-					if vip.IsIPv4(ipString) {
-						// Gratuitous ARP, will broadcast to new MAC <-> IPv4 address
-						err := vip.ARPSendGratuitous(ipString, c.Interface)
-						if err != nil {
-							log.Warnf("%v", err)
-						}
-					} else {
-						// Gratuitous NDP, will broadcast new MAC <-> IPv6 address
-						err := ndp.SendGratuitous(ipString)
-						if err != nil {
-							log.Warnf("%v", err)
-						}
-					}
+					cluster.ensureIPAndSendGratuitous(c.Interface, ndp)
 				}
 				if c.ArpBroadcastRate < 500 {
 					log.Errorf("arp broadcast rate is [%d], this shouldn't be lower that 300ms (defaulting to 3000)", c.ArpBroadcastRate)
@@ -280,4 +231,47 @@ func (cluster *Cluster) StartLoadBalancerService(c *kubevip.Config, bgp *bgp.Ser
 			}
 		}
 	}()
+}
+
+// ensureIPAndSendGratuitous - adds IP to the interface if missing, and send
+// either a gratuitous ARP or gratuitous NDP. Re-adds the interface if it is IPv6
+// and in a dadfailed state.
+func (cluster *Cluster) ensureIPAndSendGratuitous(iface string, ndp *vip.NdpResponder) {
+	ipString := cluster.Network.IP()
+	isIPv6 := vip.IsIPv6(ipString)
+	// Check if IP is dadfailed
+	if cluster.Network.IsDADFAIL() {
+		log.Warnf("IP address is in dadfailed state, removing [%s] from interface [%s]", ipString, iface)
+		err := cluster.Network.DeleteIP()
+		if err != nil {
+			log.Warnf("%v", err)
+		}
+	}
+
+	// Ensure the address exists on the interface before attempting to ARP
+	set, err := cluster.Network.IsSet()
+	if err != nil {
+		log.Warnf("%v", err)
+	}
+	if !set {
+		log.Warnf("Re-applying the VIP configuration [%s] to the interface [%s]", ipString, iface)
+		err = cluster.Network.AddIP()
+		if err != nil {
+			log.Warnf("%v", err)
+		}
+	}
+
+	if isIPv6 {
+		// Gratuitous NDP, will broadcast new MAC <-> IPv6 address
+		err := ndp.SendGratuitous(ipString)
+		if err != nil {
+			log.Warnf("%v", err)
+		}
+	} else {
+		// Gratuitous ARP, will broadcast to new MAC <-> IPv4 address
+		err := vip.ARPSendGratuitous(ipString, iface)
+		if err != nil {
+			log.Warnf("%v", err)
+		}
+	}
 }


### PR DESCRIPTION
Remove and re-add the address to the interface in the case that a duplicate address is detected. Without this change, kube-vip will take no corrective action, and the address will remain in dadfailed state. Removing and re adding the address causes duplicate address detection to happen again, hopefully successfully the next time. This behavior only applys to IPv6 addresses, as IPv4 addresses cannot get into the dadfailed state.

We suspect dadfailed happens when a new leader is elected and the old leader is too slow or fails to delete the IP address.

We attempted to add a test, but we find it impossible to reliably trigger a dadfailed state on the leader node. During manual testing we were occasionally trigger the scenario and see that this PR has the desired effect.

fixes: #523  