### PR TITLE
You can now specify the port as the fifth argument to peer config

### DIFF
--- a/pkg/bgp/peers.go
+++ b/pkg/bgp/peers.go
@@ -225,6 +225,16 @@ func ParseBGPPeerConfig(config string) (bgpPeers []Peer, err error) {
 			}
 		}
 
+		var port uint64
+		if len(peer) >= 5 {
+			port, err = strconv.ParseUint(peer[4], 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("BGP Peer AS format error [%s]", peer[1])
+			}
+		} else {
+			port = 179
+		}
+
 		var mpbgpNexthop, mpbgpIPv4, mpbgpIPv6 string
 
 		if len(config) > 1 {
@@ -247,6 +257,7 @@ func ParseBGPPeerConfig(config string) (bgpPeers []Peer, err error) {
 		peerConfig := Peer{
 			Address:      address,
 			AS:           uint32(ASNumber),
+			Port:         uint16(port),
 			Password:     password,
 			MultiHop:     multiHop,
 			MpbgpNexthop: mpbgpNexthop,

--- a/pkg/bgp/peers_test.go
+++ b/pkg/bgp/peers_test.go
@@ -1,0 +1,54 @@
+package bgp
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseBGPPeerConfig(t *testing.T) {
+	type args struct {
+		config string
+	}
+	tests := []struct {
+		name         string
+		args         args
+		wantBgpPeers []Peer
+		wantErr      bool
+	}{
+		{
+			name: "IPv4, default port",
+			args: args{config: "192.168.0.10:65000::false,192.168.0.11:65000::false"},
+			wantBgpPeers: []Peer{
+				{Address: "192.168.0.10", Port: 179, AS: 65000, MultiHop: false},
+				{Address: "192.168.0.11", Port: 179, AS: 65000, MultiHop: false},
+			},
+		},
+		{
+			name: "IPv4, different port",
+			args: args{config: "192.168.0.10:65000::false:180,192.168.0.11:65000::false:190"},
+			wantBgpPeers: []Peer{
+				{Address: "192.168.0.10", Port: 180, AS: 65000, MultiHop: false},
+				{Address: "192.168.0.11", Port: 190, AS: 65000, MultiHop: false},
+			},
+		},
+		{
+			name: "IPv6, multi-protocol",
+			args: args{config: "[fd00:1111:2222:3333:c7d9:7235:6bf7:5d52]:65501::false/mpbgp_nexthop=auto_sourceif"},
+			wantBgpPeers: []Peer{
+				{Address: "fd00:1111:2222:3333:c7d9:7235:6bf7:5d52", Port: 179, AS: 65501, MultiHop: false, MpbgpNexthop: "auto_sourceif"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotBgpPeers, err := ParseBGPPeerConfig(tt.args.config)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseBGPPeerConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotBgpPeers, tt.wantBgpPeers) {
+				t.Errorf("ParseBGPPeerConfig() = %v, want %v", gotBgpPeers, tt.wantBgpPeers)
+			}
+		})
+	}
+}

--- a/pkg/bgp/types.go
+++ b/pkg/bgp/types.go
@@ -13,6 +13,7 @@ import (
 // Peer defines a BGP Peer
 type Peer struct {
 	Address      string
+	Port         uint16
 	AS           uint32
 	Password     string
 	MultiHop     bool


### PR DESCRIPTION
Fixes #963 