### PR TITLE
[Bugfix] Parse the routingTableID correctly 

### DIFF
--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -329,7 +329,7 @@ func ParseEnvironment(c *Config) error {
 		} else if i < 0 {
 			return fmt.Errorf("no support of negative [%d] in env var %q", i, vipRoutingTableID)
 		}
-		return fmt.Errorf("no support for int64 natively on system only [int%d]", bits.OnesCount(math.MaxUint))
+		return fmt.Errorf("no support for int64, system natively supports [int%d]", bits.OnesCount(math.MaxUint))
 	}
 
 	// Routing Table Type

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -329,7 +329,8 @@ func ParseEnvironment(c *Config) error {
 		} else if i < 0 {
 			return fmt.Errorf("no support of negative [%d] in env var %q", i, vipRoutingTableID)
 		}
-		return fmt.Errorf("no support for int64, system natively supports [int%d]", bits.OnesCount(math.MaxUint))
+		// +1 for the signing bit as it is 0 for positive integers
+		return fmt.Errorf("no support for int64, system natively supports [int%d]", bits.OnesCount(math.MaxInt)+1)
 	}
 
 	// Routing Table Type

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -323,10 +323,13 @@ func ParseEnvironment(c *Config) error {
 		if err != nil {
 			return err
 		}
-		if i > math.MaxInt32 && math.MaxInt < math.MaxInt64 {
-			return fmt.Errorf("system does not support int64 natively only [int%d]", bits.OnesCount(math.MaxInt)+1)
+		if i >= 0 && i <= math.MaxInt {
+			c.RoutingTableID = int(i)
+			return nil
+		} else if i < 0 {
+			return fmt.Errorf("no support of negative [%d] in env var %q", i, vipRoutingTableID)
 		}
-		c.RoutingTableID = int(i)
+		return fmt.Errorf("no support for int64 natively on system only [int%d]", bits.OnesCount(math.MaxUint))
 	}
 
 	// Routing Table Type

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -2,6 +2,9 @@ package kubevip
 
 import (
 	"encoding/json"
+	"fmt"
+	"math"
+	"math/bits"
 	"os"
 	"strconv"
 
@@ -316,9 +319,12 @@ func ParseEnvironment(c *Config) error {
 	// Routing Table ID
 	env = os.Getenv(vipRoutingTableID)
 	if env != "" {
-		i, err := strconv.ParseInt(env, 10, 32)
+		i, err := strconv.ParseInt(env, 10, 64)
 		if err != nil {
 			return err
+		}
+		if i > math.MaxInt32 && math.MaxInt < math.MaxInt64 {
+			return fmt.Errorf("system does not support int64 natively only [int%d]", bits.OnesCount(math.MaxInt)+1)
 		}
 		c.RoutingTableID = int(i)
 	}


### PR DESCRIPTION
Current Behaviour:

kube-vip does not start.
```
time="2024-06-25T11:45:39Z" level=fatal msg="strconv.ParseInt: parsing \"2347908769\": value out of range"
```

With this fix it should start.

References:
* [rtnetlink.h](https://github.com/torvalds/linux/blob/55027e689933ba2e64f3d245fb1ff185b3e7fc81/include/uapi/linux/rtnetlink.h\#L354C15-L354C25) 
* RT_TABLE_MAX=0xFFFFFFFF