### PR TITLE
[feat] Add bgp metrics (bgp_session_info)

### DIFF
--- a/cmd/kube-vip-start.go
+++ b/cmd/kube-vip-start.go
@@ -89,7 +89,7 @@ var kubeVipStart = &cobra.Command{
 
 				if startConfig.EnableBGP {
 					log.Info("Starting the BGP server to advertise VIP routes to VGP peers")
-					bgpServer, err = bgp.NewBGPServer(&startConfig.BGPConfig)
+					bgpServer, err = bgp.NewBGPServer(&startConfig.BGPConfig, nil)
 					if err != nil {
 						log.Fatalf("%v", err)
 					}

--- a/pkg/bgp/server.go
+++ b/pkg/bgp/server.go
@@ -11,7 +11,7 @@ import (
 )
 
 // NewBGPServer takes a configuration and returns a running BGP server instance
-func NewBGPServer(c *Config) (b *Server, err error) {
+func NewBGPServer(c *Config, peerStateChangeCallback func(*api.WatchEventResponse_PeerEvent)) (b *Server, err error) {
 	if c.AS == 0 {
 		return nil, fmt.Errorf("You need to provide AS")
 	}
@@ -43,6 +43,9 @@ func NewBGPServer(c *Config) (b *Server, err error) {
 	if err = b.s.WatchEvent(context.Background(), &api.WatchEventRequest{Peer: &api.WatchEventRequest_Peer{}}, func(r *api.WatchEventResponse) {
 		if p := r.GetPeer(); p != nil && p.Type == api.WatchEventResponse_PeerEvent_STATE {
 			log.Println(p)
+			if peerStateChangeCallback != nil {
+				peerStateChangeCallback(p)
+			}
 		}
 	}); err != nil {
 		return

--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -172,7 +172,7 @@ func (cluster *Cluster) StartCluster(c *kubevip.Config, sm *Manager, bgpServer *
 	if c.EnableBGP {
 		// Lets start BGP
 		log.Info("Starting the BGP server to advertise VIP routes to VGP peers")
-		bgpServer, err = bgp.NewBGPServer(&c.BGPConfig)
+		bgpServer, err = bgp.NewBGPServer(&c.BGPConfig, nil)
 		if err != nil {
 			log.Error(err)
 		}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -49,6 +49,10 @@ type Manager struct {
 	// from the service watcher
 	countServiceWatchEvent *prometheus.CounterVec
 
+	// This is a prometheus gauge indicating the state of the sessions.
+	// 1 means "ESTABLISHED", 0 means "NOT ESTABLISHED"
+	bgpSessionInfoGauge *prometheus.GaugeVec
+
 	// This mutex is to protect calls from various goroutines
 	mutex sync.Mutex
 }
@@ -100,6 +104,12 @@ func New(configMap string, config *kubevip.Config) (*Manager, error) {
 			Name:      "all_services_events",
 			Help:      "Count all events fired by the service watcher categorised by event type",
 		}, []string{"type"}),
+		bgpSessionInfoGauge: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "kube_vip",
+			Subsystem: "manager",
+			Name:      "bgp_session_info",
+			Help:      "Display state of session by setting metric for label value with current state to 1",
+		}, []string{"state", "peer"}),
 	}, nil
 }
 

--- a/pkg/manager/manager_bgp.go
+++ b/pkg/manager/manager_bgp.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/bgp"
 	"github.com/kube-vip/kube-vip/pkg/cluster"
 	"github.com/kube-vip/kube-vip/pkg/equinixmetal"
+	api "github.com/osrg/gobgp/v3/api"
 	"github.com/packethost/packngo"
 	log "github.com/sirupsen/logrus"
 )
@@ -48,7 +49,7 @@ func (sm *Manager) startBGP() error {
 	}
 
 	log.Info("Starting the BGP server to advertise VIP routes to BGP peers")
-	sm.bgpServer, err = bgp.NewBGPServer(&sm.config.BGPConfig)
+	sm.bgpServer, err = bgp.NewBGPServer(&sm.config.BGPConfig, func(p *api.WatchEventResponse_PeerEvent) {})
 	if err != nil {
 		return err
 	}

--- a/pkg/manager/prom.go
+++ b/pkg/manager/prom.go
@@ -4,5 +4,5 @@ import "github.com/prometheus/client_golang/prometheus"
 
 // PrometheusCollector defines a service watch event counter.
 func (sm *Manager) PrometheusCollector() []prometheus.Collector {
-	return []prometheus.Collector{sm.countServiceWatchEvent}
+	return []prometheus.Collector{sm.countServiceWatchEvent, sm.bgpSessionInfoGauge}
 }

--- a/pkg/service/manager.go
+++ b/pkg/service/manager.go
@@ -42,6 +42,10 @@ type Manager struct {
 	// This is a prometheus counter used to count the number of events received
 	// from the service watcher
 	countServiceWatchEvent *prometheus.CounterVec
+
+	// This is a prometheus gauge indicating the state of the sessions.
+	// 1 means "ESTABLISHED", 0 means "NOT ESTABLISHED"
+	bgpSessionInfoGauge *prometheus.GaugeVec
 }
 
 // Instance defines an instance of everything needed to manage a vip

--- a/pkg/service/manager_bgp.go
+++ b/pkg/service/manager_bgp.go
@@ -36,7 +36,7 @@ func (sm *Manager) startBGP() error {
 	}
 
 	log.Info("Starting the BGP server to advertise VIP routes to VGP peers")
-	sm.bgpServer, err = bgp.NewBGPServer(&sm.config.BGPConfig)
+	sm.bgpServer, err = bgp.NewBGPServer(&sm.config.BGPConfig, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/service/prom.go
+++ b/pkg/service/prom.go
@@ -6,5 +6,5 @@ import "github.com/prometheus/client_golang/prometheus"
 
 // PrometheusCollector - required for statistics // TODO - improve monitoring
 func (sm *Manager) PrometheusCollector() []prometheus.Collector {
-	return []prometheus.Collector{sm.countServiceWatchEvent}
+	return []prometheus.Collector{sm.countServiceWatchEvent, sm.bgpSessionInfoGauge}
 }


### PR DESCRIPTION
As described in #547, this PR adds the metrics to monitor the current state of the bgp sessions.

The port of the peer is hard coded, since it is not currently possible to change the port in kube-vip. As soon as this feature is implemented, the port will be accessible by using the peers state, similar to `GetNeighborAddress()`.
If this should be refactored later, just tell me and I append the 179 in the `peerDescription` directly.

Example metrics look like this:
```bash
# HELP bgp_session_info Display state of session by setting metric for label value with current state to 1
# TYPE bgp_session_info gauge
bgp_session_info{peer="123.4.123.4:179",state="ACTIVE"} 0
bgp_session_info{peer="123.4.123.4:179",state="CONNECT"} 0
bgp_session_info{peer="123.4.123.4:179",state="ESTABLISHED"} 1
bgp_session_info{peer="123.4.123.4:179",state="IDLE"} 0
bgp_session_info{peer="123.4.123.4:179",state="OPENCONFIRM"} 0
bgp_session_info{peer="123.4.123.4:179",state="OPENSENT"} 0
bgp_session_info{peer="123.4.123.4:179",state="UNKNOWN"} 0
bgp_session_info{peer="123.4.123.5:179",state="ACTIVE"} 0
bgp_session_info{peer="123.4.123.5:179",state="CONNECT"} 0
bgp_session_info{peer="123.4.123.5:179",state="ESTABLISHED"} 1
bgp_session_info{peer="123.4.123.5:179",state="IDLE"} 0
bgp_session_info{peer="123.4.123.5:179",state="OPENCONFIRM"} 0
bgp_session_info{peer="123.4.123.5:179",state="OPENSENT"} 0
bgp_session_info{peer="123.4.123.5:179",state="UNKNOWN"} 0
```