### PR TITLE
Updates to the client to auto-detect

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -128,6 +128,7 @@ func init() {
 
 	// Behaviour flags
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableControlPlane, "controlplane", false, "Enable HA for control plane")
+	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.DetectControlPlane, "autodetectcp", false, "Determine working address for control plane (from loopback)")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableServices, "services", false, "Enable Kubernetes services")
 
 	// Extended behaviour flags

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	golang.org/x/exp v0.0.0-20231005195138-3e424a577f31
 	golang.org/x/sys v0.13.0
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20230429144221-925a1e7659e6
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.28.3
 	k8s.io/apimachinery v0.28.3
 	k8s.io/client-go v0.28.3
@@ -113,7 +114,6 @@ require (
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect
 	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 // indirect

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -1,8 +1,12 @@
 package k8s
 
 import (
+	"crypto/tls"
 	"fmt"
+	"net"
+	"time"
 
+	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -14,7 +18,11 @@ import (
 // Also takes a hostname which allow for overriding the config's hostname
 // before generating a client.
 func NewClientset(configPath string, inCluster bool, hostname string) (*kubernetes.Clientset, error) {
-	config, err := restConfig(configPath, inCluster)
+	return newClientset(configPath, inCluster, hostname, time.Second*10)
+}
+
+func newClientset(configPath string, inCluster bool, hostname string, timeout time.Duration) (*kubernetes.Clientset, error) {
+	config, err := restConfig(configPath, inCluster, timeout)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -30,8 +38,11 @@ func NewClientset(configPath string, inCluster bool, hostname string) (*kubernet
 	return clientset, nil
 }
 
-func restConfig(kubeconfig string, inCluster bool) (*rest.Config, error) {
+func restConfig(kubeconfig string, inCluster bool, timeout time.Duration) (*rest.Config, error) {
 	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		log.Debugf("[k8s client] we try the incluster first, this error [%v] can safely be ignored", err)
+	}
 
 	if kubeconfig != "" && !inCluster {
 		cfg, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
@@ -45,5 +56,55 @@ func restConfig(kubeconfig string, inCluster bool) (*rest.Config, error) {
 	// these should hopefully be redundant, however issues will still be logged.
 	cfg.QPS = 100
 	cfg.Burst = 250
+	cfg.Timeout = timeout
 	return cfg, nil
+}
+
+func findAddressFromRemoteCert(address string) ([]net.IP, error) {
+
+	// TODO: should we care at this point, probably not as we just want the certificates
+	conf := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true, //nolint
+	}
+	d := &net.Dialer{
+		Timeout: time.Duration(3) * time.Second,
+	}
+
+	// Create the TCP connection
+	conn, err := tls.DialWithDialer(d, "tcp", address, conf)
+	if err != nil {
+		return nil, err
+	}
+
+	defer conn.Close()
+	// Grab the certificactes
+	certs := conn.ConnectionState().PeerCertificates
+	if len(certs) > 1 {
+		return nil, fmt.Errorf("[k8s client] not designed to recive multiple certs from API server")
+	}
+
+	return certs[0].IPAddresses, nil
+}
+
+func FindWorkingKubernetesAddress(configPath string, inCluster bool) (*kubernetes.Clientset, error) {
+	// check with loopback, and retrieve its certificate
+	ips, err := findAddressFromRemoteCert("127.0.0.1:6443")
+	if err != nil {
+		return nil, err
+	}
+	for x := range ips {
+		log.Debugf("[k8s client] checking with IP address [%s]", ips[x].String())
+
+		k, err := newClientset(configPath, inCluster, ips[x].String()+":6443", time.Second*2)
+		if err != nil {
+			log.Info(err)
+		}
+		_, err = k.DiscoveryClient.ServerVersion()
+		if err == nil {
+			log.Infof("[k8s client] working with IP address [%s]", ips[x].String())
+			return NewClientset(configPath, inCluster, ips[x].String()+":6443")
+		}
+	}
+	return nil, fmt.Errorf("unable to find a working address for the local API server [%v]", err)
 }

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -1,78 +1,70 @@
 package k8s
 
-import (
-	"net"
-	"reflect"
-	"testing"
-
-	"k8s.io/client-go/kubernetes"
-)
-
 //"192.168.0.174:6443"
 
-func Test_findAddressFromRemoteCert(t *testing.T) {
-	type args struct {
-		address string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    []net.IP
-		wantErr bool
-	}{
-		{
-			name:    "test server",
-			args:    args{address: "192.168.0.174:6443"},
-			want:    []net.IP{net.IPv4(10, 96, 0, 1), net.IPv4(192, 168, 0, 174)},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := findAddressFromRemoteCert(tt.args.address)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("findAddressFromRemoteCert() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("findAddressFromRemoteCert() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+// func Test_findAddressFromRemoteCert(t *testing.T) {
+// 	type args struct {
+// 		address string
+// 	}
+// 	tests := []struct {
+// 		name    string
+// 		args    args
+// 		want    []net.IP
+// 		wantErr bool
+// 	}{
+// 		{
+// 			name:    "test server",
+// 			args:    args{address: "192.168.0.174:6443"},
+// 			want:    []net.IP{net.IPv4(10, 96, 0, 1), net.IPv4(192, 168, 0, 174)},
+// 			wantErr: false,
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			got, err := findAddressFromRemoteCert(tt.args.address)
+// 			if (err != nil) != tt.wantErr {
+// 				t.Errorf("findAddressFromRemoteCert() error = %v, wantErr %v", err, tt.wantErr)
+// 				return
+// 			}
+// 			if !reflect.DeepEqual(got, tt.want) {
+// 				t.Errorf("findAddressFromRemoteCert() = %v, want %v", got, tt.want)
+// 			}
+// 		})
+// 	}
+// }
 
-//findAddressFromRemoteCert() =
-//[10.96.0.1 192.168.0.174]
-//[10.96.0.1 192.168.0.174]
+// //findAddressFromRemoteCert() =
+// //[10.96.0.1 192.168.0.174]
+// //[10.96.0.1 192.168.0.174]
 
-func Test_findWorkingKubernetesAddress(t *testing.T) {
-	type args struct {
-		configPath string
-		inCluster  bool
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    *kubernetes.Clientset
-		wantErr bool
-	}{
-		{
-			name: "test",
-			args: args{
-				configPath: "/home/dan/super-admin.conf",
-				inCluster:  false,
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := FindWorkingKubernetesAddress(tt.args.configPath, tt.args.inCluster)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("findWorkingKubernetesAddress() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+// func Test_findWorkingKubernetesAddress(t *testing.T) {
+// 	type args struct {
+// 		configPath string
+// 		inCluster  bool
+// 	}
+// 	tests := []struct {
+// 		name    string
+// 		args    args
+// 		want    *kubernetes.Clientset
+// 		wantErr bool
+// 	}{
+// 		{
+// 			name: "test",
+// 			args: args{
+// 				configPath: "/home/dan/super-admin.conf",
+// 				inCluster:  false,
+// 			},
+// 			wantErr: false,
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			_, err := FindWorkingKubernetesAddress(tt.args.configPath, tt.args.inCluster)
+// 			if (err != nil) != tt.wantErr {
+// 				t.Errorf("findWorkingKubernetesAddress() error = %v, wantErr %v", err, tt.wantErr)
+// 				return
+// 			}
 
-		})
-	}
-}
+// 		})
+// 	}
+// }

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -1,0 +1,78 @@
+package k8s
+
+import (
+	"net"
+	"reflect"
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+//"192.168.0.174:6443"
+
+func Test_findAddressFromRemoteCert(t *testing.T) {
+	type args struct {
+		address string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []net.IP
+		wantErr bool
+	}{
+		{
+			name:    "test server",
+			args:    args{address: "192.168.0.174:6443"},
+			want:    []net.IP{net.IPv4(10, 96, 0, 1), net.IPv4(192, 168, 0, 174)},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := findAddressFromRemoteCert(tt.args.address)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("findAddressFromRemoteCert() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("findAddressFromRemoteCert() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+//findAddressFromRemoteCert() =
+//[10.96.0.1 192.168.0.174]
+//[10.96.0.1 192.168.0.174]
+
+func Test_findWorkingKubernetesAddress(t *testing.T) {
+	type args struct {
+		configPath string
+		inCluster  bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *kubernetes.Clientset
+		wantErr bool
+	}{
+		{
+			name: "test",
+			args: args{
+				configPath: "/home/dan/super-admin.conf",
+				inCluster:  false,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := FindWorkingKubernetesAddress(tt.args.configPath, tt.args.inCluster)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("findWorkingKubernetesAddress() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+		})
+	}
+}

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -152,6 +152,16 @@ func ParseEnvironment(c *Config) error {
 		c.EnableControlPlane = b
 	}
 
+	// Find controlplane toggle
+	env = os.Getenv(cpDetect)
+	if env != "" {
+		b, err := strconv.ParseBool(env)
+		if err != nil {
+			return err
+		}
+		c.DetectControlPlane = b
+	}
+
 	// Find Services toggle
 	env = os.Getenv(svcEnable)
 	if env != "" {

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -138,6 +138,9 @@ const (
 	// cpEnable enables the control plane feature
 	cpEnable = "cp_enable"
 
+	// cpDetect will attempt to automatically find a working address for the control plane from loopback
+	cpDetect = "cp_detect"
+
 	// svcEnable enables the Kubernetes service feature
 	svcEnable = "svc_enable"
 

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -24,6 +24,9 @@ type Config struct {
 	// EnableControlPlane, will enable the control plane functionality (used for hybrid behaviour)
 	EnableControlPlane bool `yaml:"enableControlPlane"`
 
+	// DetectControlPlane, will attempt to find the control plane from loopback (127.0.0.1)
+	DetectControlPlane bool `yaml:"detectControlPlane"`
+
 	// EnableServices, will enable the services functionality (used for hybrid behaviour)
 	EnableServices bool `yaml:"enableServices"`
 


### PR DESCRIPTION
There is now an option for the Kubernetes client to auto-detect the IP addresses in the API server certificate. This should allow us to find an address that works with the cert and establishes the connection.