### PR TITLE
Examples and fixes to annotation interface

### DIFF
--- a/example/deployment.yaml
+++ b/example/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - containerPort: 80

--- a/example/service-interface-annotation.yaml
+++ b/example/service-interface-annotation.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-interface-ens192-service
+  annotations:
+    kube-vip.io/serviceInterface: ens192
+spec:
+  selector:
+    app: nginx
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+    protocol: TCP

--- a/example/service.yaml
+++ b/example/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  selector:
+    app: nginx
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+    protocol: TCP

--- a/pkg/manager/services.go
+++ b/pkg/manager/services.go
@@ -106,8 +106,6 @@ func (sm *Manager) addService(svc *v1.Service) error {
 		return err
 	}
 
-	log.Infof("(svcs) adding VIP [%s] for [%s/%s]", newService.VIPs, newService.serviceSnapshot.Namespace, newService.serviceSnapshot.Name)
-
 	for x := range newService.vipConfigs {
 		newService.clusters[x].StartLoadBalancerService(newService.vipConfigs[x], sm.bgpServer)
 	}


### PR DESCRIPTION
Both the default behaviour (defaulting to the original or services Interface) is confirmed, in the event of an annotation such as:

```
metadata:
  name: nginx-interface-ens192-service
  annotations:
    kube-vip.io/serviceInterface: ens192
```

then we can see:
```
(svcs) adding VIP [192.168.0.217] via ens192 for [default/nginx-interface-ens192-service]

<on node>

$ ip a show dev ens192
3: ens192: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    link/ether 00:50:56:8c:77:a5 brd ff:ff:ff:ff:ff:ff
    altname enp11s0
    inet 192.168.0.217/32 scope global ens192
```

Looking at the applied service:

```
$ kubectl describe svc  nginx-interface-ens192-service

...

Annotations:              kube-vip.io/loadbalancerIPs: 192.168.0.217
                          kube-vip.io/serviceInterface: ens192
                          kube-vip.io/vipHost: k02
Selector:                 app=nginx
Type:                     LoadBalance
```

We can see the host that was selected and the interface the adapter is using.