### PR TITLE
Ignore different family on IPVS delete

### DIFF
--- a/pkg/loadbalancer/ipvs.go
+++ b/pkg/loadbalancer/ipvs.go
@@ -160,6 +160,10 @@ func (lb *IPVSLoadBalancer) AddBackend(address string, port int) error {
 
 func (lb *IPVSLoadBalancer) RemoveBackend(address string, port int) error {
 	ip, family := ipAndFamily(address)
+	if family != lb.loadBalancerService.Family {
+		return nil
+	}
+
 	dst := ipvs.Destination{
 		Address: ip,
 		Port:    uint16(port),


### PR DESCRIPTION
Looks like I missed the remove path in my previous PR and this corrects that.