### PR TITLE
fix: Using log instead of fmt.print

### DIFF
--- a/cmd/kube-vip-kubeadm.go
+++ b/cmd/kube-vip-kubeadm.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
@@ -54,7 +53,7 @@ var kubeKubeadmInit = &cobra.Command{
 		}
 		cfg := kubevip.GeneratePodManifestFromConfig(&initConfig, Release.Version, inCluster)
 
-		fmt.Println(cfg)
+		log.Info(cfg)
 	},
 }
 
@@ -89,6 +88,6 @@ var kubeKubeadmJoin = &cobra.Command{
 
 		// Generate manifest and print
 		cfg := kubevip.GeneratePodManifestFromConfig(&initConfig, Release.Version, inCluster)
-		fmt.Println(cfg)
+		log.Info(cfg)
 	},
 }

--- a/cmd/kube-vip-manifests.go
+++ b/cmd/kube-vip-manifests.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -54,7 +52,7 @@ var kubeManifestPod = &cobra.Command{
 		}
 		cfg := kubevip.GeneratePodManifestFromConfig(&initConfig, Release.Version, inCluster)
 
-		fmt.Println(cfg)
+		log.Info(cfg)
 	},
 }
 
@@ -79,7 +77,7 @@ var kubeManifestDaemon = &cobra.Command{
 		}
 		cfg := kubevip.GenerateDaemonsetManifestFromConfig(&initConfig, Release.Version, inCluster, taint)
 
-		fmt.Println(cfg)
+		log.Info(cfg)
 	},
 }
 
@@ -103,6 +101,6 @@ var kubeManifestRbac = &cobra.Command{
 		cfg := kubevip.GenerateSA()
 		b, _ := yaml.Marshal(cfg)
 
-		fmt.Println(string(b))
+		log.Info(string(b))
 	},
 }

--- a/pkg/equinixmetal/bgp.go
+++ b/pkg/equinixmetal/bgp.go
@@ -25,7 +25,7 @@ func BGPLookup(c *packngo.Client, k *kubevip.Config) error {
 		return fmt.Errorf("Unable to find local/this device in Equinix Metal API")
 	}
 
-	fmt.Printf("Querying BGP settings for [%s]", thisDevice.Hostname)
+	log.Infof("Querying BGP settings for [%s]", thisDevice.Hostname)
 	neighbours, _, err := c.Devices.ListBGPNeighbors(thisDevice.ID, &packngo.ListOptions{})
 	if err != nil {
 		return err


### PR DESCRIPTION
When I was looking at the source code, I noticed that print was being used here, and I felt it would be better to change it to log output.