### PR TITLE
This allows prometheus configuration to be specified in the cli

### DIFF
--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -485,15 +485,13 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 		})
 	}
 
-	if c.PrometheusHTTPServer != "" {
-		prometheus := []corev1.EnvVar{
-			{
-				Name:  prometheusServer,
-				Value: c.PrometheusHTTPServer,
-			},
-		}
-		newEnvironment = append(newEnvironment, prometheus...)
+	prometheus := []corev1.EnvVar{
+		{
+			Name:  prometheusServer,
+			Value: c.PrometheusHTTPServer,
+		},
 	}
+	newEnvironment = append(newEnvironment, prometheus...)
 
 	if c.EnableEndpointSlices {
 		newEnvironment = append(newEnvironment, corev1.EnvVar{


### PR DESCRIPTION
`--prometheusHTTPServer ""` will now create

```
    - name: prometheus_server
```

with no `- value`, which should stop prometheus from starting. 