### PR TITLE
Services aren't removed when there are no endpoints.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,3 +151,6 @@ trivy: dockerx86ActionIPTables
 		--severity  'CRITICAL,HIGH'  \
 		$(REPOSITORY)/$(TARGET):action
 
+kind-reload:
+	kind load docker-image $(REPOSITORY)/$(TARGET):$(DOCKERTAG) -n services
+	kubectl rollout restart -n kube-system daemonset/kube-vip-ds

--- a/pkg/manager/watch_endpoints.go
+++ b/pkg/manager/watch_endpoints.go
@@ -373,7 +373,7 @@ func (sm *Manager) watchEndpoint(ctx context.Context, id string, service *v1.Ser
 				}
 
 				// If there are no local endpoints, and we had one then remove it and stop the leaderElection
-				if lastKnownGoodEndpoint != "" /*&& sm.config.EnableRoutingTable*/ {
+				if lastKnownGoodEndpoint != "" {
 					log.Warnf("[%s] existing [%s] has been removed, no remaining endpoints for leaderElection", provider.getLabel(), lastKnownGoodEndpoint)
 					if err := sm.TeardownEgress(lastKnownGoodEndpoint, service.Spec.LoadBalancerIP,
 						service.Annotations[egressDestinationPorts], service.Namespace); err != nil {

--- a/pkg/manager/watch_endpoints.go
+++ b/pkg/manager/watch_endpoints.go
@@ -373,7 +373,7 @@ func (sm *Manager) watchEndpoint(ctx context.Context, id string, service *v1.Ser
 				}
 
 				// If there are no local endpoints, and we had one then remove it and stop the leaderElection
-				if lastKnownGoodEndpoint != "" && sm.config.EnableRoutingTable {
+				if lastKnownGoodEndpoint != "" /*&& sm.config.EnableRoutingTable*/ {
 					log.Warnf("[%s] existing [%s] has been removed, no remaining endpoints for leaderElection", provider.getLabel(), lastKnownGoodEndpoint)
 					if err := sm.TeardownEgress(lastKnownGoodEndpoint, service.Spec.LoadBalancerIP,
 						service.Annotations[egressDestinationPorts], service.Namespace); err != nil {

--- a/testing/e2e/services/tests.go
+++ b/testing/e2e/services/tests.go
@@ -54,7 +54,7 @@ func main() {
 	_, t.IPv6 = os.LookupEnv("IPV6_FAMILY")
 	_, t.skipHostnameChange = os.LookupEnv("SKIP_HOSTNAME_CHANGE")
 
-	flag.StringVar(&t.ImagePath, "imagepath", "plndr/kube-vip:action", "")
+	//flag.StringVar(&t.ImagePath, "imagepath", "plndr/kube-vip:action", "")
 	flag.BoolVar(&t.ControlPlane, "ControlPlane", false, "")
 	flag.BoolVar(&t.Services, "Services", false, "")
 


### PR DESCRIPTION
For some reason the endpoint watcher had a check that meant that when "local" endpoints went to 0 then it would stop being part of the leader election, however it appears that it was wrapped with only being allowed when routing mode was enabled. This has broken a few things.

This make sense @p-strusiewiczsurmacki-mobica 