### PR TITLE
Minimal implementation of DualStack Services support

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -138,6 +138,8 @@ func init() {
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableServiceSecurity, "onlyAllowTrafficServicePorts", false, "Only allow traffic to service ports, others will be dropped, defaults to false")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableNodeLabeling, "enableNodeLabeling", false, "Enable leader node labeling with \"kube-vip.io/has-ip=<VIP address>\", defaults to false")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.ServicesLeaseName, "servicesLeaseName", "plndr-svcs-lock", "Name of the lease that is used for leader election for services (in arp mode)")
+	kubeVipCmd.PersistentFlags().StringVar(&initConfig.DNSMode, "dnsMode", "first", "Name of the mode that DNS lookup will be performed (first, ipv4, ipv6, dual)")
+	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.DisableServiceUpdates, "disableServiceUpdates", false, "If true, kube-vip will process services as usal, but will not update service's Status.LoadBalancer.Ingress slice")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableEndpointSlices, "enableEndpointSlices", false, "If enabled, kube-vip will only advertise services, but will use EndpointSlices instead of endpoints to get IPs of Pods")
 
 	// Prometheus HTTP Server

--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -139,7 +139,7 @@ func init() {
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableNodeLabeling, "enableNodeLabeling", false, "Enable leader node labeling with \"kube-vip.io/has-ip=<VIP address>\", defaults to false")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.ServicesLeaseName, "servicesLeaseName", "plndr-svcs-lock", "Name of the lease that is used for leader election for services (in arp mode)")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.DNSMode, "dnsMode", "first", "Name of the mode that DNS lookup will be performed (first, ipv4, ipv6, dual)")
-	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.DisableServiceUpdates, "disableServiceUpdates", false, "If true, kube-vip will process services as usal, but will not update service's Status.LoadBalancer.Ingress slice")
+	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.DisableServiceUpdates, "disableServiceUpdates", false, "If true, kube-vip will process services as usual, but will not update service's Status.LoadBalancer.Ingress slice")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableEndpointSlices, "enableEndpointSlices", false, "If enabled, kube-vip will only advertise services, but will use EndpointSlices instead of endpoints to get IPs of Pods")
 
 	// Prometheus HTTP Server

--- a/pkg/cluster/clusterDDNS.go
+++ b/pkg/cluster/clusterDDNS.go
@@ -13,11 +13,16 @@ import (
 // dnsUpdater already have the functionality to keep trying resolve the IP
 // and update the VIP configuration if it changes
 func (cluster *Cluster) StartDDNS(ctx context.Context) error {
-	ddnsMgr := vip.NewDDNSManager(ctx, cluster.Network)
-	ip, err := ddnsMgr.Start()
-	if err != nil {
-		return err
+	for i := range cluster.Network {
+		ddnsMgr := vip.NewDDNSManager(ctx, cluster.Network[i])
+		ip, err := ddnsMgr.Start()
+		if err != nil {
+			return err
+		}
+		if err = cluster.Network[i].SetIP(ip); err != nil {
+			return err
+		}
 	}
 
-	return cluster.Network.SetIP(ip)
+	return nil
 }

--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -117,9 +117,12 @@ func (cluster *Cluster) StartCluster(c *kubevip.Config, sm *Manager, bgpServer *
 	}()
 
 	// (attempt to) Remove the virtual IP, in case it already exists
-	err = cluster.Network.DeleteIP()
-	if err != nil {
-		log.Errorf("could not delete virtualIP: %v", err)
+
+	for i := range cluster.Network {
+		err = cluster.Network[i].DeleteIP()
+		if err != nil {
+			log.Errorf("could not delete virtualIP: %v", err)
+		}
 	}
 
 	// Defer a function to check if the bgpServer has been created and if so attempt to close it
@@ -195,9 +198,11 @@ func (cluster *Cluster) StartCluster(c *kubevip.Config, sm *Manager, bgpServer *
 				}
 			}
 
-			err := cluster.Network.DeleteIP()
-			if err != nil {
-				log.Warnf("%v", err)
+			for i := range cluster.Network {
+				err := cluster.Network[i].DeleteIP()
+				if err != nil {
+					log.Warnf("%v", err)
+				}
 			}
 
 			log.Fatal("lost leadership, restarting kube-vip")

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -313,6 +313,22 @@ func ParseEnvironment(c *Config) error {
 		c.RoutingTableType = int(i)
 	}
 
+	// DNS mode
+	env = os.Getenv(dnsMode)
+	if env != "" {
+		c.DNSMode = env
+	}
+
+	// Disable updates for services (status.LoadBalancer.Ingress will not be updated)
+	env = os.Getenv(disableServiceUpdates)
+	if env != "" {
+		b, err := strconv.ParseBool(env)
+		if err != nil {
+			return err
+		}
+		c.DisableServiceUpdates = b
+	}
+
 	// BGP Server options
 	env = os.Getenv(bgpEnable)
 	if env != "" {

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -187,6 +187,12 @@ const (
 	//k8sConfigFile defines the path to the configfile used to speak with the API server
 	k8sConfigFile = "k8s_config_file"
 
+	// dnsMode defines mode that DNS lookup will be performed with (first, ipv4, ipv6, dual)
+	dnsMode = "dns_mode"
+
+	// disableServiceUpdates disables service updating
+	disableServiceUpdates = "disable_service_updates"
+
 	// enableEndpointSlices enables use of EndpointSlices instead of Endpoints
 	enableEndpointSlices = "enable_endpointslices"
 )

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -170,6 +170,17 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 		newEnvironment = append(newEnvironment, cidr...)
 	}
 
+	if c.DNSMode != "" {
+		// build environment variables
+		dnsModeSelector := []corev1.EnvVar{
+			{
+				Name:  dnsMode,
+				Value: c.DNSMode,
+			},
+		}
+		newEnvironment = append(newEnvironment, dnsModeSelector...)
+	}
+
 	// If we're doing the hybrid mode
 	if c.EnableControlPlane {
 		cp := []corev1.EnvVar{
@@ -481,6 +492,17 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 			Name:  enableEndpointSlices,
 			Value: strconv.FormatBool(c.EnableEndpointSlices),
 		})
+	}
+
+	if c.DisableServiceUpdates {
+		// Disable service updates
+		disServiceUpdates := []corev1.EnvVar{
+			{
+				Name:  disableServiceUpdates,
+				Value: strconv.FormatBool(c.DisableServiceUpdates),
+			},
+		}
+		newEnvironment = append(newEnvironment, disServiceUpdates...)
 	}
 
 	newManifest := &corev1.Pod{

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -158,6 +158,12 @@ type Config struct {
 	// K8sConfigFile, this is the path to the config file used to speak with the API server
 	K8sConfigFile string `yaml:"k8sConfigFile"`
 
+	// DNSMode, this will set the mode DSN lookup will be performed (first, ipv4, ipv6, dual)
+	DNSMode string `yaml:"dnsDualStackMode"`
+
+	// DisableServiceUpdates, if true, kube-vip will only advertise service, but it will not update service's Status.LoadBalancer.Ingress slice
+	DisableServiceUpdates bool `yaml:"disableServiceUpdates"`
+
 	// EnableEndpointSlices, if enabled, EndpointSlices will be used instead of Endpoints
 	EnableEndpointSlices bool `yaml:"enableEndpointSlices"`
 }

--- a/pkg/manager/instance.go
+++ b/pkg/manager/instance.go
@@ -67,6 +67,8 @@ func NewInstance(svc *v1.Service, config *kubevip.Config) (*Instance, error) {
 			RoutingTableType:      config.RoutingTableType,
 			ArpBroadcastRate:      config.ArpBroadcastRate,
 			EnableServiceSecurity: config.EnableServiceSecurity,
+			DNSMode:               config.DNSMode,
+			DisableServiceUpdates: config.DisableServiceUpdates,
 		})
 	}
 
@@ -124,9 +126,12 @@ func NewInstance(svc *v1.Service, config *kubevip.Config) (*Instance, error) {
 			log.Errorf("Failed to add Service %s/%s", svc.Namespace, svc.Name)
 			return nil, err
 		}
-		c.Network.SetServicePorts(svc)
-		instance.clusters = append(instance.clusters, c)
 
+		for i := range c.Network {
+			c.Network[i].SetServicePorts(svc)
+		}
+
+		instance.clusters = append(instance.clusters, c)
 	}
 
 	return instance, nil

--- a/pkg/manager/manager_arp.go
+++ b/pkg/manager/manager_arp.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 
 	"github.com/kube-vip/kube-vip/pkg/cluster"
+	"github.com/kube-vip/kube-vip/pkg/iptables"
 	"github.com/kube-vip/kube-vip/pkg/vip"
 )
 
@@ -102,7 +103,7 @@ func (sm *Manager) startARP() error {
 
 	// This will tidy any dangling kube-vip iptables rules
 	if os.Getenv("EGRESS_CLEAN") != "" {
-		i, err := vip.CreateIptablesClient(sm.config.EgressWithNftables, sm.config.ServiceNamespace)
+		i, err := vip.CreateIptablesClient(sm.config.EgressWithNftables, sm.config.ServiceNamespace, iptables.ProtocolIPv4)
 		if err != nil {
 			log.Warnf("(egress) Unable to clean any dangling egress rules [%v]", err)
 			log.Warn("(egress) Can be ignored in non iptables release of kube-vip")

--- a/pkg/manager/servicesLeader.go
+++ b/pkg/manager/servicesLeader.go
@@ -24,7 +24,9 @@ func (sm *Manager) startServicesWatchForLeaderElection(ctx context.Context) erro
 
 	for _, instance := range sm.serviceInstances {
 		for _, cluster := range instance.clusters {
-			_ = cluster.Network.DeleteRoute()
+			for i := range cluster.Network {
+				_ = cluster.Network[i].DeleteRoute()
+			}
 			cluster.Stop()
 		}
 	}

--- a/pkg/manager/watch_services.go
+++ b/pkg/manager/watch_services.go
@@ -105,9 +105,10 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 				break
 			}
 
+			svcAddresses := fetchServiceAddresses(svc)
+
 			// We only care about LoadBalancer services that have been allocated an address
-			serviceAddresses := fetchServiceAddresses(svc)
-			if len(serviceAddresses) == 0 || serviceAddresses[0] == "" {
+			if len(svcAddresses) <= 0 {
 				break
 			}
 
@@ -132,13 +133,15 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 
 			// The modified event should only be triggered if the service has been modified (i.e. moved somewhere else)
 			if event.Type == watch.Modified {
-				//log.Debugf("(svcs) Retreiving local addresses, to ensure that this modified address doesn't exist")
-				f, err := vip.GarbageCollect(sm.config.Interface, svc.Spec.LoadBalancerIP)
-				if err != nil {
-					log.Errorf("(svcs) cleaning existing address error: [%s]", err.Error())
-				}
-				if f {
-					log.Warnf("(svcs) already found existing address [%s] on adapter [%s]", svc.Spec.LoadBalancerIP, sm.config.Interface)
+				for _, addr := range svcAddresses {
+					//log.Debugf("(svcs) Retreiving local addresses, to ensure that this modified address doesn't exist: %s", addr)
+					f, err := vip.GarbageCollect(sm.config.Interface, addr)
+					if err != nil {
+						log.Errorf("(svcs) cleaning existing address error: [%s]", err.Error())
+					}
+					if f {
+						log.Warnf("(svcs) already found existing address [%s] on adapter [%s]", addr, sm.config.Interface)
+					}
 				}
 			}
 			// Scenarios:
@@ -161,7 +164,7 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 							// background the endpoint watcher
 							go func() {
 								if svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal {
-									// Add Endpoint watcher
+									// Add Endpoint or EndpointSlices watcher
 									wg.Add(1)
 									if !sm.config.EnableEndpointSlices {
 										err = sm.watchEndpoint(activeServiceLoadBalancer[string(svc.UID)], id, svc, &wg)

--- a/pkg/vip/dns.go
+++ b/pkg/vip/dns.go
@@ -32,15 +32,20 @@ func (d *ipUpdater) Run(ctx context.Context) {
 				log.Infof("stop ipUpdater")
 				return
 			default:
-				ip, err := lookupHost(d.vip.DNSName())
+				mode := "ipv4"
+				if IsIPv6(d.vip.IP()) {
+					mode = "ipv6"
+				}
+
+				ip, err := LookupHost(d.vip.DNSName(), mode)
 				if err != nil {
 					log.Warnf("cannot lookup %s: %v", d.vip.DNSName(), err)
 					// fallback to renewing the existing IP
-					ip = d.vip.IP()
+					ip = []string{d.vip.IP()}
 				}
 
 				log.Infof("setting %s as an IP", ip)
-				if err := d.vip.SetIP(ip); err != nil {
+				if err := d.vip.SetIP(ip[0]); err != nil {
 					log.Errorf("setting %s as an IP: %v", ip, err)
 				}
 

--- a/pkg/vip/egress.go
+++ b/pkg/vip/egress.go
@@ -33,11 +33,19 @@ type Egress struct {
 	comment        string
 }
 
-func CreateIptablesClient(nftables bool, namespace string) (*Egress, error) {
+func CreateIptablesClient(nftables bool, namespace string, protocol iptables.Protocol) (*Egress, error) {
 	log.Infof("[egress] Creating an iptables client, nftables mode [%t]", nftables)
 	e := new(Egress)
 	var err error
-	e.ipTablesClient, err = iptables.New(iptables.EnableNFTables(nftables))
+
+	options := []iptables.Option{}
+	options = append(options, iptables.EnableNFTables(nftables))
+
+	if protocol == iptables.ProtocolIPv6 {
+		options = append(options, iptables.IPFamily(iptables.ProtocolIPv6), iptables.Timeout(5))
+	}
+
+	e.ipTablesClient, err = iptables.New(options...)
 	e.comment = Comment + "-" + namespace
 	return e, err
 }

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/gexec"
 
+	"github.com/kube-vip/kube-vip/pkg/vip"
 	"github.com/kube-vip/kube-vip/testing/e2e"
 )
 
@@ -270,6 +271,87 @@ var _ = Describe("kube-vip broadcast neighbor", func() {
 			assertControlPlaneIsRoutable(ipv6VIP, 1*time.Second, 30*time.Second)
 		})
 	})
+
+	Describe("kube-vip DualStack functionality", func() {
+		var (
+			clusterConfig  kindconfigv1alpha4.Cluster
+			vips           []string
+			ipDualStackVIP string
+		)
+
+		BeforeEach(func() {
+			clusterName = fmt.Sprintf("%s-dualstack", filepath.Base(tempDirPath))
+
+			clusterConfig = kindconfigv1alpha4.Cluster{
+				Networking: kindconfigv1alpha4.Networking{
+					IPFamily: kindconfigv1alpha4.DualStackFamily,
+				},
+				Nodes: []kindconfigv1alpha4.Node{},
+			}
+
+			manifestPath := filepath.Join(tempDirPath, "kube-vip-dualstack.yaml")
+
+			for i := 0; i < 3; i++ {
+				nodeConfig := kindconfigv1alpha4.Node{
+					Role: kindconfigv1alpha4.ControlPlaneRole,
+					ExtraMounts: []kindconfigv1alpha4.Mount{
+						{
+							HostPath:      manifestPath,
+							ContainerPath: "/etc/kubernetes/manifests/kube-vip.yaml",
+						},
+					},
+				}
+				// Override the kind image version
+				if k8sImagePath != "" {
+					nodeConfig.Image = k8sImagePath
+				}
+				clusterConfig.Nodes = append(clusterConfig.Nodes, nodeConfig)
+			}
+
+			ipDualStackVIP = e2e.GenerateDualStackVIP()
+			vips = vip.GetIPs(ipDualStackVIP)
+
+			manifestFile, err := os.Create(manifestPath)
+			Expect(err).NotTo(HaveOccurred())
+
+			defer manifestFile.Close()
+
+			Expect(kubeVIPManifestTemplate.Execute(manifestFile, e2e.KubevipManifestValues{
+				ControlPlaneVIP: ipDualStackVIP,
+				ImagePath:       imagePath,
+			})).To(Succeed())
+		})
+
+		It("provides an DualStack VIP address for the Kubernetes control plane nodes", func() {
+
+			By(withTimestamp("creating a kind cluster with multiple control plane nodes"))
+			createKindCluster(logger, &clusterConfig, clusterName)
+
+			By(withTimestamp("loading local docker image to kind cluster"))
+			e2e.LoadDockerImageToKind(logger, imagePath, clusterName)
+
+			By(withTimestamp("checking that the Kubernetes control plane nodes are accessible via the assigned IPv4 VIP"))
+			// Allow enough time for control plane nodes to load the docker image and
+			// use the default timeout for establishing a connection to the VIP
+			assertControlPlaneIsRoutable(vips[0], time.Duration(0), 20*time.Second)
+
+			By(withTimestamp("checking that the Kubernetes control plane nodes are accessible via the assigned IPv6 VIP"))
+			// Allow enough time for control plane nodes to load the docker image and
+			// use the default timeout for establishing a connection to the VIP
+			assertControlPlaneIsRoutable(vips[1], time.Duration(0), 20*time.Second)
+
+			By(withTimestamp("killing the leader Kubernetes control plane node to trigger a fail-over scenario"))
+			killLeader(vips[0], clusterName)
+
+			By(withTimestamp("checking that the Kubernetes control plane nodes are still accessible via the assigned IPv4 VIP with little downtime"))
+			// Allow at most 20 seconds of downtime when polling the control plane nodes
+			assertControlPlaneIsRoutable(vips[0], 1*time.Second, 20*time.Second)
+
+			By(withTimestamp("checking that the Kubernetes control plane nodes are still accessible via the assigned IPv6 VIP with little downtime"))
+			// Allow at most 120 seconds of downtime when polling the control plane nodes
+			assertControlPlaneIsRoutable(vips[1], 1*time.Second, 20*time.Second)
+		})
+	})
 })
 
 func createKindCluster(logger log.Logger, config *v1alpha4.Cluster, clusterName string) {
@@ -317,8 +399,7 @@ func killLeader(leaderIPAddr string, clusterName string) {
 			"docker", "exec", name, "ip", "addr",
 		)
 		cmd.Stdout = cmdOut
-
-		Eventually(cmd.Run).Should(Succeed())
+		Eventually(cmd.Run(), "20s").Should(Succeed())
 
 		if strings.Contains(cmdOut.String(), leaderIPAddr) {
 			leaderName = name

--- a/testing/e2e/ip.go
+++ b/testing/e2e/ip.go
@@ -102,6 +102,10 @@ func GenerateIPv4VIP() string {
 	return ""
 }
 
+func GenerateDualStackVIP() string {
+	return GenerateIPv4VIP() + "," + GenerateIPv6VIP()
+}
+
 func getKindNetworkSubnetCIDRs() []string {
 	cmd := exec.Command(
 		"docker", "inspect", "kind",

--- a/testing/e2e/services/kind.go
+++ b/testing/e2e/services/kind.go
@@ -110,7 +110,13 @@ func (config *testConfig) createKind() error {
 				_, _ = cmd.CombinedOutput()
 			}
 		}
-		cmd := exec.Command("kubectl", "create", "configmap", "--namespace", "kube-system", "kubevip", "--from-literal", "range-global=172.18.100.10-172.18.100.30")
+
+		globalRange := "172.18.100.10-172.18.100.30"
+		if config.IPv6 {
+			globalRange = "fd34:70db:8529:1e3d:0000:0000:0000:0010-fd34:70db:8529:1e3d:0000:0000:0000:0030"
+		}
+
+		cmd := exec.Command("kubectl", "create", "configmap", "--namespace", "kube-system", "kubevip", "--from-literal", "range-global="+globalRange)
 		if _, err := cmd.CombinedOutput(); err != nil {
 			return err
 		}

--- a/testing/e2e/services/tests.go
+++ b/testing/e2e/services/tests.go
@@ -48,6 +48,7 @@ func main() {
 	_, t.ignoreEgress = os.LookupEnv("IGNORE_EGRESS")
 	_, t.ignoreDualStack = os.LookupEnv("IGNORE_DUALSTACK")
 	_, t.retainCluster = os.LookupEnv("RETAIN_CLUSTER")
+	_, t.IPv6 = os.LookupEnv("IPV6_FAMILY")
 
 	flag.StringVar(&t.ImagePath, "imagepath", "plndr/kube-vip:action", "")
 	flag.BoolVar(&t.ControlPlane, "ControlPlane", false, "")


### PR DESCRIPTION
This PR introduces minimal implementation for DualStack support. Main changes are:

- `status.loadbalancer.ingress` can be used to obtain service IP address if `kube-vip.io/loadbalancerIPs` annotation is not set
- way to disable updates of status.loadbalancer.ingress , so kube-vip can be used alongside other loadbalancers as e.g. routing table configuration service (configured with `DisableServiceUpdates` flag).
- support for enpointslices (this will be merged alongside #720)
- egress can be now configured for IPv6
- DNS lookup can now return IPv4, IPv6 or both (configured with `DNSMode` flag).

This PR has to be thoroughly reviewed and tested as I have no means to test all the possible configurations.