### PR TITLE
enable leaderelection for bgp in CP mode

### DIFF
--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -167,7 +167,7 @@ func (cluster *Cluster) StartCluster(c *kubevip.Config, sm *Manager, bgpServer *
 		}
 	}
 
-	if c.EnableBGP {
+	if c.EnableBGP && bgpServer == nil {
 		// Lets start BGP
 		log.Info("Starting the BGP server to advertise VIP routes to VGP peers")
 		bgpServer, err = bgp.NewBGPServer(&c.BGPConfig, nil)

--- a/pkg/manager/manager_bgp.go
+++ b/pkg/manager/manager_bgp.go
@@ -109,7 +109,11 @@ func (sm *Manager) startBGP() error {
 		}
 
 		go func() {
-			err = cpCluster.StartVipService(sm.config, clusterManager, sm.bgpServer, packetClient)
+			if sm.config.EnableLeaderElection {
+				err = cpCluster.StartCluster(sm.config, clusterManager, sm.bgpServer)
+			} else {
+				err = cpCluster.StartVipService(sm.config, clusterManager, sm.bgpServer, packetClient)
+			}
 			if err != nil {
 				log.Errorf("Control Plane Error [%v]", err)
 				// Trigger the shutdown of this manager instance


### PR DESCRIPTION
Hi kube-vip, in order to implement a BGP based VIP with leader election, I had to make this tweak.

I have tested this on a test cluster in control plane however a notable deficiency in my testing is that I have not tried this change in services mode. It does not look like there is an automated test for BGP so I could use some advice on how to proceed with this change- Thank you!