### PR TITLE
Added e2e tests for control-plane in routing table mode, fixed IPv6 issue

### DIFF
--- a/testing/e2e/kube-vip-routing-table.yaml.tmpl
+++ b/testing/e2e/kube-vip-routing-table.yaml.tmpl
@@ -1,0 +1,61 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-vip
+  namespace: kube-system
+spec:
+  containers:
+  - name: kube-vip
+    args:
+    - manager
+    - --prometheusHTTPServer
+    - ""
+    env:
+    - name: vip_arp
+      value: "false"
+    - name: vip_interface
+      value: eth0
+    - name: vip_leaderelection
+      value: "false"
+    - name: address
+      value: "{{ .ControlPlaneVIP }}"
+    - name: vip_leaseduration
+      value: "5"
+    - name: vip_renewdeadline
+      value: "3"
+    - name: vip_retryperiod
+      value: "1"
+    - name: cp_enable
+      value: "true"
+    - name: vip_nodename
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: vip_cidr
+      value: '32'
+    - name: cp_namespace
+      value: kube-system
+    - name: svc_enable
+      value: 'false'
+    - name: vip_routingtable
+      value: 'true'
+    image: "{{ .ImagePath }}"
+    imagePullPolicy: Never
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+        - NET_RAW
+    volumeMounts:
+    - mountPath: /etc/kubernetes/admin.conf
+      name: kubeconfig
+  hostAliases:
+    - hostnames:
+      - kubernetes
+      ip: 127.0.0.1
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: "{{ .ConfigPath }}"
+    name: kubeconfig


### PR DESCRIPTION
This PR is a followup for #957 

It adds simple E2E tests for control-plane in routing table mode.

While writing the tests I've found an issue with IPv6 handling that should be fixed now as well.