### PR TITLE
Added possibility to remove redundant routes

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -127,6 +127,7 @@ func init() {
 	// Routing Table flags
 	kubeVipCmd.PersistentFlags().IntVar(&initConfig.RoutingTableID, "tableID", 198, "The routing table used for all table entries")
 	kubeVipCmd.PersistentFlags().IntVar(&initConfig.RoutingTableType, "tableType", 0, "The type of route that will be added to the routing table")
+	kubeVipCmd.PersistentFlags().IntVar(&initConfig.RoutingProtocol, "routingProtocol", 198, "The routing protocol value used to create routes")
 
 	// Behaviour flags
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableControlPlane, "controlplane", false, "Enable HA for control plane")

--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -127,7 +127,8 @@ func init() {
 	// Routing Table flags
 	kubeVipCmd.PersistentFlags().IntVar(&initConfig.RoutingTableID, "tableID", 198, "The routing table used for all table entries")
 	kubeVipCmd.PersistentFlags().IntVar(&initConfig.RoutingTableType, "tableType", 0, "The type of route that will be added to the routing table")
-	kubeVipCmd.PersistentFlags().IntVar(&initConfig.RoutingProtocol, "routingProtocol", 198, "The routing protocol value used to create routes")
+	kubeVipCmd.PersistentFlags().IntVar(&initConfig.RoutingProtocol, "routingProtocol", 248, "The routing protocol value used to create routes")
+	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.CleanRoutingTable, "cleanRoutingTable", false, "Clean routing table of redundant routes on start")
 
 	// Behaviour flags
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableControlPlane, "controlplane", false, "Enable HA for control plane")

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -50,7 +50,7 @@ func startNetworking(c *kubevip.Config) ([]vip.Network, error) {
 
 	networks := []vip.Network{}
 	for _, addr := range addresses {
-		network, err := vip.NewConfig(addr, c.Interface, c.VIPSubnet, c.DDNS, c.RoutingTableID, c.RoutingTableType, c.DNSMode)
+		network, err := vip.NewConfig(addr, c.Interface, c.VIPSubnet, c.DDNS, c.RoutingTableID, c.RoutingTableType, c.RoutingProtocol, c.DNSMode)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -313,6 +313,16 @@ func ParseEnvironment(c *Config) error {
 		c.RoutingTableType = int(i)
 	}
 
+	// Routing protocol
+	env = os.Getenv(vipRoutingProtocol)
+	if env != "" {
+		i, err := strconv.ParseInt(env, 10, 32)
+		if err != nil {
+			return err
+		}
+		c.RoutingProtocol = int(i)
+	}
+
 	// DNS mode
 	env = os.Getenv(dnsMode)
 	if env != "" {

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -323,6 +323,16 @@ func ParseEnvironment(c *Config) error {
 		c.RoutingProtocol = int(i)
 	}
 
+	// Clean routing table
+	env = os.Getenv(vipCleanRoutingTable)
+	if env != "" {
+		b, err := strconv.ParseBool(env)
+		if err != nil {
+			return err
+		}
+		c.CleanRoutingTable = b
+	}
+
 	// DNS mode
 	env = os.Getenv(dnsMode)
 	if env != "" {

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -136,6 +136,9 @@ const (
 	//						 you should say `vip_routingtabletype=2` for RTN_LOCAL
 	vipRoutingTableType = "vip_routingtabletype" //nolint
 
+	// vipRoutingProtocol - defines what value will be used as protcol when creating routes
+	vipRoutingProtocol = "vip_routingprotocol" //nolint
+
 	// cpNamespace defines the namespace the control plane pods will run in
 	cpNamespace = "cp_namespace"
 

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -136,8 +136,11 @@ const (
 	//						 you should say `vip_routingtabletype=2` for RTN_LOCAL
 	vipRoutingTableType = "vip_routingtabletype" //nolint
 
-	// vipRoutingProtocol - defines what value will be used as protcol when creating routes
+	// vipRoutingProtocol - defines what value will be used as protocol when creating routes
 	vipRoutingProtocol = "vip_routingprotocol" //nolint
+
+	// vipCleanRoutingTable - defines if routing table will be cleaned of redundant routes on kube-vip's start
+	vipCleanRoutingTable = "vip_cleanroutingtable" //nolint
 
 	// cpNamespace defines the namespace the control plane pods will run in
 	cpNamespace = "cp_namespace"

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -118,6 +118,9 @@ type Config struct {
 	// Routing Protocol, value that will be used as protocol when creating rutes
 	RoutingProtocol int `yaml:"routingProtocol"`
 
+	// Clean routing table of redundant routes on start
+	CleanRoutingTable bool `yaml:"cleanRoutingTable"`
+
 	// BGP Configuration
 	BGPConfig     bgp.Config
 	BGPPeerConfig bgp.Peer

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -115,6 +115,9 @@ type Config struct {
 	// Routing Table Type, what sort of route should be added to the routing table
 	RoutingTableType int `yaml:"routingTableType"`
 
+	// Routing Protocol, value that will be used as protocol when creating rutes
+	RoutingProtocol int `yaml:"routingProtocol"`
+
 	// BGP Configuration
 	BGPConfig     bgp.Config
 	BGPPeerConfig bgp.Peer

--- a/pkg/manager/instance.go
+++ b/pkg/manager/instance.go
@@ -65,6 +65,7 @@ func NewInstance(svc *v1.Service, config *kubevip.Config) (*Instance, error) {
 			EnableRoutingTable:     config.EnableRoutingTable,
 			RoutingTableID:         config.RoutingTableID,
 			RoutingTableType:       config.RoutingTableType,
+			RoutingProtocol:        config.RoutingProtocol,
 			ArpBroadcastRate:       config.ArpBroadcastRate,
 			EnableServiceSecurity:  config.EnableServiceSecurity,
 			DNSMode:                config.DNSMode,

--- a/pkg/manager/manager_table.go
+++ b/pkg/manager/manager_table.go
@@ -40,8 +40,6 @@ func (sm *Manager) startTableMode() error {
 		}()
 	}
 
-	log.Infof("started route watcher")
-
 	// Shutdown function that will wait on this signal, unless we call it ourselves
 	go func() {
 		<-sm.signalChan
@@ -132,7 +130,7 @@ func (sm *Manager) startTableMode() error {
 }
 
 func (sm *Manager) cleanRoutes() error {
-	routes, err := vip.GetRoutes(sm.config.RoutingTableID, sm.config.RoutingProtocol)
+	routes, err := vip.ListRoutes(sm.config.RoutingTableID, sm.config.RoutingProtocol)
 	if err != nil {
 		return fmt.Errorf("error getting routes: %w", err)
 	}

--- a/pkg/manager/manager_table.go
+++ b/pkg/manager/manager_table.go
@@ -30,13 +30,15 @@ func (sm *Manager) startTableMode() error {
 	defer cancel()
 	log.Infof("all routing table entries will exist in table [%d] with protocol [%d]", sm.config.RoutingTableID, sm.config.RoutingProtocol)
 
-	go func() {
-		// we assume that after 10s all services should be configured so we can delete redundant routes
-		time.Sleep(time.Second * 10)
-		if err := sm.purgeRoutes(); err != nil {
-			log.Errorf("error checking for old routes: %v", err)
-		}
-	}()
+	if sm.config.CleanRoutingTable {
+		go func() {
+			// we assume that after 10s all services should be configured so we can delete redundant routes
+			time.Sleep(time.Second * 10)
+			if err := sm.cleanRoutes(); err != nil {
+				log.Errorf("error checking for old routes: %v", err)
+			}
+		}()
+	}
 
 	log.Infof("started route watcher")
 
@@ -129,7 +131,7 @@ func (sm *Manager) startTableMode() error {
 	return nil
 }
 
-func (sm *Manager) purgeRoutes() error {
+func (sm *Manager) cleanRoutes() error {
 	routes, err := vip.GetRoutes(sm.config.RoutingTableID, sm.config.RoutingProtocol)
 	if err != nil {
 		return fmt.Errorf("error getting routes: %w", err)

--- a/pkg/manager/watch_services.go
+++ b/pkg/manager/watch_services.go
@@ -334,5 +334,6 @@ func isRouteConfigured(serviceUID types.UID) (bool, error) {
 			return false, fmt.Errorf("error converting configuredLocalRoute item to boolean value")
 		}
 	}
+
 	return isConfigured, nil
 }


### PR DESCRIPTION
This PR introduces a possibility to clean reduntant routes created in routing table mode as described in #762 

Created routes will be tagged using `protocol` as explained in [ip-route man](https://man7.org/linux/man-pages/man8/ip-route.8.html) (value `protocol RTPROTO`) which is configurable using `routingProtocol` flag (defaults to ~~`198`~~ `248`, ~~same as table~~).

On every kube-vip start, if `cleanRoutingTable` flag is set `true`, _after 10s of initial delay_, all routes from the configured table that have protocol set to the same value as `routingProtocol`, will be get from node and checked against watched services. If no service will have LB IP same as the route `dst` field, the route will be deleted.