### PR TITLE
Added create rbac settings section for kind deployment

### DIFF
--- a/docs/usage/kind/index.md
+++ b/docs/usage/kind/index.md
@@ -4,6 +4,12 @@
 
 The documentation for KIND is fantastic and its [quick start](https://kind.sigs.k8s.io/docs/user/quick-start/) guide will have you up and running in no time.
 
+## Create RBAC settings
+
+```
+kubectl apply -f https://kube-vip.io/manifests/rbac.yaml
+```
+
 ## Find Address Pool for Kube-Vip
 
 We will need to find addresses that can be used by Kube-Vip:


### PR DESCRIPTION
Hey @thebsdbox, all,
I have been trying kube-vip for the first time. Started with `kind` and realized that the usage instructions (if followed as-is) doesn't quite get the LB in a working state.

The RBAC settings were missing and hence the daemonset was never reaching out to running state.

Sorry if that is obvious step, but I would have a better user journey if it was mentioned, hence this PR.

Cheers.