### PR TITLE
This removes some weird pointless code

### DIFF
--- a/pkg/manager/instance.go
+++ b/pkg/manager/instance.go
@@ -34,9 +34,9 @@ type Instance struct {
 	upnpGatewayIPs []string
 
 	// Kubernetes service mapping
-	VIPs          []string
-	UID           string
-	ExternalPorts []Port
+	//VIPs          []string
+	//UID           string
+	//ExternalPorts []Port
 
 	serviceSnapshot *v1.Service
 }
@@ -48,7 +48,7 @@ type Port struct {
 
 func NewInstance(svc *v1.Service, config *kubevip.Config) (*Instance, error) {
 	instanceAddresses := fetchServiceAddresses(svc)
-	instanceUID := string(svc.UID)
+	//instanceUID := string(svc.UID)
 
 	var newVips []*kubevip.Config
 	var link netlink.Link
@@ -174,16 +174,16 @@ func NewInstance(svc *v1.Service, config *kubevip.Config) (*Instance, error) {
 
 	// Create new service
 	instance := &Instance{
-		UID:             instanceUID,
-		VIPs:            instanceAddresses,
+		//UID:             instanceUID,
+		//VIPs:            instanceAddresses,
 		serviceSnapshot: svc,
 	}
-	for _, port := range svc.Spec.Ports {
-		instance.ExternalPorts = append(instance.ExternalPorts, Port{
-			Port: uint16(port.Port), //nolint
-			Type: string(port.Protocol),
-		})
-	}
+	// for _, port := range svc.Spec.Ports {
+	// 	instance.ExternalPorts = append(instance.ExternalPorts, Port{
+	// 		Port: uint16(port.Port), //nolint
+	// 		Type: string(port.Protocol),
+	// 	})
+	// }
 
 	if svc.Annotations != nil {
 		instance.dhcpInterfaceHwaddr = svc.Annotations[hwAddrKey]
@@ -192,9 +192,9 @@ func NewInstance(svc *v1.Service, config *kubevip.Config) (*Instance, error) {
 	}
 
 	configPorts := make([]kubevip.Port, 0)
-	for _, p := range instance.ExternalPorts {
+	for _, p := range svc.Spec.Ports {
 		configPorts = append(configPorts, kubevip.Port{
-			Type: p.Type,
+			Type: string(p.Protocol),
 			Port: int(p.Port),
 		})
 	}
@@ -316,7 +316,7 @@ func (i *Instance) startDHCP() error {
 	}
 
 	// Generate name from UID
-	interfaceName := fmt.Sprintf("vip-%s", i.UID[0:8])
+	interfaceName := fmt.Sprintf("vip-%s", i.serviceSnapshot.UID[0:8])
 
 	// Check if the interface doesn't exist first
 	iface, err := net.InterfaceByName(interfaceName)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -314,11 +314,10 @@ func (sm *Manager) stopTrafficMirroringIfEnabled() error {
 }
 
 func (sm *Manager) findServiceInstance(svc *v1.Service) *Instance {
-	svcUID := string(svc.UID)
-	log.Debugf("service UID: %s", svcUID)
+	log.Debugf("service UID: %s", svc.UID)
 	for i := range sm.serviceInstances {
-		log.Debugf("saved service instance %d UID: %s", i, sm.serviceInstances[i].UID)
-		if sm.serviceInstances[i].UID == svcUID {
+		log.Debugf("saved service instance %d UID: %s", i, sm.serviceInstances[i].serviceSnapshot.UID)
+		if sm.serviceInstances[i].serviceSnapshot.UID == svc.UID {
 			return sm.serviceInstances[i]
 		}
 	}

--- a/pkg/manager/services.go
+++ b/pkg/manager/services.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vishvananda/netlink"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 
 	"github.com/kube-vip/kube-vip/pkg/upnp"
@@ -27,7 +28,7 @@ func (sm *Manager) syncServices(ctx context.Context, svc *v1.Service, wg *sync.W
 	// Iterate through the synchronising services
 	foundInstance := false
 	newServiceAddresses := fetchServiceAddresses(svc)
-	newServiceUID := string(svc.UID)
+	newServiceUID := svc.UID
 
 	ingressIPs := []string{}
 
@@ -43,7 +44,7 @@ func (sm *Manager) syncServices(ctx context.Context, svc *v1.Service, wg *sync.W
 		}
 		for _, newServiceAddress := range newServiceAddresses {
 			log.Debugf("isDHCP: %t, newServiceAddress: %s", sm.serviceInstances[x].isDHCP, newServiceAddress)
-			if sm.serviceInstances[x].UID == newServiceUID {
+			if sm.serviceInstances[x].serviceSnapshot.UID == newServiceUID {
 				// If the found instance's DHCP configuration doesn't match the new service, delete it.
 				if (sm.serviceInstances[x].isDHCP && newServiceAddress != "0.0.0.0") ||
 					(!sm.serviceInstances[x].isDHCP && newServiceAddress == "0.0.0.0") ||
@@ -120,7 +121,7 @@ func (sm *Manager) addService(ctx context.Context, svc *v1.Service) error {
 		log.Debugf("(svcs) will update [%s/%s]", newService.serviceSnapshot.Namespace, newService.serviceSnapshot.Name)
 		if err := sm.updateStatus(newService); err != nil {
 			// delete service to collect garbage
-			if deleteErr := sm.deleteService(newService.UID); deleteErr != nil {
+			if deleteErr := sm.deleteService(newService.serviceSnapshot.UID); deleteErr != nil {
 				return deleteErr
 			}
 			return err
@@ -205,7 +206,7 @@ func (sm *Manager) addService(ctx context.Context, svc *v1.Service) error {
 	return nil
 }
 
-func (sm *Manager) deleteService(uid string) error {
+func (sm *Manager) deleteService(uid types.UID) error {
 	// protect multiple calls
 	sm.mutex.Lock()
 	defer sm.mutex.Unlock()
@@ -214,9 +215,9 @@ func (sm *Manager) deleteService(uid string) error {
 	var serviceInstance *Instance
 	found := false
 	for x := range sm.serviceInstances {
-		log.Debugf("Looking for [%s], found [%s]", uid, sm.serviceInstances[x].UID)
+		log.Debugf("Looking for [%s], found [%s]", uid, sm.serviceInstances[x].serviceSnapshot.UID)
 		// Add the running services to the new array
-		if sm.serviceInstances[x].UID != uid {
+		if sm.serviceInstances[x].serviceSnapshot.UID != uid {
 			updatedInstances = append(updatedInstances, sm.serviceInstances[x])
 		} else {
 			// Flip the found when we match
@@ -230,14 +231,16 @@ func (sm *Manager) deleteService(uid string) error {
 		// return fmt.Errorf("unable to find/stop service [%s]", uid)
 		return nil
 	}
+
+	// Determine if this this VIP is shared with other loadbalancers
 	shared := false
 	vipSet := make(map[string]interface{})
 	for x := range updatedInstances {
-		for _, vip := range updatedInstances[x].VIPs {
+		for _, vip := range fetchServiceAddresses(updatedInstances[x].serviceSnapshot) { //updatedInstances[x].serviceSnapshot.Spec.LoadBalancerIP {
 			vipSet[vip] = nil
 		}
 	}
-	for _, vip := range serviceInstance.VIPs {
+	for _, vip := range fetchServiceAddresses(serviceInstance.serviceSnapshot) {
 		if _, found := vipSet[vip]; found {
 			shared = true
 		}
@@ -308,14 +311,14 @@ func (sm *Manager) upnpMap(ctx context.Context, s *Instance) {
 	// Reset Gateway IPs to remove stale addresses
 	s.upnpGatewayIPs = make([]string, 0)
 
-	for _, vip := range s.VIPs {
-		for _, port := range s.ExternalPorts {
+	for _, vip := range fetchServiceAddresses(s.serviceSnapshot) {
+		for _, port := range s.serviceSnapshot.Spec.Ports {
 			for _, gw := range gateways {
 				log.Infof("[UPNP] Adding map to [%s:%d - %s] on gateway %s", vip, port.Port, s.serviceSnapshot.Name, gw.WANIPv6FirewallControlClient.Location)
 
 				forwardSucessful := false
 				if gw.WANIPv6FirewallControlClient != nil {
-					pinholeID, pinholeErr := gw.WANIPv6FirewallControlClient.AddPinholeCtx(ctx, "0.0.0.0", port.Port, vip, port.Port, upnp.MapProtocolToIANA(port.Type), 3600)
+					pinholeID, pinholeErr := gw.WANIPv6FirewallControlClient.AddPinholeCtx(ctx, "0.0.0.0", uint16(port.Port), vip, uint16(port.Port), upnp.MapProtocolToIANA(string(port.Protocol)), 3600)
 					if pinholeErr == nil {
 						forwardSucessful = true
 						log.Infof("[UPNP] Service should be accessible externally on port [%d]; PinholeID is [%d]", port.Port, pinholeID)
@@ -326,7 +329,7 @@ func (sm *Manager) upnpMap(ctx context.Context, s *Instance) {
 				}
 				// Fallback to PortForward
 				if !forwardSucessful {
-					portMappingErr := gw.ConnectionClient.AddPortMapping("0.0.0.0", port.Port, strings.ToUpper(port.Type), port.Port, vip, true, s.serviceSnapshot.Name, 3600)
+					portMappingErr := gw.ConnectionClient.AddPortMapping("0.0.0.0", uint16(port.Port), strings.ToUpper(string(port.Protocol)), uint16(port.Port), vip, true, s.serviceSnapshot.Name, 3600)
 					if portMappingErr == nil {
 						log.Infof("[UPNP] Service should be accessible externally on port [%d]", port.Port)
 						forwardSucessful = true

--- a/pkg/manager/servicesLeader.go
+++ b/pkg/manager/servicesLeader.go
@@ -80,7 +80,7 @@ func (sm *Manager) StartServicesLeaderElection(ctx context.Context, service *v1.
 				// we can do cleanup here
 				log.Infof("(svc election) service [%s] leader lost: [%s]", service.Name, sm.config.NodeName)
 				if activeService[string(service.UID)] {
-					if err := sm.deleteService(string(service.UID)); err != nil {
+					if err := sm.deleteService(service.UID); err != nil {
 						log.Error(err)
 					}
 				}

--- a/pkg/manager/watch_services.go
+++ b/pkg/manager/watch_services.go
@@ -150,7 +150,7 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 				}
 			}
 
-			// Architecture walkthrough: (Had to do this as this codfe path is making my head hurt)
+			// Architecture walkthrough: (Had to do this as this code path is making my head hurt)
 
 			// Is the service active (bool), if not then process this new service
 			// Does this service use an election per service?
@@ -297,7 +297,7 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 				}
 
 				// If this is an active service then and additional leaderElection will handle stopping
-				err = sm.deleteService(string(svc.UID))
+				err = sm.deleteService(svc.UID)
 				if err != nil {
 					log.Error(err)
 				}


### PR DESCRIPTION
Randomly we point to the service *and* copy some pieces of information from the service into other variables.. why not just reference the service and remove the duplicate data  ¯\_(ツ)_/¯