### PR TITLE
ARP: Add node labeling for ARP mode DaemonSet deployment.

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -133,6 +133,7 @@ func init() {
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.LoadBalancerClassOnly, "lbClassOnly", false, "Enable load balancing only for services with LoadBalancerClass \"kube-vip.io/kube-vip-class\"")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.LoadBalancerClassName, "lbClassName", "kube-vip.io/kube-vip-class", "Name of load balancer class for kube-VIP, defaults to \"kube-vip.io/kube-vip-class\"")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableServiceSecurity, "onlyAllowTrafficServicePorts", false, "Only allow traffic to service ports, others will be dropped, defaults to false")
+	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableNodeLabeling, "enableNodeLabeling", false, "Enable leader node labeling with \"kube-vip.io/has-ip=<VIP address>\", defaults to false")
 
 	// Prometheus HTTP Server
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.PrometheusHTTPServer, "prometheusHTTPServer", ":2112", "Host and port used to expose Prometheus metrics via an HTTP server")

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -425,6 +425,16 @@ func ParseEnvironment(c *Config) error {
 		c.EnableServiceSecurity = b
 	}
 
+	// Find if node labeling is enabled
+	env = os.Getenv(EnableNodeLabeling)
+	if env != "" {
+		b, err := strconv.ParseBool(env)
+		if err != nil {
+			return err
+		}
+		c.EnableNodeLabeling = b
+	}
+
 	// Find Prometheus configuration
 	env = os.Getenv(prometheusServer)
 	if env != "" {

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -154,6 +154,9 @@ const (
 	// EnableServiceSecurity defines if the load-balancer should only allow traffic to service ports
 	EnableServiceSecurity = "enable_service_security"
 
+	// EnableNodeLabeling, will enable node labeling as the node becomes leader
+	EnableNodeLabeling = "enable_node_labeling"
+
 	// prometheusServer defines the address prometheus listens on
 	prometheusServer = "prometheus_server"
 

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -181,6 +181,17 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 		newEnvironment = append(newEnvironment, leaderElection...)
 	}
 
+	// If we're enabling node labeling on leader election
+	if c.EnableNodeLabeling {
+		EnableNodeLabeling := []corev1.EnvVar{
+			{
+				Name:  EnableNodeLabeling,
+				Value: strconv.FormatBool(c.EnableNodeLabeling),
+			},
+		}
+		newEnvironment = append(newEnvironment, EnableNodeLabeling...)
+	}
+
 	// If we're specifying an annotation configuration
 	if c.Annotations != "" {
 		annotations := []corev1.EnvVar{

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -32,6 +32,9 @@ type Config struct {
 	// EnableServicesElection, will enable leaderElection per service
 	EnableServicesElection bool `yaml:"enableServicesElection"`
 
+	// EnableNodeLabeling, will enable node labeling as it becomes leader
+	EnableNodeLabeling bool `yaml:"enableNodeLabeling"`
+
 	// LoadBalancerClassOnly, will enable load balancing only for services with LoadBalancerClass set to "kube-vip.io/kube-vip-class"
 	LoadBalancerClassOnly bool `yaml:"lbClassOnly"`
 

--- a/pkg/manager/manager_arp.go
+++ b/pkg/manager/manager_arp.go
@@ -169,6 +169,9 @@ func (sm *Manager) startARP() error {
 				},
 				OnNewLeader: func(identity string) {
 					// we're notified when new leader elected
+					if sm.config.EnableNodeLabeling {
+						applyNodeLabel(sm.clientSet, sm.config.Address, id, identity)
+					}
 					if identity == id {
 						// I just got the lock
 						return

--- a/pkg/manager/node_labeling.go
+++ b/pkg/manager/node_labeling.go
@@ -1,0 +1,73 @@
+package manager
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	nodeLabelIndex    = "kube-vip.io/has-ip"
+	nodeLabelJSONPath = `kube-vip.io~1has-ip`
+)
+
+type patchStringLabel struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value string `json:"value"`
+}
+
+// applyNodeLabel add/remove node label `kube-vip.io/has-ip=<VIP-Address>` to/from
+// the node where the virtual IP was added to/removed from.
+func applyNodeLabel(clientSet *kubernetes.Clientset, address, id, identity string) {
+	ctx := context.Background()
+	node, err := clientSet.CoreV1().Nodes().Get(ctx, id, metav1.GetOptions{})
+	if err != nil {
+		log.Errorf("can't query node %s labels. error: %v", id, err)
+		return
+	}
+
+	log.Debugf("node %s labels: %+v", id, node.Labels)
+
+	value, ok := node.Labels[nodeLabelIndex]
+	path := fmt.Sprintf("/metadata/labels/%s", nodeLabelJSONPath)
+	if (!ok || value != address) && id == identity {
+		log.Debugf("setting node label `has-ip=%s` on %s", address, id)
+		// Append label
+		applyPatchLabels(ctx, clientSet, id, "add", path, address)
+	} else if ok && value == address {
+		log.Debugf("removing node label `has-ip=%s` on %s", address, id)
+		// Remove label
+		applyPatchLabels(ctx, clientSet, id, "remove", path, address)
+	} else {
+		log.Debugf("no node label change needed")
+	}
+}
+
+// applyPatchLabels add/remove node labels
+func applyPatchLabels(ctx context.Context, clientSet *kubernetes.Clientset,
+	name, operation, path, value string) {
+	patchLabels := []patchStringLabel{{
+		Op:    operation,
+		Path:  path,
+		Value: value,
+	}}
+	patchData, err := json.Marshal(patchLabels)
+	if err != nil {
+		log.Errorf("node patch marshaling failed. error: %v", err)
+		return
+	}
+	// patch node
+	node, err := clientSet.CoreV1().Nodes().Patch(ctx,
+		name, types.JSONPatchType, patchData, metav1.PatchOptions{})
+	if err != nil {
+		log.Errorf("can't patch node %s. error: %v", name, err)
+		return
+	}
+	log.Debugf("updated node %s labels: %+v", name, node.Labels)
+}


### PR DESCRIPTION
This feature is related to #611, to configure the _**CiliumEgressGatewayPolicy**_ *EgressIP* correctly.

As this is not a very common usage for this project, there is a default disabled configuration flag added, `enable_node_labeling`.

The *ClusterRole* also needed patch rights to adjust the node labels.

Let me know what you think about the change, and where is the best place to document this feature.

Thank you!

