### PR TITLE
Egress rules deletion fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,11 @@ dockerx86Iptables:
 	@docker buildx build  --platform linux/amd64 -f ./Dockerfile_iptables --push -t $(REPOSITORY)/$(TARGET):dev .
 	@echo New single x86 Architecture Docker image created
 
+dockerx86IptablesLocal:
+	@-rm ./kube-vip
+	@docker buildx build  --platform linux/amd64 -f ./Dockerfile_iptables -t $(REPOSITORY)/$(TARGET):$(DOCKERTAG) .
+	@echo New single x86 Architecture Docker image created
+
 dockerx86:
 	@-rm ./kube-vip
 	@docker buildx build  --platform linux/amd64 --push -t $(REPOSITORY)/$(TARGET):$(DOCKERTAG) .

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -334,12 +334,12 @@ func ParseEnvironment(c *Config) error {
 		}
 		if i >= 0 && i <= math.MaxInt {
 			c.RoutingTableID = int(i)
-			return nil
 		} else if i < 0 {
 			return fmt.Errorf("no support of negative [%d] in env var %q", i, vipRoutingTableID)
+		} else {
+			// +1 for the signing bit as it is 0 for positive integers
+			return fmt.Errorf("no support for int64, system natively supports [int%d]", bits.OnesCount(math.MaxInt)+1)
 		}
-		// +1 for the signing bit as it is 0 for positive integers
-		return fmt.Errorf("no support for int64, system natively supports [int%d]", bits.OnesCount(math.MaxInt)+1)
 	}
 
 	// Routing Table Type

--- a/pkg/manager/manager_arp.go
+++ b/pkg/manager/manager_arp.go
@@ -98,17 +98,7 @@ func (sm *Manager) startARP(id string) error {
 
 	// This will tidy any dangling kube-vip iptables rules
 	if os.Getenv("EGRESS_CLEAN") != "" {
-		i, err := vip.CreateIptablesClient(sm.config.EgressWithNftables, sm.config.ServiceNamespace, iptables.ProtocolIPv4)
-		if err != nil {
-			log.Warnf("(egress) Unable to clean any dangling egress rules [%v]", err)
-			log.Warn("(egress) Can be ignored in non iptables release of kube-vip")
-		} else {
-			log.Info("(egress) Cleaning any dangling kube-vip egress rules")
-			cleanErr := i.CleanIPtables()
-			if cleanErr != nil {
-				log.Errorf("Error cleaning rules [%v]", cleanErr)
-			}
-		}
+		vip.ClearIPTables(sm.config.EgressWithNftables, sm.config.ServiceNamespace, iptables.ProtocolIPv4)
 	}
 
 	// Start a services watcher (all kube-vip pods will watch services), upon a new service

--- a/pkg/manager/service_egress.go
+++ b/pkg/manager/service_egress.go
@@ -138,7 +138,7 @@ func (sm *Manager) configureEgress(vipIP, podIP, destinationPorts, namespace str
 
 	log.Infof("[Egress] pod CIDR [%s], service CIDR [%s] for vip [%s] / pod [%s]", podCidr, serviceCidr, vipIP, podIP)
 
-	// checking if all adresses are of the same IP family
+	// checking if all addresses are of the same IP family
 	if vip.IsIPv4(podIP) != vip.IsIPv4CIDR(podCidr) {
 		log.Errorf("[Egress] pod's IP [%s] and Pod CIDR [%s] family is not matching. Backing off...", podIP, podCidr)
 		return nil

--- a/pkg/manager/watch_services.go
+++ b/pkg/manager/watch_services.go
@@ -155,7 +155,7 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 				log.Debugf("(svcs) [%s] has been added/modified with addresses [%s]", svc.Name, fetchServiceAddresses(svc))
 
 				wg.Add(1)
-				activeServiceLoadBalancer[string(svc.UID)], activeServiceLoadBalancerCancel[string(svc.UID)] = context.WithCancel(context.TODO())
+				activeServiceLoadBalancer[string(svc.UID)], activeServiceLoadBalancerCancel[string(svc.UID)] = context.WithCancel(ctx)
 				// Background the services election
 				// EnableServicesElection enabled
 				// watchEndpoint will do a ServicesElection by Service and understands local endpoints

--- a/pkg/vip/egress.go
+++ b/pkg/vip/egress.go
@@ -87,7 +87,7 @@ func (e *Egress) DeleteSourceNat(podIP, vip string) error {
 }
 
 func (e *Egress) DeleteSourceNatForDestinationPort(podIP, vip, port, proto string) error {
-	log.Infof("[egress] Adding source nat from [%s] => [%s]", podIP, vip)
+	log.Infof("[egress] Removing source nat from [%s] => [%s], with destination port [%s]", podIP, vip, port)
 
 	exists, _ := e.ipTablesClient.Exists("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-p", proto, "--dport", port, "-m", "comment", "--comment", e.comment)
 
@@ -380,10 +380,10 @@ func (e *Egress) findExistingVIP(rules []string, vip string) [][]string {
 func ClearIPTables(useNftables bool, namespace string, protocol iptables.Protocol) {
 	i, err := CreateIptablesClient(useNftables, namespace, protocol)
 	if err != nil {
-		log.Warnf("(egress) Unable to clean any dangling egress rules [%v]", err)
-		log.Warn("(egress) Can be ignored in non iptables release of kube-vip")
+		log.Warnf("[egress] Unable to clean any dangling egress rules [%v]", err)
+		log.Warn("[egress] Can be ignored in non iptables release of kube-vip")
 	} else {
-		log.Info("(egress) Cleaning any dangling kube-vip egress rules")
+		log.Info("[egress] Cleaning any dangling kube-vip egress rules")
 		cleanErr := i.CleanIPtables()
 		if cleanErr != nil {
 			log.Errorf("Error cleaning rules [%v]", cleanErr)

--- a/pkg/vip/egress.go
+++ b/pkg/vip/egress.go
@@ -376,3 +376,17 @@ func (e *Egress) findExistingVIP(rules []string, vip string) [][]string {
 
 	return foundRules
 }
+
+func ClearIPTables(useNftables bool, namespace string, protocol iptables.Protocol) {
+	i, err := CreateIptablesClient(useNftables, namespace, protocol)
+	if err != nil {
+		log.Warnf("(egress) Unable to clean any dangling egress rules [%v]", err)
+		log.Warn("(egress) Can be ignored in non iptables release of kube-vip")
+	} else {
+		log.Info("(egress) Cleaning any dangling kube-vip egress rules")
+		cleanErr := i.CleanIPtables()
+		if cleanErr != nil {
+			log.Errorf("Error cleaning rules [%v]", cleanErr)
+		}
+	}
+}

--- a/pkg/vip/egress.go
+++ b/pkg/vip/egress.go
@@ -35,7 +35,11 @@ type Egress struct {
 }
 
 func CreateIptablesClient(nftables bool, namespace string, protocol iptables.Protocol) (*Egress, error) {
-	log.Infof("[egress] Creating an iptables client, nftables mode [%t]", nftables)
+	proto := "IPv4"
+	if protocol == iptables.ProtocolIPv6 {
+		proto = "IPv6"
+	}
+	log.Infof("[egress] Creating an iptables client, nftables mode [%t], protocol [%s]", nftables, proto)
 	e := new(Egress)
 	var err error
 

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -159,14 +159,11 @@ var _ = Describe("kube-vip broadcast neighbor", func() {
 		})
 
 		It("provides an IPv4 VIP address for the Kubernetes control plane nodes", func() {
-			go func() {
-				time.Sleep(30 * time.Second)
-				By(withTimestamp("loading local docker image to kind cluster"))
-				e2e.LoadDockerImageToKind(logger, imagePath, clusterName)
-			}()
-
 			By(withTimestamp("creating a kind cluster with multiple control plane nodes"))
 			createKindCluster(logger, &clusterConfig, clusterName)
+
+			By(withTimestamp("loading local docker image to kind cluster"))
+			e2e.LoadDockerImageToKind(logger, imagePath, clusterName)
 
 			By(withTimestamp("checking that the Kubernetes control plane nodes are accessible via the assigned IPv4 VIP"))
 			// Allow enough time for control plane nodes to load the docker image and
@@ -255,14 +252,11 @@ var _ = Describe("kube-vip broadcast neighbor", func() {
 		})
 
 		It("provides an IPv6 VIP address for the Kubernetes control plane nodes", func() {
-			go func() {
-				time.Sleep(30 * time.Second)
-				By(withTimestamp("loading local docker image to kind cluster"))
-				e2e.LoadDockerImageToKind(logger, imagePath, clusterName)
-			}()
-
 			By(withTimestamp("creating a kind cluster with multiple control plane nodes"))
 			createKindCluster(logger, &clusterConfig, clusterName)
+
+			By(withTimestamp("loading local docker image to kind cluster"))
+			e2e.LoadDockerImageToKind(logger, imagePath, clusterName)
 
 			By(withTimestamp("checking that the Kubernetes control plane nodes are accessible via the assigned IPv6 VIP"))
 			// Allow enough time for control plane nodes to load the docker image and
@@ -351,16 +345,13 @@ var _ = Describe("kube-vip broadcast neighbor", func() {
 		})
 
 		It("provides an DualStack VIP addresses for the Kubernetes control plane nodes", func() {
-			go func() {
-				time.Sleep(30 * time.Second)
-				By(withTimestamp("loading local docker image to kind cluster"))
-				e2e.LoadDockerImageToKind(logger, imagePath, clusterName)
-			}()
-
 			vips := vip.GetIPs(dualstackVIP)
 
 			By(withTimestamp("creating a kind cluster with multiple control plane nodes"))
 			createKindCluster(logger, &clusterConfig, clusterName)
+
+			By(withTimestamp("loading local docker image to kind cluster"))
+			e2e.LoadDockerImageToKind(logger, imagePath, clusterName)
 
 			By(withTimestamp("checking that the Kubernetes control plane nodes are accessible via the assigned IPv6 VIP"))
 			// Allow enough time for control plane nodes to load the docker image and
@@ -458,14 +449,11 @@ var _ = Describe("kube-vip broadcast neighbor", func() {
 		})
 
 		It("uses hostname fallback while providing an IPv4 VIP address for the Kubernetes control plane nodes", func() {
-			go func() {
-				time.Sleep(30 * time.Second)
-				By(withTimestamp("loading local docker image to kind cluster"))
-				e2e.LoadDockerImageToKind(logger, imagePath, clusterName)
-			}()
-
 			By(withTimestamp("creating a kind cluster with multiple control plane nodes"))
 			createKindCluster(logger, &clusterConfig, clusterName)
+
+			By(withTimestamp("loading local docker image to kind cluster"))
+			e2e.LoadDockerImageToKind(logger, imagePath, clusterName)
 
 			By(withTimestamp("checking that the Kubernetes control plane nodes are accessible via the assigned IPv4 VIP"))
 			// Allow enough time for control plane nodes to load the docker image and
@@ -556,14 +544,11 @@ var _ = Describe("kube-vip broadcast neighbor", func() {
 		})
 
 		It("setups IPv4 address and route on control-plane node", func() {
-			go func() {
-				time.Sleep(30 * time.Second)
-				By(withTimestamp("loading local docker image to kind cluster"))
-				e2e.LoadDockerImageToKind(logger, imagePath, clusterName)
-			}()
-
 			By(withTimestamp("creating a kind cluster with multiple control plane nodes"))
 			createKindCluster(logger, &clusterConfig, clusterName)
+
+			By(withTimestamp("loading local docker image to kind cluster"))
+			e2e.LoadDockerImageToKind(logger, imagePath, clusterName)
 
 			By(withTimestamp("sitting for a few seconds to hopefully allow kube-vip to start"))
 			time.Sleep(30 * time.Second)
@@ -656,14 +641,11 @@ var _ = Describe("kube-vip broadcast neighbor", func() {
 		})
 
 		It("setups IPv6 address and route on control-plane node", func() {
-			go func() {
-				time.Sleep(30 * time.Second)
-				By(withTimestamp("loading local docker image to kind cluster"))
-				e2e.LoadDockerImageToKind(logger, imagePath, clusterName)
-			}()
-
 			By(withTimestamp("creating a kind cluster with multiple control plane nodes"))
 			createKindCluster(logger, &clusterConfig, clusterName)
+
+			By(withTimestamp("loading local docker image to kind cluster"))
+			e2e.LoadDockerImageToKind(logger, imagePath, clusterName)
 
 			By(withTimestamp("sitting for a few seconds to hopefully allow kube-vip to start"))
 			time.Sleep(30 * time.Second)

--- a/testing/e2e/services/controlplane.go
+++ b/testing/e2e/services/controlplane.go
@@ -52,7 +52,7 @@ func generateIPv4VIP() (string, error) {
 	}
 	for _, cidr := range cidrs {
 		ip, ipNet, parseErr := net.ParseCIDR(cidr)
-		if err != nil {
+		if parseErr != nil {
 			return "", parseErr
 		}
 		if ip.To4() != nil {
@@ -75,7 +75,7 @@ func generateIPv6VIP() (string, error) {
 	}
 	for _, cidr := range cidrs {
 		ip, ipNet, parseErr := net.ParseCIDR(cidr)
-		if err != nil {
+		if parseErr != nil {
 			return "", parseErr
 		}
 		if ip.To4() == nil {


### PR DESCRIPTION
This PR fixes #966 

It introduces a few changes:

1. Egress rules should be now deleted properly in service-election routing table mode when service is deleted, election is lost or kube-vip's pod is terminated.

2. Auto service/pod CIDR discovery will now not be used if `egress_servicecidr` and/or `egress_podcidr` is defined.

3. A minor change in the e2e tests - docker image will be now loaded only after the cluster was created. (this can be discarded in favor of better e2e test fix if possible. Added that just to run the tests for now.)

