### PR TITLE
Change service interface to `macvlan` when using DHCP

### DIFF
--- a/pkg/manager/instance.go
+++ b/pkg/manager/instance.go
@@ -125,10 +125,12 @@ func NewInstance(svc *v1.Service, config *kubevip.Config) (*Instance, error) {
 			return nil, fmt.Errorf("error starting DHCP for %s/%s: error: %s",
 				instance.serviceSnapshot.Namespace, instance.serviceSnapshot.Name, err)
 		case ip := <-instance.dhcpClient.IPChannel():
+			instance.vipConfigs[0].Interface = instance.dhcpInterface
 			instance.vipConfigs[0].VIP = ip
 			instance.dhcpInterfaceIP = ip
 		}
 	}
+
 	for _, vipConfig := range instance.vipConfigs {
 		c, err := cluster.InitCluster(vipConfig, false)
 		if err != nil {


### PR DESCRIPTION
When using DHCP for LB services, the resulting IP was assigned to the `serviceInterface` while most (not all) DHCP communication was done through a per-service `macvlan` interface that is created on demand.

This has been the cause of DHCP lease renewal failures for some users, as the response packets from the server never reached kube-vip. For more details, see issue #871.

To remedy this, the primary interface used for a service is now being set to the `macvlan`. Consequently, the IP address is also assigned to it.

As a result, all traffic related to an LB service (DHCP or not) is now originating from and sent to the per-service `macvlan` interface that is tied to the user-configured `serviceInterface`.

Fixes #871