### PR TITLE
Fixed retry-watcher timeout issue

### DIFF
--- a/pkg/manager/watch_annotations.go
+++ b/pkg/manager/watch_annotations.go
@@ -58,7 +58,7 @@ func (sm *Manager) annotationsWatcher() error {
 
 	rw, err := watchtools.NewRetryWatcher(node.ResourceVersion, &cache.ListWatch{
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return sm.clientSet.CoreV1().Nodes().Watch(context.Background(), listOptions)
+			return sm.rwClientSet.CoreV1().Nodes().Watch(context.Background(), listOptions)
 		},
 	})
 	if err != nil {

--- a/pkg/manager/watch_endpoints.go
+++ b/pkg/manager/watch_endpoints.go
@@ -47,7 +47,7 @@ func (ep *endpointsProvider) createRetryWatcher(ctx context.Context, sm *Manager
 
 	rw, err := watchtools.NewRetryWatcher("1", &cache.ListWatch{
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return sm.clientSet.CoreV1().Endpoints(service.Namespace).Watch(ctx, opts)
+			return sm.rwClientSet.CoreV1().Endpoints(service.Namespace).Watch(ctx, opts)
 		},
 	})
 

--- a/pkg/manager/watch_endpointslices.go
+++ b/pkg/manager/watch_endpointslices.go
@@ -32,7 +32,7 @@ func (ep *endpointslicesProvider) createRetryWatcher(ctx context.Context, sm *Ma
 
 	rw, err := watchtools.NewRetryWatcher("1", &cache.ListWatch{
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return sm.clientSet.DiscoveryV1().EndpointSlices(service.Namespace).Watch(ctx, opts)
+			return sm.rwClientSet.DiscoveryV1().EndpointSlices(service.Namespace).Watch(ctx, opts)
 		},
 	})
 	if err != nil {

--- a/pkg/manager/watch_services.go
+++ b/pkg/manager/watch_services.go
@@ -71,7 +71,7 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 	// Use a restartable watcher, as this should help in the event of etcd or timeout issues
 	rw, err := watchtools.NewRetryWatcher("1", &cache.ListWatch{
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return sm.clientSet.CoreV1().Services(sm.config.ServiceNamespace).Watch(ctx, metav1.ListOptions{})
+			return sm.rwClientSet.CoreV1().Services(sm.config.ServiceNamespace).Watch(ctx, metav1.ListOptions{})
 		},
 	})
 	if err != nil {

--- a/testing/e2e/services/tests.go
+++ b/testing/e2e/services/tests.go
@@ -118,7 +118,11 @@ func main() {
 		ctx, cancel := context.WithCancel(context.TODO())
 		defer cancel()
 		homeConfigPath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
-		clientset, err := k8s.NewClientset(homeConfigPath, false, "")
+		config, err := k8s.NewRestConfig(homeConfigPath, false, "")
+		if err != nil {
+			log.Fatalf("could not create k8s REST config from external file: %q: %v", homeConfigPath, err)
+		}
+		clientset, err := k8s.NewClientset(config)
 		if err != nil {
 			log.Fatalf("could not create k8s clientset from external file: %q: %v", homeConfigPath, err)
 		}


### PR DESCRIPTION
This should fix #930 

Between v0.6.4 and v0.7.0 some k8s client changes were introduced. One of those changes was introduction of client timeout set by default to `10s`.

The same client is used by RetryWatcher, and it seems that this timeout makes retry watcher to restart every 10s, which creates a a lot of logs.

I've added separate k8s clientset which does not use timeout value  for RetryWatcher to use.