### PR TITLE
This adds a health check

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -136,6 +136,7 @@ func init() {
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.DisableServiceUpdates, "disableServiceUpdates", false, "If true, kube-vip will process services as usual, but will not update service's Status.LoadBalancer.Ingress slice")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableEndpointSlices, "enableEndpointSlices", false, "If enabled, kube-vip will only advertise services, but will use EndpointSlices instead of endpoints to get IPs of Pods")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.LoInterfaceGlobalScope, "loInterfaceGlobalScope", false, "If true, kube-vip will set global scope when using the lo interface, otherwise a host scope will be used by default")
+	kubeVipCmd.PersistentFlags().IntVar(&initConfig.HealthCheckPort, "healthCheckPort", 0, "If set to non-zero (> 1024), then this is the port that the healthcheck will listen on")
 
 	// Prometheus HTTP Server
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.PrometheusHTTPServer, "prometheusHTTPServer", ":2112", "Host and port used to expose Prometheus metrics via an HTTP server")
@@ -147,7 +148,6 @@ func init() {
 	kubeVipCmd.PersistentFlags().StringSliceVar(&initConfig.Etcd.Endpoints, "etcdEndpoints", nil, "Etcd member endpoints")
 
 	// Kubernetes client specific flags
-
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.K8sConfigFile, "k8sConfigPath", "/etc/kubernetes/admin.conf", "Path to the configuration file used with the Kubernetes client")
 
 	kubeVipCmd.AddCommand(kubeKubeadm)

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -642,5 +642,17 @@ func ParseEnvironment(c *Config) error {
 		c.BackendHealthCheckInterval = int(i)
 	}
 
+	env = os.Getenv(healthCheckPort)
+	if env != "" {
+		i, err := strconv.ParseInt(env, 10, 32)
+		if err != nil {
+			return err
+		}
+		if i < 1024 {
+			return fmt.Errorf("health check port should be > 1024")
+		}
+		c.HealthCheckPort = int(i)
+	}
+
 	return nil
 }

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -231,4 +231,7 @@ const (
 
 	// backendHealthCheckInterval Interval in seconds for checking backend health.
 	backendHealthCheckInterval = "backend_health_check_interval"
+
+	// healthCheckPort, if set to non-zero will be the port the health check will listen on
+	healthCheckPort = "health_check_port"
 )

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -528,6 +528,16 @@ func generatePodSpec(c *Config, imageVersion string, inCluster bool) *corev1.Pod
 		newEnvironment = append(newEnvironment, mdif...)
 	}
 
+	if c.HealthCheckPort != 0 {
+		healthPort := []corev1.EnvVar{
+			{
+				Name:  healthCheckPort,
+				Value: fmt.Sprintf("%d", c.HealthCheckPort),
+			},
+		}
+		newEnvironment = append(newEnvironment, healthPort...)
+	}
+
 	var securityContext *corev1.SecurityContext
 	if c.LoadBalancerForwardingMethod == "masquerade" {
 		var privileged = true

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -195,6 +195,9 @@ type Config struct {
 
 	// LoInterfaceGlobalScope, if true will set global scope when using the lo interface, otherwise a host scope will be used
 	LoInterfaceGlobalScope bool `yaml:"loInterfaceGlobalScope"`
+
+	// HealthCheckPort, if non-zero then will enable the healthcheck to return ok on this port
+	HealthCheckPort int `yaml:"healthCheckPort"`
 }
 
 // KubernetesLeaderElection defines all of the settings for Kubernetes KubernetesLeaderElection

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -208,11 +208,14 @@ func (sm *Manager) Start() error {
 		if sm.config.HealthCheckPort < 1024 {
 			return fmt.Errorf("healthcheck port is using a port that is less than 1024 [%d]", sm.config.HealthCheckPort)
 		}
-		http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		http.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 			fmt.Fprintf(w, "OK")
 		})
 		go func() {
-			http.ListenAndServe(fmt.Sprintf(":%d", sm.config.HealthCheckPort), nil)
+			err := http.ListenAndServe(fmt.Sprintf(":%d", sm.config.HealthCheckPort), nil)
+			if err != nil {
+				log.Error("healthcheck", "unable to start", err)
+			}
 		}()
 	}
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -212,7 +212,11 @@ func (sm *Manager) Start() error {
 			fmt.Fprintf(w, "OK")
 		})
 		go func() {
-			err := http.ListenAndServe(fmt.Sprintf(":%d", sm.config.HealthCheckPort), nil)
+			server := &http.Server{
+				Addr:              fmt.Sprintf(":%d", sm.config.HealthCheckPort),
+				ReadHeaderTimeout: 3 * time.Second,
+			}
+			err := server.ListenAndServe()
 			if err != nil {
 				log.Error("healthcheck", "unable to start", err)
 			}


### PR DESCRIPTION
The env variable `health_check_port` as long an `!= 0` and `> 1024` will enable a health check on `/healthz`.. be aware that kube-vip uses `hostNetwork` so it would be easy for a port conflict.