### PR TITLE
Add masquerade mode

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/equinixmetal"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/manager"
+	"github.com/kube-vip/kube-vip/pkg/sysctl"
 	"github.com/kube-vip/kube-vip/pkg/vip"
 )
 
@@ -347,6 +348,14 @@ var kubeVipManager = &cobra.Command{
 				}
 				initConfig.MetalAPIKey = providerAPI
 				initConfig.MetalProject = providerProject
+			}
+		}
+
+		if initConfig.LoadBalancerForwardingMethod == "masquerade" {
+			log.Infof("sysctl set net.ipv4.vs.conntrack to 1")
+			err := sysctl.WriteProcSys("/proc/sys/net/ipv4/vs/conntrack", "1")
+			if err != nil {
+				log.Fatalln(err)
 			}
 		}
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -50,7 +50,7 @@ func startNetworking(c *kubevip.Config) ([]vip.Network, error) {
 
 	networks := []vip.Network{}
 	for _, addr := range addresses {
-		network, err := vip.NewConfig(addr, c.Interface, c.VIPSubnet, c.DDNS, c.RoutingTableID, c.RoutingTableType, c.RoutingProtocol, c.DNSMode)
+		network, err := vip.NewConfig(addr, c.Interface, c.VIPSubnet, c.DDNS, c.RoutingTableID, c.RoutingTableType, c.RoutingProtocol, c.DNSMode, c.LoadBalancerForwardingMethod, c.IptablesBackend)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -80,7 +80,7 @@ func (cluster *Cluster) vipService(ctxArp, ctxDNS context.Context, c *kubevip.Co
 
 			log.Infof("Starting IPVS LoadBalancer")
 
-			lb, err := loadbalancer.NewIPVSLB(cluster.Network[i].IP(), c.LoadBalancerPort, c.LoadBalancerForwardingMethod)
+			lb, err := loadbalancer.NewIPVSLB(cluster.Network[i].IP(), c.LoadBalancerPort, c.LoadBalancerForwardingMethod, c.BackendHealthCheckInterval)
 			if err != nil {
 				log.Errorf("Error creating IPVS LoadBalancer [%s]", err)
 			}

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -64,8 +64,12 @@ const (
 )
 
 const (
-	TableFilter = "filter"
-	ChainInput  = "INPUT"
+	TableFilter      = "filter"
+	TableMangle      = "mangle"
+	TableNat         = "nat"
+	ChainInput       = "INPUT"
+	ChainPREROUTING  = "PREROUTING"
+	ChainPOSTROUTING = "POSTROUTING"
 )
 
 type IPTables struct {

--- a/pkg/iptables/version.go
+++ b/pkg/iptables/version.go
@@ -1,0 +1,91 @@
+package iptables
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type Version struct {
+	Major       int
+	Minor       int
+	Patch       int
+	BackendMode string
+}
+
+func (v Version) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+func (v Version) Compare(other Version) int {
+	if v.Major != other.Major {
+		return v.Major - other.Major
+	}
+	if v.Minor != other.Minor {
+		return v.Minor - other.Minor
+	}
+	return v.Patch - other.Patch
+}
+
+func ParseVersion(versionString string) (Version, error) {
+	re := regexp.MustCompile(`v([0-9]+)\.([0-9]+)\.([0-9]+)`)
+	match := re.FindStringSubmatch(versionString)
+	if len(match) != 4 {
+		return Version{}, fmt.Errorf("invalid version string: %s", versionString)
+	}
+	major, _ := strconv.Atoi(match[1])
+	minor, _ := strconv.Atoi(match[2])
+	patch, _ := strconv.Atoi(match[3])
+	return Version{Major: major, Minor: minor, Patch: patch}, nil
+}
+
+func GetVersion() (Version, error) {
+	ver := Version{}
+	cmd := exec.Command("iptables", "--version")
+	out, err := cmd.Output()
+	if err != nil {
+		return ver, fmt.Errorf("run cmd 'iptables --version' wtith error: %v", err)
+	}
+
+	ver, err = ParseVersion(string(out))
+	if err != nil {
+		return ver, err
+	}
+
+	nft4 := getOutput("iptables-nft-save")
+	legacy4 := getOutput("iptables-legacy-save")
+
+	nft6 := getOutput("ip6tables-nft-save")
+	legacy6 := getOutput("ip6tables-legacy-save")
+
+	if strings.Contains(nft4, "KUBE-IPTABLES") ||
+		strings.Contains(nft6, "KUBE-IPTABLES") ||
+		strings.Contains(nft4, "KUBE-KUBELET") ||
+		strings.Contains(nft6, "KUBE-KUBELET") {
+		ver.BackendMode = "nft"
+	} else if strings.Contains(legacy4, "KUBE-IPTABLES") ||
+		strings.Contains(legacy6, "KUBE-IPTABLES") ||
+		strings.Contains(legacy4, "KUBE-KUBELET") ||
+		strings.Contains(legacy6, "KUBE-KUBELET") {
+		ver.BackendMode = "legacy"
+	} else {
+		nftCount := strings.Count(nft4, "\n") + strings.Count(nft6, "\n")
+		legacyCount := strings.Count(legacy4, "\n") + strings.Count(legacy6, "\n")
+
+		if nftCount >= legacyCount {
+			ver.BackendMode = "nft"
+		} else {
+			ver.BackendMode = "legacy"
+		}
+	}
+
+	return ver, nil
+}
+
+func getOutput(name string) string {
+	cmd := exec.Command(name)
+	out, _ := cmd.Output()
+	return string(out)
+}

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -162,6 +162,11 @@ func ParseEnvironment(c *Config) error {
 		c.DetectControlPlane = b
 	}
 
+	env = os.Getenv(kubernetesAddr)
+	if env != "" {
+		c.KubernetesAddr = env
+	}
+
 	// Find Services toggle
 	env = os.Getenv(svcEnable)
 	if env != "" {
@@ -568,6 +573,20 @@ func ParseEnvironment(c *Config) error {
 			return err
 		}
 		c.EnableEndpointSlices = b
+	}
+
+	env = os.Getenv(iptablesBackend)
+	if env != "" {
+		c.IptablesBackend = env
+	}
+
+	env = os.Getenv(backendHealthCheckInterval)
+	if env != "" {
+		i, err := strconv.ParseInt(env, 10, 32)
+		if err != nil {
+			return err
+		}
+		c.BackendHealthCheckInterval = int(i)
 	}
 
 	return nil

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -151,6 +151,9 @@ const (
 	// cpDetect will attempt to automatically find a working address for the control plane from loopback
 	cpDetect = "cp_detect"
 
+	// kubernetesAddr，is the address of the Kubernetes API server on this machine
+	kubernetesAddr = "kubernetes_addr"
+
 	// svcEnable enables the Kubernetes service feature
 	svcEnable = "svc_enable"
 
@@ -190,7 +193,7 @@ const (
 	// vipConfigMap defines the configmap that kube-vip will watch for service definitions
 	// vipConfigMap = "vip_configmap"
 
-	//k8sConfigFile defines the path to the configfile used to speak with the API server
+	// k8sConfigFile defines the path to the configfile used to speak with the API server
 	k8sConfigFile = "k8s_config_file"
 
 	// dnsMode defines mode that DNS lookup will be performed with (first, ipv4, ipv6, dual)
@@ -201,4 +204,10 @@ const (
 
 	// enableEndpointSlices enables use of EndpointSlices instead of Endpoints
 	enableEndpointSlices = "enable_endpointslices"
+
+	// iptablesBackend iptables backend, can be specified as `nft` or `legacy`. If not set, it defaults to automatic detection.
+	iptablesBackend = "iptables_backend"
+
+	// backendHealthCheckInterval Interval in seconds for checking backend health.
+	backendHealthCheckInterval = "backend_health_check_interval"
 )

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -27,6 +27,9 @@ type Config struct {
 	// DetectControlPlane, will attempt to find the control plane from loopback (127.0.0.1)
 	DetectControlPlane bool `yaml:"detectControlPlane"`
 
+	// KubernetesAddr，is the address of the Kubernetes API server on this machine
+	KubernetesAddr string `yaml:"kubernetesAddr"`
+
 	// EnableServices, will enable the services functionality (used for hybrid behaviour)
 	EnableServices bool `yaml:"enableServices"`
 
@@ -172,6 +175,12 @@ type Config struct {
 
 	// EnableEndpointSlices, if enabled, EndpointSlices will be used instead of Endpoints
 	EnableEndpointSlices bool `yaml:"enableEndpointSlices"`
+
+	// IptablesBackend iptables backend, can be specified as `nft` or `legacy`. If not set, it defaults to automatic detection.
+	IptablesBackend string `yaml:"iptablesBackend"`
+
+	// BackendHealthCheckInterval Interval in seconds for checking backend health.
+	BackendHealthCheckInterval int `yaml:"backendHealthCheckInterval"`
 }
 
 // KubernetesLeaderElection defines all of the settings for Kubernetes KubernetesLeaderElection

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -71,7 +71,10 @@ func New(configMap string, config *kubevip.Config) (*Manager, error) {
 	case config.LeaderElectionType == "etcd":
 		// Do nothing, we don't construct a k8s client for etcd leader election
 	case fileExists(adminConfigPath):
-		if config.EnableControlPlane {
+		if config.KubernetesAddr != "" {
+			fmt.Println(config.KubernetesAddr)
+			clientset, err = k8s.NewClientset(adminConfigPath, false, config.KubernetesAddr)
+		} else if config.EnableControlPlane {
 			// If this is a control plane host it will likely have started as a static pod or won't have the
 			// VIP up before trying to connect to the API server, we set the API endpoint to this machine to
 			// ensure connectivity.

--- a/pkg/sysctl/sysctl.go
+++ b/pkg/sysctl/sysctl.go
@@ -1,0 +1,29 @@
+package sysctl
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func WriteProcSys(path, value string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	defer func() {
+		if cErr := f.Close(); cErr != nil && err == nil {
+			err = fmt.Errorf("failed to close file: %w", cErr)
+		}
+	}()
+
+	n, err := f.Write([]byte(value))
+	if err != nil {
+		return fmt.Errorf("failed to write value: %w", err)
+	}
+	if n < len(value) {
+		return io.ErrShortWrite
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Additional configuration list

| Configuration Key                | Type    | Unit | Default | Options     | Required |
|----------------------------------|---------|------|---------|-------------|----------|
| `backend_health_check_interval`  | int     | seconds    |    5     |             | No       |
| `iptables_backend`               | string  |      |         | `nft`, `legacy` | No       |
| ~~`masquerade_mark`~~                | string  |      | `0x1119`|             | No       |

* `iptables_backend`: Although we already have egress_withnftables, it is not sufficiently clear for users who want to configure`masquerade` mode. The newly added field does not require user specification by default; the program will determine it automatically.
* ~~`masquerade_mark`~~: we change iptable rule to `iptables -t nat -A POSTROUTING -m ipvs --vaddr 192.168.113.200 --vport 8443 -j MASQUERADE`, so remove this configration item, thanks @wyike .

## Required Permissions

```yaml
securityContext:
  privileged: true
```

We require the necessary permissions to set `net.ipv4.vs.conntrack=1`.


## Usage
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: kube-vip
  namespace: kube-system
  labels:
    addonmanager.kubernetes.io/mode: Reconcile
    k8s-app: kube-vip
spec:
  containers:
    - args:
        - manager
      env:
        - name: vip_arp
          value: "True"
        - name: port
          value: "6443"
        - name: vip_cidr
          value: "32"
        - name: cp_enable
          value: "true"
        - name: cp_namespace
          value: kube-system
        - name: vip_ddns
          value: "False"
        - name: vip_leaderelection
          value: "true"
        - name: vip_leaseduration
          value: "5"
        - name: vip_renewdeadline
          value: "3"
        - name: vip_retryperiod
          value: "1"
        - name: address
          value: "172.16.25.136"
        - name: lb_enable
          value: "true"
        - name: lb_fwdmethod
          value: "masquerade"
        - name: "kubernetes_addr"
          value: "172.16.25.131:6443" # current node api-server
      image: "" 
      imagePullPolicy: IfNotPresent
      name: kube-vip
      resources: {}
      securityContext:
        privileged: true
      volumeMounts:
        - mountPath: /etc/kubernetes/admin.conf
          name: kubeconfig
  hostNetwork: true
  volumes:
    - hostPath:
        path: /etc/kubernetes/admin.conf
      name: kubeconfig
```

## Test

The cluster I am testing has 3 nodes.

```shell
$ kubectl get nodes
NAME           STATUS   ROLES           AGE   VERSION
workstation1   Ready    control-plane   47h   v1.28.7
workstation2   Ready    control-plane   41h   v1.28.7
workstation3   Ready    control-plane   39h   v1.28.7
```

`172.16.25.136` is a VIP address in my cluster. He is currently located at node `workstation1`.
```shell
$ ip a | grep 136 -B 5
2: ens160: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 00:0c:29:d8:0d:79 brd ff:ff:ff:ff:ff:ff
    altname enp2s0
    inet 172.16.25.131/24 metric 100 brd 172.16.25.255 scope global dynamic ens160
       valid_lft 1293sec preferred_lft 1293sec
    inet 172.16.25.136/32 scope global ens160
```

```
$ sudo ipvsadm -Ln
IP Virtual Server version 1.2.1 (size=4096)
Prot LocalAddress:Port Scheduler Flags
  -> RemoteAddress:Port           Forward Weight ActiveConn InActConn
TCP  172.16.25.136:6443 rr
  -> 172.16.25.131:6443           Masq    1      4          0
  -> 172.16.25.132:6443           Masq    1      0          0
  -> 172.16.25.133:6443           Masq    1      0          0
```

When I run `kubectl get pods -n some-not-found-ns`, I can observe specific logs in each kube-api-server.
```
I0313 07:04:01.881205       1 httplog.go:132] "HTTP" verb="LIST" URI="/api/v1/namespaces/some-not-found-ns/pods?limit=500" latency="2.603368ms" userAgent="kubectl/v1.29.2 (linux/arm64) kubernetes/4b8e819" audit-ID="bb650a25-5565-413e-8616-ca7402b7861b" srcIP="172.16.25.136:34090" apf_pl="exempt" apf_fs="exempt" apf_iseats=1 apf_fseats=0 apf_additionalLatency="0s" apf_execution_time="1.926017ms" resp=200
```

And then i am shutdown `workstation1`, VIP is move to `workstation3`.

```shell
$ sudo ipvsadm -Ln
[sudo] password for node:
IP Virtual Server version 1.2.1 (size=4096)
Prot LocalAddress:Port Scheduler Flags
  -> RemoteAddress:Port           Forward Weight ActiveConn InActConn
TCP  172.16.25.136:6443 rr
  -> 172.16.25.132:6443           Masq    1      0          2
  -> 172.16.25.133:6443           Masq    1      2          0
```

In the above log, we can see `172.16.25.131` is removed.