### PR TITLE
fixes a bug that wouldn't return CIDRs for egress

### DIFF
--- a/pkg/manager/service_egress.go
+++ b/pkg/manager/service_egress.go
@@ -47,11 +47,13 @@ func (sm *Manager) iptablesCheck() error {
 func getSameFamilyCidr(source, ip string) string {
 	cidrs := strings.Split(source, ",")
 	for _, cidr := range cidrs {
+		source = cidr
 		if vip.IsIPv4(cidr) == vip.IsIPv4(ip) {
 			return cidr
 		}
 	}
-	return ""
+	// return to the default behaviour of setting the CIDR to the first one (or only one)
+	return source
 }
 
 func (sm *Manager) configureEgress(vipIP, podIP, destinationPorts, namespace string) error {

--- a/pkg/manager/service_egress_test.go
+++ b/pkg/manager/service_egress_test.go
@@ -1,0 +1,47 @@
+package manager
+
+import "testing"
+
+func Test_getSameFamilyCidr(t *testing.T) {
+	type args struct {
+		source string
+		ip     string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "This is wrong",
+			args: args{
+				source: "10.96.0.0",
+				ip:     "172.16.0.1",
+			},
+			want: "10.96.0.0",
+		},
+		{
+			name: "This returns the correct cidr",
+			args: args{
+				source: "10.96.0.0/16",
+				ip:     "10.96.0.1",
+			},
+			want: "10.96.0.0/16",
+		},
+		{
+			name: "This returns the correct cidr from multiple",
+			args: args{
+				source: "192.168.0.0/16,10.96.0.0/16",
+				ip:     "10.96.0.1",
+			},
+			want: "10.96.0.0/16",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getSameFamilyCidr(tt.args.source, tt.args.ip); got != tt.want {
+				t.Errorf("getSameFamilyCidr() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The function `getSameFamilyCidr` is a bit buggy, and introduced an issue where people manually specify ranges in the kube-vip config. This change allows the function to work, but also restores the default behaviour too.