### PR TITLE
Allow specifying annotations for created Lease resources

### DIFF
--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -83,8 +83,9 @@ func (cluster *Cluster) StartCluster(c *kubevip.Config, sm *Manager, bgpServer *
 	// and fewer objects in the cluster watch "all Leases".
 	lock := &resourcelock.LeaseLock{
 		LeaseMeta: metav1.ObjectMeta{
-			Name:      c.LeaseName,
-			Namespace: c.Namespace,
+			Name:        c.LeaseName,
+			Namespace:   c.Namespace,
+			Annotations: c.LeaseAnnotations,
 		},
 		Client: sm.KubernetesClient.CoordinationV1(),
 		LockConfig: resourcelock.ResourceLockConfig{

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -3,6 +3,7 @@ package kubevip
 import (
 	"os"
 	"strconv"
+	"encoding/json"
 
 	"github.com/kube-vip/kube-vip/pkg/bgp"
 	"github.com/kube-vip/kube-vip/pkg/detector"
@@ -85,6 +86,15 @@ func ParseEnvironment(c *Config) error {
 			return err
 		}
 		c.RetryPeriod = int(i)
+	}
+
+	// Attempt to find the Lease annotations from the environment variables
+	env = os.Getenv(vipLeaseAnnotations)
+	if env != "" {
+		err := json.Unmarshal([]byte(env), &c.LeaseAnnotations)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Find vip address

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -1,9 +1,9 @@
 package kubevip
 
 import (
+	"encoding/json"
 	"os"
 	"strconv"
-	"encoding/json"
 
 	"github.com/kube-vip/kube-vip/pkg/bgp"
 	"github.com/kube-vip/kube-vip/pkg/detector"

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -24,6 +24,9 @@ const (
 	// vipLeaderElection - defines if the kubernetes algorithm should be used
 	vipRetryPeriod = "vip_retryperiod"
 
+	// vipLeaderElection - defines the annotations given to the lease lock
+	vipLeaseAnnotations = "vip_leaseannotations"
+
 	// vipLogLevel - defines the level of logging to produce (5 being the most verbose)
 	vipLogLevel = "vip_loglevel"
 

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -155,6 +155,9 @@ type LeaderElection struct {
 
 	// RetryPerion - Number of times the host will retry to hold a lease
 	RetryPeriod int
+
+	// LeaseAnnotations - annotations which will be given to the lease object
+	LeaseAnnotations map[string]string
 }
 
 // LoadBalancer contains the configuration of a load balancing instance


### PR DESCRIPTION
It would be nice to be able to watch for changes for certain Lease resources, and not others. This PR adds the ability to add annotations to the Lease resources being created by kube-vip, allowing for easy filtering of the leases.