### PR TITLE
Set iptables rules to restrict user access to ports other than the load balancer service port through the VIP

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -130,6 +130,7 @@ func init() {
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableServicesElection, "servicesElection", false, "Enable leader election per kubernetes service")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.LoadBalancerClassOnly, "lbClassOnly", false, "Enable load balancing only for services with LoadBalancerClass \"kube-vip.io/kube-vip-class\"")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.LoadBalancerClassName, "lbClassName", "kube-vip.io/kube-vip-class", "Name of load balancer class for kube-VIP, defaults to \"kube-vip.io/kube-vip-class\"")
+	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableServiceSecurity, "onlyAllowTrafficServicePorts", false, "Only allow traffic to service ports, others will be dropped, defaults to false")
 
 	// Prometheus HTTP Server
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.PrometheusHTTPServer, "prometheusHTTPServer", ":2112", "Host and port used to expose Prometheus metrics via an HTTP server")

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -3,6 +3,8 @@ package cluster
 import (
 	"sync"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/vip"
 )
@@ -31,6 +33,8 @@ func InitCluster(c *kubevip.Config, disableVIP bool) (*Cluster, error) {
 	newCluster := &Cluster{
 		Network: network,
 	}
+
+	log.Debugf("init enable service security: %t", c.EnableServiceSecurity)
 
 	return newCluster, nil
 }

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -63,6 +63,11 @@ const (
 	ProtocolIPv6
 )
 
+const (
+	TableFilter = "filter"
+	ChainInput  = "INPUT"
+)
+
 type IPTables struct {
 	path              string
 	proto             Protocol
@@ -718,4 +723,15 @@ func filterRuleOutput(rule string) string {
 	}
 
 	return out
+}
+
+func GetIPTablesRuleSpecification(rule, specification string) string {
+	parts := strings.Split(rule, " ")
+	for i, part := range parts {
+		if part == specification && i+1 < len(parts) {
+			return parts[i+1]
+		}
+	}
+
+	return ""
 }

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -167,7 +167,7 @@ func ParseEnvironment(c *Config) error {
 		if env != "" {
 			c.LoadBalancerClassName = env
 		}
-		
+
 		// Find the namespace that the control plane should use (for leaderElection lock)
 		env = os.Getenv(svcNamespace)
 		if env != "" {
@@ -398,6 +398,15 @@ func ParseEnvironment(c *Config) error {
 	env = os.Getenv(lbForwardingMethod)
 	if env != "" {
 		c.LoadBalancerForwardingMethod = env
+	}
+
+	env = os.Getenv(EnableServiceSecurity)
+	if env != "" {
+		b, err := strconv.ParseBool(env)
+		if err != nil {
+			return err
+		}
+		c.EnableServiceSecurity = b
 	}
 
 	// Find Prometheus configuration

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -135,7 +135,7 @@ const (
 
 	//lbClassName enables load-balancer for a specific class only
 	lbClassName = "lb_class_name"
-	
+
 	//lbEnable defines if the load-balancer should be enabled
 	lbEnable = "lb_enable"
 
@@ -144,6 +144,9 @@ const (
 
 	//lbForwardingMethod defines the forwarding method of load-balancer
 	lbForwardingMethod = "lb_fwdmethod"
+
+	// EnableServiceSecurity defines if the load-balancer should only allow traffic to service ports
+	EnableServiceSecurity = "enable_service_security"
 
 	//prometheusServer defines the address prometheus listens on
 	prometheusServer = "prometheus_server"

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -127,6 +127,15 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 			}
 			newEnvironment = append(newEnvironment, lbClassOnlyVar...)
 		}
+		if c.EnableServiceSecurity {
+			EnableServiceSecurityVar := []corev1.EnvVar{
+				{
+					Name:  EnableServiceSecurity,
+					Value: strconv.FormatBool(c.EnableServiceSecurity),
+				},
+			}
+			newEnvironment = append(newEnvironment, EnableServiceSecurityVar...)
+		}
 	}
 
 	// If Leader election is enabled then add the configuration to the manifest

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -38,7 +38,10 @@ type Config struct {
 
 	// LoadBalancerClassName, will limit the load balancing services to services with LoadBalancerClass set to this value
 	LoadBalancerClassName string `yaml:"lbClassName"`
-	
+
+	// EnableServiceSecurity, will enable the use of iptables to secure services
+	EnableServiceSecurity bool `yaml:"EnableServiceSecurity"`
+
 	// ArpBroadcastRate, defines how often kube-vip will update the network about updates to the network
 	ArpBroadcastRate int64 `yaml:"arpBroadcastRate"`
 

--- a/pkg/manager/watch_services.go
+++ b/pkg/manager/watch_services.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/kube-vip/kube-vip/pkg/service"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -16,6 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 	watchtools "k8s.io/client-go/tools/watch"
+
+	"github.com/kube-vip/kube-vip/pkg/service"
 )
 
 // TODO: Fix the naming of these contexts
@@ -125,54 +126,51 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 				break
 			}
 
-			log.Debugf("service [%s] has been added/modified with addresses [%s] and is active [%t]", svc.Name, service.FetchServiceAddress(svc), activeService[string(svc.UID)])
+			log.Debugf("service [%s] has been added/modified with addresses [%s]", svc.Name, service.FetchServiceAddress(svc))
 
 			// Scenarios:
 			// 1.
-			if !activeService[string(svc.UID)] {
-				wg.Add(1)
-				activeServiceLoadBalancer[string(svc.UID)], activeServiceLoadBalancerCancel[string(svc.UID)] = context.WithCancel(context.TODO())
-				// Background the services election
-				if sm.config.EnableServicesElection {
-					if svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal {
-						// Start an endpoint watcher if we're not watching it already
-						if !watchedService[string(svc.UID)] {
-							// background the endpoint watcher
-							go func() {
-								if svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal {
-									// Add Endpoint watcher
-									wg.Add(1)
-									err = sm.watchEndpoint(activeServiceLoadBalancer[string(svc.UID)], id, svc, &wg)
-									if err != nil {
-										log.Error(err)
-									}
-									wg.Done()
-								}
-							}()
-							// We're now watching this service
-							watchedService[string(svc.UID)] = true
-						}
-					} else {
-						// Increment the waitGroup before the service Func is called (Done is completed in there)
-						wg.Add(1)
+			wg.Add(1)
+			activeServiceLoadBalancer[string(svc.UID)], activeServiceLoadBalancerCancel[string(svc.UID)] = context.WithCancel(context.TODO())
+			// Background the services election
+			if sm.config.EnableServicesElection {
+				if svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal {
+					// Start an endpoint watcher if we're not watching it already
+					if !watchedService[string(svc.UID)] {
+						// background the endpoint watcher
 						go func() {
-							err = serviceFunc(activeServiceLoadBalancer[string(svc.UID)], svc, &wg)
-							if err != nil {
-								log.Error(err)
+							if svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal {
+								// Add Endpoint watcher
+								wg.Add(1)
+								err = sm.watchEndpoint(activeServiceLoadBalancer[string(svc.UID)], id, svc, &wg)
+								if err != nil {
+									log.Error(err)
+								}
+								wg.Done()
 							}
-							wg.Done()
 						}()
+						// We're now watching this service
+						watchedService[string(svc.UID)] = true
 					}
 				} else {
 					// Increment the waitGroup before the service Func is called (Done is completed in there)
 					wg.Add(1)
-					err = serviceFunc(activeServiceLoadBalancer[string(svc.UID)], svc, &wg)
-					if err != nil {
-						log.Error(err)
-					}
-					wg.Done()
+					go func() {
+						err = serviceFunc(activeServiceLoadBalancer[string(svc.UID)], svc, &wg)
+						if err != nil {
+							log.Error(err)
+						}
+						wg.Done()
+					}()
 				}
-				activeService[string(svc.UID)] = true
+			} else {
+				// Increment the waitGroup before the service Func is called (Done is completed in there)
+				wg.Add(1)
+				err = serviceFunc(activeServiceLoadBalancer[string(svc.UID)], svc, &wg)
+				if err != nil {
+					log.Error(err)
+				}
+				wg.Done()
 			}
 		case watch.Deleted:
 			svc, ok := event.Object.(*v1.Service)
@@ -180,29 +178,27 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 				return fmt.Errorf("unable to parse Kubernetes services from API watcher")
 			}
 
-			if activeService[string(svc.UID)] {
-				// We only care about LoadBalancer services
-				if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
-					break
-				}
-
-				// We can ignore this service
-				if svc.Annotations["kube-vip.io/ignore"] == "true" {
-					log.Infof("service [%s] has an ignore annotation for kube-vip", svc.Name)
-					break
-				}
-				// If this is an active service then and additional leaderElection will handle stopping
-				err := sm.deleteService(string(svc.UID))
-				if err != nil {
-					log.Error(err)
-				}
-				// Calls the cancel function of the context
-				activeServiceLoadBalancerCancel[string(svc.UID)]()
-				activeService[string(svc.UID)] = false
-				watchedService[string(svc.UID)] = false
-
-				log.Infof("service [%s/%s] has been deleted", svc.Namespace, svc.Name)
+			// We only care about LoadBalancer services
+			if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
+				break
 			}
+
+			// We can ignore this service
+			if svc.Annotations["kube-vip.io/ignore"] == "true" {
+				log.Infof("service [%s] has an ignore annotation for kube-vip", svc.Name)
+				break
+			}
+			// If this is an active service then and additional leaderElection will handle stopping
+			err := sm.deleteService(string(svc.UID))
+			if err != nil {
+				log.Error(err)
+			}
+			// Calls the cancel function of the context
+			activeServiceLoadBalancerCancel[string(svc.UID)]()
+			activeService[string(svc.UID)] = false
+			watchedService[string(svc.UID)] = false
+
+			log.Infof("service [%s/%s] has been deleted", svc.Namespace, svc.Name)
 		case watch.Bookmark:
 			// Un-used
 		case watch.Error:

--- a/pkg/service/services.go
+++ b/pkg/service/services.go
@@ -7,12 +7,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kube-vip/kube-vip/pkg/cluster"
-	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kube-vip/kube-vip/pkg/cluster"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
 )
 
 const (
@@ -91,12 +92,13 @@ func (sm *Manager) syncServices(service *v1.Service) error {
 
 	// Generate new Virtual IP configuration
 	newVip := kubevip.Config{
-		VIP:        newServiceAddress, //TODO support more than one vip?
-		Interface:  sm.config.Interface,
-		SingleNode: true,
-		EnableARP:  sm.config.EnableARP,
-		EnableBGP:  sm.config.EnableBGP,
-		VIPCIDR:    sm.config.VIPCIDR,
+		VIP:                   newServiceAddress, //TODO support more than one vip?
+		Interface:             sm.config.Interface,
+		SingleNode:            true,
+		EnableARP:             sm.config.EnableARP,
+		EnableBGP:             sm.config.EnableBGP,
+		VIPCIDR:               sm.config.VIPCIDR,
+		EnableServiceSecurity: sm.config.EnableServiceSecurity,
 	}
 
 	// This instance wasn't found, we need to add it to the manager

--- a/pkg/vip/dhcp.go
+++ b/pkg/vip/dhcp.go
@@ -14,6 +14,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const dhcpClientPort = "68"
+
 // Callback is a function called on certain events
 type Callback func(*nclient4.Lease)
 


### PR DESCRIPTION
Set IPTables rules to Restricts user access to ports other than the load balancer service port through the VIP. Moreover, considering DHCP and any other protocol port requirement, those ports should be reachable.

By the way, we also modify the watch_services.go to support changing service load balancer IP.

IPTables Rules example:
```
-A INPUT -d 172.19.104.147/32 -p tcp -m tcp --dport 80 -m comment --comment "default/primary kube-vip load balancer IP" -j ACCEPT
-A INPUT -d 172.19.104.147/32 -p udp -m udp --dport 68 -m comment --comment "default/primary kube-vip load balancer IP" -j ACCEPT
-A INPUT -d 172.19.104.147/32 -m comment --comment "default/primary kube-vip load balancer IP" -j DROP
```

Related issue: https://github.com/kube-vip/kube-vip/issues/479