### PR TITLE
Add support for multiple BGP peers when using Equinix Metal annotations

### DIFF
--- a/pkg/manager/watch_annotations.go
+++ b/pkg/manager/watch_annotations.go
@@ -214,7 +214,7 @@ func parseBgpAnnotations(node *v1.Node, prefix string) (bgp.Config, bgp.Peer, er
 		}
 	}
 	peerIPString = strings.TrimRight(peerIPString, ",")
-	
+
 	peerIPs := strings.Split(peerIPString, ",")
 
 	for _, peerIP := range peerIPs {

--- a/pkg/manager/watch_annotations.go
+++ b/pkg/manager/watch_annotations.go
@@ -208,11 +208,13 @@ func parseBgpAnnotations(node *v1.Node, prefix string) (bgp.Config, bgp.Peer, er
 
 	peerIPString := ""
 	for k, v := range node.Annotations {
-		regex := regexp.MustCompile(fmt.Sprintf("^%s/(bgp-peers-0-)?peer-ip", prefix))
+		regex := regexp.MustCompile(fmt.Sprintf("^%s/(bgp-peers-[0-9]+-)?peer-ip", prefix))
 		if regex.Match([]byte(k)) {
-			peerIPString = v
+			peerIPString += v + ","
 		}
 	}
+	peerIPString = strings.TrimRight(peerIPString, ",")
+	
 	peerIPs := strings.Split(peerIPString, ",")
 
 	for _, peerIP := range peerIPs {


### PR DESCRIPTION
Using Equinix Metal annotations was limited to only the first BGP peer. This PR adds support for multiple BGP peer by looking at all bgp peer node annotations.

Fixes #543 