### PR TITLE
Use configurable LeaseName instead of hardcoded

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -87,6 +87,7 @@ func init() {
 
 	// Clustering type (leaderElection)
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableLeaderElection, "leaderElection", false, "Use the Kubernetes leader election mechanism for clustering")
+	kubeVipCmd.PersistentFlags().StringVar(&initConfig.LeaseName, "leaseName", "plndr-cp-lock", "Name of the lease that is used for leader election")
 	kubeVipCmd.PersistentFlags().IntVar(&initConfig.LeaseDuration, "leaseDuration", 5, "Length of time a Kubernetes leader lease can be held for")
 	kubeVipCmd.PersistentFlags().IntVar(&initConfig.RenewDeadline, "leaseRenewDuration", 3, "Length of time a Kubernetes leader can attempt to renew its lease")
 	kubeVipCmd.PersistentFlags().IntVar(&initConfig.RetryPeriod, "leaseRetry", 1, "Number of times the host will retry to hold a lease")

--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -30,8 +30,6 @@ import (
 	watchtools "k8s.io/client-go/tools/watch"
 )
 
-const plunderLock = "plndr-cp-lock"
-
 // Manager degines the manager of the load-balancing services
 type Manager struct {
 	KubernetesClient *kubernetes.Clientset
@@ -79,13 +77,13 @@ func (cluster *Cluster) StartCluster(c *kubevip.Config, sm *Manager, bgpServer *
 		return err
 	}
 
-	log.Infof("Beginning cluster membership, namespace [%s], lock name [%s], id [%s]", c.Namespace, plunderLock, id)
+	log.Infof("Beginning cluster membership, namespace [%s], lock name [%s], id [%s]", c.Namespace, c.LeaseName, id)
 
 	// we use the Lease lock type since edits to Leases are less common
 	// and fewer objects in the cluster watch "all Leases".
 	lock := &resourcelock.LeaseLock{
 		LeaseMeta: metav1.ObjectMeta{
-			Name:      plunderLock,
+			Name:      c.LeaseName,
 			Namespace: c.Namespace,
 		},
 		Client: sm.KubernetesClient.CoordinationV1(),

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -53,6 +53,12 @@ func ParseEnvironment(c *Config) error {
 		c.EnableLeaderElection = b
 	}
 
+	// Attempt to find the Lease name from the environment variables
+	env = os.Getenv(vipLeaseName)
+	if env != "" {
+		c.LeaseName = env
+	}
+
 	// Attempt to find the Lease configuration from the environment variables
 	env = os.Getenv(vipLeaseDuration)
 	if env != "" {

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -12,6 +12,9 @@ const (
 	// vipLeaderElection - defines if the kubernetes algorithm should be used
 	vipLeaderElection = "vip_leaderelection"
 
+	// vipLeaseName - defines the name of the lease lock
+	vipLeaseName = "vip_leasename"
+
 	// vipLeaderElection - defines if the kubernetes algorithm should be used
 	vipLeaseDuration = "vip_leaseduration"
 

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -147,6 +147,10 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 				Value: strconv.FormatBool(c.EnableLeaderElection),
 			},
 			{
+				Name:  vipLeaseName,
+				Value: c.LeaseName,
+			},
+			{
 				Name:  vipLeaseDuration,
 				Value: fmt.Sprintf("%d", c.LeaseDuration),
 			},

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -144,6 +144,9 @@ type LeaderElection struct {
 	// EnableLeaderElection will use the Kubernetes leader election algorithm
 	EnableLeaderElection bool `yaml:"enableLeaderElection"`
 
+	// LeaseName - name of the lease for leader election
+	LeaseName string `yaml:"leaseName"`
+
 	// Lease Duration - length of time a lease can be held for
 	LeaseDuration int
 


### PR DESCRIPTION
At the moment the lease name for leader election is hardcoded to 'plndr-cp-lock'. If you want to run multiple kube-vip instances in the same namespace this will conflict.

Code has not been tested yet since the testing instructions in CONTRIBUTING.md do not work and I did not manage to find any other testing scripts in the short time that I looked.