### PR TITLE
Use IGD:2 and Pinhole Port Forwarding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,9 @@ require (
 	github.com/florianl/go-conntrack v0.4.0
 	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.6.0
+	github.com/huin/goupnp v1.3.0
 	github.com/insomniacslk/dhcp v0.0.0-20230731140434-0f9eb93a696c
 	github.com/jpillora/backoff v1.0.0
-	github.com/kamhlos/upnp v0.0.0-20210324072331-5661950dff08
 	github.com/mdlayher/ndp v1.0.1
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
@@ -29,6 +29,7 @@ require (
 	go.etcd.io/etcd/client/v3 v3.5.13
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8
+	golang.org/x/sync v0.7.0
 	golang.org/x/sys v0.20.0
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20230429144221-925a1e7659e6
 	gopkg.in/yaml.v2 v2.4.0
@@ -106,7 +107,6 @@ require (
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/oauth2 v0.16.0 // indirect
-	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/term v0.20.0 // indirect
 	golang.org/x/text v0.15.0 // indirect
 	golang.org/x/time v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -197,6 +197,8 @@ github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714 h1:/jC7qQFrv8CrSJVmaolDVOxTfS9kc36uB6H40kdbQq8=
 github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714/go.mod h1:2Goc3h8EklBH5mspfHFxBnEoURQCGzQQH1ga9Myjvis=
+github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
+github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
@@ -230,8 +232,6 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/k-sone/critbitgo v1.4.0 h1:l71cTyBGeh6X5ATh6Fibgw3+rtNT80BA0uNNWgkPrbE=
 github.com/k-sone/critbitgo v1.4.0/go.mod h1:7E6pyoyADnFxlUBEKcnfS49b7SUAQGMK+OAp/UQvo0s=
-github.com/kamhlos/upnp v0.0.0-20210324072331-5661950dff08 h1:UQlM3K8NSN3cqIsICAQnSVOQe9B4LyFEu/xJUr+Scn4=
-github.com/kamhlos/upnp v0.0.0-20210324072331-5661950dff08/go.mod h1:0L/S1RSG4wA4M2Vhau3z7VsYMLxFnsX0bzzgwYRIdYU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -304,7 +304,7 @@ func (sm *Manager) refreshUPNPForwards() {
 	for {
 		time.Sleep(1800 * time.Second)
 
-		log.Infof("Refreshing %d Instances", len(sm.serviceInstances))
+		log.Infof("[UPNP] Refreshing %d Instances", len(sm.serviceInstances))
 		for i := range sm.serviceInstances {
 			sm.upnpMap(context.TODO(), sm.serviceInstances[i])
 		}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1,19 +1,21 @@
 package manager
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
 
-	"github.com/kamhlos/upnp"
 	"github.com/kube-vip/kube-vip/pkg/bgp"
 	"github.com/kube-vip/kube-vip/pkg/k8s"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/trafficmirror"
+	"github.com/kube-vip/kube-vip/pkg/upnp"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
@@ -35,9 +37,8 @@ type Manager struct {
 	// Keeps track of all running instances
 	serviceInstances []*Instance
 
-	// Additional functionality
-	upnp *upnp.Upnp
-
+	// UPNP functionality
+	upnp bool
 	// BGP Manager, this is a singleton that manages all BGP advertisements
 	bgpServer *bgp.Server
 
@@ -183,6 +184,26 @@ func (sm *Manager) Start() error {
 
 		log.Infoln("Starting Kube-vip Manager with the BGP engine")
 		return sm.startBGP()
+	}
+
+	if sm.config.EnableARP || sm.config.EnableWireguard {
+		// Before starting the leader Election enable any additional functionality
+		upnpEnabled, _ := strconv.ParseBool(os.Getenv("enableUPNP"))
+
+		if upnpEnabled {
+			sm.upnp = true
+			clients := upnp.GetConnectionClients(context.TODO())
+			if len(clients) == 0 {
+				log.Errorf("Error Enabling UPNP. No Clients found")
+				// Set the struct to false so nothing should use it in future
+				sm.upnp = false
+			} else {
+				for _, c := range clients {
+					ip, err := c.GetExternalIPAddress()
+					log.Infof("Found UPNP IGD2 Gateway address[%s] error: [%s]", ip, err)
+				}
+			}
+		}
 	}
 
 	// If ARP is enabled then we start a LeaderElection that will use ARP to advertise VIPs

--- a/pkg/manager/manager_arp.go
+++ b/pkg/manager/manager_arp.go
@@ -3,11 +3,9 @@ package manager
 import (
 	"context"
 	"os"
-	"strconv"
 	"syscall"
 	"time"
 
-	"github.com/kamhlos/upnp"
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/leaderelection"
@@ -78,21 +76,6 @@ func (sm *Manager) startARP(id string) error {
 		if err != nil {
 			log.Warnf("unable to auto-detect namespace, dropping to [%s]", sm.config.Namespace)
 			ns = sm.config.Namespace
-		}
-	}
-
-	// Before starting the leader Election enable any additional functionality
-	upnpEnabled, _ := strconv.ParseBool(os.Getenv("enableUPNP"))
-
-	if upnpEnabled {
-		sm.upnp = new(upnp.Upnp)
-		err := sm.upnp.ExternalIPAddr()
-		if err != nil {
-			log.Errorf("Error Enabling UPNP %s", err.Error())
-			// Set the struct to nil so nothing should use it in future
-			sm.upnp = nil
-		} else {
-			log.Infof("Successfully enabled UPNP, Gateway address [%s]", sm.upnp.GatewayOutsideIP)
 		}
 	}
 

--- a/pkg/manager/manager_wireguard.go
+++ b/pkg/manager/manager_wireguard.go
@@ -2,11 +2,8 @@ package manager
 
 import (
 	"context"
-	"os"
-	"strconv"
 	"time"
 
-	"github.com/kamhlos/upnp"
 	"github.com/kube-vip/kube-vip/pkg/wireguard"
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,21 +49,6 @@ func (sm *Manager) startWireguard(id string) error {
 	if err != nil {
 		log.Warnf("unable to auto-detect namespace, dropping to [%s]", sm.config.Namespace)
 		ns = sm.config.Namespace
-	}
-
-	// Before starting the leader Election enable any additional functionality
-	upnpEnabled, _ := strconv.ParseBool(os.Getenv("enableUPNP"))
-
-	if upnpEnabled {
-		sm.upnp = new(upnp.Upnp)
-		err := sm.upnp.ExternalIPAddr()
-		if err != nil {
-			log.Errorf("Error Enabling UPNP %s", err.Error())
-			// Set the struct to nil so nothing should use it in future
-			sm.upnp = nil
-		} else {
-			log.Infof("Successfully enabled UPNP, Gateway address [%s]", sm.upnp.GatewayOutsideIP)
-		}
 	}
 
 	// Start a services watcher (all kube-vip pods will watch services), upon a new service

--- a/pkg/manager/services.go
+++ b/pkg/manager/services.go
@@ -315,7 +315,7 @@ func (sm *Manager) upnpMap(ctx context.Context, s *Instance) {
 		return
 	}
 	if !sm.upnp {
-		log.Warnf("Found kube-vip.io/forwardUPNP on service while UPNP forwarding is disabled in the kube-vip config. Not forwarding service %s", s.serviceSnapshot.Name)
+		log.Warnf("[UPNP] Found kube-vip.io/forwardUPNP on service while UPNP forwarding is disabled in the kube-vip config. Not forwarding service %s", s.serviceSnapshot.Name)
 	}
 	// If upnp is enabled then update the gateway/router with the address
 	// TODO - check if this implementation for dualstack is correct
@@ -332,21 +332,21 @@ func (sm *Manager) upnpMap(ctx context.Context, s *Instance) {
 					pinholeID, pinholeErr := gw.WANIPv6FirewallControlClient.AddPinholeCtx(ctx, "0.0.0.0", uint16(port.Port), vip, uint16(port.Port), upnp.MapProtocolToIANA(port.Type), 3600)
 					if pinholeErr == nil {
 						forwardSucessful = true
-						log.Infof("service should be accessible externally on port [%d]; PinholeID is [%d]", port.Port, pinholeID)
+						log.Infof("[UPNP] Service should be accessible externally on port [%d]; PinholeID is [%d]", port.Port, pinholeID)
 					} else {
 						//TODO: Cleanup
-						log.Errorf("unable to map port to gateway using Pinhole API[%s]", pinholeErr.Error())
+						log.Errorf("[UPNP] Unable to map port to gateway using Pinhole API[%s]", pinholeErr.Error())
 					}
 				}
 				// Fallback to PortForward
 				if !forwardSucessful {
 					portMappingErr := gw.ConnectionClient.AddPortMapping("0.0.0.0", uint16(port.Port), strings.ToUpper(port.Type), uint16(port.Port), vip, true, s.serviceSnapshot.Name, 3600)
 					if portMappingErr == nil {
-						log.Infof("service should be accessible externally on port [%d]", port.Port)
+						log.Infof("[UPNP] Service should be accessible externally on port [%d]", port.Port)
 						forwardSucessful = true
 					} else {
 						//TODO: Cleanup
-						log.Errorf("unable to map port to gateway using PortForward API[%s]", portMappingErr.Error())
+						log.Errorf("[UPNP] Unable to map port to gateway using PortForward API[%s]", portMappingErr.Error())
 					}
 				}
 

--- a/pkg/manager/services.go
+++ b/pkg/manager/services.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/kube-vip/kube-vip/pkg/upnp"
 	"github.com/kube-vip/kube-vip/pkg/vip"
 )
 
@@ -35,7 +36,7 @@ const (
 	upnpEnabled              = "kube-vip.io/forwardUPNP"
 )
 
-func (sm *Manager) syncServices(_ context.Context, svc *v1.Service, wg *sync.WaitGroup) error {
+func (sm *Manager) syncServices(ctx context.Context, svc *v1.Service, wg *sync.WaitGroup) error {
 	defer wg.Done()
 
 	log.Debugf("[STARTING] Service Sync")
@@ -79,7 +80,7 @@ func (sm *Manager) syncServices(_ context.Context, svc *v1.Service, wg *sync.Wai
 
 	// This instance wasn't found, we need to add it to the manager
 	if !foundInstance && len(newServiceAddresses) > 0 {
-		if err := sm.addService(svc); err != nil {
+		if err := sm.addService(ctx, svc); err != nil {
 			return err
 		}
 	}
@@ -100,7 +101,7 @@ func comparePortsAndPortStatuses(svc *v1.Service) bool {
 	return true
 }
 
-func (sm *Manager) addService(svc *v1.Service) error {
+func (sm *Manager) addService(ctx context.Context, svc *v1.Service) error {
 	startTime := time.Now()
 
 	newService, err := NewInstance(svc, sm.config)
@@ -112,8 +113,8 @@ func (sm *Manager) addService(svc *v1.Service) error {
 		newService.clusters[x].StartLoadBalancerService(newService.vipConfigs[x], sm.bgpServer)
 	}
 	if metav1.HasAnnotation(svc.ObjectMeta, upnpEnabled) && svc.Annotations[upnpEnabled] == "true" {
-		if sm.upnp != nil {
-			sm.upnpMap(newService)
+		if sm.upnp {
+			sm.upnpMap(ctx, newService)
 		} else {
 			log.Warnf("Found kube-vip.io/forwardUPNP on service while UPNP forwarding is disabled in the kube-vip config. Not forwarding service %s", svc.Name)
 		}
@@ -311,18 +312,43 @@ func (sm *Manager) deleteService(uid string) error {
 	return nil
 }
 
-func (sm *Manager) upnpMap(s *Instance) {
+// Set up UPNP forwards for a service
+// We first try to use the more modern Pinhole API introduced in UPNPv2 and fall back to UPNPv2 Port Forwarding if no forward was successful
+func (sm *Manager) upnpMap(ctx context.Context, s *Instance) {
 	// If upnp is enabled then update the gateway/router with the address
-	// TODO - work out if we need to mapping.Reclaim()
 	// TODO - check if this implementation for dualstack is correct
+
+	firewallClients := upnp.GetWANIPv6FirewallControl1ClientsCtx(ctx)
+	upnpClients := upnp.GetConnectionClients(ctx)
+
 	for _, vip := range s.VIPs {
 		for _, port := range s.ExternalPorts {
-			log.Infof("[UPNP] Adding map to [%s:%d - %s]", vip, port.Port, s.serviceSnapshot.Name)
-			if err := sm.upnp.AddPortMapping(int(port.Port), int(port.Port), 0, vip, strings.ToUpper(port.Type), s.serviceSnapshot.Name); err == nil {
-				log.Infof("service should be accessible externally on port [%d]", port.Port)
-			} else {
-				sm.upnp.Reclaim()
-				log.Errorf("unable to map port to gateway [%s]", err.Error())
+			pinholeSuccessful := false
+
+			for _, firewallClient := range firewallClients {
+				log.Infof("[UPNP] Adding map to [%s:%d - %s] on external IP", vip, port.Port, s.serviceSnapshot.Name)
+				pinholeID, pinholeErr := firewallClient.AddPinholeCtx(ctx, "0.0.0.0", uint16(port.Port), vip, uint16(port.Port), upnp.MapProtocolToIANA(port.Type), 3600)
+				if pinholeErr == nil {
+					pinholeSuccessful = true
+					log.Infof("service should be accessible externally on port [%d]; PinholeID is [%d]", port.Port, pinholeID)
+				} else {
+					//TODO: Cleanup
+					log.Errorf("unable to map port to gateway using Pinhole API[%s]", pinholeErr.Error())
+				}
+			}
+
+			// Fallback to Port Mapping using UPNP2 Port mapping
+			if !pinholeSuccessful {
+				for _, upnpClient := range upnpClients {
+					log.Infof("[UPNP] Adding map to [%s:%d - %s] on external IP", vip, port.Port, s.serviceSnapshot.Name)
+					portMappingErr := upnpClient.AddPortMapping("0.0.0.0", uint16(port.Port), strings.ToUpper(port.Type), uint16(port.Port), vip, true, s.serviceSnapshot.Name, 3600)
+					if portMappingErr == nil {
+						log.Infof("service should be accessible externally on port [%d]", port.Port)
+					} else {
+						//TODO: Cleanup
+						log.Errorf("unable to map port to gateway using PortForward API[%s]", portMappingErr.Error())
+					}
+				}
 			}
 		}
 	}

--- a/pkg/upnp/upnp.go
+++ b/pkg/upnp/upnp.go
@@ -1,0 +1,120 @@
+package upnp
+
+import (
+	"context"
+	"strings"
+
+	"github.com/huin/goupnp/dcps/internetgateway2"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+)
+
+type ConnectionClient interface {
+	AddPortMapping(
+		NewRemoteHost string,
+		NewExternalPort uint16,
+		NewProtocol string,
+		NewInternalPort uint16,
+		NewInternalClient string,
+		NewEnabled bool,
+		NewPortMappingDescription string,
+		NewLeaseDuration uint32,
+	) (err error)
+
+	GetExternalIPAddress() (
+		NewExternalIPAddress string,
+		err error,
+	)
+}
+
+// Gather WANIPv6FirewallControl1 clients in the network and treats errors as non-critical.
+// Use this to create Pinholes in the UPNP IGD2
+func GetWANIPv6FirewallControl1ClientsCtx(ctx context.Context) []internetgateway2.WANIPv6FirewallControl1 {
+	c, errors, err := internetgateway2.NewWANIPv6FirewallControl1ClientsCtx(ctx)
+	var validClients []internetgateway2.WANIPv6FirewallControl1
+	if err != nil {
+		log.Warnf("Unable to query for WAN Firewall Clients [%s]", err.Error())
+	}
+	for _, e := range errors {
+		log.Warnf("UPNP Gateway responded with an error while querying WAN Firewall Client [%s]", e.Error())
+	}
+	for _, c := range c {
+		if c != nil {
+			validClients = append(validClients, *c)
+		}
+	}
+	return validClients
+}
+
+// Gather UPNPConnectionClients in the network and treats errors as non-critical. Use this to find out the external IPs of the network and configure port forwarding
+func GetConnectionClients(ctx context.Context) []ConnectionClient {
+	tasks, _ := errgroup.WithContext(ctx)
+	// This code sucks and I did not manage to make it more concise.
+	//Turns out using []*type instead of []type prevents you from casting to an interface.
+	// If you have any better ideas please take a stab at it.
+	var ip1Clients []*internetgateway2.WANIPConnection1
+	var ip1Error []error
+	tasks.Go(func() error {
+		var err error
+		ip1Clients, ip1Error, err = internetgateway2.NewWANIPConnection1Clients()
+		return err
+	})
+	var ip2Clients []*internetgateway2.WANIPConnection2
+	var ip2Error []error
+	tasks.Go(func() error {
+		var err error
+		ip2Clients, ip2Error, err = internetgateway2.NewWANIPConnection2Clients()
+		return err
+	})
+	var ppp1Clients []*internetgateway2.WANPPPConnection1
+	var ppp1Error []error
+	tasks.Go(func() error {
+		var err error
+		ppp1Clients, ppp1Error, err = internetgateway2.NewWANPPPConnection1Clients()
+		return err
+	})
+
+	var routers []ConnectionClient
+
+	if err := tasks.Wait(); err != nil {
+		log.Errorf("Could not finish querying UPNP connection clients [%s]", err.Error())
+		return routers
+	}
+
+	errors := append(ip1Error, ip2Error...)
+	errors = append(errors, ppp1Error...)
+
+	for _, e := range errors {
+		log.Warnf("UPNP Gateway responded with an error while querying WAN Connection Client [%s]", e.Error())
+	}
+
+	for _, c := range ip1Clients {
+		if c != nil {
+			routers = append(routers, c)
+		}
+	}
+
+	for _, c := range ip2Clients {
+		if c != nil {
+			routers = append(routers, c)
+		}
+	}
+
+	for _, c := range ppp1Clients {
+		if c != nil {
+			routers = append(routers, c)
+		}
+	}
+	return routers
+}
+
+func MapProtocolToIANA(p string) uint16 {
+	switch strings.ToUpper(p) {
+	case "TCP":
+		return 6
+	case "UDP":
+		return 17
+	default:
+		return 0
+	}
+}

--- a/pkg/upnp/upnp.go
+++ b/pkg/upnp/upnp.go
@@ -47,7 +47,7 @@ func GetGatewayClients(ctx context.Context) []Gateway {
 		if wanipv6clients, err := internetgateway2.NewWANIPv6FirewallControl1ClientsByURLCtx(ctx, gatewayURL); err == nil {
 			gatewayClients[i].WANIPv6FirewallControlClient = wanipv6clients[0]
 		} else {
-			log.Warnf("Unable to find WANIPv6FirewallControl1Clients for Gateway %s [%s]", gatewayURL, err.Error())
+			log.Warnf("[UPNP] Unable to find WANIPv6FirewallControl1Clients for Gateway %s [%s]", gatewayURL, err.Error())
 		}
 	}
 	return gatewayClients
@@ -84,7 +84,7 @@ func GetConnectionClients(ctx context.Context) []ConnectionClient {
 	var routers []ConnectionClient
 
 	if err := tasks.Wait(); err != nil {
-		log.Errorf("Could not finish querying UPNP connection clients [%s]", err.Error())
+		log.Errorf("[UPNP] Could not finish querying UPNP connection clients [%s]", err.Error())
 		return routers
 	}
 
@@ -92,7 +92,7 @@ func GetConnectionClients(ctx context.Context) []ConnectionClient {
 	errors = append(errors, ppp1Error...)
 
 	for _, e := range errors {
-		log.Warnf("UPNP Gateway responded with an error while querying WAN Connection Client [%s]", e.Error())
+		log.Warnf("[UPNP] UPNP Gateway responded with an error while querying WAN Connection Client [%s]", e.Error())
 	}
 
 	for _, c := range ip1Clients {


### PR DESCRIPTION
Implement Pinhole Firewall traversal.

Changes:
- Replace UPNP Implementation with https://github.com/huin/goupnp
- Use WANIPv6FirewallControl to expose Services to the Internet

### Why?

Consumer Routers (in my case a FritzBox) only allow port forwarding for your own device when using the IGD:1 (Internet Gateway Device: A UPNP role allows control over  router and similar devices). You can disable this security feature on other devices, but not on Fritz Boxes, which are quite popular in Germany.

After messing around with it a bit I found out that the IGD:2  WANIPv6FirewallControl control endpoints work much in the same way like port forwarding but my FritzBox does not check the origin of the forwarding request.

We also need to implement Lease Refreshing. It is unclear why it was missing in the previous implementation, since UPNPv2 clearly specifies that a lease time of 0 is not infinity, but invalid. So a perpetual refresher for UPNP forwards is included.

This allows UPNP Port forwarding to work on more routers.

IGD:2 also introduces IPv6 support. But this is out of scope for this PR.

### Open questions

It is unclear if the old IGD:1 implementation is still required. For now I think we should keep both implementations and use the Pinhole style forward first and fall back to Port Mapping if required. IGD:2 is supposed to be backwards compatible and has been around since 2006.

TODO:

- [x] Reimplement IGD:2 Port mapping


Out of scope:

- IPv6 support

Spec: https://www.upnp.org/specs/gw/UPnP-gw-WANIPv6FirewallControl-v1-Service.pdf page 16