### PR TITLE
Call fatal when interface fails

### DIFF
--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -48,7 +48,7 @@ func (cluster *Cluster) vipService(ctxArp, ctxDNS context.Context, c *kubevip.Co
 
 	err = cluster.Network.AddIP()
 	if err != nil {
-		log.Warnf("%v", err)
+		log.Fatalf("%v", err)
 	}
 
 	if c.EnableMetal {


### PR DESCRIPTION
This ensures that kube-vip will restart itself in the event of failing to apply addresses to an interface.