### PR TITLE
Fix flaky e2e test

### DIFF
--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -393,6 +393,7 @@ func createKindCluster(logger log.Logger, config *v1alpha4.Cluster, clusterName 
 	)).To(Succeed())
 }
 
+// Assume the VIP is routable if status code is 200 or 500. Since etcd might glitch.
 func assertControlPlaneIsRoutable(controlPlaneVIP string, transportTimeout, eventuallyTimeout time.Duration) {
 	if strings.Contains(controlPlaneVIP, ":") {
 		controlPlaneVIP = fmt.Sprintf("[%s]", controlPlaneVIP)
@@ -409,7 +410,7 @@ func assertControlPlaneIsRoutable(controlPlaneVIP string, transportTimeout, even
 		}
 		defer resp.Body.Close()
 		return resp.StatusCode
-	}, eventuallyTimeout).Should(Equal(http.StatusOK), "Failed to connect to VIP")
+	}, eventuallyTimeout).Should(BeElementOf([]int{http.StatusOK, http.StatusInternalServerError}), "Failed to connect to VIP")
 }
 
 func killLeader(leaderIPAddr string, clusterName string) {


### PR DESCRIPTION
…ne VIP
Fix https://github.com/kube-vip/kube-vip/issues/771

Assume VIP is routable even if API server returns 500, since that means VIP is routable, it just might be because etcd is glitching.

Another way to fix is to increase the timeout, but I think better not to increase that since 30s is already a long time
considering the default config
```
- name: vip_leaseduration
      value: "5"
    - name: vip_renewdeadline
      value: "3"
    - name: vip_retryperiod
      value: "1"
```