### PR TITLE
Adds annotation support for service interfaces.

### DIFF
--- a/pkg/manager/instance.go
+++ b/pkg/manager/instance.go
@@ -44,6 +44,7 @@ func NewInstance(svc *v1.Service, config *kubevip.Config) (*Instance, error) {
 
 	// Detect if we're using a specific interface for services
 	var serviceInterface string
+	config.ServicesInterface = svc.Annotations[serviceInterface] // If the service has a specific interface defined, then use it
 	if config.ServicesInterface != "" {
 		serviceInterface = config.ServicesInterface
 	} else {

--- a/pkg/manager/services.go
+++ b/pkg/manager/services.go
@@ -31,6 +31,7 @@ const (
 	flushContrack            = "kube-vip.io/flush-conntrack"
 	loadbalancerIPAnnotation = "kube-vip.io/loadbalancerIPs"
 	loadbalancerHostname     = "kube-vip.io/loadbalancerHostname"
+	serviceInterface         = "kube-vip.io/serviceInterface"
 )
 
 func (sm *Manager) syncServices(_ context.Context, svc *v1.Service, wg *sync.WaitGroup) error {
@@ -136,7 +137,7 @@ func (sm *Manager) addService(svc *v1.Service) error {
 		log.Debugf("(svcs) will update [%s/%s]", newService.serviceSnapshot.Namespace, newService.serviceSnapshot.Name)
 		if err := sm.updateStatus(newService); err != nil {
 			// delete service to collect garbage
-			if deleteErr := sm.deleteService(newService.UID); err != nil {
+			if deleteErr := sm.deleteService(newService.UID); deleteErr != nil {
 				return deleteErr
 			}
 			return err


### PR DESCRIPTION
The annotation `kube-vip.io/serviceInterface: ens160`  will now mean that the service will be bound to a specific interface `ens160` in this example. 

cc /@yankcrime