### PR TITLE
Restart on modification

### DIFF
--- a/pkg/manager/instance.go
+++ b/pkg/manager/instance.go
@@ -34,9 +34,9 @@ type Instance struct {
 	upnpGatewayIPs []string
 
 	// Kubernetes service mapping
-	VIPs          []string
-	UID           string
-	ExternalPorts []Port
+	//VIPs          []string
+	//UID           string
+	//ExternalPorts []Port
 
 	serviceSnapshot *v1.Service
 }
@@ -48,7 +48,7 @@ type Port struct {
 
 func NewInstance(svc *v1.Service, config *kubevip.Config) (*Instance, error) {
 	instanceAddresses := fetchServiceAddresses(svc)
-	instanceUID := string(svc.UID)
+	//instanceUID := string(svc.UID)
 
 	var newVips []*kubevip.Config
 	var link netlink.Link
@@ -174,16 +174,16 @@ func NewInstance(svc *v1.Service, config *kubevip.Config) (*Instance, error) {
 
 	// Create new service
 	instance := &Instance{
-		UID:             instanceUID,
-		VIPs:            instanceAddresses,
+		//UID:             instanceUID,
+		//VIPs:            instanceAddresses,
 		serviceSnapshot: svc,
 	}
-	for _, port := range svc.Spec.Ports {
-		instance.ExternalPorts = append(instance.ExternalPorts, Port{
-			Port: uint16(port.Port), //nolint
-			Type: string(port.Protocol),
-		})
-	}
+	// for _, port := range svc.Spec.Ports {
+	// 	instance.ExternalPorts = append(instance.ExternalPorts, Port{
+	// 		Port: uint16(port.Port), //nolint
+	// 		Type: string(port.Protocol),
+	// 	})
+	// }
 
 	if svc.Annotations != nil {
 		instance.dhcpInterfaceHwaddr = svc.Annotations[hwAddrKey]
@@ -192,9 +192,9 @@ func NewInstance(svc *v1.Service, config *kubevip.Config) (*Instance, error) {
 	}
 
 	configPorts := make([]kubevip.Port, 0)
-	for _, p := range instance.ExternalPorts {
+	for _, p := range svc.Spec.Ports {
 		configPorts = append(configPorts, kubevip.Port{
-			Type: p.Type,
+			Type: string(p.Protocol),
 			Port: int(p.Port),
 		})
 	}
@@ -316,7 +316,7 @@ func (i *Instance) startDHCP() error {
 	}
 
 	// Generate name from UID
-	interfaceName := fmt.Sprintf("vip-%s", i.UID[0:8])
+	interfaceName := fmt.Sprintf("vip-%s", i.serviceSnapshot.UID[0:8])
 
 	// Check if the interface doesn't exist first
 	iface, err := net.InterfaceByName(interfaceName)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -314,11 +314,10 @@ func (sm *Manager) stopTrafficMirroringIfEnabled() error {
 }
 
 func (sm *Manager) findServiceInstance(svc *v1.Service) *Instance {
-	svcUID := string(svc.UID)
-	log.Debugf("service UID: %s", svcUID)
+	log.Debugf("service UID: %s", svc.UID)
 	for i := range sm.serviceInstances {
-		log.Debugf("saved service instance %d UID: %s", i, sm.serviceInstances[i].UID)
-		if sm.serviceInstances[i].UID == svcUID {
+		log.Debugf("saved service instance %d UID: %s", i, sm.serviceInstances[i].serviceSnapshot.UID)
+		if sm.serviceInstances[i].serviceSnapshot.UID == svc.UID {
 			return sm.serviceInstances[i]
 		}
 	}

--- a/pkg/manager/services.go
+++ b/pkg/manager/services.go
@@ -318,7 +318,7 @@ func (sm *Manager) upnpMap(ctx context.Context, s *Instance) {
 
 				forwardSucessful := false
 				if gw.WANIPv6FirewallControlClient != nil {
-					pinholeID, pinholeErr := gw.WANIPv6FirewallControlClient.AddPinholeCtx(ctx, "0.0.0.0", uint16(port.Port), vip, uint16(port.Port), upnp.MapProtocolToIANA(string(port.Protocol)), 3600) //nolint: TODO
+					pinholeID, pinholeErr := gw.WANIPv6FirewallControlClient.AddPinholeCtx(ctx, "0.0.0.0", uint16(port.Port), vip, uint16(port.Port), upnp.MapProtocolToIANA(string(port.Protocol)), 3600) //nolint  TODO
 					if pinholeErr == nil {
 						forwardSucessful = true
 						log.Infof("[UPNP] Service should be accessible externally on port [%d]; PinholeID is [%d]", port.Port, pinholeID)
@@ -329,7 +329,7 @@ func (sm *Manager) upnpMap(ctx context.Context, s *Instance) {
 				}
 				// Fallback to PortForward
 				if !forwardSucessful {
-					portMappingErr := gw.ConnectionClient.AddPortMapping("0.0.0.0", uint16(port.Port), strings.ToUpper(string(port.Protocol)), uint16(port.Port), vip, true, s.serviceSnapshot.Name, 3600) //nolint: TODO
+					portMappingErr := gw.ConnectionClient.AddPortMapping("0.0.0.0", uint16(port.Port), strings.ToUpper(string(port.Protocol)), uint16(port.Port), vip, true, s.serviceSnapshot.Name, 3600) //nolint  TODO
 					if portMappingErr == nil {
 						log.Infof("[UPNP] Service should be accessible externally on port [%d]", port.Port)
 						forwardSucessful = true

--- a/pkg/manager/services.go
+++ b/pkg/manager/services.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vishvananda/netlink"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 
 	"github.com/kube-vip/kube-vip/pkg/upnp"
@@ -27,7 +28,7 @@ func (sm *Manager) syncServices(ctx context.Context, svc *v1.Service, wg *sync.W
 	// Iterate through the synchronising services
 	foundInstance := false
 	newServiceAddresses := fetchServiceAddresses(svc)
-	newServiceUID := string(svc.UID)
+	newServiceUID := svc.UID
 
 	ingressIPs := []string{}
 
@@ -43,7 +44,7 @@ func (sm *Manager) syncServices(ctx context.Context, svc *v1.Service, wg *sync.W
 		}
 		for _, newServiceAddress := range newServiceAddresses {
 			log.Debugf("isDHCP: %t, newServiceAddress: %s", sm.serviceInstances[x].isDHCP, newServiceAddress)
-			if sm.serviceInstances[x].UID == newServiceUID {
+			if sm.serviceInstances[x].serviceSnapshot.UID == newServiceUID {
 				// If the found instance's DHCP configuration doesn't match the new service, delete it.
 				if (sm.serviceInstances[x].isDHCP && newServiceAddress != "0.0.0.0") ||
 					(!sm.serviceInstances[x].isDHCP && newServiceAddress == "0.0.0.0") ||
@@ -120,7 +121,7 @@ func (sm *Manager) addService(ctx context.Context, svc *v1.Service) error {
 		log.Debugf("(svcs) will update [%s/%s]", newService.serviceSnapshot.Namespace, newService.serviceSnapshot.Name)
 		if err := sm.updateStatus(newService); err != nil {
 			// delete service to collect garbage
-			if deleteErr := sm.deleteService(newService.UID); deleteErr != nil {
+			if deleteErr := sm.deleteService(newService.serviceSnapshot.UID); deleteErr != nil {
 				return deleteErr
 			}
 			return err
@@ -205,7 +206,7 @@ func (sm *Manager) addService(ctx context.Context, svc *v1.Service) error {
 	return nil
 }
 
-func (sm *Manager) deleteService(uid string) error {
+func (sm *Manager) deleteService(uid types.UID) error {
 	// protect multiple calls
 	sm.mutex.Lock()
 	defer sm.mutex.Unlock()
@@ -214,9 +215,9 @@ func (sm *Manager) deleteService(uid string) error {
 	var serviceInstance *Instance
 	found := false
 	for x := range sm.serviceInstances {
-		log.Debugf("Looking for [%s], found [%s]", uid, sm.serviceInstances[x].UID)
+		log.Debugf("Looking for [%s], found [%s]", uid, sm.serviceInstances[x].serviceSnapshot.UID)
 		// Add the running services to the new array
-		if sm.serviceInstances[x].UID != uid {
+		if sm.serviceInstances[x].serviceSnapshot.UID != uid {
 			updatedInstances = append(updatedInstances, sm.serviceInstances[x])
 		} else {
 			// Flip the found when we match
@@ -230,14 +231,16 @@ func (sm *Manager) deleteService(uid string) error {
 		// return fmt.Errorf("unable to find/stop service [%s]", uid)
 		return nil
 	}
+
+	// Determine if this this VIP is shared with other loadbalancers
 	shared := false
 	vipSet := make(map[string]interface{})
 	for x := range updatedInstances {
-		for _, vip := range updatedInstances[x].VIPs {
+		for _, vip := range fetchServiceAddresses(updatedInstances[x].serviceSnapshot) { //updatedInstances[x].serviceSnapshot.Spec.LoadBalancerIP {
 			vipSet[vip] = nil
 		}
 	}
-	for _, vip := range serviceInstance.VIPs {
+	for _, vip := range fetchServiceAddresses(serviceInstance.serviceSnapshot) {
 		if _, found := vipSet[vip]; found {
 			shared = true
 		}
@@ -308,14 +311,14 @@ func (sm *Manager) upnpMap(ctx context.Context, s *Instance) {
 	// Reset Gateway IPs to remove stale addresses
 	s.upnpGatewayIPs = make([]string, 0)
 
-	for _, vip := range s.VIPs {
-		for _, port := range s.ExternalPorts {
+	for _, vip := range fetchServiceAddresses(s.serviceSnapshot) {
+		for _, port := range s.serviceSnapshot.Spec.Ports {
 			for _, gw := range gateways {
 				log.Infof("[UPNP] Adding map to [%s:%d - %s] on gateway %s", vip, port.Port, s.serviceSnapshot.Name, gw.WANIPv6FirewallControlClient.Location)
 
 				forwardSucessful := false
 				if gw.WANIPv6FirewallControlClient != nil {
-					pinholeID, pinholeErr := gw.WANIPv6FirewallControlClient.AddPinholeCtx(ctx, "0.0.0.0", port.Port, vip, port.Port, upnp.MapProtocolToIANA(port.Type), 3600)
+					pinholeID, pinholeErr := gw.WANIPv6FirewallControlClient.AddPinholeCtx(ctx, "0.0.0.0", uint16(port.Port), vip, uint16(port.Port), upnp.MapProtocolToIANA(string(port.Protocol)), 3600)
 					if pinholeErr == nil {
 						forwardSucessful = true
 						log.Infof("[UPNP] Service should be accessible externally on port [%d]; PinholeID is [%d]", port.Port, pinholeID)
@@ -326,7 +329,7 @@ func (sm *Manager) upnpMap(ctx context.Context, s *Instance) {
 				}
 				// Fallback to PortForward
 				if !forwardSucessful {
-					portMappingErr := gw.ConnectionClient.AddPortMapping("0.0.0.0", port.Port, strings.ToUpper(port.Type), port.Port, vip, true, s.serviceSnapshot.Name, 3600)
+					portMappingErr := gw.ConnectionClient.AddPortMapping("0.0.0.0", uint16(port.Port), strings.ToUpper(string(port.Protocol)), uint16(port.Port), vip, true, s.serviceSnapshot.Name, 3600)
 					if portMappingErr == nil {
 						log.Infof("[UPNP] Service should be accessible externally on port [%d]", port.Port)
 						forwardSucessful = true

--- a/pkg/manager/services.go
+++ b/pkg/manager/services.go
@@ -318,7 +318,7 @@ func (sm *Manager) upnpMap(ctx context.Context, s *Instance) {
 
 				forwardSucessful := false
 				if gw.WANIPv6FirewallControlClient != nil {
-					pinholeID, pinholeErr := gw.WANIPv6FirewallControlClient.AddPinholeCtx(ctx, "0.0.0.0", uint16(port.Port), vip, uint16(port.Port), upnp.MapProtocolToIANA(string(port.Protocol)), 3600)
+					pinholeID, pinholeErr := gw.WANIPv6FirewallControlClient.AddPinholeCtx(ctx, "0.0.0.0", uint16(port.Port), vip, uint16(port.Port), upnp.MapProtocolToIANA(string(port.Protocol)), 3600) //nolint: TODO
 					if pinholeErr == nil {
 						forwardSucessful = true
 						log.Infof("[UPNP] Service should be accessible externally on port [%d]; PinholeID is [%d]", port.Port, pinholeID)
@@ -329,7 +329,7 @@ func (sm *Manager) upnpMap(ctx context.Context, s *Instance) {
 				}
 				// Fallback to PortForward
 				if !forwardSucessful {
-					portMappingErr := gw.ConnectionClient.AddPortMapping("0.0.0.0", uint16(port.Port), strings.ToUpper(string(port.Protocol)), uint16(port.Port), vip, true, s.serviceSnapshot.Name, 3600)
+					portMappingErr := gw.ConnectionClient.AddPortMapping("0.0.0.0", uint16(port.Port), strings.ToUpper(string(port.Protocol)), uint16(port.Port), vip, true, s.serviceSnapshot.Name, 3600) //nolint: TODO
 					if portMappingErr == nil {
 						log.Infof("[UPNP] Service should be accessible externally on port [%d]", port.Port)
 						forwardSucessful = true

--- a/pkg/manager/servicesLeader.go
+++ b/pkg/manager/servicesLeader.go
@@ -70,11 +70,9 @@ func (sm *Manager) StartServicesLeaderElection(ctx context.Context, service *v1.
 				// Mark this service as active (as we've started leading)
 				// we run this in background as it's blocking
 				wg.Add(1)
-				go func() {
-					if err := sm.syncServices(ctx, service, wg); err != nil {
-						log.Error(err)
-					}
-				}()
+				if err := sm.syncServices(ctx, service, wg); err != nil {
+					log.Error(err)
+				}
 			},
 			OnStoppedLeading: func() {
 				// we can do cleanup here

--- a/pkg/manager/servicesLeader.go
+++ b/pkg/manager/servicesLeader.go
@@ -80,7 +80,7 @@ func (sm *Manager) StartServicesLeaderElection(ctx context.Context, service *v1.
 				// we can do cleanup here
 				log.Infof("(svc election) service [%s] leader lost: [%s]", service.Name, sm.config.NodeName)
 				if activeService[string(service.UID)] {
-					if err := sm.deleteService(string(service.UID)); err != nil {
+					if err := sm.deleteService(service.UID); err != nil {
 						log.Error(err)
 					}
 				}

--- a/pkg/manager/watch_services.go
+++ b/pkg/manager/watch_services.go
@@ -149,11 +149,6 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 					}
 				}
 
-				// This service has been modified, but it was also active..
-				if activeService[string(svc.UID)] {
-					//	i := sm.findServiceInstance(svc)
-					//if i.ExternalPorts
-				}
 			}
 
 			// Architecture walkthrough: (Had to do this as this code path is making my head hurt)

--- a/pkg/manager/watch_services.go
+++ b/pkg/manager/watch_services.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sync"
 
 	"github.com/davecgh/go-spew/spew"
@@ -148,7 +149,29 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 						log.Warnf("(svcs) already found existing address [%s] on adapter [%s]", addr, sm.config.Interface)
 					}
 				}
+				// This service has been modified, but it was also active..
+				if activeService[string(svc.UID)] {
 
+					i := sm.findServiceInstance(svc)
+					if i != nil {
+						orig := fetchServiceAddresses(i.serviceSnapshot)
+						new := fetchServiceAddresses(svc)
+						if !reflect.DeepEqual(orig, new) {
+
+							// Calls the cancel function of the context
+							if activeServiceLoadBalancerCancel[string(svc.UID)] != nil {
+								log.Warn("(svcs) The load balancer has changed, cancelling original load balancer")
+								activeServiceLoadBalancerCancel[string(svc.UID)]()
+								<-activeServiceLoadBalancer[string(svc.UID)].Done()
+								log.Warn("(svcs) waiting for load balancer to finish")
+							}
+							sm.deleteService(svc.UID)
+						}
+						// in theory this should never fail
+
+					}
+
+				}
 			}
 
 			// Architecture walkthrough: (Had to do this as this code path is making my head hurt)
@@ -230,30 +253,25 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 							wg.Done()
 						}()
 					} else {
-						log.Info("(svcs) restartable service watcher starting")
-						// Increment the waitGroup before the service Func is called (Done is completed in there)
 						wg.Add(1)
 
 						go func() {
-							leaderContext := context.WithoutCancel(ctx)
-
-							// This is a blocking function, that will restart (in the event of failure)
+							defer wg.Done()
 							for {
-								// if the context isn't cancelled restart
-								if leaderContext.Err() != context.Canceled {
-									activeService[string(svc.UID)] = true
-
+								select {
+								case <-activeServiceLoadBalancer[string(svc.UID)].Done():
+									fmt.Println("Task cancelled")
+									return
+								default:
+									log.Infof("(svcs) restartable service watcher starting for [%s]", svc.UID)
 									err = serviceFunc(activeServiceLoadBalancer[string(svc.UID)], svc, &wg)
 
 									if err != nil {
 										log.Error(err)
 									}
-									activeService[string(svc.UID)] = false
-								} else {
-									activeService[string(svc.UID)] = false
-									break
 								}
 							}
+
 						}()
 					}
 				} else {

--- a/pkg/manager/watch_services.go
+++ b/pkg/manager/watch_services.go
@@ -150,7 +150,7 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 				}
 			}
 
-			// Architecture walkthrough: (Had to do this as this codfe path is making my head hurt)
+			// Architecture walkthrough: (Had to do this as this code path is making my head hurt)
 
 			// Is the service active (bool), if not then process this new service
 			// Does this service use an election per service?
@@ -297,7 +297,7 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 				}
 
 				// If this is an active service then and additional leaderElection will handle stopping
-				err = sm.deleteService(string(svc.UID))
+				err = sm.deleteService(svc.UID)
 				if err != nil {
 					log.Error(err)
 				}

--- a/pkg/manager/watch_services.go
+++ b/pkg/manager/watch_services.go
@@ -148,6 +148,12 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 						log.Warnf("(svcs) already found existing address [%s] on adapter [%s]", addr, sm.config.Interface)
 					}
 				}
+
+				// This service has been modified, but it was also active..
+				if activeService[string(svc.UID)] {
+					//	i := sm.findServiceInstance(svc)
+					//if i.ExternalPorts
+				}
 			}
 
 			// Architecture walkthrough: (Had to do this as this code path is making my head hurt)


### PR DESCRIPTION
When a existing service is modified the changes are captured and the service will be recreated.

Create a service:
```
dan@code:~/kube-vip$ k apply -f ./example/service.yaml
service/nginx-service created
dan@code:~/kube-vip$ k get svc
NAME            TYPE           CLUSTER-IP    EXTERNAL-IP     PORT(S)        AGE
kubernetes      ClusterIP      10.96.0.1     <none>          443/TCP        6d14h
nginx-service   LoadBalancer   10.96.32.52   172.18.100.10   80:30333/TCP   20s
```

Modify the service:
```
dan@code:~/kube-vip$ kubectl annotate --overwrite service nginx-service kube-vip.io/loadbalancerIPs=172.18.100.12
service/nginx-service annotated
dan@code:~/kube-vip$ curl 172.18.100.12
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
...
```

Logs on active pod:
```
time="2025-01-15T11:14:04Z" level=debug msg="(svcs) [nginx-service] has been added/modified with addresses [[172.18.100.10]]"
time="2025-01-15T11:14:04Z" level=info msg="(svcs) restartable service watcher starting for [2c3a2bee-5b2e-446e-88b8-420ede8c1e1f]"
time="2025-01-15T11:14:04Z" level=info msg="(svcs) restartable service watcher starting"
time="2025-01-15T11:14:04Z" level=info msg="(svc election) service [nginx-service], namespace [default], lock name [kubevip-nginx-service], host id [kube-vip-worker2]"
I0115 11:14:04.017611       1 leaderelection.go:257] attempting to acquire leader lease default/kubevip-nginx-service...
time="2025-01-15T11:14:04Z" level=info msg="(svc election) new leader elected: kube-vip-worker3"
time="2025-01-15T11:14:04Z" level=debug msg="(svcs) ending ARP update for 172.18.100.12 via eth0, every 3000ms"
I0115 11:14:05.036938       1 leaderelection.go:271] successfully acquired lease default/kubevip-nginx-service
time="2025-01-15T11:14:05Z" level=debug msg="[STARTING] Service Sync"
time="2025-01-15T11:14:05Z" level=debug msg="init enable service security: false"
time="2025-01-15T11:14:05Z" level=info msg="(svcs) adding VIP [172.18.100.10] via eth0 for [default/nginx-service]"
time="2025-01-15T11:14:05Z" level=debug msg="(svcs) will update [default/nginx-service]"
time="2025-01-15T11:14:05Z" level=debug msg="(svcs) broadcasting ARP update for 172.18.100.10 via eth0, every 3000ms"
time="2025-01-15T11:14:05Z" level=warning msg="(svcs) already found existing address [172.18.100.10] on adapter [eth0]"
time="2025-01-15T11:14:05Z" level=debug msg="service UID: 2c3a2bee-5b2e-446e-88b8-420ede8c1e1f"
time="2025-01-15T11:14:05Z" level=debug msg="saved service instance 0 UID: 2c3a2bee-5b2e-446e-88b8-420ede8c1e1f"
time="2025-01-15T11:14:05Z" level=info msg="[service] synchronised in 20ms"
time="2025-01-15T11:14:05Z" level=debug msg="service UID: 2c3a2bee-5b2e-446e-88b8-420ede8c1e1f"
time="2025-01-15T11:14:05Z" level=debug msg="saved service instance 0 UID: 2c3a2bee-5b2e-446e-88b8-420ede8c1e1f"
time="2025-01-15T11:14:08Z" level=warning msg="Re-applying the VIP configuration [172.18.100.10] to the interface [eth0]"
time="2025-01-15T11:14:12Z" level=debug msg="service UID: 2c3a2bee-5b2e-446e-88b8-420ede8c1e1f"
time="2025-01-15T11:14:12Z" level=debug msg="saved service instance 0 UID: 2c3a2bee-5b2e-446e-88b8-420ede8c1e1f"
time="2025-01-15T11:14:12Z" level=warning msg="(svcs) The load balancer has changed, cancelling original load balancer"
time="2025-01-15T11:14:12Z" level=warning msg="(svcs) waiting for load balancer to finish"
time="2025-01-15T11:14:12Z" level=debug msg="Looking for [2c3a2bee-5b2e-446e-88b8-420ede8c1e1f], found [2c3a2bee-5b2e-446e-88b8-420ede8c1e1f]"
time="2025-01-15T11:14:12Z" level=info msg="[LOADBALANCER] Stopping load balancers"
time="2025-01-15T11:14:12Z" level=info msg="[VIP] Releasing the Virtual IP [172.18.100.10]"
time="2025-01-15T11:14:12Z" level=info msg="Removed [2c3a2bee-5b2e-446e-88b8-420ede8c1e1f] from manager, [0] advertised services remain"
time="2025-01-15T11:14:12Z" level=info msg="(svc election) service [nginx-service] leader lost: [kube-vip-worker2]"
time="2025-01-15T11:14:12Z" level=info msg="(svc election) for service [nginx-service] stopping"
time="2025-01-15T11:14:13Z" level=debug msg="(svcs) [nginx-service] has been added/modified with addresses [[172.18.100.12]]"
time="2025-01-15T11:14:13Z" level=info msg="(svcs) restartable service watcher starting for [2c3a2bee-5b2e-446e-88b8-420ede8c1e1f]"
time="2025-01-15T11:14:13Z" level=info msg="(svcs) restartable service watcher starting"
time="2025-01-15T11:14:13Z" level=info msg="(svc election) service [nginx-service], namespace [default], lock name [kubevip-nginx-service], host id [kube-vip-worker2]"
I0115 11:14:13.730957       1 leaderelection.go:257] attempting to acquire leader lease default/kubevip-nginx-service...
time="2025-01-15T11:14:13Z" level=info msg="(svc election) new leader elected: kube-vip-worker3"
time="2025-01-15T11:14:14Z" level=debug msg="(svcs) ending ARP update for 172.18.100.10 via eth0, every 3000ms"
time="2025-01-15T11:14:14Z" level=debug msg="service UID: 2c3a2bee-5b2e-446e-88b8-420ede8c1e1f"
I0115 11:14:15.208175       1 leaderelection.go:271] successfully acquired lease default/kubevip-nginx-service
time="2025-01-15T11:14:15Z" level=debug msg="[STARTING] Service Sync"
time="2025-01-15T11:14:15Z" level=debug msg="init enable service security: false"
time="2025-01-15T11:14:15Z" level=info msg="(svcs) adding VIP [172.18.100.12] via eth0 for [default/nginx-service]"
time="2025-01-15T11:14:15Z" level=debug msg="(svcs) will update [default/nginx-service]"
time="2025-01-15T11:14:15Z" level=debug msg="(svcs) broadcasting ARP update for 172.18.100.12 via eth0, every 3000ms"
time="2025-01-15T11:14:15Z" level=warning msg="(svcs) already found existing address [172.18.100.12] on adapter [eth0]"
time="2025-01-15T11:14:15Z" level=debug msg="service UID: 2c3a2bee-5b2e-446e-88b8-420ede8c1e1f"
time="2025-01-15T11:14:15Z" level=debug msg="saved service instance 0 UID: 2c3a2bee-5b2e-446e-88b8-420ede8c1e1f"
time="2025-01-15T11:14:15Z" level=info msg="[service] synchronised in 19ms"
time="2025-01-15T11:14:15Z" level=debug msg="service UID: 2c3a2bee-5b2e-446e-88b8-420ede8c1e1f"
time="2025-01-15T11:14:15Z" level=debug msg="saved service instance 0 UID: 2c3a2bee-5b2e-446e-88b8-420ede8c1e1f"
time="2025-01-15T11:14:18Z" level=warning msg="Re-applying the VIP configuration [172.18.100.12] to the interface [eth0]"
```