### PR TITLE
Fixes an issue with watchers having an old reference

### DIFF
--- a/pkg/manager/watch_services.go
+++ b/pkg/manager/watch_services.go
@@ -70,8 +70,8 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 
 	// Use a restartable watcher, as this should help in the event of etcd or timeout issues
 	rw, err := watchtools.NewRetryWatcher("1", &cache.ListWatch{
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return sm.rwClientSet.CoreV1().Services(sm.config.ServiceNamespace).Watch(ctx, options)
+		WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) {
+			return sm.rwClientSet.CoreV1().Services(sm.config.ServiceNamespace).Watch(ctx, metav1.ListOptions{})
 		},
 	})
 	if err != nil {

--- a/testing/services/main.go
+++ b/testing/services/main.go
@@ -41,7 +41,7 @@ func main() {
 	flag.BoolVar(&t.EgressIPv6, "egressIPv6", false, "Perform an egress test")
 	flag.BoolVar(&t.DualStack, "dualStack", false, "Perform an dual stack test")
 	flag.BoolVar(&t.RetainCluster, "retain", false, "Retain the cluster")
-
+	flag.StringVar(&t.KindVersionImage, "kindImage", "", "The image to use for the kind nodes e.g. (kindest/node:v1.21.14)")
 	flag.BoolVar(&existing, "existing", false, "Use an existing cluster")
 
 	flag.Parse()

--- a/testing/services/pkg/deployment/kind.go
+++ b/testing/services/pkg/deployment/kind.go
@@ -38,6 +38,7 @@ func (config *TestConfig) CreateKind() error {
 			},
 		},
 	}
+
 	if config.IPv6 {
 		// Change Networking Family
 		clusterConfig.Networking.IPFamily = kindconfigv1alpha4.IPv6Family
@@ -72,6 +73,13 @@ func (config *TestConfig) CreateKind() error {
 		clusterConfig.Nodes = append(clusterConfig.Nodes, kindconfigv1alpha4.Node{Role: kindconfigv1alpha4.WorkerRole})
 		clusterConfig.Nodes = append(clusterConfig.Nodes, kindconfigv1alpha4.Node{Role: kindconfigv1alpha4.WorkerRole})
 		//clusterConfig.Nodes = append(clusterConfig.Nodes, kindconfigv1alpha4.Node{Role: kindconfigv1alpha4.WorkerRole})
+	}
+
+	// Change the default image if required
+	if config.KindVersionImage != "" {
+		for x := range clusterConfig.Nodes {
+			clusterConfig.Nodes[x].Image = config.KindVersionImage
+		}
 	}
 
 	provider = cluster.NewProvider(cluster.ProviderWithLogger(cmd.NewLogger()), cluster.ProviderWithDocker())

--- a/testing/services/pkg/deployment/kubernetes.go
+++ b/testing/services/pkg/deployment/kubernetes.go
@@ -277,8 +277,8 @@ func (s *Service) CreateService(ctx context.Context, clientset *kubernetes.Clien
 	}
 	// Use a restartable watcher, as this should help in the event of etcd or timeout issues
 	rw, err := watchtools.NewRetryWatcher("1", &cache.ListWatch{
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return clientset.CoreV1().Services(v1.NamespaceDefault).Watch(ctx, options)
+		WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) {
+			return clientset.CoreV1().Services(v1.NamespaceDefault).Watch(ctx, metav1.ListOptions{})
 		},
 	})
 	if err != nil {

--- a/testing/services/pkg/deployment/services.go
+++ b/testing/services/pkg/deployment/services.go
@@ -148,8 +148,8 @@ func leaderFailover(ctx context.Context, name, leaderNode *string, clientset *ku
 
 	// Use a restartable watcher, as this should help in the event of etcd or timeout issues
 	rw, err := watchtools.NewRetryWatcher("1", &cache.ListWatch{
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return clientset.CoreV1().Services(v1.NamespaceDefault).Watch(ctx, options)
+		WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) {
+			return clientset.CoreV1().Services(v1.NamespaceDefault).Watch(ctx, metav1.ListOptions{})
 		},
 	})
 	if err != nil {
@@ -231,8 +231,8 @@ func podFailover(ctx context.Context, name, leaderNode *string, clientset *kuber
 
 	// Use a restartable watcher, as this should help in the event of etcd or timeout issues
 	rw, err := watchtools.NewRetryWatcher("1", &cache.ListWatch{
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return clientset.CoreV1().Services(v1.NamespaceDefault).Watch(ctx, options)
+		WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) {
+			return clientset.CoreV1().Services(v1.NamespaceDefault).Watch(ctx, metav1.ListOptions{})
 		},
 	})
 	if err != nil {

--- a/testing/services/pkg/deployment/tests.go
+++ b/testing/services/pkg/deployment/tests.go
@@ -13,9 +13,9 @@ import (
 )
 
 type TestConfig struct {
-	SuccessCounter int
-
-	ImagePath string
+	SuccessCounter   int
+	KindVersionImage string
+	ImagePath        string
 
 	ControlPlane bool
 	// control plane settings


### PR DESCRIPTION
The golang-ci linter was complaining about unused variables, which resulted in a fix that ended up with long running references to objects. This returns it back to its original behaviour and fixes the linting issue.

Fixes #1028 