### PR TITLE
Ensures multi-tenant egress

### DIFF
--- a/pkg/manager/instance.go
+++ b/pkg/manager/instance.go
@@ -73,6 +73,7 @@ func NewInstance(service *v1.Service, config *kubevip.Config) (*Instance, error)
 		Vip:             instanceAddress,
 		serviceSnapshot: service,
 	}
+
 	if len(service.Spec.Ports) > 0 {
 		instance.Type = string(service.Spec.Ports[0].Protocol)
 		instance.Port = service.Spec.Ports[0].Port
@@ -89,8 +90,10 @@ func NewInstance(service *v1.Service, config *kubevip.Config) (*Instance, error)
 		Type:      instance.Type,
 		BindToVip: true,
 	}
+
 	// Add Load Balancer Configuration
 	newVip.LoadBalancers = append(newVip.LoadBalancers, newLB)
+
 	// Create Add configuration to the new service
 	instance.vipConfig = newVip
 

--- a/pkg/manager/manager_arp.go
+++ b/pkg/manager/manager_arp.go
@@ -102,7 +102,7 @@ func (sm *Manager) startARP() error {
 
 	// This will tidy any dangling kube-vip iptables rules
 	if os.Getenv("EGRESS_CLEAN") != "" {
-		i, err := vip.CreateIptablesClient()
+		i, err := vip.CreateIptablesClient(sm.config.ServiceNamespace)
 		if err != nil {
 			log.Warnf("[egress] Unable to clean any dangling egress rules [%v]", err)
 		} else {

--- a/pkg/manager/service_egress.go
+++ b/pkg/manager/service_egress.go
@@ -64,7 +64,7 @@ func (sm *Manager) configureEgress(vipIP, podIP, destinationPorts string) error 
 		serviceCidr = defaultServiceCIDR
 	}
 
-	i, err := vip.CreateIptablesClient()
+	i, err := vip.CreateIptablesClient(sm.config.ServiceNamespace)
 	if err != nil {
 		return fmt.Errorf("error Creating iptables client [%s]", err)
 	}
@@ -157,8 +157,8 @@ func (sm *Manager) AutoDiscoverCIDRs() (serviceCIDR, podCIDR string, err error) 
 	return
 }
 
-func TeardownEgress(podIP, vipIP, destinationPorts string) error {
-	i, err := vip.CreateIptablesClient()
+func TeardownEgress(podIP, vipIP, destinationPorts, namespace string) error {
+	i, err := vip.CreateIptablesClient(namespace)
 	if err != nil {
 		return fmt.Errorf("error Creating iptables client [%s]", err)
 	}

--- a/pkg/manager/services.go
+++ b/pkg/manager/services.go
@@ -166,7 +166,7 @@ func (sm *Manager) deleteService(uid string) error {
 				if sm.serviceInstances[x].serviceSnapshot.Annotations[endpoint] != "" {
 
 					log.Infof("service [%s] has an egress re-write enabled", sm.serviceInstances[x].serviceSnapshot.Name)
-					err := TeardownEgress(sm.serviceInstances[x].serviceSnapshot.Annotations[endpoint], sm.serviceInstances[x].serviceSnapshot.Spec.LoadBalancerIP, sm.serviceInstances[x].serviceSnapshot.Annotations[egressDestinationPorts])
+					err := TeardownEgress(sm.serviceInstances[x].serviceSnapshot.Annotations[endpoint], sm.serviceInstances[x].serviceSnapshot.Spec.LoadBalancerIP, sm.serviceInstances[x].serviceSnapshot.Annotations[egressDestinationPorts], sm.serviceInstances[x].serviceSnapshot.Namespace)
 					if err != nil {
 						log.Errorf("%v", err)
 					}

--- a/pkg/vip/egress.go
+++ b/pkg/vip/egress.go
@@ -30,12 +30,14 @@ const Comment = "a3ViZS12aXAK=kube-vip"
 
 type Egress struct {
 	ipTablesClient *iptables.IPTables
+	comment        string
 }
 
-func CreateIptablesClient() (*Egress, error) {
+func CreateIptablesClient(namespace string) (*Egress, error) {
 	e := new(Egress)
 	var err error
 	e.ipTablesClient, err = iptables.New()
+	e.comment = Comment + "-" + namespace
 	return e, err
 }
 
@@ -53,31 +55,31 @@ func (e *Egress) DeleteManglePrerouting(name string) error {
 }
 
 func (e *Egress) DeleteMangleMarking(podIP, name string) error {
-	exists, _ := e.ipTablesClient.Exists("mangle", name, "-s", podIP, "-j", "MARK", "--set-mark", "64/64", "-m", "comment", "--comment", Comment)
+	exists, _ := e.ipTablesClient.Exists("mangle", name, "-s", podIP, "-j", "MARK", "--set-mark", "64/64", "-m", "comment", "--comment", e.comment)
 
 	if !exists {
 		return fmt.Errorf("unable to find source Mangle rule for [%s]", podIP)
 	}
-	return e.ipTablesClient.Delete("mangle", name, "-s", podIP, "-j", "MARK", "--set-mark", "64/64", "-m", "comment", "--comment", Comment)
+	return e.ipTablesClient.Delete("mangle", name, "-s", podIP, "-j", "MARK", "--set-mark", "64/64", "-m", "comment", "--comment", e.comment)
 }
 
 func (e *Egress) DeleteSourceNat(podIP, vip string) error {
-	exists, _ := e.ipTablesClient.Exists("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-m", "comment", "--comment", Comment)
+	exists, _ := e.ipTablesClient.Exists("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-m", "comment", "--comment", e.comment)
 
 	if !exists {
 		return fmt.Errorf("unable to find source Nat rule for [%s]", podIP)
 	}
-	return e.ipTablesClient.Delete("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-m", "comment", "--comment", Comment)
+	return e.ipTablesClient.Delete("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-m", "comment", "--comment", e.comment)
 }
 
 func (e *Egress) DeleteSourceNatForDestinationPort(podIP, vip, port, proto string) error {
 
-	exists, _ := e.ipTablesClient.Exists("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-p", proto, "--dport", port, "-m", "comment", "--comment", Comment)
+	exists, _ := e.ipTablesClient.Exists("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-p", proto, "--dport", port, "-m", "comment", "--comment", e.comment)
 
 	if !exists {
 		return fmt.Errorf("unable to find source Nat rule for [%s], with destination port [%s]", podIP, port)
 	}
-	return e.ipTablesClient.Delete("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-p", proto, "--dport", port, "-m", "comment", "--comment", Comment)
+	return e.ipTablesClient.Delete("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-p", proto, "--dport", port, "-m", "comment", "--comment", e.comment)
 }
 
 func (e *Egress) CreateMangleChain(name string) error {
@@ -89,59 +91,59 @@ func (e *Egress) CreateMangleChain(name string) error {
 }
 func (e *Egress) AppendReturnRulesForDestinationSubnet(name, subnet string) error {
 	log.Infof("[egress] Adding jump for subnet [%s] to RETURN to previous chain/rules", subnet)
-	exists, _ := e.ipTablesClient.Exists("mangle", name, "-d", subnet, "-j", "RETURN", "-m", "comment", "--comment", Comment)
+	exists, _ := e.ipTablesClient.Exists("mangle", name, "-d", subnet, "-j", "RETURN", "-m", "comment", "--comment", e.comment)
 	if !exists {
-		return e.ipTablesClient.Append("mangle", name, "-d", subnet, "-j", "RETURN", "-m", "comment", "--comment", Comment)
+		return e.ipTablesClient.Append("mangle", name, "-d", subnet, "-j", "RETURN", "-m", "comment", "--comment", e.comment)
 	}
 	return nil
 }
 
 func (e *Egress) AppendReturnRulesForMarking(name, subnet string) error {
 	log.Infof("[egress] Marking packets on network [%s]", subnet)
-	exists, _ := e.ipTablesClient.Exists("mangle", name, "-s", subnet, "-j", "MARK", "--set-mark", "64/64", "-m", "comment", "--comment", Comment)
+	exists, _ := e.ipTablesClient.Exists("mangle", name, "-s", subnet, "-j", "MARK", "--set-mark", "64/64", "-m", "comment", "--comment", e.comment)
 	if !exists {
-		return e.ipTablesClient.Append("mangle", name, "-s", subnet, "-j", "MARK", "--set-mark", "64/64", "-m", "comment", "--comment", Comment)
+		return e.ipTablesClient.Append("mangle", name, "-s", subnet, "-j", "MARK", "--set-mark", "64/64", "-m", "comment", "--comment", e.comment)
 	}
 	return nil
 }
 
 func (e *Egress) InsertMangeTableIntoPrerouting(name string) error {
 	log.Infof("[egress] Adding jump from mangle prerouting to [%s]", name)
-	if exists, err := e.ipTablesClient.Exists("mangle", "PREROUTING", "-j", name, "-m", "comment", "--comment", Comment); err != nil {
+	if exists, err := e.ipTablesClient.Exists("mangle", "PREROUTING", "-j", name, "-m", "comment", "--comment", e.comment); err != nil {
 		return err
 	} else if exists {
-		if err2 := e.ipTablesClient.Delete("mangle", "PREROUTING", "-j", name, "-m", "comment", "--comment", Comment); err2 != nil {
+		if err2 := e.ipTablesClient.Delete("mangle", "PREROUTING", "-j", name, "-m", "comment", "--comment", e.comment); err2 != nil {
 			return err2
 		}
 	}
 
-	return e.ipTablesClient.Insert("mangle", "PREROUTING", 1, "-j", name, "-m", "comment", "--comment", Comment)
+	return e.ipTablesClient.Insert("mangle", "PREROUTING", 1, "-j", name, "-m", "comment", "--comment", e.comment)
 }
 
 func (e *Egress) InsertSourceNat(vip, podIP string) error {
 	log.Infof("[egress] Adding source nat from [%s] => [%s]", podIP, vip)
-	if exists, err := e.ipTablesClient.Exists("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-m", "comment", "--comment", Comment); err != nil {
+	if exists, err := e.ipTablesClient.Exists("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-m", "comment", "--comment", e.comment); err != nil {
 		return err
 	} else if exists {
-		if err2 := e.ipTablesClient.Delete("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-m", "comment", "--comment", Comment); err2 != nil {
+		if err2 := e.ipTablesClient.Delete("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-m", "comment", "--comment", e.comment); err2 != nil {
 			return err2
 		}
 	}
 
-	return e.ipTablesClient.Insert("nat", "POSTROUTING", 1, "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-m", "comment", "--comment", Comment)
+	return e.ipTablesClient.Insert("nat", "POSTROUTING", 1, "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-m", "comment", "--comment", e.comment)
 }
 
 func (e *Egress) InsertSourceNatForDestinationPort(vip, podIP, port, proto string) error {
 	log.Infof("[egress] Adding source nat from [%s] => [%s], with destination port [%s]", podIP, vip, port)
-	if exists, err := e.ipTablesClient.Exists("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-p", proto, "--dport", port, "-m", "comment", "--comment", Comment); err != nil {
+	if exists, err := e.ipTablesClient.Exists("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-p", proto, "--dport", port, "-m", "comment", "--comment", e.comment); err != nil {
 		return err
 	} else if exists {
-		if err2 := e.ipTablesClient.Delete("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-p", proto, "--dport", port, "-m", "comment", "--comment", Comment); err2 != nil {
+		if err2 := e.ipTablesClient.Delete("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-p", proto, "--dport", port, "-m", "comment", "--comment", e.comment); err2 != nil {
 			return err2
 		}
 	}
 
-	return e.ipTablesClient.Insert("nat", "POSTROUTING", 1, "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-p", proto, "--dport", port, "-m", "comment", "--comment", Comment)
+	return e.ipTablesClient.Insert("nat", "POSTROUTING", 1, "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-p", proto, "--dport", port, "-m", "comment", "--comment", e.comment)
 }
 
 func DeleteExistingSessions(sessionIP string, destination bool) error {
@@ -207,7 +209,7 @@ func (e *Egress) CleanIPtables() error {
 	if err != nil {
 		return err
 	}
-	foundNatRules := findRules(natRules)
+	foundNatRules := e.findRules(natRules)
 	log.Warnf("[egress] Cleaning [%d] dangling postrouting nat rules", len(foundNatRules))
 	for x := range foundNatRules {
 		err = e.ipTablesClient.Delete("nat", "POSTROUTING", foundNatRules[x][2:]...)
@@ -220,7 +222,7 @@ func (e *Egress) CleanIPtables() error {
 	if err != nil {
 		return err
 	}
-	foundNatRules = findRules(mangleRules)
+	foundNatRules = e.findRules(mangleRules)
 	log.Warnf("[egress] Cleaning [%d] dangling prerouting mangle rules", len(foundNatRules))
 	for x := range foundNatRules {
 		err = e.ipTablesClient.Delete("mangle", MangleChainName, foundNatRules[x][2:]...)
@@ -231,14 +233,14 @@ func (e *Egress) CleanIPtables() error {
 	return nil
 }
 
-func findRules(rules []string) [][]string {
+func (e *Egress) findRules(rules []string) [][]string {
 	var foundRules [][]string
 
 	for i := range rules {
 		r := strings.Split(rules[i], " ")
 		for x := range r {
-			if r[x] == "\""+Comment+"\"" {
-				// Remove the quotes around the comment
+			if r[x] == "\""+e.comment+"\"" {
+				// Remove the quotes around the e.comment
 				r[x] = strings.Trim(r[x], "\"")
 				foundRules = append(foundRules, r)
 			}

--- a/pkg/vip/egress_test.go
+++ b/pkg/vip/egress_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func Test_findRules(t *testing.T) {
+	e := Egress{comment: Comment + "-" + "default"}
 	type args struct {
 		rules []string
 	}
@@ -15,20 +16,19 @@ func Test_findRules(t *testing.T) {
 		args args
 		want [][]string
 	}{
-
 		{
 			"test",
 			args{[]string{
 				"-A PREROUTING -m comment --comment \"cali:6gwbT8clXdHdC1b1\" -j cali-PREROUTING",
-				fmt.Sprintf("-A KUBE-VIP-EGRESS -s 172.17.88.190/32 -m comment --comment \"%s\" -j MARK --set-xmark 0x40/0x40", Comment),
-				fmt.Sprintf("-A POSTROUTING -m comment --comment \"%s\" -j RETURN", Comment),
+				fmt.Sprintf("-A KUBE-VIP-EGRESS -s 172.17.88.190/32 -m comment --comment \"%s\" -j MARK --set-xmark 0x40/0x40", e.comment),
+				fmt.Sprintf("-A POSTROUTING -m comment --comment \"%s\" -j RETURN", e.comment),
 			}},
-			[][]string{{"-A", "KUBE-VIP-EGRESS", "-s", "172.17.88.190/32", "-m", "comment", "--comment", Comment, "-j", "MARK", "--set-xmark", "0x40/0x40"}, {"-A", "POSTROUTING", "-m", "comment", "--comment", Comment, "-j", "RETURN"}},
+			[][]string{{"-A", "KUBE-VIP-EGRESS", "-s", "172.17.88.190/32", "-m", "comment", "--comment", e.comment, "-j", "MARK", "--set-xmark", "0x40/0x40"}, {"-A", "POSTROUTING", "-m", "comment", "--comment", e.comment, "-j", "RETURN"}},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := findRules(tt.args.rules); !reflect.DeepEqual(got, tt.want) {
+			if got := e.findRules(tt.args.rules); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("findRules() = \n%v, want \n%v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
This allows the same node to do egress for multiple tenants without the EGRESS_CLEAN removing *all* rules. It will now only clean rules for the namespace the kube-vip pod is running in.

```
Chain KUBE-VIP-EGRESS (2 references)
target     prot opt source               destination
RETURN     all  --  anywhere             10.0.0.0/16          /* a3ViZS12aXAK=kube-vip-hr */
RETURN     all  --  anywhere             10.96.0.0/12         /* a3ViZS12aXAK=kube-vip-hr */
MARK       all  --  10.0.1.189           anywhere             /* a3ViZS12aXAK=kube-vip-hr */ MARK or 0x40
RETURN     all  --  anywhere             10.0.0.0/16          /* a3ViZS12aXAK=kube-vip-finance */
RETURN     all  --  anywhere             10.96.0.0/12         /* a3ViZS12aXAK=kube-vip-finance */
MARK       all  --  10.0.1.149           anywhere             /* a3ViZS12aXAK=kube-vip-finance */ MARK or 0x40
```

Kill the kube-vip pod in the _hr_ namespace and...

```
dan@k02:~$ sudo iptables-legacy -L -t mangle
...
Chain KUBE-VIP-EGRESS (2 references)
target     prot opt source               destination
RETURN     all  --  anywhere             10.0.0.0/16          /* a3ViZS12aXAK=kube-vip-finance */
RETURN     all  --  anywhere             10.96.0.0/12         /* a3ViZS12aXAK=kube-vip-finance */
MARK       all  --  10.0.1.149           anywhere             /* a3ViZS12aXAK=kube-vip-finance */ MARK or 0x40
RETURN     all  --  anywhere             10.0.0.0/16          /* a3ViZS12aXAK=kube-vip-hr */
RETURN     all  --  anywhere             10.96.0.0/12         /* a3ViZS12aXAK=kube-vip-hr */
MARK       all  --  10.0.1.189           anywhere             /* a3ViZS12aXAK=kube-vip-hr */ MARK or 0x40
```