### PR TITLE
Add loInterfaceGlobalScope flag for enabling global scope for vip lo interface

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -137,6 +137,7 @@ func init() {
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.DNSMode, "dnsMode", "first", "Name of the mode that DNS lookup will be performed (first, ipv4, ipv6, dual)")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.DisableServiceUpdates, "disableServiceUpdates", false, "If true, kube-vip will process services as usual, but will not update service's Status.LoadBalancer.Ingress slice")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableEndpointSlices, "enableEndpointSlices", false, "If enabled, kube-vip will only advertise services, but will use EndpointSlices instead of endpoints to get IPs of Pods")
+	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.LoInterfaceGlobalScope, "loInterfaceGlobalScope", false, "If true, kube-vip will set global scope when using the lo interface, otherwise a host scope will be used by default")
 
 	// Prometheus HTTP Server
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.PrometheusHTTPServer, "prometheusHTTPServer", ":2112", "Host and port used to expose Prometheus metrics via an HTTP server")

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -50,7 +50,7 @@ func startNetworking(c *kubevip.Config) ([]vip.Network, error) {
 
 	networks := []vip.Network{}
 	for _, addr := range addresses {
-		network, err := vip.NewConfig(addr, c.Interface, c.VIPSubnet, c.DDNS, c.RoutingTableID, c.RoutingTableType, c.RoutingProtocol, c.DNSMode, c.LoadBalancerForwardingMethod, c.IptablesBackend)
+		network, err := vip.NewConfig(addr, c.Interface, c.LoInterfaceGlobalScope, c.VIPSubnet, c.DDNS, c.RoutingTableID, c.RoutingTableType, c.RoutingProtocol, c.DNSMode, c.LoadBalancerForwardingMethod, c.IptablesBackend)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -38,6 +38,15 @@ func ParseEnvironment(c *Config) error {
 		c.Interface = env
 	}
 
+	env = os.Getenv(vipInterfaceLoGlobal)
+	if env != "" {
+		b, err := strconv.ParseBool(env)
+		if err != nil {
+			return err
+		}
+		c.LoInterfaceGlobalScope = b
+	}
+
 	// Find (services) interface
 	env = os.Getenv(vipServicesInterface)
 	if env != "" {

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -33,6 +33,9 @@ const (
 	// vipInterface - defines the interface that the vip should bind too
 	vipInterface = "vip_interface"
 
+	// vipInterfaceLoGlobal - defines if the lo interface (if used) should have a global scope
+	vipInterfaceLoGlobal = "vip_interfaceloglobal"
+
 	// vipServicesInterface - defines the interface that the service vips should bind too
 	vipServicesInterface = "vip_servicesinterface"
 

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -139,6 +139,13 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 				Value: c.Interface,
 			},
 		}
+		// specify if global scope should be set when using the lo interface
+		if c.LoInterfaceGlobalScope {
+			iface = append(iface, corev1.EnvVar{
+				Name:  vipInterfaceLoGlobal,
+				Value: strconv.FormatBool(c.LoInterfaceGlobalScope),
+			})
+		}
 		newEnvironment = append(newEnvironment, iface...)
 	}
 

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -192,6 +192,9 @@ type Config struct {
 
 	// BackendHealthCheckInterval Interval in seconds for checking backend health.
 	BackendHealthCheckInterval int `yaml:"backendHealthCheckInterval"`
+
+	// LoInterfaceGlobalScope, if true will set global scope when using the lo interface, otherwise a host scope will be used
+	LoInterfaceGlobalScope bool `yaml:"loInterfaceGlobalScope"`
 }
 
 // KubernetesLeaderElection defines all of the settings for Kubernetes KubernetesLeaderElection

--- a/pkg/vip/address.go
+++ b/pkg/vip/address.go
@@ -75,7 +75,7 @@ func netlinkParse(addr string) (*netlink.Addr, error) {
 }
 
 // NewConfig will attempt to provide an interface to the kernel network configuration
-func NewConfig(address string, iface string, subnet string, isDDNS bool, tableID int, tableType int, routingProtocol int, dnsMode, forwardMethod, iptablesBackend string) ([]Network, error) {
+func NewConfig(address string, iface string, loGlobalScope bool, subnet string, isDDNS bool, tableID int, tableType int, routingProtocol int, dnsMode, forwardMethod, iptablesBackend string) ([]Network, error) {
 	networks := []Network{}
 
 	link, err := netlink.LinkByName(iface)
@@ -105,10 +105,12 @@ func NewConfig(address string, iface string, subnet string, isDDNS bool, tableID
 				return networks, errors.Wrapf(err, "could not parse address '%s'", address)
 			}
 		}
-		// Ensure we don't have a global address on loopback
-		if iface == "lo" {
+
+		if iface == "lo" && !loGlobalScope {
+			// set host scope on loopback, otherwise global scope will be used by default
 			result.address.Scope = unix.RT_SCOPE_HOST
 		}
+
 		networks = append(networks, result)
 	} else {
 		// try to resolve the address


### PR DESCRIPTION
Fixes https://github.com/kube-vip/kube-vip/issues/922

This PR adds a new flag to allow for overriding the current default behavior when creating a kube VIP on the localhost (lo) interface, which automatically sets the scope to `host`. Enabling the new `loInterfaceGlobalScope` flag will prevent kube-vip from setting a `host` scope and will instead use the `global` scope.