### PR TITLE
Updating version in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TARGET := kube-vip
 .DEFAULT_GOAL := $(TARGET)
 
 # These will be provided to the target
-VERSION := v0.6.0
+VERSION := v0.6.1
 
 BUILD := `git rev-parse HEAD`
 


### PR DESCRIPTION
It looks like when v.0.6.1 was cut, the makefile wasn't updated to reflect the new version. This affects manifest generation (not too sure the implications beyond this).