### PR TITLE
Fixed IPVS deletion issues

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -14,8 +14,9 @@ import (
 )
 
 type Entry struct {
-	Addr string
-	Port uint16
+	Addr    string
+	Port    uint16
+	IsLocal bool
 }
 
 type Map map[Entry]bool

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -50,7 +50,8 @@ func startNetworking(c *kubevip.Config) ([]vip.Network, error) {
 
 	networks := []vip.Network{}
 	for _, addr := range addresses {
-		network, err := vip.NewConfig(addr, c.Interface, c.LoInterfaceGlobalScope, c.VIPSubnet, c.DDNS, c.RoutingTableID, c.RoutingTableType, c.RoutingProtocol, c.DNSMode, c.LoadBalancerForwardingMethod, c.IptablesBackend)
+		network, err := vip.NewConfig(addr, c.Interface, c.LoInterfaceGlobalScope, c.VIPSubnet, c.DDNS, c.RoutingTableID,
+			c.RoutingTableType, c.RoutingProtocol, c.DNSMode, c.LoadBalancerForwardingMethod, c.IptablesBackend, c.EnableLoadBalancer)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -192,7 +192,7 @@ func (cluster *Cluster) StartCluster(c *kubevip.Config, sm *Manager, bgpServer *
 		sm:      sm,
 		onStartedLeading: func(ctx context.Context) { //nolint TODO: potential clean code
 			// As we're leading lets start the vip service
-			err := cluster.vipService(ctxArp, ctxDNS, c, sm, bgpServer, packetClient)
+			err := cluster.vipService(ctxArp, ctxDNS, c, sm, bgpServer, packetClient, cancel)
 			if err != nil {
 				log.Error("starting VIP service on leader", "err", err)
 			}

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func (cluster *Cluster) vipService(ctxArp, ctxDNS context.Context, c *kubevip.Config, sm *Manager, bgpServer *bgp.Server, packetClient *packngo.Client) error {
+func (cluster *Cluster) vipService(ctxArp, ctxDNS context.Context, c *kubevip.Config, sm *Manager, bgpServer *bgp.Server, packetClient *packngo.Client, cancelLeaderElection context.CancelFunc) error {
 	var err error
 
 	// listen for interrupts or the Linux SIGTERM signal and cancel
@@ -103,7 +103,7 @@ func (cluster *Cluster) vipService(ctxArp, ctxDNS context.Context, c *kubevip.Co
 		if c.EnableLoadBalancer {
 			log.Info("Starting IPVS LoadBalancer")
 
-			lb, err := loadbalancer.NewIPVSLB(cluster.Network[i].IP(), c.LoadBalancerPort, c.LoadBalancerForwardingMethod, c.BackendHealthCheckInterval)
+			lb, err := loadbalancer.NewIPVSLB(cluster.Network[i].IP(), c.LoadBalancerPort, c.LoadBalancerForwardingMethod, c.BackendHealthCheckInterval, c.Interface, cancelLeaderElection, signalChan)
 			if err != nil {
 				log.Error("Error creating IPVS LoadBalancer", "err", err)
 			}

--- a/pkg/cluster/singleNode.go
+++ b/pkg/cluster/singleNode.go
@@ -76,5 +76,5 @@ func (cluster *Cluster) StartVipService(c *kubevip.Config, sm *Manager, bgp *bgp
 	ctxDNS, cancelDNS := context.WithCancel(context.Background())
 	defer cancelDNS()
 
-	return cluster.vipService(ctxArp, ctxDNS, c, sm, bgp, packetClient)
+	return cluster.vipService(ctxArp, ctxDNS, c, sm, bgp, packetClient, nil)
 }

--- a/pkg/loadbalancer/ipvs.go
+++ b/pkg/loadbalancer/ipvs.go
@@ -62,6 +62,9 @@ func NewIPVSLB(address string, port uint16, forwardingMethod string, backendHeal
 	if err != nil {
 		log.Error("ensure IPVS kernel modules are loaded")
 		log.Error("Error retrieving IPVS info", "err", err)
+		if errors.Is(err, os.ErrPermission) {
+			log.Error("no permission to get IPVS info - please ensure that kube-vip is running with proper capabilities/privileged mode")
+		}
 		panic("")
 	}
 	log.Info("IPVS Loadbalancer enabled", "version", fmt.Sprintf(" %d.%d.%d", i.Version[0], i.Version[1], i.Version[2]))
@@ -81,7 +84,7 @@ func NewIPVSLB(address string, port uint16, forwardingMethod string, backendHeal
 			err = sysctl.WriteProcSys(conntrackFile, "1")
 			if err != nil {
 				if errors.Is(err, os.ErrPermission) {
-					log.Error("no permission to write to the file - please ensure that the kube-vip is running with proper capabilities/privileged mode to write to sysfs",
+					log.Error("no permission to write to the file - please ensure that kube-vip is running with proper capabilities/privileged mode to write to sysfs",
 						"file", conntrackFile, "err", err)
 				} else {
 					log.Error("ensuring net.ipv4.vs.conntrack enabled", "err", err)

--- a/pkg/manager/manager_arp.go
+++ b/pkg/manager/manager_arp.go
@@ -58,13 +58,12 @@ func (sm *Manager) startARP(id string) error {
 				log.Error("starting control plane", "err", err)
 				// Trigger the shutdown of this manager instance
 				sm.signalChan <- syscall.SIGINT
-
 			}
 		}()
 
 		// Check if we're also starting the services, if not we can sit and wait on the closing channel and return here
 		if !sm.config.EnableServices {
-			<-sm.signalChan
+			<-sm.shutdownChan
 			log.Info("Shutting down Kube-Vip")
 
 			return nil

--- a/pkg/manager/node_labeling.go
+++ b/pkg/manager/node_labeling.go
@@ -66,7 +66,7 @@ func applyPatchLabels(ctx context.Context, clientSet *kubernetes.Clientset,
 	node, err := clientSet.CoreV1().Nodes().Patch(ctx,
 		name, types.JSONPatchType, patchData, metav1.PatchOptions{})
 	if err != nil {
-		log.Error("node patch marshaling failed", "err", err)
+		log.Error("node patching failed", "err", err)
 		return
 	}
 	log.Debug("updated", "node", name, "labels", node.Labels)

--- a/pkg/sysctl/sysctl.go
+++ b/pkg/sysctl/sysctl.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 )
 
 func WriteProcSys(path, value string) error {
@@ -26,4 +27,30 @@ func WriteProcSys(path, value string) error {
 	}
 
 	return nil
+}
+
+func CheckProcSys(path string) (bool, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		return false, fmt.Errorf("failed to open file: %w", err)
+	}
+	defer func() {
+		if cErr := f.Close(); cErr != nil && err == nil {
+			err = fmt.Errorf("failed to close file: %w", cErr)
+		}
+	}()
+
+	buffer := make([]byte, 1)
+
+	if n, err := f.Read(buffer); err != nil || n < len(buffer) {
+		return false, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	var isEnabled bool
+	isEnabled, err = strconv.ParseBool(string(buffer))
+	if err != nil {
+		return false, fmt.Errorf("failed to parse value: %w", err)
+	}
+
+	return isEnabled, nil
 }

--- a/pkg/sysctl/sysctl.go
+++ b/pkg/sysctl/sysctl.go
@@ -54,3 +54,21 @@ func CheckProcSys(path string) (bool, error) {
 
 	return isEnabled, nil
 }
+
+func EnableProcSys(path string) (bool, error) {
+	isEnabled, err := CheckProcSys(path)
+	if err != nil {
+		return false, fmt.Errorf("failed to check '%s' status: %w", path, err)
+	}
+	if !isEnabled {
+		if err := WriteProcSys(path, "1"); err != nil {
+			if os.IsPermission(err) {
+				return false, fmt.Errorf("no permission to write to the file '%s' - please ensure that kube-vip is running with proper capabilities/privileged mode to write to sysfs: %w", path, err)
+			}
+			return false, fmt.Errorf("failed to enable '%s': %w", path, err)
+		}
+
+		return true, nil
+	}
+	return false, nil
+}

--- a/pkg/vip/address.go
+++ b/pkg/vip/address.go
@@ -313,7 +313,8 @@ func (configurator *network) configureIPTables() error {
 		}
 	}
 
-	if configurator.ipvsEnabled && configurator.forwardMethod == "masquerade" {
+	// It seems that masquerading is only reuired with IPv4 for IPVS to work.
+	if configurator.ipvsEnabled && configurator.forwardMethod == "masquerade" && configurator.address.IP.To4() != nil {
 		if err := configurator.addIptablesRulesForMasquerade(); err != nil {
 			return errors.Wrap(err, "could not add iptables rules for masquerade")
 		}
@@ -487,7 +488,7 @@ func (configurator *network) DeleteIP() error {
 		}
 	}
 
-	if configurator.ipvsEnabled && configurator.forwardMethod == "masquerade" {
+	if configurator.ipvsEnabled && configurator.forwardMethod == "masquerade" && configurator.address.IP.To4() != nil {
 		if err := configurator.removeIptablesRulesForMasquerade(); err != nil {
 			return errors.Wrap(err, "could not remove iptables masquerade rules ")
 		}


### PR DESCRIPTION
I think this should fix the followup issue described in [the comment](https://github.com/kube-vip/kube-vip/issues/895#issuecomment-2702888317) in #895

Upon investigation it turned out that when kube-vip tries to delete IPVS loadbalancer it tries to close `nil` channel which results in panic and pre-mature exit. So I added initialization for this channel.


```
2025/03/10 12:25:02 INFO IPVS Loadbalancer enabled version=" 1.2.1"
2025/03/10 12:25:02 INFO sysctl set net.ipv4.vs.conntrack to 1
2025/03/10 12:25:02 INFO sysctl set net.ipv4.ip_forward to 1
2025/03/10 12:25:02 INFO layer 2 broadcaster starting
2025/03/10 12:25:02 DEBUG layer 2 update ip=10.0.1.10 interface=eth0 ms=3000
2025/03/10 12:25:02 INFO Kube-Vip is watching nodes for control-plane labels
2025/03/10 12:27:29 INFO Received termination, signaling cluster shutdown
panic: close of nil channel

goroutine 154 [running]:
github.com/kube-vip/kube-vip/pkg/loadbalancer.(*IPVSLoadBalancer).RemoveIPVSLB(0xc0003e4180)
	/src/pkg/loadbalancer/ipvs.go:139 +0x2b
github.com/kube-vip/kube-vip/pkg/cluster.(*Cluster).vipService.func2()
	/src/pkg/cluster/service.go:120 +0x39
created by github.com/kube-vip/kube-vip/pkg/cluster.(*Cluster).vipService in goroutine 89
	/src/pkg/cluster/service.go:118 +0xa2b
```

It also turned out that 2 goroutines were waiting for an OS signal on the same channel. This caused kube-vip to not remove IPVS loadbalancer on exit sometimes (depending on which goroutine got the signal first). Changed that so goroutines should always exit in proper order.

EDIT: It seems that backends were not watched if LB forwarding method was not set as `masquerade`. I've decided to enable backend watching for all forwarding methods as I believe this should be not dependent on the mode. Additionally I've added a piece of code hat will remove a backend from the watch if node will enter `NotReady` state.