### PR TITLE
fix: add iptables-legacy package

### DIFF
--- a/Dockerfile_iptables
+++ b/Dockerfile_iptables
@@ -14,7 +14,7 @@ RUN --mount=type=cache,sharing=locked,id=gomod,target=/go/pkg/mod/cache \
 FROM alpine:3.19.1
 # Update pkgs and add iptables
 RUN apk upgrade && \
-    apk add --no-cache iptables 
+    apk add --no-cache iptables iptables-legacy
 
 # Add kube-vip binary
 COPY --from=dev /src/kube-vip /


### PR DESCRIPTION
Adding `iptables-legacy` package for backward compatibility as Alpine 3.19 defaults to nft and legacy symlinks no longer exist.

Related issue: #808 