### PR TITLE
Add config options for BGP timers

### DIFF
--- a/docs/flags/index.md
+++ b/docs/flags/index.md
@@ -92,6 +92,8 @@ More environment variables can be read through the `pkg/kubevip/config_envvar.go
 |                     | `bgp_multihop`         | Enables eBGP MultiHop                                       | Enable multiHop with a single BGP Peer                                          |
 |                     | `bgp_sourceif`         | Source Interface                                            | Determines which interface BGP should peer _from_                               |
 |                     | `bgp_sourceip`         | Source Address                                              | Determines which IP address BGP should peer _from_                              |
+|                     | `bgp_hold_time`        | default 0                                                   | BGP timer HoldTime config. Defaults to 0, using the peer's default              |
+|                     | `bgp_keepalive_interval`| default 0                                                  | BGP timer KeepaliveInterval config. Defaults to 0, using peer's default         |
 |                     | `annotations`          | `<provider string>`                                         | Startup will be paused until the node annotations contain the BGP configuration |
 | **Equinix Metal**   |                        |                                                             | (May be deprecated)                                                             |
 |                     | `vip_packet`           | Enables Equinix Metal API calls                             |                                                                                 |

--- a/pkg/bgp/peers.go
+++ b/pkg/bgp/peers.go
@@ -23,7 +23,9 @@ func (b *Server) AddPeer(peer Peer) (err error) {
 
 		Timers: &api.Timers{
 			Config: &api.TimersConfig{
-				ConnectRetry: 10,
+				ConnectRetry:      10,
+				HoldTime:          b.c.HoldTime,
+				KeepaliveInterval: b.c.KeepaliveInterval,
 			},
 		},
 

--- a/pkg/bgp/types.go
+++ b/pkg/bgp/types.go
@@ -17,6 +17,9 @@ type Config struct {
 	SourceIP string
 	SourceIF string
 
+	HoldTime          uint64
+	KeepaliveInterval uint64
+
 	Peers []Peer
 }
 

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -395,6 +395,24 @@ func ParseEnvironment(c *Config) error {
 		c.BGPConfig.Peers = append(c.BGPConfig.Peers, c.BGPPeerConfig)
 	}
 
+	// BGP Timers options
+	env = os.Getenv(bgpHoldTime)
+	if env != "" {
+		u64, err := strconv.ParseUint(env, 10, 32)
+		if err != nil {
+			return err
+		}
+		c.BGPConfig.HoldTime = u64
+	}
+	env = os.Getenv(bgpKeepaliveInterval)
+	if env != "" {
+		u64, err := strconv.ParseUint(env, 10, 32)
+		if err != nil {
+			return err
+		}
+		c.BGPConfig.KeepaliveInterval = u64
+	}
+
 	// Enable the Equinix Metal API calls
 	env = os.Getenv(vipPacket)
 	if env != "" {

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -114,6 +114,10 @@ const (
 	bgpSourceIF = "bgp_sourceif"
 	// bgpSourceIP defines the source address for BGP peering
 	bgpSourceIP = "bgp_sourceip"
+	// bgpHoldTime defines bgp timers hold time
+	bgpHoldTime = "bgp_hold_time"
+	// bgpKeepaliveInterval defines bgp timers keepalive interval
+	bgpKeepaliveInterval = "bgp_keepalive_interval"
 
 	// vipWireguard - defines if wireguard will be used for vips
 	vipWireguard = "vip_wireguard" //nolint


### PR DESCRIPTION
In certain scenarios, it's easier to change the BGP timer settings from the kube-vip side rather than configuring the routers' peer-group timer settings for kube-vip. This is desirable if the router defaults are higher than what we'd like to configure on the kube-vip side for the purpose of quickly reacting to a node down or network partition.

This change adds two new env vars for configuring these settings during the start of peering.

I was able to validate on my local deployment, that the switch side was picking up the modified timer settings.

```
kube-vip manifest yaml envvars
...
    - name: bgp_hold_time
      value: "9"
    - name: bgp_keepalive_interval
      value: "3"
...

Router `show ip bgp neighbors`
...
BGP neighbor is x.x.x.x, remote AS xxxx, internal link
  BGP version 4, remote router ID x.x.x.x, VRF default
  Inherits configuration from and member of peer-group xxx
  Negotiated BGP version 4
  Member of update group 2
  Last read 00:00:01, last write 00:00:01
  Hold time is 9, keepalive interval is 3 seconds

...where the default is 120 40
```