### PR TITLE
This adds ipv6 egress & test

### DIFF
--- a/pkg/manager/instance.go
+++ b/pkg/manager/instance.go
@@ -81,7 +81,7 @@ func NewInstance(svc *v1.Service, config *kubevip.Config) (*Instance, error) {
 			}
 		}
 
-		log.Info("new instance", "svc", *svc, "interface", svcInterface)
+		//log.Info("new instance", "svc", *svc, "interface", svcInterface)
 
 		// Generate new Virtual IP configuration
 		newVips = append(newVips, &kubevip.Config{

--- a/pkg/manager/service_egress.go
+++ b/pkg/manager/service_egress.go
@@ -46,7 +46,7 @@ func (sm *Manager) iptablesCheck() error {
 	return nil
 }
 
-func getSameFamilyCidr(sourceCidrs, ip string) string {
+func getSameFamilyCidr(sourceCidrs, ip string) string { //Todo: not sure how this ever worked
 	cidrs := strings.Split(sourceCidrs, ",")
 	for _, cidr := range cidrs {
 		// Is the ip an IPv6 address
@@ -56,7 +56,9 @@ func getSameFamilyCidr(sourceCidrs, ip string) string {
 			}
 		} else {
 			if vip.IsIPv4CIDR(cidr) {
-				return cidr
+				if vip.IsIPv4(cidr) == vip.IsIPv4(ip) {
+					return cidr
+				}
 			}
 		}
 	}

--- a/pkg/manager/service_egress.go
+++ b/pkg/manager/service_egress.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"strings"
 
@@ -56,7 +57,8 @@ func getSameFamilyCidr(sourceCidrs, ip string) string { //Todo: not sure how thi
 			}
 		} else {
 			if vip.IsIPv4CIDR(cidr) {
-				if vip.IsIPv4(cidr) == vip.IsIPv4(ip) {
+				_, ipnetA, _ := net.ParseCIDR(cidr)
+				if ipnetA.Contains(net.ParseIP(ip)) {
 					return cidr
 				}
 			}

--- a/pkg/manager/watch_endpoints.go
+++ b/pkg/manager/watch_endpoints.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"sync"
 	"syscall"
@@ -222,6 +223,11 @@ func (sm *Manager) watchEndpoint(ctx context.Context, id string, service *v1.Ser
 
 			// Check that we have local endpoints
 			if len(endpoints) != 0 {
+				// Ignore IPv4
+				if service.Annotations[egressIPv6] == "true" && net.ParseIP(endpoints[0]).To4() != nil {
+					continue
+				}
+
 				// if we haven't populated one, then do so
 				if lastKnownGoodEndpoint != "" {
 

--- a/pkg/vip/util.go
+++ b/pkg/vip/util.go
@@ -105,21 +105,19 @@ func IsIPv6(address string) bool {
 }
 
 func IsIPv4CIDR(cidr string) bool {
-	_, n, _ := net.ParseCIDR(cidr)
-	if n == nil {
+	ip, _, _ := net.ParseCIDR(cidr)
+	if ip == nil {
 		return false
 	}
-	_, bits := n.Mask.Size()
-	return bits/8 == net.IPv4len
+	return ip.To4() != nil
 }
 
 func IsIPv6CIDR(cidr string) bool {
-	_, n, _ := net.ParseCIDR(cidr)
-	if n == nil {
+	ip, _, _ := net.ParseCIDR(cidr)
+	if ip == nil {
 		return false
 	}
-	_, bits := n.Mask.Size()
-	return bits/8 == net.IPv6len
+	return ip.To4() == nil
 }
 
 // GetFullMask returns /32 for an IPv4 address and /128 for an IPv6 address

--- a/pkg/vip/util.go
+++ b/pkg/vip/util.go
@@ -104,6 +104,18 @@ func IsIPv6(address string) bool {
 	return ip.To4() == nil
 }
 
+func IsIPv4CIDR(cidr string) bool {
+	_, n, _ := net.ParseCIDR(cidr)
+	_, bits := n.Mask.Size()
+	return bits/8 == net.IPv4len
+}
+
+func IsIPv6CIDR(cidr string) bool {
+	_, n, _ := net.ParseCIDR(cidr)
+	_, bits := n.Mask.Size()
+	return bits/8 == net.IPv6len
+}
+
 // GetFullMask returns /32 for an IPv4 address and /128 for an IPv6 address
 func GetFullMask(address string) (string, error) {
 	if IsIPv4(address) {

--- a/pkg/vip/util.go
+++ b/pkg/vip/util.go
@@ -106,12 +106,18 @@ func IsIPv6(address string) bool {
 
 func IsIPv4CIDR(cidr string) bool {
 	_, n, _ := net.ParseCIDR(cidr)
+	if n == nil {
+		return false
+	}
 	_, bits := n.Mask.Size()
 	return bits/8 == net.IPv4len
 }
 
 func IsIPv6CIDR(cidr string) bool {
 	_, n, _ := net.ParseCIDR(cidr)
+	if n == nil {
+		return false
+	}
 	_, bits := n.Mask.Size()
 	return bits/8 == net.IPv6len
 }

--- a/testing/e2e/services/kind.go
+++ b/testing/e2e/services/kind.go
@@ -71,7 +71,7 @@ func (config *testConfig) createKind() error {
 		// Add three additional worker nodes
 		clusterConfig.Nodes = append(clusterConfig.Nodes, kindconfigv1alpha4.Node{Role: kindconfigv1alpha4.WorkerRole})
 		clusterConfig.Nodes = append(clusterConfig.Nodes, kindconfigv1alpha4.Node{Role: kindconfigv1alpha4.WorkerRole})
-		clusterConfig.Nodes = append(clusterConfig.Nodes, kindconfigv1alpha4.Node{Role: kindconfigv1alpha4.WorkerRole})
+		//clusterConfig.Nodes = append(clusterConfig.Nodes, kindconfigv1alpha4.Node{Role: kindconfigv1alpha4.WorkerRole})
 	}
 
 	provider = cluster.NewProvider(cluster.ProviderWithLogger(cmd.NewLogger()), cluster.ProviderWithDocker())

--- a/testing/e2e/services/tests.go
+++ b/testing/e2e/services/tests.go
@@ -32,6 +32,7 @@ type testConfig struct {
 	ignoreLocalDeploy    bool
 	ignoreDualStack      bool
 	ignoreEgress         bool
+	ignoreEgressIPv6     bool
 	retainCluster        bool
 	skipHostnameChange   bool
 }
@@ -47,6 +48,7 @@ func main() {
 	_, t.ignoreLeaderActive = os.LookupEnv("IGNORE_ACTIVE")
 	_, t.ignoreLocalDeploy = os.LookupEnv("IGNORE_LOCALDEPLOY")
 	_, t.ignoreEgress = os.LookupEnv("IGNORE_EGRESS")
+	_, t.ignoreEgressIPv6 = os.LookupEnv("IGNORE_EGRESSIPV6")
 	_, t.ignoreDualStack = os.LookupEnv("IGNORE_DUALSTACK")
 	_, t.retainCluster = os.LookupEnv("RETAIN_CLUSTER")
 	_, t.IPv6 = os.LookupEnv("IPV6_FAMILY")


### PR DESCRIPTION
The original Egress functionality with IPv4 only, this PR adds the capability for egress addresses to be IPv6.

An additional annotation is required, and the `rbac.yaml` will need updating with pod-list/get in order to auto-detect the pod/service CIDRs.