### PR TITLE
fix: unecessary string modification

### DIFF
--- a/demo/server/main.go
+++ b/demo/server/main.go
@@ -32,7 +32,7 @@ func main() {
 		}
 	}
 
-	if serverType == strings.ToLower("udp") {
+	if serverType == "udp" {
 		// Start the UDP echo server
 
 		ServerAddr, err := net.ResolveUDPAddr("udp", ":10002")


### PR DESCRIPTION
The usage of `strings.ToLower` in the demo server implementation is unnecessary because it's a hard-coded lowercase string already. 

Tiny fix, I know, but it was really bugging me. 