### PR TITLE
Fixed service/endpoints discovery concurrent issue

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -350,6 +350,31 @@ func (sm *Manager) findServiceInstance(svc *v1.Service) *Instance {
 	return nil
 }
 
+func (sm *Manager) findServiceInstanceWithTimeout(ctx context.Context, svc *v1.Service) (*Instance, error) {
+	log.Debug("finding service with timeout", "UID", svc.UID)
+
+	ctxTimeout, ctxTimeoutCancel := context.WithTimeout(ctx, time.Minute)
+	defer ctxTimeoutCancel()
+
+	for {
+		for i := range sm.serviceInstances {
+			log.Debug("saved service", "instance", i, "UID", sm.serviceInstances[i].serviceSnapshot.UID)
+			if sm.serviceInstances[i].serviceSnapshot.UID == svc.UID {
+				return sm.serviceInstances[i], nil
+			}
+		}
+
+		t := time.NewTimer(time.Millisecond * 100)
+		select {
+		case <-ctxTimeout.Done():
+			t.Stop()
+			return nil, fmt.Errorf("failed to wait for the service instance: %w", ctx.Err())
+		case <-t.C:
+			log.Debug("waiting for the service to be discovered", "UID", svc.UID)
+		}
+	}
+}
+
 // Refresh UPNP Port Forwards for all Service Instances registered in the SM
 func (sm *Manager) refreshUPNPForwards() {
 	log.Info("Starting UPNP Port Refresher")

--- a/pkg/manager/watch_endpoints.go
+++ b/pkg/manager/watch_endpoints.go
@@ -291,7 +291,11 @@ func (sm *Manager) watchEndpoint(ctx context.Context, id string, service *v1.Ser
 				if !sm.config.EnableServicesElection && !sm.config.EnableLeaderElection && !isRouteConfigured {
 					// If routing table mode is enabled - routes should be added per node
 					if sm.config.EnableRoutingTable {
-						if instance := sm.findServiceInstance(service); instance != nil {
+						instance, err := sm.findServiceInstanceWithTimeout(ctx, service)
+						if err != nil {
+							log.Error("error finding instance", "service", service.UID, "provider", provider.getLabel(), "err", err)
+						}
+						if instance != nil {
 							for _, cluster := range instance.clusters {
 								for i := range cluster.Network {
 									err := cluster.Network[i].AddRoute(false)
@@ -322,7 +326,11 @@ func (sm *Manager) watchEndpoint(ctx context.Context, id string, service *v1.Ser
 
 					// If BGP mode is enabled - hosts should be added per node
 					if sm.config.EnableBGP {
-						if instance := sm.findServiceInstance(service); instance != nil {
+						instance, err := sm.findServiceInstanceWithTimeout(ctx, service)
+						if err != nil {
+							log.Error("error finding instance", "service", service.UID, "provider", provider.getLabel(), "err", err)
+						}
+						if instance != nil {
 							for _, cluster := range instance.clusters {
 								for i := range cluster.Network {
 									address := fmt.Sprintf("%s/%s", cluster.Network[i].IP(), sm.config.VIPCIDR)


### PR DESCRIPTION
This should fix #1092 

This PR adds new function that finds service instance but waits a bit for service watcher to be able to discover all instances.

This is more a workaround, just for now, than a proper fix, I believe. I think that some kind of synchronization between services and endpoints watcher should be added, but cannot wrap my head around how to do that just yet.