### PR TITLE
[Hotfix] Routes get not deleted when kube-vip is running without LeaderElection/ServiceElection in Table Mode

### DIFF
--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -220,8 +220,11 @@ func (cluster *Cluster) StartLoadBalancerService(c *kubevip.Config, bgp *bgp.Ser
 		// Stop the Arp context if it is running
 		cancelArp()
 
-		if c.EnableRoutingTable && (c.EnableLeaderElection || c.EnableServicesElection) {
+		log.Info("[LOADBALANCER] Stopping load balancers")
+
+		if c.EnableRoutingTable {
 			for i := range cluster.Network {
+				log.Infof("[VIP] Deleting Route for Virtual IP [%s]", cluster.Network[i].IP())
 				if err := cluster.Network[i].DeleteRoute(); err != nil {
 					log.Warnf("%v", err)
 				}
@@ -230,9 +233,6 @@ func (cluster *Cluster) StartLoadBalancerService(c *kubevip.Config, bgp *bgp.Ser
 			close(cluster.completed)
 			return
 		}
-
-		log.Info("[LOADBALANCER] Stopping load balancers")
-
 		for i := range cluster.Network {
 			log.Infof("[VIP] Releasing the Virtual IP [%s]", cluster.Network[i].IP())
 			if err := cluster.Network[i].DeleteIP(); err != nil {


### PR DESCRIPTION
* When running kube-vip without `vip_leaderelection` or `svc_election` it only deletes IPs from interfaces but never deleted the Route from the RoutingTable in Table Mode
* This change would introduce a bit of cluttering in the logs, when Routes are not installed on a particular node but kube-vip is trying to delete the route for a service when in TableMode
* Functionally it should not break any existing setup using TableMode it just cleans Routes after the Service gets deleted