### PR TITLE
remove the waitgroups as we never wait

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	golang.org/x/sync v0.10.0
 	golang.org/x/sys v0.29.0
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10
+	google.golang.org/protobuf v1.36.1
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.32.0
 	k8s.io/apimachinery v0.32.1
@@ -125,7 +126,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20250102185135-69823020774d // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250102185135-69823020774d // indirect
 	google.golang.org/grpc v1.69.2 // indirect
-	google.golang.org/protobuf v1.36.1 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/pkg/manager/services.go
+++ b/pkg/manager/services.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
 	log "log/slog"
@@ -21,9 +20,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/vip"
 )
 
-func (sm *Manager) syncServices(ctx context.Context, svc *v1.Service, wg *sync.WaitGroup) error {
-	defer wg.Done()
-
+func (sm *Manager) syncServices(ctx context.Context, svc *v1.Service) error {
 	log.Debug("[STARTING] Service Sync")
 
 	// Iterate through the synchronising services

--- a/pkg/manager/watch_endpoints.go
+++ b/pkg/manager/watch_endpoints.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"strings"
-	"sync"
 	"syscall"
 
 	log "log/slog"
@@ -144,7 +143,7 @@ func (ep *endpointsProvider) getProtocol() string {
 	return ""
 }
 
-func (sm *Manager) watchEndpoint(ctx context.Context, id string, service *v1.Service, wg *sync.WaitGroup, provider epProvider) error {
+func (sm *Manager) watchEndpoint(ctx context.Context, id string, service *v1.Service, provider epProvider) error {
 	log.Info("watching", "provider", provider.getLabel(), "service_name", service.Name, "namespace", service.Namespace)
 	// Use a restartable watcher, as this should help in the event of etcd or timeout issues
 	leaderContext, cancel := context.WithCancel(ctx)
@@ -271,7 +270,7 @@ func (sm *Manager) watchEndpoint(ctx context.Context, id string, service *v1.Ser
 							// if the context isn't cancelled restart
 							if leaderContext.Err() != context.Canceled {
 								leaderElectionActive = true
-								err := sm.StartServicesLeaderElection(leaderContext, service, wg)
+								err := sm.StartServicesLeaderElection(leaderContext, service)
 								if err != nil {
 									log.Error(err.Error())
 								}


### PR DESCRIPTION
For whatever reason we have wait groups, which we add and remove (`done`). But we never actually `wait` or use them to synchronise jobs  ¯\_(ツ)_/¯ this basically just presents the opportunity for us to overly `done` a wait group that doesn't have the relevant `add`s.

`tl;dr` we're half using this but not properly so it's not providing any benefits, and at worse can cause a panic if used wrong.