### PR TITLE
Fixed network mask setting function

### DIFF
--- a/pkg/vip/address.go
+++ b/pkg/vip/address.go
@@ -720,8 +720,7 @@ func (configurator *network) SetMask(mask string) error {
 	}
 
 	if m > size {
-		log.Warn("provided mask is greater than the highest mask value for the IP family - will use max possible value", "family", family, "mask", m, "max", size)
-		m = size
+		return fmt.Errorf("provided CIDR mask '%d' is greater than the highest mask value for the %s family (%d)", m, family, size)
 	}
 
 	toSet := net.CIDRMask(m, size)


### PR DESCRIPTION
This should fix #1052 

In case someone uses DualStack cluster but provides `vip_cidr` only for IPv6 addresses (e.g. `vip_cidr: "128"`) kube-vip, when IPv4 service is used,  tries to create a mask with `net.CIDRMask(128, 32)` which results in `nil` pointer and causes panic later.

This PR fixes this by checking if provided `vip_cidr` is not greater than max for IP family and using max value if so (e.g. if someone will try to set mask 128 for IPv4 service, ~~a warning will be logged and a mask of 32 will be used)~~ error will be returned.

Also added missing mutex locks when setting the mask itself.