### PR TITLE
Auto network interface discovery for services

### DIFF
--- a/pkg/kubevip/config_manager.go
+++ b/pkg/kubevip/config_manager.go
@@ -24,6 +24,10 @@ func (c *Config) CheckInterface() error {
 }
 
 func isValidInterface(iface string) error {
+	// auto interface discovery for services is enabled
+	if iface == "auto" {
+		return nil
+	}
 	l, err := netlink.LinkByName(iface)
 	if err != nil {
 		return fmt.Errorf("get %s failed, error: %w", iface, err)


### PR DESCRIPTION
This PR fixes #903 

It introduces feature to automatically discover proper networking interface for the service based on the service's loadbalancer's IP.

To enable this feature `vip_servicesinterface` should be set to value `auto` (to enable it globally) or `kube-vip.io/serviceInterface` annotation should be set to `auto` to enable this for selected service.