### PR TITLE
Fix etcd e2e tests in GitHub actions

### DIFF
--- a/testing/e2e/etcd/election_test.go
+++ b/testing/e2e/etcd/election_test.go
@@ -24,7 +24,6 @@ type testConfig struct {
 	kubeVipImage        string
 	kubeVipManifestPath string
 	clusterName         string
-	tempDirPath         string
 	vip                 string
 	etcdCertsFolder     string
 	currentDir          string
@@ -37,7 +36,7 @@ func (t *testConfig) cleanup() {
 	}
 
 	t.cluster.Delete()
-	Expect(os.RemoveAll(t.tempDirPath)).To(Succeed())
+	Expect(os.RemoveAll(t.kubeVipManifestPath)).To(Succeed())
 	Expect(os.RemoveAll(t.etcdCertsFolder)).To(Succeed())
 }
 
@@ -67,10 +66,10 @@ var _ = Describe("kube-vip with etcd leader election", func() {
 			test.currentDir, err = os.Getwd()
 			Expect(err).NotTo(HaveOccurred())
 
-			test.tempDirPath, err = os.MkdirTemp("", "kube-vip-test")
+			tempDirPath, err := os.MkdirTemp("", "kube-vip-test")
 			Expect(err).NotTo(HaveOccurred())
 
-			test.kubeVipManifestPath = filepath.Join(test.tempDirPath, "etcd-vip-ipv4.yaml")
+			test.kubeVipManifestPath = filepath.Join(tempDirPath, "etcd-vip-ipv4.yaml")
 			manifestFile, err := os.Create(test.kubeVipManifestPath)
 			Expect(err).NotTo(HaveOccurred())
 			defer manifestFile.Close()

--- a/testing/e2e/etcd/etcd_suite_test.go
+++ b/testing/e2e/etcd/etcd_suite_test.go
@@ -8,9 +8,18 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/kube-vip/kube-vip/testing/e2e"
 )
 
 func TestEtcd(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Etcd Suite")
 }
+
+var _ = SynchronizedBeforeSuite(
+	func() {
+		e2e.EnsureKindNetwork()
+	},
+	func() {},
+)

--- a/testing/e2e/etcd/kubelet.yaml
+++ b/testing/e2e/etcd/kubelet.yaml
@@ -18,3 +18,9 @@ podCIDR: 10.241.1.0/24
 staticPodPath: /etc/kubernetes/manifests
 cgroupDriver: systemd
 cgroupRoot: /kubelet
+failSwapOn: false
+imageGCHighThresholdPercent: 100
+evictionHard:
+  nodefs.available: "0%"
+  nodefs.inodesFree: "0%"
+  imagefs.available: "0%"

--- a/testing/e2e/ip.go
+++ b/testing/e2e/ip.go
@@ -7,14 +7,55 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"net"
 	"os/exec"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+	kindconfigv1alpha4 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
+	"sigs.k8s.io/kind/pkg/cluster"
 )
+
+func EnsureKindNetwork() {
+	By("checking if the Docker \"kind\" network exists")
+	cmd := exec.Command("docker", "inspect", "kind")
+	session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(session).Should(gexec.Exit())
+	if session.ExitCode() == 0 {
+		return
+	}
+
+	By("Docker \"kind\" network was not found. Creating dummy Kind cluster to ensure creation")
+	clusterConfig := kindconfigv1alpha4.Cluster{
+		Networking: kindconfigv1alpha4.Networking{
+			IPFamily: kindconfigv1alpha4.IPv6Family,
+		},
+	}
+
+	provider := cluster.NewProvider(
+		cluster.ProviderWithDocker(),
+	)
+	dummyClusterName := fmt.Sprintf("dummy-cluster-%d", time.Now().Unix())
+	Expect(provider.Create(
+		dummyClusterName,
+		cluster.CreateWithV1Alpha4Config(&clusterConfig),
+	)).To(Succeed())
+
+	By("deleting dummy Kind cluster")
+	Expect(provider.Delete(dummyClusterName, ""))
+
+	By("checking if the Docker \"kind\" network was successfully created")
+	cmd = exec.Command("docker", "inspect", "kind")
+	session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(session).Should(gexec.Exit(0))
+}
 
 func GenerateIPv6VIP() string {
 	cidrs := getKindNetworkSubnetCIDRs()


### PR DESCRIPTION
In order to run the kubelet in kind containers on the vms provided by github, the kubelet needed some extra configuration.

I also added some setup for the kind network so the the etcd tests don't depend on being run together with the other e2e tests.