### PR TITLE
Manifest fix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,8 @@ jobs:
           go-version-file: go.mod
       - name: Build image locally
         run: make dockerx86Local
+      - name: Run Manifest generation tests
+        run: make manifest-test
       - name: Run Control plane tests
         run: make e2e-tests
       - name: Run Control plane tests v1.29.0 onwards

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,14 @@ manifests:
 	@./kube-vip manifest daemonset --interface eth0 --vip 192.168.0.1 --bgp --leaderElection --controlplane --services --inCluster --provider-config /etc/cloud-sa/cloud-sa.json > ./docs/manifests/$(VERSION)/kube-vip-bgp-em-ds.yaml
 	@-rm ./kube-vip
 
+manifest-test: 
+	docker run $(REPOSITORY)/$(TARGET):$(DOCKERTAG) manifest pod --interface eth0 --vip 192.168.0.1 --arp --leaderElection --controlplane --services
+	docker run $(REPOSITORY)/$(TARGET):$(DOCKERTAG) manifest pod --interface eth0 --vip 192.168.0.1 --arp --leaderElection --controlplane --services --enableLoadBalancer
+	docker run $(REPOSITORY)/$(TARGET):$(DOCKERTAG) manifest pod --interface eth0 --vip 192.168.0.1 --bgp --controlplane --services 
+	docker run $(REPOSITORY)/$(TARGET):$(DOCKERTAG) manifest daemonset --interface eth0 --vip 192.168.0.1 --arp --leaderElection --controlplane --services --inCluster
+	docker run $(REPOSITORY)/$(TARGET):$(DOCKERTAG) manifest daemonset --interface eth0 --vip 192.168.0.1 --arp --leaderElection --controlplane --services --inCluster --enableLoadBalancer
+	docker run $(REPOSITORY)/$(TARGET):$(DOCKERTAG) manifest daemonset --interface eth0 --vip 192.168.0.1 --bgp --leaderElection --controlplane --services --inCluster
+
 unit-tests:
 	go test ./...
 

--- a/cmd/kube-vip-manifests.go
+++ b/cmd/kube-vip-manifests.go
@@ -57,9 +57,9 @@ var kubeManifestPod = &cobra.Command{
 			log.Fatalln("No address is specified for kube-vip to expose services on")
 		}
 
-		if initConfig.VIPCIDR == "" {
+		// Ensure there is an address to generate the CIDR from
+		if initConfig.VIPCIDR == "" && initConfig.Address != "" {
 			initConfig.VIPCIDR, err = generateCidrRange(initConfig.Address)
-
 			if err != nil {
 				log.Fatalln(err)
 			}
@@ -92,9 +92,9 @@ var kubeManifestDaemon = &cobra.Command{
 			log.Fatalln("No address is specified for kube-vip to expose services on")
 		}
 
-		if initConfig.VIPCIDR == "" {
+		// Ensure there is an address to generate the CIDR from
+		if initConfig.VIPCIDR == "" && initConfig.Address != "" {
 			initConfig.VIPCIDR, err = generateCidrRange(initConfig.Address)
-
 			if err != nil {
 				log.Fatalln(err)
 			}
@@ -125,9 +125,9 @@ var kubeManifestRbac = &cobra.Command{
 			log.Fatalln("No address is specified for kube-vip to expose services on")
 		}
 
-		if initConfig.VIPCIDR == "" {
+		// Ensure there is an address to generate the CIDR from
+		if initConfig.VIPCIDR == "" && initConfig.Address != "" {
 			initConfig.VIPCIDR, err = generateCidrRange(initConfig.Address)
-
 			if err != nil {
 				log.Fatalln(err)
 			}
@@ -147,7 +147,7 @@ func generateCidrRange(address string) (string, error) {
 		ip := net.ParseIP(a)
 
 		if ip == nil {
-			return "", fmt.Errorf("invalid IP address: %v", a)
+			return "", fmt.Errorf("invalid IP address: %s from [%s]", a, address)
 		}
 
 		if ip.To4() != nil {

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -700,5 +700,12 @@ func GenerateDaemonsetManifestFromConfig(c *Config, imageVersion string, inClust
 		}
 	}
 	b, _ := yaml.Marshal(newManifest)
+
+	// This additional step is required to be able to delete a section of the manifest being generated
+	m := make(map[string]interface{})
+	yaml.Unmarshal(b, &m)
+	delete(m, "status")
+
+	b, _ = yaml.Marshal(m)
 	return string(b)
 }

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -699,11 +699,13 @@ func GenerateDaemonsetManifestFromConfig(c *Config, imageVersion string, inClust
 			},
 		}
 	}
+
+	// TODO: we don't check error return values for any of these marshall/unmarshall functions
 	b, _ := yaml.Marshal(newManifest)
 
 	// This additional step is required to be able to delete a section of the manifest being generated
 	m := make(map[string]interface{})
-	yaml.Unmarshal(b, &m)
+	_ = yaml.Unmarshal(b, &m)
 	delete(m, "status")
 
 	b, _ = yaml.Marshal(m)


### PR DESCRIPTION
This adds:
- CI test for manifests
- Ensures Manifests are created without a VIP (control plane) #885
- No `.status` for daemonset #876 