### PR TITLE
Added auto subnet discovery for services in ARP mode

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -289,6 +289,14 @@ var kubeVipManager = &cobra.Command{
 			log.Fatalln("no features are enabled")
 		}
 
+		if !initConfig.EnableARP && strings.Contains(initConfig.VIPCIDR, kubevip.Auto) {
+			log.Fatalln("auto subnet discovery cannot be used outside ARP mode")
+		}
+
+		if strings.Contains(initConfig.VIPCIDR, kubevip.Auto) && initConfig.Address != "" {
+			log.Fatalln("auto subnet discovery cannot be used if VIP address was provided")
+		}
+
 		// If we're using wireguard then all traffic goes through the wg0 interface
 		if initConfig.EnableWireguard {
 			if initConfig.Interface == "" {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -46,7 +46,7 @@ func startNetworking(c *kubevip.Config) ([]vip.Network, error) {
 		address = c.Address
 	}
 
-	addresses := vip.GetIPs(address)
+	addresses := vip.Split(address)
 
 	networks := []vip.Network{}
 	for _, addr := range addresses {

--- a/pkg/kubevip/config_manager.go
+++ b/pkg/kubevip/config_manager.go
@@ -7,6 +7,10 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+const (
+	Auto = "auto"
+)
+
 func (c *Config) CheckInterface() error {
 	if c.Interface != "" {
 		if err := isValidInterface(c.Interface); err != nil {
@@ -25,7 +29,7 @@ func (c *Config) CheckInterface() error {
 
 func isValidInterface(iface string) error {
 	// auto interface discovery for services is enabled
-	if iface == "auto" {
+	if iface == Auto {
 		return nil
 	}
 	l, err := netlink.LinkByName(iface)

--- a/pkg/manager/service_egress.go
+++ b/pkg/manager/service_egress.go
@@ -49,18 +49,33 @@ func (sm *Manager) iptablesCheck() error {
 
 func getSameFamilyCidr(sourceCidrs, ip string) string { //Todo: not sure how this ever worked
 	cidrs := strings.Split(sourceCidrs, ",")
+	isV6 := vip.IsIPv6(ip)
 	matchingFamily := []string{}
 	for _, cidr := range cidrs {
 		// Is the ip an IPv6 address
-		if vip.IsIPv4(ip) == vip.IsIPv4CIDR(cidr) {
-			matchingFamily = append(matchingFamily, cidr)
-			selectedCIDR, err := checkCIDR(ip, cidr)
-			if err != nil {
-				log.Warnf("CIDR check failed: %s", err.Error())
-				continue
+		if isV6 {
+			if vip.IsIPv6CIDR(cidr) {
+				matchingFamily = append(matchingFamily, cidr)
+				selectedCIDR, err := checkCIDR(ip, cidr)
+				if err != nil {
+					log.Warnf("IPv6 CIDR check failed: %s", err.Error())
+					continue
+				}
+				if selectedCIDR != "" {
+					return selectedCIDR
+				}
 			}
-			if selectedCIDR != "" {
-				return selectedCIDR
+		} else {
+			if vip.IsIPv4CIDR(cidr) {
+				matchingFamily = append(matchingFamily, cidr)
+				selectedCidr, err := checkCIDR(ip, cidr)
+				if err != nil {
+					log.Warnf("IPv4 CIDR check failed: %s", err.Error())
+					continue
+				}
+				if selectedCidr != "" {
+					return selectedCidr
+				}
 			}
 		}
 	}

--- a/pkg/vip/address.go
+++ b/pkg/vip/address.go
@@ -43,6 +43,7 @@ type Network interface {
 	IsDDNS() bool
 	DDNSHostName() string
 	DNSName() string
+	SetMask(mask string) error
 }
 
 // network - This allows network configuration
@@ -286,6 +287,7 @@ func (configurator *network) AddIP(precheck bool) error {
 			return errors.Wrap(err, "could not check if address exists")
 		}
 	}
+
 	if !exists {
 		if err := netlink.AddrReplace(configurator.link, configurator.address); err != nil {
 			return errors.Wrap(err, "could not add ip")
@@ -691,4 +693,17 @@ func GarbageCollect(adapter, address string) (found bool, err error) {
 		}
 	}
 	return // Didn't find the address on the adapter
+}
+
+func (configurator *network) SetMask(mask string) error {
+	m, err := strconv.Atoi(mask)
+	if err != nil {
+		return err
+	}
+	size := 32
+	if IsIPv6(configurator.address.IP.String()) {
+		size = 128
+	}
+	configurator.address.IPNet.Mask = net.CIDRMask(m, size)
+	return nil
 }

--- a/pkg/vip/util.go
+++ b/pkg/vip/util.go
@@ -195,11 +195,10 @@ func GenerateMac() (mac string) {
 	return mac
 }
 
-func GetIPs(vip string) []string {
-	addresses := []string{}
-	vips := strings.Split(vip, ",")
-	for _, v := range vips {
-		addresses = append(addresses, strings.TrimSpace(v))
+func Split(values string) []string {
+	result := strings.Split(values, ",")
+	for i := range result {
+		result[i] = strings.TrimSpace(result[i])
 	}
-	return addresses
+	return result
 }

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -345,7 +345,7 @@ var _ = Describe("kube-vip broadcast neighbor", func() {
 		})
 
 		It("provides an DualStack VIP addresses for the Kubernetes control plane nodes", func() {
-			vips := vip.GetIPs(dualstackVIP)
+			vips := vip.Split(dualstackVIP)
 
 			By(withTimestamp("creating a kind cluster with multiple control plane nodes"))
 			createKindCluster(logger, &clusterConfig, clusterName)


### PR DESCRIPTION
This PR adds auto subnet discovery for services deployed in ARP mode.

As for now all service VIP addresses have subnet of /32 and /128 for IPv4 and IPv6 respectively, if `vip_cidr` is not defined. After this changes if `vip_address` was not provided in config and `vip_cidr` will be set to `auto,auto` (first value is for IPv4, second for IPv6 addresses) kube-vip will try to find suitable subnet based on addresses available on the `vip_servicesinterface`. This is complementary to #926 . 

Example:

Config:
vip_servicesinterface: "eth0"
vip_cidr: "auto,auto"

Interface on the node:

```
14: eth0@if15: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
    link/ether 02:42:ac:12:00:04 brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet 172.18.0.4/16 brd 172.18.255.255 scope global eth0
       valid_lft forever preferred_lft forever
    inet 192.0.3.103/17 scope global eth0
       valid_lft forever preferred_lft forever
```

Service configured for address 192.168.3.200
```yaml
annotations:
    kube-vip.io/loadbalancerIPs: "192.0.3.200"
```

As an address `192.0.3.200` is in the same subnet as `192.0.3.103/17`, the configured IP address will be `192.0.3.200/17`.