### PR TITLE
make the service status update timeout configurable

### DIFF
--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -194,6 +194,16 @@ func ParseEnvironment(c *Config) error {
 			c.EnableServicesElection = b
 		}
 
+		// configure how for how long we will try to update a service before failing.
+		env = os.Getenv(svcStatusUpdateRetrySeconds)
+		if env != "" {
+			b, err := strconv.Atoi(env)
+			if err != nil {
+				return err
+			}
+			c.ServiceStatusUpdateRetrySeconds = b
+		}
+
 		// Find load-balancer class only
 		env = os.Getenv(lbClassOnly)
 		if env != "" {

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -166,6 +166,9 @@ const (
 	// svcElection enables election per Kubernetes service
 	svcElection = "svc_election"
 
+	// svcStatusUpdateRetrySeconds enables election per Kubernetes service
+	svcStatusUpdateRetrySeconds = "svcStatusUpdateRetrySeconds"
+
 	// svcLeaseName Name of the lease that is used for leader election for services (in arp mode)
 	svcLeaseName = "svc_leasename"
 

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -238,6 +238,15 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 			}
 			newEnvironment = append(newEnvironment, svcElection...)
 		}
+		if c.ServiceStatusUpdateRetrySeconds != 0 {
+			svcElection := []corev1.EnvVar{
+				{
+					Name:  svcStatusUpdateRetrySeconds,
+					Value: strconv.Itoa(c.ServiceStatusUpdateRetrySeconds),
+				},
+			}
+			newEnvironment = append(newEnvironment, svcElection...)
+		}
 		if c.LoadBalancerClassOnly {
 			lbClassOnlyVar := []corev1.EnvVar{
 				{

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -36,6 +36,10 @@ type Config struct {
 	// EnableServicesElection, will enable leaderElection per service
 	EnableServicesElection bool `yaml:"enableServicesElection"`
 
+	// ServiceStatusUpdateRetrySeconds this dictates how long between retries that kube-vip will wait before trying to update the status.
+	// kube-vip retries to update the status only 5 times.
+	ServiceStatusUpdateRetrySeconds int `yaml:"serviceStatusUpdateRetrySeconds"`
+
 	// EnableNodeLabeling, will enable node labeling as it becomes leader
 	EnableNodeLabeling bool `yaml:"enableNodeLabeling"`
 

--- a/pkg/manager/services.go
+++ b/pkg/manager/services.go
@@ -3,11 +3,12 @@ package manager
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"slices"
 	"strings"
 	"sync"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/google/go-cmp/cmp"
 	log "github.com/sirupsen/logrus"


### PR DESCRIPTION
I raised the following issue here: https://github.com/kube-vip/kube-vip/issues/928

We are seeing that kube-vip never add the status to a service. 
the retries are extremely aggressive, in the case that other edits are happening to the service we want to kube-vip to try for more than just 50 milliseconds. 
We will probably let it try for cluster to a minute.  

