### PR TITLE
New service class filtering behavior

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -129,6 +129,7 @@ func init() {
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableServicesElection, "servicesElection", false, "Enable leader election per kubernetes service")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.LoadBalancerClassOnly, "lbClassOnly", false, "Enable load balancing only for services with LoadBalancerClass \"kube-vip.io/kube-vip-class\"")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.LoadBalancerClassName, "lbClassName", "kube-vip.io/kube-vip-class", "Name of load balancer class for kube-VIP, defaults to \"kube-vip.io/kube-vip-class\"")
+	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.LoadBalancerClassLegacyHandling, "lbClassNameLegacyHandling", true, "Use legacy LoadBalancer class name handling (e.g. accepting services both with empty and non-empty class)")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableServiceSecurity, "onlyAllowTrafficServicePorts", false, "Only allow traffic to service ports, others will be dropped, defaults to false")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableNodeLabeling, "enableNodeLabeling", false, "Enable leader node labeling with \"kube-vip.io/has-ip=<VIP address>\", defaults to false")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.ServicesLeaseName, "servicesLeaseName", "plndr-svcs-lock", "Name of the lease that is used for leader election for services (in arp mode)")

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -202,9 +202,19 @@ func ParseEnvironment(c *Config) error {
 		}
 
 		// Load-balancer class name
-		env = os.Getenv(lbClassName)
-		if env != "" {
+		env, exists := os.LookupEnv(lbClassName)
+		if exists {
 			c.LoadBalancerClassName = env
+		}
+
+		// Load-balancer class legacy handling
+		env = os.Getenv(lbClassLegacyHandling)
+		if env != "" {
+			b, err := strconv.ParseBool(env)
+			if err != nil {
+				return err
+			}
+			c.LoadBalancerClassLegacyHandling = b
 		}
 
 		// Find the namespace that the control plane should use (for leaderElection lock)

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -175,6 +175,9 @@ const (
 	// lbClassName enables load-balancer for a specific class only
 	lbClassName = "lb_class_name"
 
+	// lbClassLegacyHandling enables legacy handing of load-balancer class
+	lbClassLegacyHandling = "lb_class_legacy_handling"
+
 	// lbEnable defines if the load-balancer should be enabled
 	lbEnable = "lb_enable"
 

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -45,6 +45,9 @@ type Config struct {
 	// LoadBalancerClassName, will limit the load balancing services to services with LoadBalancerClass set to this value
 	LoadBalancerClassName string `yaml:"lbClassName"`
 
+	// LoadBalancerClassLegacyHandling, will enable legacy loadbalancer class handling which does not force service loadbalancer class and kube-vip's loadbalancer class to be the same.
+	LoadBalancerClassLegacyHandling bool `yaml:"lbClassNameLegacyHandling"`
+
 	// EnableServiceSecurity, will enable the use of iptables to secure services
 	EnableServiceSecurity bool `yaml:"EnableServiceSecurity"`
 


### PR DESCRIPTION
This PR introduces new behavior for LoadBalancer Class Name service filtering. With this new implementation only services that have LB class name set to the value configured in kube-vip (`LoadBalancerClassName` flag) will be processed. This is consistent with implementation in e.g. [MetalLB](https://github.com/metallb/metallb/blob/main/internal/k8s/controllers/service_controller.go#L159) or with how the ingress classes behave.

However this might be a braking change, so it is implemented (for now) as an option. 'Legacy' behavior is a default and can be disabled by setting `LoadBalancerClassLegacyHandling` config flag to `false`. In one of next releases this could become a default setting, and then legacy behavior could be removed altogether.

Fixes #851
