### PR TITLE
Ndp error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TARGET := kube-vip
 .DEFAULT_GOAL := $(TARGET)
 
 # These will be provided to the target
-VERSION := v0.8.9
+VERSION := v0.8.10
 
 BUILD := `git rev-parse HEAD`
 

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -131,7 +131,7 @@ func (cluster *Cluster) vipService(ctxArp, ctxDNS context.Context, c *kubevip.Co
 				if isIPv6 {
 					ndp, err = vip.NewNDPResponder(cluster.Network[i].Interface())
 					if err != nil {
-						log.Fatalf("failed to create new NDP Responder")
+						log.Fatalf("failed to create new NDP Responder: %v", err)
 					}
 				}
 
@@ -350,7 +350,7 @@ func (cluster *Cluster) StartLoadBalancerService(c *kubevip.Config, bgp *bgp.Ser
 			if vip.IsIPv6(ipString) {
 				ndp, err = vip.NewNDPResponder(network.Interface())
 				if err != nil {
-					log.Fatalf("failed to create new NDP Responder")
+					log.Fatalf("failed to create new NDP Responder: %v", err)
 				}
 			}
 			go func(ctx context.Context) {

--- a/testing/services/main.go
+++ b/testing/services/main.go
@@ -44,6 +44,8 @@ func main() {
 	flag.StringVar(&t.KindVersionImage, "kindImage", "", "The image to use for the kind nodes e.g. (kindest/node:v1.21.14)")
 	flag.BoolVar(&existing, "existing", false, "Use an existing cluster")
 
+	flag.BoolVar(&t.Cilium, "cilium", false, "Use cilium as a CNI")
+
 	flag.Parse()
 
 	slog.Infof("🔬 beginning e2e tests, image: [%s] DualStack [%t]", t.ImagePath, t.DualStack)

--- a/testing/services/pkg/deployment/kind.go
+++ b/testing/services/pkg/deployment/kind.go
@@ -48,6 +48,10 @@ func (config *TestConfig) CreateKind() error {
 		clusterConfig.Networking.IPFamily = kindconfigv1alpha4.DualStackFamily
 	}
 
+	if config.Cilium {
+		clusterConfig.Networking.DisableDefaultCNI = true
+	}
+
 	if config.ControlPlane {
 		err := config.manifestGen()
 		if err != nil {
@@ -120,6 +124,11 @@ func (config *TestConfig) CreateKind() error {
 					return err
 				}
 			}
+		}
+
+		if config.Cilium {
+			cmd := exec.Command("cilium", "install", "--helm-set", "ipv6.enabled=true", "--helm-set", "--enable-ipv6-ndp=true")
+			_, _ = cmd.CombinedOutput()
 		}
 
 		// HMMM, if we want to run workloads on the control planes (todo)

--- a/testing/services/pkg/deployment/tests.go
+++ b/testing/services/pkg/deployment/tests.go
@@ -42,6 +42,9 @@ type TestConfig struct {
 	DeploymentName string
 	ServiceName    string
 	LeaderName     string
+
+	// Cilium config
+	Cilium bool
 }
 
 func (config *TestConfig) SimpleDeployment(ctx context.Context, clientset *kubernetes.Clientset) error {


### PR DESCRIPTION
This PR ensures that NDP errors are reported to the caller, before they were ignored and the user wasn't informed as to why NDP wasn't working. 

I've accidentally pulled in some changes:
- Bump Makefile to v0.8.9
- Adds some local testing for Cilium as a CNI, not going to be added to CI (for now  ¯\_(ツ)_/¯ )