### PR TITLE
Dualstack support for Loadbalancer Services

### DIFF
--- a/pkg/manager/manager_arp.go
+++ b/pkg/manager/manager_arp.go
@@ -162,8 +162,10 @@ func (sm *Manager) startARP() error {
 				OnStoppedLeading: func() {
 					// we can do cleanup here
 					log.Infof("leader lost: %s", id)
-					for x := range sm.serviceInstances {
-						sm.serviceInstances[x].cluster.Stop()
+					for _, instance := range sm.serviceInstances {
+						for _, cluster := range instance.clusters {
+							cluster.Stop()
+						}
 					}
 
 					log.Fatal("lost leadership, restarting kube-vip")

--- a/pkg/manager/manager_table.go
+++ b/pkg/manager/manager_table.go
@@ -89,8 +89,10 @@ func (sm *Manager) startTableMode() error {
 				OnStoppedLeading: func() {
 					// we can do cleanup here
 					log.Infof("leader lost: %s", id)
-					for x := range sm.serviceInstances {
-						sm.serviceInstances[x].cluster.Stop()
+					for _, instance := range sm.serviceInstances {
+						for _, cluster := range instance.clusters {
+							cluster.Stop()
+						}
 					}
 
 					log.Fatal("lost leadership, restarting kube-vip")

--- a/pkg/manager/manager_wireguard.go
+++ b/pkg/manager/manager_wireguard.go
@@ -121,8 +121,10 @@ func (sm *Manager) startWireguard() error {
 				OnStoppedLeading: func() {
 					// we can do cleanup here
 					log.Infof("leader lost: %s", id)
-					for x := range sm.serviceInstances {
-						sm.serviceInstances[x].cluster.Stop()
+					for _, instance := range sm.serviceInstances {
+						for _, cluster := range instance.clusters {
+							cluster.Stop()
+						}
 					}
 
 					log.Fatal("lost leadership, restarting kube-vip")

--- a/pkg/manager/services.go
+++ b/pkg/manager/services.go
@@ -37,17 +37,22 @@ func (sm *Manager) syncServices(_ context.Context, svc *v1.Service, wg *sync.Wai
 
 	// Iterate through the synchronising services
 	foundInstance := false
-	newServiceAddress := fetchServiceAddress(svc)
+	newServiceAddresses := fetchServiceAddresses(svc)
 	newServiceUID := string(svc.UID)
+
+	firstServiceAddress := ""
+	if len(newServiceAddresses) > 0 {
+		firstServiceAddress = newServiceAddresses[0]
+	}
 
 	for x := range sm.serviceInstances {
 		if sm.serviceInstances[x].UID == newServiceUID {
-			log.Debugf("isDHCP: %t, newServiceAddress: %s", sm.serviceInstances[x].isDHCP, newServiceAddress)
+			log.Debugf("isDHCP: %t, newServiceAddresses: %s", sm.serviceInstances[x].isDHCP, newServiceAddresses)
 			// If the found instance's DHCP configuration doesn't match the new service, delete it.
-			if (sm.serviceInstances[x].isDHCP && newServiceAddress != "0.0.0.0") ||
-				(!sm.serviceInstances[x].isDHCP && newServiceAddress == "0.0.0.0") ||
+			if (sm.serviceInstances[x].isDHCP && firstServiceAddress != "0.0.0.0") ||
+				(!sm.serviceInstances[x].isDHCP && firstServiceAddress == "0.0.0.0") ||
 				(!sm.serviceInstances[x].isDHCP && len(svc.Status.LoadBalancer.Ingress) > 0 &&
-					newServiceAddress != svc.Status.LoadBalancer.Ingress[0].IP) ||
+					firstServiceAddress != svc.Status.LoadBalancer.Ingress[0].IP) ||
 				(len(svc.Status.LoadBalancer.Ingress) > 0 && !comparePortsAndPortStatuses(svc)) ||
 				(sm.serviceInstances[x].isDHCP && len(svc.Status.LoadBalancer.Ingress) > 0 &&
 					sm.serviceInstances[x].dhcpInterfaceIP != svc.Status.LoadBalancer.Ingress[0].IP) {
@@ -61,7 +66,7 @@ func (sm *Manager) syncServices(_ context.Context, svc *v1.Service, wg *sync.Wai
 	}
 
 	// This instance wasn't found, we need to add it to the manager
-	if !foundInstance && newServiceAddress != "" {
+	if !foundInstance && firstServiceAddress != "" {
 		if err := sm.addService(svc); err != nil {
 			return err
 		}
@@ -91,17 +96,19 @@ func (sm *Manager) addService(svc *v1.Service) error {
 		return err
 	}
 
-	log.Infof("(svcs) adding VIP [%s] for [%s/%s]", newService.Vip, newService.serviceSnapshot.Namespace, newService.serviceSnapshot.Name)
+	log.Infof("(svcs) adding VIP(s) [%s] for [%s/%s]", newService.VIPs, newService.serviceSnapshot.Namespace, newService.serviceSnapshot.Name)
 
-	newService.cluster.StartLoadBalancerService(newService.vipConfig, sm.bgpServer)
+	for x := range newService.vipConfigs {
+		newService.clusters[x].StartLoadBalancerService(newService.vipConfigs[x], sm.bgpServer)
+	}
 
 	sm.upnpMap(newService)
 
-	if newService.isDHCP {
+	if newService.isDHCP && len(newService.vipConfigs) == 1 {
 		go func() {
 			for ip := range newService.dhcpClient.IPChannel() {
 				log.Debugf("IP %s may have changed", ip)
-				newService.vipConfig.VIP = ip
+				newService.vipConfigs[0].VIP = ip
 				newService.dhcpInterfaceIP = ip
 				if err := sm.updateStatus(newService); err != nil {
 					log.Warnf("error updating svc: %s", err)
@@ -121,11 +128,14 @@ func (sm *Manager) addService(svc *v1.Service) error {
 		return err
 	}
 
-	serviceIP := fetchServiceAddress(svc)
+	// TODO: Currently this only implements egress for the primary load balancer
+	// IP of the service
+	serviceIPs := fetchServiceAddresses(svc)
 
 	// Check if we need to flush any conntrack connections (due to some dangling conntrack connections)
-	if svc.Annotations[flushContrack] == "true" {
+	if svc.Annotations[flushContrack] == "true" && len(serviceIPs) > 0 {
 		log.Debugf("Flushing conntrack rules for service [%s]", svc.Name)
+		serviceIP := serviceIPs[0]
 		err = vip.DeleteExistingSessions(serviceIP, false)
 		if err != nil {
 			log.Errorf("Error flushing any remaining egress connections [%s]", err)
@@ -137,8 +147,9 @@ func (sm *Manager) addService(svc *v1.Service) error {
 	}
 
 	// Check if egress is enabled on the service, if so we'll need to configure some rules
-	if svc.Annotations[egress] == "true" {
+	if svc.Annotations[egress] == "true" && len(serviceIPs) > 0 {
 		log.Debugf("Enabling egress for the service [%s]", svc.Name)
+		serviceIP := serviceIPs[0]
 		if svc.Annotations[endpoint] != "" {
 			// We will need to modify the iptables rules
 			err = sm.iptablesCheck()
@@ -156,6 +167,7 @@ func (sm *Manager) addService(svc *v1.Service) error {
 			}
 		}
 	}
+
 	finishTime := time.Since(startTime)
 	log.Infof("[service] synchronised in %dms", finishTime.Milliseconds())
 
@@ -188,13 +200,21 @@ func (sm *Manager) deleteService(uid string) error {
 		return nil
 	}
 	shared := false
+	vipSet := make(map[string]interface{})
 	for x := range updatedInstances {
-		if updatedInstances[x].Vip == serviceInstance.Vip {
+		for _, vip := range updatedInstances[x].VIPs {
+			vipSet[vip] = nil
+		}
+	}
+	for _, vip := range serviceInstance.VIPs {
+		if _, found := vipSet[vip]; found {
 			shared = true
 		}
 	}
 	if !shared {
-		serviceInstance.cluster.Stop()
+		for x := range serviceInstance.clusters {
+			serviceInstance.clusters[x].Stop()
+		}
 		if serviceInstance.isDHCP {
 			serviceInstance.dhcpClient.Stop()
 			macvlan, err := netlink.LinkByName(serviceInstance.dhcpInterface)
@@ -207,8 +227,9 @@ func (sm *Manager) deleteService(uid string) error {
 				return fmt.Errorf("error deleting DHCP Link : %v", err)
 			}
 		}
-		if serviceInstance.vipConfig.EnableBGP {
-			cidrVip := fmt.Sprintf("%s/%s", serviceInstance.vipConfig.VIP, serviceInstance.vipConfig.VIPCIDR)
+		// TODO: Implement dual-stack loadbalancer support if BGP is enabled
+		if serviceInstance.vipConfigs[0].EnableBGP {
+			cidrVip := fmt.Sprintf("%s/%s", serviceInstance.vipConfigs[0].VIP, serviceInstance.vipConfigs[0].VIPCIDR)
 			err := sm.bgpServer.DelHost(cidrVip)
 			return err
 		}
@@ -237,9 +258,10 @@ func (sm *Manager) deleteService(uid string) error {
 func (sm *Manager) upnpMap(s *Instance) {
 	// If upnp is enabled then update the gateway/router with the address
 	// TODO - work out if we need to mapping.Reclaim()
-	if sm.upnp != nil {
-		log.Infof("[UPNP] Adding map to [%s:%d - %s]", s.Vip, s.Port, s.serviceSnapshot.Name)
-		if err := sm.upnp.AddPortMapping(int(s.Port), int(s.Port), 0, s.Vip, strings.ToUpper(s.Type), s.serviceSnapshot.Name); err == nil {
+	// TODO: Handle upnp in the dualstack case
+	if sm.upnp != nil && len(s.VIPs) == 1 {
+		log.Infof("[UPNP] Adding map to [%s:%d - %s]", s.VIPs[0], s.Port, s.serviceSnapshot.Name)
+		if err := sm.upnp.AddPortMapping(int(s.Port), int(s.Port), 0, s.VIPs[0], strings.ToUpper(s.Type), s.serviceSnapshot.Name); err == nil {
 			log.Infof("service should be accessible externally on port [%d]", s.Port)
 		} else {
 			sm.upnp.Reclaim()
@@ -290,10 +312,14 @@ func (sm *Manager) updateStatus(i *Instance) error {
 				Protocol: port.Protocol,
 			})
 		}
-		updatedService.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{
-			IP:    i.vipConfig.VIP,
-			Ports: ports,
-		}}
+		var ingresses []v1.LoadBalancerIngress
+		for _, vipConfig := range i.vipConfigs {
+			ingresses = append(ingresses, v1.LoadBalancerIngress{
+				IP:    vipConfig.VIP,
+				Ports: ports,
+			})
+		}
+		updatedService.Status.LoadBalancer.Ingress = ingresses
 		_, err = sm.clientSet.CoreV1().Services(updatedService.Namespace).UpdateStatus(context.TODO(), updatedService, metav1.UpdateOptions{})
 		if err != nil {
 			log.Errorf("Error updating Service %s/%s Status: %v", i.serviceSnapshot.Namespace, i.serviceSnapshot.Name, err)
@@ -309,13 +335,19 @@ func (sm *Manager) updateStatus(i *Instance) error {
 	return nil
 }
 
-// fetchServiceAddress tries to get the address from annotations
+// fetchServiceAddresses tries to get the addresses from annotations
 // kube-vip.io/loadbalancerIPs, then from spec.loadbalancerIP
-func fetchServiceAddress(s *v1.Service) string {
+// May return []string{""} (with length 1) if neither exist.
+func fetchServiceAddresses(s *v1.Service) []string {
 	if s.Annotations != nil {
 		if v, ok := s.Annotations[loadbalancerIPAnnotation]; ok {
-			return v
+			ips := strings.Split(v, ",")
+			var trimmedIPs []string
+			for _, ip := range ips {
+				trimmedIPs = append(trimmedIPs, strings.TrimSpace(ip))
+			}
+			return trimmedIPs
 		}
 	}
-	return s.Spec.LoadBalancerIP
+	return []string{s.Spec.LoadBalancerIP}
 }

--- a/pkg/manager/servicesLeader.go
+++ b/pkg/manager/servicesLeader.go
@@ -22,8 +22,10 @@ func (sm *Manager) startServicesWatchForLeaderElection(ctx context.Context) erro
 		return err
 	}
 
-	for x := range sm.serviceInstances {
-		sm.serviceInstances[x].cluster.Stop()
+	for _, instance := range sm.serviceInstances {
+		for _, cluster := range instance.clusters {
+			cluster.Stop()
+		}
 	}
 
 	log.Infof("Shutting down kube-Vip")

--- a/pkg/manager/watch_services.go
+++ b/pkg/manager/watch_services.go
@@ -102,7 +102,8 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 			}
 
 			// We only care about LoadBalancer services that have been allocated an address
-			if fetchServiceAddress(svc) == "" {
+			serviceAddresses := fetchServiceAddresses(svc)
+			if len(serviceAddresses) == 0 || serviceAddresses[0] == "" {
 				break
 			}
 
@@ -139,7 +140,7 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 			// Scenarios:
 			// 1.
 			if !activeService[string(svc.UID)] {
-				log.Debugf("(svcs) [%s] has been added/modified with addresses [%s]", svc.Name, fetchServiceAddress(svc))
+				log.Debugf("(svcs) [%s] has been added/modified with addresses [%s]", svc.Name, fetchServiceAddresses(svc))
 
 				wg.Add(1)
 				activeServiceLoadBalancer[string(svc.UID)], activeServiceLoadBalancerCancel[string(svc.UID)] = context.WithCancel(context.TODO())

--- a/testing/e2e/services/kind.go
+++ b/testing/e2e/services/kind.go
@@ -42,6 +42,10 @@ func (config *testConfig) createKind() error {
 		// Change Networking Family
 		clusterConfig.Networking.IPFamily = kindconfigv1alpha4.IPv6Family
 	}
+	if config.Dualstack {
+		// Change Networking Family
+		clusterConfig.Networking.IPFamily = kindconfigv1alpha4.DualStackFamily
+	}
 
 	if config.ControlPlane {
 		err := config.manifestGen()

--- a/testing/e2e/services/tests.go
+++ b/testing/e2e/services/tests.go
@@ -21,6 +21,7 @@ type testConfig struct {
 	ControlPlaneAddress string
 	ManifestPath        string
 	IPv6                bool
+	Dualstack           bool
 
 	Services bool
 	// service tests
@@ -29,6 +30,7 @@ type testConfig struct {
 	ignoreLeaderFailover bool
 	ignoreLeaderActive   bool
 	ignoreLocalDeploy    bool
+	ignoreDualStack      bool
 	ignoreEgress         bool
 	retainCluster        bool
 }
@@ -44,6 +46,7 @@ func main() {
 	_, t.ignoreLeaderActive = os.LookupEnv("IGNORE_ACTIVE")
 	_, t.ignoreLocalDeploy = os.LookupEnv("IGNORE_LOCALDEPLOY")
 	_, t.ignoreEgress = os.LookupEnv("IGNORE_EGRESS")
+	_, t.ignoreDualStack = os.LookupEnv("IGNORE_DUALSTACK")
 	_, t.retainCluster = os.LookupEnv("RETAIN_CLUSTER")
 
 	flag.StringVar(&t.ImagePath, "imagepath", "plndr/kube-vip:action", "")
@@ -53,6 +56,10 @@ func main() {
 	flag.Parse()
 
 	log.Infof("🔬 beginning e2e tests, image: [%s]", t.ImagePath)
+
+	if !t.ignoreDualStack {
+		t.Dualstack = true
+	}
 
 	if t.ControlPlane {
 		err := t.createKind()


### PR DESCRIPTION
As a preliminary step towards dualstack support, I've made some changes to allow handling the case where the field `metadata.annotations["kube-vip.io/loadbalancerIPs"]` has multiple IPs.

Right now, there are some cases where I couldn't quite figure out the best UX for multiple loadbalancer IPs for a single service, so for now I'm only supporting dualstack LoadBalancer services in the EnableARP configuration of kube-vip and leaving cases like DHCP, EnableBGP, and uPnP as supporting only one LoadBalancer IP per service. Also egress only supports the first IP in the list of loadbalancer IPs.

I think I'd like to do some more cleanup for this PR, but I've added a test for a dualstack LoadBalancer service and it passes now:

```
time="2023-12-16T04:02:44Z" level=info msg="🧪 ---> testing dualstack loadbalancer service <---"
time="2023-12-16T04:02:44Z" level=info msg="📝 created deployment [kube-vip-deploy]"
time="2023-12-16T04:02:44Z" level=info msg="🌍 creating service [kube-vip-service]"
time="2023-12-16T04:02:44Z" level=info msg="🔎 found load balancer addresses [[172.18.255.250 fc00:f853:ccd:e793:ffff:ffff:ffff:fffa]] on node [services-worker2]"
time="2023-12-16T04:02:44Z" level=info msg="🕷️  testing HTTP request against [172.18.255.250]"
time="2023-12-16T04:02:47Z" level=info msg="🕸️  successfully retrieved web data in [2s]"
time="2023-12-16T04:02:47Z" level=info msg="🕷️  testing HTTP request against [fc00:f853:ccd:e793:ffff:ffff:ffff:fffa]"
time="2023-12-16T04:02:49Z" level=info msg="🕸️  successfully retrieved web data in [1s]"
time="2023-12-16T04:02:49Z" level=info msg="🧹 deleting Service [kube-vip-service], deployment [kube-vip-deploy]"
```