### PR TITLE
Add annotation to specify DHCP lease hostname

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TARGET := kube-vip
 .DEFAULT_GOAL := $(TARGET)
 
 # These will be provided to the target
-VERSION := v0.6.3
+VERSION := v0.6.4
 
 BUILD := `git rev-parse HEAD`
 

--- a/docs/usage/on-prem/index.md
+++ b/docs/usage/on-prem/index.md
@@ -142,6 +142,27 @@ kubernetes   ClusterIP      10.96.0.1       <none>          443/TCP        17m
 nginx-dhcp   LoadBalancer   10.97.150.208   192.168.0.155   80:31184/TCP   3s
 ```
 
+You can also specify a hostname used for the DHCP lease by adding an annotation to your service.
+
+```
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-dhcp
+  annotations:
+    kube-vip.io/loadbalancerHostname: mydhcp-test
+spec:
+  loadBalancerIP: 0.0.0.0
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: hello-world
+  type: LoadBalancer
+```
+
 ### Using UPnP to expose a Service to the outside world
 
 With `kube-vip` > 0.2.1, it is possible to expose a Service of type `LoadBalancer` on a specific port to the Internet by using UPnP (on a supported gateway).

--- a/pkg/manager/instance.go
+++ b/pkg/manager/instance.go
@@ -26,6 +26,7 @@ type Instance struct {
 	dhcpInterface       string
 	dhcpInterfaceHwaddr string
 	dhcpInterfaceIP     string
+	dhcpHostname		string
 	dhcpClient          *vip.DHCPClient
 
 	// Kubernetes service mapping
@@ -78,6 +79,7 @@ func NewInstance(svc *v1.Service, config *kubevip.Config) (*Instance, error) {
 	if svc.Annotations != nil {
 		instance.dhcpInterfaceHwaddr = svc.Annotations[hwAddrKey]
 		instance.dhcpInterfaceIP = svc.Annotations[requestedIP]
+		instance.dhcpHostname = svc.Annotations[loadbalancerHostname]
 	}
 
 	// Generate Load Balancer config
@@ -178,6 +180,12 @@ func (i *Instance) startDHCP() error {
 	}
 
 	client := vip.NewDHCPClient(iface, initRebootFlag, i.dhcpInterfaceIP)
+
+	// Add hostname to dhcp client if annotated
+	if i.dhcpHostname != "" {
+		log.Infof("Hostname specified for dhcp lease: [%s] - [%s]", interfaceName, i.dhcpHostname)
+		client.WithHostName(i.dhcpHostname)
+	}
 
 	go client.Start()
 

--- a/pkg/manager/services.go
+++ b/pkg/manager/services.go
@@ -27,6 +27,7 @@ const (
 	endpoint                 = "kube-vip.io/active-endpoint"
 	flushContrack            = "kube-vip.io/flush-conntrack"
 	loadbalancerIPAnnotation = "kube-vip.io/loadbalancerIPs"
+	loadbalancerHostname     = "kube-vip.io/loadbalancerHostname"
 )
 
 func (sm *Manager) syncServices(_ context.Context, svc *v1.Service, wg *sync.WaitGroup) error {


### PR DESCRIPTION
Following my previous issue #614 , i made little changes to be able to specify hostname sent to dhcp server when requesting lease using an annotation as the following:
```yaml
apiVersion: v1
kind: Service
metadata:
  name: nginx-dhcp
  annotations:
    kube-vip.io/loadbalancerHostname: mydhcp-test
spec:
  loadBalancerIP: 0.0.0.0
  ports:
  - name: http
    port: 80
    protocol: TCP
    targetPort: 80
  selector:
    app: hello-world
  type: LoadBalancer
```

This makes DHCP aware of the hostname and makes the service accessible though local hostname resolution:
```
curl mydhcp-test.lan
```
