### PR TITLE
Fixed service update in BGP and ARP mode

### DIFF
--- a/pkg/manager/watch_endpoints.go
+++ b/pkg/manager/watch_endpoints.go
@@ -329,7 +329,7 @@ func (sm *Manager) watchEndpoint(ctx context.Context, id string, service *v1.Ser
 									log.Debug("attempting to advertise BGP service", "provider", provider.getLabel(), "ip", address)
 									err := sm.bgpServer.AddHost(address)
 									if err != nil {
-										log.Error("error adding BGP hos", "provider", provider.getLabel(), "err", err)
+										log.Error("error adding BGP host", "provider", provider.getLabel(), "err", err)
 									} else {
 										log.Info("added BGP host", "provider",
 											provider.getLabel(), "ip", address, "service name", service.Name, "namespace", service.Namespace)

--- a/pkg/manager/watch_services.go
+++ b/pkg/manager/watch_services.go
@@ -167,6 +167,10 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 							if err != nil {
 								log.Error("(svc) unable to remove", "service", svc.UID)
 							}
+							activeService[string(svc.UID)] = false
+							watchedService[string(svc.UID)] = false
+							delete(activeServiceLoadBalancer, string(svc.UID))
+							configuredLocalRoutes.Store(string(svc.UID), false)
 						}
 						// in theory this should never fail
 


### PR DESCRIPTION
This **should** fix #998 and #953

While working on the BGP changes I've noticed that services are not properly updated in BGP mode, so decided to give it a go. Tested this in BGP, ARP and RT modes and it seems to work just fine now.

Main changes:

- Added missing status reset to the existing `event.Modified` check.
- Changed the way `fetchServiceAddresses` works - it will now check if IPv4 or IPv6 provided in `s.Spec.LoadBalancerIP` is different from the same family IP address in `s.Status.LoadBalancer.Ingress` and if so will use it to update the address.
- Added mutex for service leader election - in case of update it sometimes happened that the restarted leader (on the same node) tried to acquire service lease before the stopped leader was able to fully step down. This seems to prevent that.