### PR TITLE
Fixed route deletion when route is used by more than one service

### DIFF
--- a/pkg/manager/manager_table.go
+++ b/pkg/manager/manager_table.go
@@ -151,3 +151,18 @@ func (sm *Manager) cleanRoutes() error {
 	}
 	return nil
 }
+
+func (sm *Manager) countRouteReferences(route *netlink.Route) int {
+	cnt := 0
+	for _, instance := range sm.serviceInstances {
+		for _, cluster := range instance.clusters {
+			for n := range cluster.Network {
+				r := cluster.Network[n].PrepareRoute()
+				if r.Dst.String() == route.Dst.String() {
+					cnt++
+				}
+			}
+		}
+	}
+	return cnt
+}


### PR DESCRIPTION
This PR should fix route deletion issue in routing table mode as described in #823.

The issue was, that when a service with no endpoints was created, kube-vip deleted the route as there were no endpoints but did not check if any other service references the same loadbalancer IP.

Now, when deleting the routes, kube-vip will scan all the known services to check if more than one service references the route that is being deleted. If so, it will cancel the deletion.