### PR TITLE
Fixed logging level configuration with command line argument

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -28,9 +28,6 @@ var inCluster bool
 // ConfigMap name within a Kubernetes cluster
 var configMap string
 
-// Configure the level of logging
-var logLevel int32
-
 // Provider Config
 var providerConfig string
 
@@ -111,7 +108,7 @@ func init() {
 	kubeVipCmd.PersistentFlags().StringVarP(&initConfig.Namespace, "namespace", "n", "kube-system", "The namespace for the configmap defined within the cluster")
 
 	// Manage logging
-	kubeVipCmd.PersistentFlags().Int32Var(&logLevel, "log", 0, "Set the level of logging")
+	kubeVipCmd.PersistentFlags().IntVar(&initConfig.Logging, "log", 0, "Set the level of logging")
 
 	// Service flags
 	kubeVipService.Flags().StringVarP(&configMap, "configMap", "c", "plndr", "The configuration map defined within the cluster")
@@ -161,7 +158,7 @@ func init() {
 	kubeVipCmd.AddCommand(kubeVipVersion)
 
 	// Set the logging level for all subsequent functions
-	log.SetLogLoggerLevel(log.Level(logLevel))
+	log.SetLogLoggerLevel(log.Level(initConfig.Logging))
 }
 
 // Execute - starts the command parsing process


### PR DESCRIPTION
It seems I've made an error in #1073 - it fixed ENV configuration for logging level but in the meantime it has broken the ability to configure logging level with `--log` flag, as value defined by it will be always overridden with empty value of `initConfig.Logging` which is `0`.

Proposed patch should fix that. The value passed with `--log` will now set `initConfig.Logging` instead of separate variable and will not be overridden if `vip_loglevel` is not set explicitly.