### PR TITLE
Ensuring nodelabel will be always present

### DIFF
--- a/pkg/manager/node_labeling.go
+++ b/pkg/manager/node_labeling.go
@@ -36,6 +36,7 @@ func applyNodeLabel(clientSet *kubernetes.Clientset, address, id, identity strin
 
 	value, ok := node.Labels[nodeLabelIndex]
 	path := fmt.Sprintf("/metadata/labels/%s", nodeLabelJSONPath)
+	log.Debugf("Received identity: %s - id: %$", identity, id)
 	if ok && value == address {
 		log.Debugf("removing node label `has-ip=%s` on %s", address, id)
 		// Remove label


### PR DESCRIPTION
As reported in the issue #863, nodelabel is missing sometimes.

for example, if the VIP is already associated with a node and you delete the kube-vip pods, once they're re-created, there's a good chance that none of your nodes will include the kube-vip/has-ip=xx label.
As a result, the existence of this label is unreliable.

The aim of this change is to ensure that the nodelabel is always added.