### PR TITLE
Fixes on masquerade forwarding mode

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -17,7 +17,6 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/equinixmetal"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/manager"
-	"github.com/kube-vip/kube-vip/pkg/sysctl"
 	"github.com/kube-vip/kube-vip/pkg/vip"
 )
 
@@ -348,14 +347,6 @@ var kubeVipManager = &cobra.Command{
 				}
 				initConfig.MetalAPIKey = providerAPI
 				initConfig.MetalProject = providerProject
-			}
-		}
-
-		if initConfig.LoadBalancerForwardingMethod == "masquerade" {
-			log.Infof("sysctl set net.ipv4.vs.conntrack to 1")
-			err := sysctl.WriteProcSys("/proc/sys/net/ipv4/vs/conntrack", "1")
-			if err != nil {
-				log.Fatalln(err)
 			}
 		}
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -9,11 +9,11 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/kube-vip/kube-vip/pkg/k8s"
-
 	"github.com/kamhlos/upnp"
 	"github.com/kube-vip/kube-vip/pkg/bgp"
+	"github.com/kube-vip/kube-vip/pkg/k8s"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -70,7 +70,7 @@ func New(configMap string, config *kubevip.Config) (*Manager, error) {
 	switch {
 	case config.LeaderElectionType == "etcd":
 		// Do nothing, we don't construct a k8s client for etcd leader election
-	case fileExists(adminConfigPath):
+	case utils.FileExists(adminConfigPath):
 		if config.KubernetesAddr != "" {
 			fmt.Println(config.KubernetesAddr)
 			clientset, err = k8s.NewClientset(adminConfigPath, false, config.KubernetesAddr)
@@ -91,7 +91,7 @@ func New(configMap string, config *kubevip.Config) (*Manager, error) {
 			return nil, fmt.Errorf("could not create k8s clientset from external file: %q: %v", adminConfigPath, err)
 		}
 		log.Debugf("Using external Kubernetes configuration from file [%s]", adminConfigPath)
-	case fileExists(homeConfigPath):
+	case utils.FileExists(homeConfigPath):
 		clientset, err = k8s.NewClientset(homeConfigPath, false, "")
 		if err != nil {
 			return nil, fmt.Errorf("could not create k8s clientset from external file: %q: %v", homeConfigPath, err)
@@ -211,14 +211,6 @@ func (sm *Manager) parseAnnotations() error {
 		return err
 	}
 	return nil
-}
-
-func fileExists(filename string) bool {
-	info, err := os.Stat(filename)
-	if os.IsNotExist(err) {
-		return false
-	}
-	return !info.IsDir()
 }
 
 func (sm *Manager) findServiceInstance(svc *v1.Service) *Instance {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,11 @@
+package utils
+
+import "os"
+
+func FileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}


### PR DESCRIPTION
- Fixes:

  -  Set ipvs conntrack enablement after IPVS kernel module validation, otherwise with current code, it will raise error like
  ```
  time="2024-04-04T12:11:15Z" level=info msg="Starting kube-vip.io [v0.7.2]"
  time="2024-04-04T12:11:15Z" level=info msg="namespace [kube-system], Mode: [ARP], Features(s): Control Plane:[true], Services:[false]"
  time="2024-04-04T12:11:15Z" level=info msg="sysctl set net.ipv4.vs.conntrack to 1"
  time="2024-04-04T12:11:15Z" level=fatal msg="failed to open file: open /proc/sys/net/ipv4/vs/conntrack: no such file or directory
  ```
  -  when controlplane backend health checks should regard kubeconfig either from "/etc/kubernetes/admin.conf" when kubevip running as a kubeadm Pod or incluster service account when kubevip running as a daemonset.  Otherwise it will raise error when daemonset
   ```
  time="2024-04-04T12:27:58Z" level=info msg="Kube-Vip is watching nodes for control-plane labels"
  panic: stat /etc/kubernetes/admin.conf: no such file or directory
  ```
    -  correct the `comment` value of masquerade iptables deletion, to be consistent with the adding operation.
    -  remove useless `-d`  in the command for masquerade iptables deletion. Otherwise it will raise error:
  ```
  time="2024-04-10T04:29:50Z" level=info msg="Beginning cluster membership, namespace [kube-system], lock name [plndr-cp-lock], id [c100-md-0-fjcl8-4rzrp-j5w7j]"
  time="2024-04-10T04:29:50Z" level=error msg="could not delete virtualIP: could not remove iptables masquerade rules : could not del masquerade rule for VIP 10.10.10.201: running [/sbin/iptables-nft -t nat -C POSTROUTING -d -m ipvs --vaddr 10.10.10.201 -j MASQUERADE -m comment --comment  kube-vip load balancer IP --wait]: exit status 2: Bad argument `ipvs'\nTry `iptables -h' or 'iptables --help' for more information.\n"
  ```



- To enable masquerade forwarding mode as control plane LB default mode, there are still things to do:
  -  the cleanup on VIP/Iptables/IPVS on kube-vip deletion (SIGTERM or SIGINT) doesn't ever happen which is not good. The staled things may impact setup.
  - enable masquerade as the default mode.

  I will open two new issues regarding on above.