### PR TITLE
Revert "adding iptables-wrappers script to entrypoint"

### DIFF
--- a/Dockerfile_iptables
+++ b/Dockerfile_iptables
@@ -16,9 +16,4 @@ FROM alpine:3.16.2
 RUN apk add --no-cache iptables
 # Add kube-vip binary
 COPY --from=dev /src/kube-vip /
-COPY /entrypoint_iptables.sh /
-# Adding iptables-wrapper-installer from https://github.com/kubernetes-sigs/iptables-wrappers
-ADD https://raw.githubusercontent.com/kubernetes-sigs/iptables-wrappers/v2/iptables-wrapper-installer.sh /
-RUN chmod 755 /entrypoint_iptables.sh /iptables-wrapper-installer.sh
-
-ENTRYPOINT ["/entrypoint_iptables.sh"]
+ENTRYPOINT ["/kube-vip"]

--- a/entrypoint_iptables.sh
+++ b/entrypoint_iptables.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-echo "Executing /iptables-wrapper-installer.sh to configure iptables ..."
-/iptables-wrapper-installer.sh
-
-echo "Executing /kube-vip $@"
-exec /kube-vip "$@"


### PR DESCRIPTION
Reverts kube-vip/kube-vip#502

Not required.. this was implemented in a PR ages ago to auto-detect iptables/nftables.