### PR TITLE
Fixed IPVS backend re-add

### DIFF
--- a/pkg/loadbalancer/ipvs.go
+++ b/pkg/loadbalancer/ipvs.go
@@ -152,7 +152,7 @@ func (lb *IPVSLoadBalancer) AddBackend(address string, port uint16) error {
 	if _, ok := lb.backendMap[backend]; !ok {
 		isHealth := backend.Check()
 		if isHealth {
-			err := lb.addBackend(backend)
+			err := lb.addBackend(address, port)
 			if err != nil {
 				return err
 			}
@@ -162,7 +162,8 @@ func (lb *IPVSLoadBalancer) AddBackend(address string, port uint16) error {
 	return nil
 }
 
-func (lb *IPVSLoadBalancer) addBackend(backend backend.Entry) error {
+func (lb *IPVSLoadBalancer) addBackend(address string, port uint16) error {
+	backend := backend.Entry{Addr: address, Port: port}
 	// Check if this is the first backend
 	backends, err := lb.client.Destinations(lb.loadBalancerService)
 	if err != nil && strings.Contains(err.Error(), "file does not exist") {
@@ -279,7 +280,7 @@ func (lb *IPVSLoadBalancer) healthCheck() {
 			if newStatus {
 				// old status -> health
 				if !oldStatus {
-					err := lb.AddBackend(backend.Addr, backend.Port)
+					err := lb.addBackend(backend.Addr, backend.Port)
 					if err != nil {
 						log.Error("add backend", "err", err)
 					}


### PR DESCRIPTION
This PR should fix #875 and #895

It turned out that the AddBackend function was called and it tried to acquire mutex that was already locked, so the backend was never re-added.