### PR TITLE
prometheus: Handle root path

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -354,6 +354,15 @@ func servePrometheusHTTPServer(ctx context.Context, config PrometheusHTTPServerC
 	var err error
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<html>
+			<head><title>kube-vip</title></head>
+			<body>
+			<h1>kube-vip Metrics</h1>
+			<p><a href="` + "/metrics" + `">Metrics</a></p>
+			</body>
+			</html>`))
+	})
 
 	srv := &http.Server{
 		Addr:              config.Addr,


### PR DESCRIPTION
Hi,

This is a trivial PR for handling the prometheus root path `/`.

Currently,
```console
curl localhost:2112
404 page not found
```

With this PR,
```console
curl localhost:2112
<html>
                        <head><title>kube-vip</title></head>
                        <body>
                        <h1>kube-vip Metrics</h1>
                        <p><a href="/metrics">Metrics</a></p>
                        </body>
                        </html>%
```