### PR TITLE
Enable unit and e2e tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,34 +2,80 @@ name: For each commit and PR
 on:
   push:
   pull_request:
+env:
+  GO_VERSION: "1.20"
 jobs:
   validation:
     runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
+    name: Checks and linters
     steps:
-    - name: Init
-      run: sudo apt-get update && sudo apt-get install -y build-essential golint
-    - name: Checkout code
-      uses: actions/checkout@v3
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: '1.20'
-    - name: Install golangci-lint
-      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.3
-    - name: checks
-      run: make check
-    - name: test docker build (with iptables)
-      run: make dockerx86ActionIPTables
-    - name: e2e services
-      run: DOCKERTAG=action make service-tests
-    - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
-      with:
-        image-ref: 'plndr/kube-vip:action'
-        format: 'table'
-        exit-code: '1'
-        ignore-unfixed: true
-        vuln-type: 'os,library'
-        severity: 'CRITICAL,HIGH'
+      - name: Init
+        run: sudo apt-get update && sudo apt-get install -y build-essential golint
+      - name: Install golangci-lint
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.3
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: All checks
+        run: make check
+  unit-tests:
+    runs-on: ubuntu-latest
+    name: Unit tests
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Run tests
+        run: make unit-tests
+  e2e-tests:
+    runs-on: ubuntu-latest
+    name: E2E ARP tests
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Build image locally
+        run: make dockerx86Local
+      - name: Run tests
+        run: make e2e-tests
+  service-e2e-tests:
+    runs-on: ubuntu-latest
+    name: E2E service tests
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Build image with iptables
+        run: make dockerx86ActionIPTables
+      - name: Run tests
+        run: DOCKERTAG=action make service-tests
+  image-vul-check:
+    runs-on: ubuntu-latest
+    name: Image vulnerability scan
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Build image with iptables
+        run: make dockerx86ActionIPTables
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'plndr/kube-vip:action'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+      

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 kube-vip
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,11 @@ manifests:
 	@./kube-vip manifest daemonset --interface eth0 --vip 192.168.0.1 --bgp --leaderElection --controlplane --services --inCluster --provider-config /etc/cloud-sa/cloud-sa.json > ./docs/manifests/$(VERSION)/kube-vip-bgp-em-ds.yaml
 	@-rm ./kube-vip
 
+unit-tests:
+	go test ./...
+
 e2e-tests:
-	E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo  -tags=e2e -v -p testing/e2e
+	E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v -p ./testing/e2e
 
 service-tests:
 	E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run ./testing/e2e/services -Services

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -11,6 +11,9 @@ import (
 
 // ParseEnvironment - will popultate the configuration from environment variables
 func ParseEnvironment(c *Config) error {
+	if c == nil {
+		return nil
+	}
 	// Ensure that logging is set through the environment variables
 	env := os.Getenv(vipLogLevel)
 	// Set default value

--- a/pkg/manager/watcher_test.go
+++ b/pkg/manager/watcher_test.go
@@ -77,8 +77,8 @@ func TestParseNewBgpAnnotations(t *testing.T) {
 	node.Annotations = map[string]string{
 		"bgp/bgp-peers-0-node-asn": "65000",
 		"bgp/bgp-peers-0-peer-asn": "64000",
-		"bgp/bgp-peers-0-peer-ip":  "10.0.0.254",
-		"bgp/bgp-peers-0-src-ip":   "10.0.0.1,10.0.0.2,10.0.0.3",
+		"bgp/bgp-peers-0-peer-ip":  "10.0.0.1,10.0.0.2,10.0.0.3",
+		"bgp/bgp-peers-0-src-ip":   "10.0.0.254",
 		"bgp/bgp-peers-0-bgp-pass": "cGFzc3dvcmQ=", // password
 	}
 
@@ -93,6 +93,8 @@ func TestParseNewBgpAnnotations(t *testing.T) {
 		{Address: "10.0.0.3", AS: uint32(64000), Password: "password"},
 	}
 	assert.Equal(t, bgpPeers, bgpConfig.Peers, "bgpConfig.Peers parsed incorrectly")
+	assert.Equal(t, "10.0.0.254", bgpConfig.SourceIP, "bgpConfig.SourceIP parsed incorrectly")
+	assert.Equal(t, "10.0.0.254", bgpConfig.RouterID, "bgpConfig.RouterID parsed incorrectly")
 	assert.Equal(t, "10.0.0.3", bgpPeer.Address, "bgpPeer.Address parsed incorrectly")
 	assert.Equal(t, "password", bgpPeer.Password, "bgpPeer.Password parsed incorrectly")
 }

--- a/testing/e2e/e2e_suite_test.go
+++ b/testing/e2e/e2e_suite_test.go
@@ -22,10 +22,12 @@ func TestE2E(t *testing.T) {
 	RunSpecs(t, "E2E Suite")
 }
 
-var _ = SynchronizedBeforeSuite(func() []byte {
-	ensureKindNetwork()
-	return []byte{}
-}, func(_ []byte) {})
+var _ = SynchronizedBeforeSuite(
+	func() {
+		ensureKindNetwork()
+	},
+	func() {},
+)
 
 func ensureKindNetwork() {
 	By("checking if the Docker \"kind\" network exists")

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -98,7 +98,7 @@ var _ = Describe("kube-vip broadcast neighbor", func() {
 
 			manifestPath := filepath.Join(tempDirPath, "kube-vip-ipv4.yaml")
 
-			for i := 0; i < 2; i++ {
+			for i := 0; i < 3; i++ {
 				clusterConfig.Nodes = append(clusterConfig.Nodes, kindconfigv1alpha4.Node{
 					Role: kindconfigv1alpha4.ControlPlaneRole,
 					ExtraMounts: []kindconfigv1alpha4.Mount{
@@ -217,6 +217,7 @@ func createKindCluster(logger log.Logger, config *v1alpha4.Cluster, clusterName 
 	Expect(provider.Create(
 		clusterName,
 		cluster.CreateWithV1Alpha4Config(config),
+		cluster.CreateWithRetain(os.Getenv("E2E_PRESERVE_CLUSTER") == "true"), // If create fails, we'll need the cluster alive to debug
 	)).To(Succeed())
 }
 


### PR DESCRIPTION
Maybe there was a reason to not run unit tests but I thought it could be useful to run what we already have and it makes it easier for folks to add more as they write new code.

A couple extra things:
* Fixed 2 broken tests
* Separated unit tests, e2e tests, linter and scans in different jobs so they run concurrently.