### PR TITLE
Refactoring endpoint-watcher code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ e2e-tests129-rt:
 e2e-tests129-bgp:
 	GOMAXPROCS=4 TEST_MODE=bgp V129=true K8S_IMAGE_PATH=kindest/node:v1.29.0 E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v -p ./testing/e2e
 
-e2e-tests129: e2e-tests129-arp e2e-tests129-rt
+e2e-tests129: e2e-tests129-arp e2e-tests129-rt e2e-tests129-bgp
 
 service-tests:
 	E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run ./testing/services -Services -simple -deployments -leaderActive -leaderFailover -localDeploy -egress -egressIPv6 -dualStack

--- a/pkg/manager/endpoints.go
+++ b/pkg/manager/endpoints.go
@@ -1,0 +1,157 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	log "log/slog"
+
+	v1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+type Processor struct {
+	sm       *Manager
+	provider epProvider
+	worker   EndpointWorker
+}
+
+func NewEndpointProcessor(sm *Manager, provider epProvider) *Processor {
+	return &Processor{
+		sm:       sm,
+		provider: provider,
+	}
+}
+
+func (p *Processor) AddModify(ctx context.Context, event watch.Event, cancel context.CancelFunc,
+	lastKnownGoodEndpoint *string, service *v1.Service, id string, leaderElectionActive *bool) (bool, error) {
+
+	var err error
+	if err = p.provider.loadObject(event.Object, cancel); err != nil {
+		return false, fmt.Errorf("[%s] error loading k8s object: %w", p.provider.getLabel(), err)
+	}
+
+	p.worker = NewEndpointWorker(p.sm, p.provider) // TODO: this could be created on kube-vip's start
+
+	endpoints, err := p.worker.GetEndpoints(service, id)
+	if err != nil {
+		return false, err
+	}
+
+	if err := p.worker.SetInstanceEndpointsStatus(service, len(endpoints) > 0); err != nil {
+		log.Error("updating instance", "err", err)
+	}
+
+	// Find out if we have any local endpoints
+	// if out endpoint is empty then populate it
+	// if not, go through the endpoints and see if ours still exists
+	// If we have a local endpoint then begin the leader Election, unless it's already running
+	//
+
+	// Check that we have local endpoints
+	if len(endpoints) != 0 {
+		// Ignore IPv4
+		if service.Annotations[egressIPv6] == "true" && net.ParseIP(endpoints[0]).To4() != nil {
+			return true, nil
+		}
+
+		p.updateLastKnownGoodEndpoint(lastKnownGoodEndpoint, endpoints, service, leaderElectionActive, cancel)
+
+		// start leader election if it's enabled and not already started
+		if !*leaderElectionActive && p.sm.config.EnableServicesElection {
+			go startLeaderElection(ctx, p.sm, leaderElectionActive, service)
+		}
+
+		isRouteConfigured, err := isRouteConfigured(service.UID)
+		if err != nil {
+			return false, fmt.Errorf("[%s] error while checking if route is configured: %w", p.provider.getLabel(), err)
+		}
+
+		// There are local endpoints available on the node
+		if !p.sm.config.EnableServicesElection && !p.sm.config.EnableLeaderElection && !isRouteConfigured {
+			if err := p.worker.ProcessInstance(ctx, service, leaderElectionActive); err != nil {
+				return false, fmt.Errorf("failed to process non-empty instance: %w", err)
+			}
+		}
+	} else {
+		// There are no local endpoints
+		p.worker.Clear(lastKnownGoodEndpoint, service, cancel, leaderElectionActive)
+	}
+
+	// Set the service accordingly
+	p.updateAnnotations(service, lastKnownGoodEndpoint)
+
+	log.Debug("watcher", "provider",
+		p.provider.getLabel(), "service name", service.Name, "namespace", service.Namespace, "endpoints", len(endpoints), "last endpoint", lastKnownGoodEndpoint, "active leader election", leaderElectionActive)
+
+	return false, nil
+}
+
+func (p *Processor) Delete(service *v1.Service, id string) error {
+	if err := p.worker.Delete(service, id); err != nil {
+		return fmt.Errorf("[%s] error deleting service: %w", p.provider.getLabel(), err)
+	}
+	return nil
+}
+
+func (p *Processor) updateLastKnownGoodEndpoint(lastKnownGoodEndpoint *string, endpoints []string, service *v1.Service, leaderElectionActive *bool, cancel context.CancelFunc) {
+	// if we haven't populated one, then do so
+	if *lastKnownGoodEndpoint == "" {
+		*lastKnownGoodEndpoint = endpoints[0]
+		return
+	}
+
+	// check out previous endpoint exists
+	stillExists := false
+
+	for x := range endpoints {
+		if endpoints[x] == *lastKnownGoodEndpoint {
+			stillExists = true
+		}
+	}
+	// If the last endpoint no longer exists, we cancel our leader Election, and set another endpoint as last known good
+	if !stillExists {
+		p.worker.RemoveEgress(service, lastKnownGoodEndpoint)
+		if *leaderElectionActive && (p.sm.config.EnableServicesElection || p.sm.config.EnableLeaderElection) {
+			log.Warn("existing endpoint has been removed, restarting leaderElection", "provider", p.provider.getLabel(), "endpoint", lastKnownGoodEndpoint)
+			// Stop the existing leaderElection
+			cancel()
+			// disable last leaderElection flag
+			*leaderElectionActive = false
+		}
+		// Set our active endpoint to an existing one
+		*lastKnownGoodEndpoint = endpoints[0]
+	}
+}
+
+func (p *Processor) updateAnnotations(service *v1.Service, lastKnownGoodEndpoint *string) {
+	// Set the service accordingly
+	if service.Annotations[egress] == "true" {
+		activeEndpointAnnotation := activeEndpoint
+
+		if p.sm.config.EnableEndpointSlices && p.provider.getProtocol() == string(discoveryv1.AddressTypeIPv6) {
+			activeEndpointAnnotation = activeEndpointIPv6
+		}
+		service.Annotations[activeEndpointAnnotation] = *lastKnownGoodEndpoint
+	}
+}
+
+func startLeaderElection(ctx context.Context, sm *Manager, leaderElectionActive *bool, service *v1.Service) {
+	// This is a blocking function, that will restart (in the event of failure)
+	for {
+		// if the context isn't cancelled restart
+		if ctx.Err() != context.Canceled {
+			*leaderElectionActive = true
+			err := sm.StartServicesLeaderElection(ctx, service)
+			if err != nil {
+				log.Error(err.Error())
+			}
+			*leaderElectionActive = false
+		} else {
+			*leaderElectionActive = false
+			break
+		}
+	}
+}

--- a/pkg/manager/endpoints_bgp.go
+++ b/pkg/manager/endpoints_bgp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	log "log/slog"
 
+	"github.com/kube-vip/kube-vip/pkg/cluster"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -21,24 +22,22 @@ func NewBGP(sm *Manager, provider epProvider) EndpointWorker {
 	}
 }
 
-func (b *BGP) ProcessInstance(ctx context.Context, service *v1.Service, leaderElectionActive *bool) error {
-	instance, err := b.sm.findServiceInstanceWithTimeout(ctx, service)
-	if err != nil {
-		log.Error("error finding instance", "service", service.UID, "provider", b.provider.getLabel(), "err", err)
-	}
-	if instance != nil {
-		for _, cluster := range instance.clusters {
+func (b *BGP) ProcessInstance(svcCtx *serviceContext, service *v1.Service, leaderElectionActive *bool) error {
+	if instance := b.sm.findServiceInstance(service); instance != nil {
+		for _, cluster := range instance.Clusters {
 			for i := range cluster.Network {
-				address := fmt.Sprintf("%s/%s", cluster.Network[i].IP(), b.sm.config.VIPCIDR)
-				log.Debug("attempting to advertise BGP service", "provider", b.provider.getLabel(), "ip", address)
-				err := b.sm.bgpServer.AddHost(address)
-				if err != nil {
-					log.Error("error adding BGP host", "provider", b.provider.getLabel(), "err", err)
-				} else {
-					log.Info("added BGP host", "provider",
-						b.provider.getLabel(), "ip", address, "service name", service.Name, "namespace", service.Namespace)
-					configuredLocalRoutes.Store(string(service.UID), true)
-					*leaderElectionActive = true
+				if !svcCtx.isNetworkConfigured(cluster.Network[i].IP()) {
+					network := cluster.Network[i]
+					log.Debug("attempting to advertise BGP service", "provider", b.provider.getLabel(), "ip", network.CIDR())
+					err := b.sm.bgpServer.AddHost(network.CIDR())
+					if err != nil {
+						log.Error("error adding BGP host", "provider", b.provider.getLabel(), "err", err)
+					} else {
+						log.Info("added BGP host", "provider",
+							b.provider.getLabel(), "ip", network.CIDR(), "service name", service.Name, "namespace", service.Namespace)
+						svcCtx.configuredNetworks.Store(cluster.Network[i].IP(), cluster.Network[i])
+						*leaderElectionActive = true
+					}
 				}
 			}
 		}
@@ -46,25 +45,25 @@ func (b *BGP) ProcessInstance(ctx context.Context, service *v1.Service, leaderEl
 	return nil
 }
 
-func (b *BGP) Clear(lastKnownGoodEndpoint *string, service *v1.Service, cancel context.CancelFunc, leaderElectionActive *bool) {
+func (b *BGP) Clear(svcCtx *serviceContext, lastKnownGoodEndpoint *string, service *v1.Service, cancel context.CancelFunc, leaderElectionActive *bool) {
 	if !b.sm.config.EnableServicesElection && !b.sm.config.EnableLeaderElection {
 		// If BGP mode is enabled - routes should be deleted
 		if instance := b.sm.findServiceInstance(service); instance != nil {
-			for _, cluster := range instance.clusters {
+			for _, cluster := range instance.Clusters {
 				for i := range cluster.Network {
-					address := fmt.Sprintf("%s/%s", cluster.Network[i].IP(), b.sm.config.VIPCIDR)
-					err := b.sm.bgpServer.DelHost(address)
+					network := cluster.Network[i]
+					err := b.sm.bgpServer.DelHost(network.CIDR())
 					if err != nil {
-						log.Error("deleting BGP host", "provider", b.provider.getLabel(), "ip", address, "err", err)
+						log.Error("[endpoint] deleting BGP host", "provider", b.provider.getLabel(), "ip", network.CIDR(), "err", err)
 					} else {
-						log.Info("deleted BGP host", "provider",
-							b.provider.getLabel(), "ip", address, "service name", service.Name, "namespace", service.Namespace)
-						configuredLocalRoutes.Store(string(service.UID), false)
+						log.Info("[endpoint] deleted BGP host", "provider",
+							b.provider.getLabel(), "ip", network.CIDR(), "service name", service.Name, "namespace", service.Namespace)
+
+						svcCtx.configuredNetworks.Delete(cluster.Network[i].IP())
 						*leaderElectionActive = false
 					}
 				}
 			}
-
 		}
 	}
 
@@ -99,21 +98,25 @@ func (b *BGP) deleteAction(service *v1.Service) {
 
 func (sm *Manager) ClearBGPHosts(service *v1.Service) {
 	if instance := sm.findServiceInstance(service); instance != nil {
-		for _, cluster := range instance.clusters {
-			for i := range cluster.Network {
-				address := fmt.Sprintf("%s/%s", cluster.Network[i].IP(), sm.config.VIPCIDR)
-				err := sm.bgpServer.DelHost(address)
-				if err != nil {
-					log.Error("[endpoint] error deleting BGP host", "err", err)
-				} else {
-					log.Debug("[endpoint] deleted BGP host", "ip",
-						address, "service name", service.Name, "namespace", service.Namespace)
-				}
+		sm.clearBGPHostsByInstance(instance)
+	}
+}
+
+func (sm *Manager) clearBGPHostsByInstance(instance *cluster.Instance) {
+	for _, cluster := range instance.Clusters {
+		for i := range cluster.Network {
+			// address := fmt.Sprintf("%s/%s", cluster.Network[i].IP(), sm.config.VIPSubnet)
+			err := sm.bgpServer.DelHost(cluster.Network[i].CIDR())
+			if err != nil {
+				log.Error("[endpoint] error deleting BGP host", "err", err)
+			} else {
+				log.Debug("[endpoint] deleted BGP host", "ip",
+					cluster.Network[i].CIDR(), "service name", instance.ServiceSnapshot.Name, "namespace", instance.ServiceSnapshot.Namespace)
 			}
 		}
 	}
 }
 
-func (b *BGP) SetInstanceEndpointsStatus(_ *v1.Service, _ bool) error {
+func (b *BGP) SetInstanceEndpointsStatus(_ *v1.Service, _ []string) error {
 	return nil
 }

--- a/pkg/manager/endpoints_bgp.go
+++ b/pkg/manager/endpoints_bgp.go
@@ -1,0 +1,119 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+	log "log/slog"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+type BGP struct {
+	Generic
+}
+
+func NewBGP(sm *Manager, provider epProvider) EndpointWorker {
+	return &BGP{
+		Generic: Generic{
+			sm:       sm,
+			provider: provider,
+		},
+	}
+}
+
+func (b *BGP) ProcessInstance(ctx context.Context, service *v1.Service, leaderElectionActive *bool) error {
+	instance, err := b.sm.findServiceInstanceWithTimeout(ctx, service)
+	if err != nil {
+		log.Error("error finding instance", "service", service.UID, "provider", b.provider.getLabel(), "err", err)
+	}
+	if instance != nil {
+		for _, cluster := range instance.clusters {
+			for i := range cluster.Network {
+				address := fmt.Sprintf("%s/%s", cluster.Network[i].IP(), b.sm.config.VIPCIDR)
+				log.Debug("attempting to advertise BGP service", "provider", b.provider.getLabel(), "ip", address)
+				err := b.sm.bgpServer.AddHost(address)
+				if err != nil {
+					log.Error("error adding BGP host", "provider", b.provider.getLabel(), "err", err)
+				} else {
+					log.Info("added BGP host", "provider",
+						b.provider.getLabel(), "ip", address, "service name", service.Name, "namespace", service.Namespace)
+					configuredLocalRoutes.Store(string(service.UID), true)
+					*leaderElectionActive = true
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (b *BGP) Clear(lastKnownGoodEndpoint *string, service *v1.Service, cancel context.CancelFunc, leaderElectionActive *bool) {
+	if !b.sm.config.EnableServicesElection && !b.sm.config.EnableLeaderElection {
+		// If BGP mode is enabled - routes should be deleted
+		if instance := b.sm.findServiceInstance(service); instance != nil {
+			for _, cluster := range instance.clusters {
+				for i := range cluster.Network {
+					address := fmt.Sprintf("%s/%s", cluster.Network[i].IP(), b.sm.config.VIPCIDR)
+					err := b.sm.bgpServer.DelHost(address)
+					if err != nil {
+						log.Error("deleting BGP host", "provider", b.provider.getLabel(), "ip", address, "err", err)
+					} else {
+						log.Info("deleted BGP host", "provider",
+							b.provider.getLabel(), "ip", address, "service name", service.Name, "namespace", service.Namespace)
+						configuredLocalRoutes.Store(string(service.UID), false)
+						*leaderElectionActive = false
+					}
+				}
+			}
+
+		}
+	}
+
+	b.clearEgress(lastKnownGoodEndpoint, service, cancel, leaderElectionActive)
+}
+
+func (b *BGP) GetEndpoints(service *v1.Service, id string) ([]string, error) {
+	return b.getAllEndpoints(service, id)
+}
+
+func (b *BGP) Delete(service *v1.Service, id string) error {
+	// When no-leader-elecition mode
+	if !b.sm.config.EnableServicesElection && !b.sm.config.EnableLeaderElection {
+		// find all existing local endpoints
+		endpoints, err := b.GetEndpoints(service, id)
+		if err != nil {
+			return fmt.Errorf("[%s] error getting endpoints: %w", b.provider.getLabel(), err)
+		}
+
+		// If there were local endpoints deleted
+		if len(endpoints) > 0 {
+			b.deleteAction(service)
+		}
+	}
+
+	return nil
+}
+
+func (b *BGP) deleteAction(service *v1.Service) {
+	b.sm.ClearBGPHosts(service)
+}
+
+func (sm *Manager) ClearBGPHosts(service *v1.Service) {
+	if instance := sm.findServiceInstance(service); instance != nil {
+		for _, cluster := range instance.clusters {
+			for i := range cluster.Network {
+				address := fmt.Sprintf("%s/%s", cluster.Network[i].IP(), sm.config.VIPCIDR)
+				err := sm.bgpServer.DelHost(address)
+				if err != nil {
+					log.Error("[endpoint] error deleting BGP host", "err", err)
+				} else {
+					log.Debug("[endpoint] deleted BGP host", "ip",
+						address, "service name", service.Name, "namespace", service.Namespace)
+				}
+			}
+		}
+	}
+}
+
+func (b *BGP) SetInstanceEndpointsStatus(_ *v1.Service, _ bool) error {
+	return nil
+}

--- a/pkg/manager/endpoints_generic.go
+++ b/pkg/manager/endpoints_generic.go
@@ -9,12 +9,12 @@ import (
 )
 
 type EndpointWorker interface {
-	ProcessInstance(ctx context.Context, service *v1.Service, leaderElectionActive *bool) error
-	Clear(lastKnownGoodEndpoint *string, service *v1.Service, cancel context.CancelFunc, leaderElectionActive *bool)
+	ProcessInstance(svcCtx *serviceContext, service *v1.Service, leaderElectionActive *bool) error
+	Clear(svcCtx *serviceContext, lastKnownGoodEndpoint *string, service *v1.Service, cancel context.CancelFunc, leaderElectionActive *bool)
 	GetEndpoints(service *v1.Service, id string) ([]string, error)
 	RemoveEgress(service *v1.Service, lastKnownGoodEndpoint *string)
 	Delete(service *v1.Service, id string) error
-	SetInstanceEndpointsStatus(service *v1.Service, state bool) error
+	SetInstanceEndpointsStatus(service *v1.Service, endpoints []string) error
 }
 
 func NewEndpointWorker(sm *Manager, provider epProvider) EndpointWorker {
@@ -35,11 +35,11 @@ type Generic struct {
 	provider epProvider
 }
 
-func (g *Generic) ProcessInstance(_ context.Context, _ *v1.Service, _ *bool) error {
+func (g *Generic) ProcessInstance(_ *serviceContext, _ *v1.Service, _ *bool) error {
 	return nil
 }
 
-func (g *Generic) Clear(lastKnownGoodEndpoint *string, service *v1.Service, cancel context.CancelFunc, leaderElectionActive *bool) {
+func (g *Generic) Clear(_ *serviceContext, lastKnownGoodEndpoint *string, service *v1.Service, cancel context.CancelFunc, leaderElectionActive *bool) {
 	g.clearEgress(lastKnownGoodEndpoint, service, cancel, leaderElectionActive)
 }
 
@@ -98,6 +98,6 @@ func (g *Generic) Delete(_ *v1.Service, _ string) error {
 	return nil
 }
 
-func (g *Generic) SetInstanceEndpointsStatus(_ *v1.Service, _ bool) error {
+func (g *Generic) SetInstanceEndpointsStatus(_ *v1.Service, _ []string) error {
 	return nil
 }

--- a/pkg/manager/endpoints_generic.go
+++ b/pkg/manager/endpoints_generic.go
@@ -1,0 +1,103 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+	log "log/slog"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+type EndpointWorker interface {
+	ProcessInstance(ctx context.Context, service *v1.Service, leaderElectionActive *bool) error
+	Clear(lastKnownGoodEndpoint *string, service *v1.Service, cancel context.CancelFunc, leaderElectionActive *bool)
+	GetEndpoints(service *v1.Service, id string) ([]string, error)
+	RemoveEgress(service *v1.Service, lastKnownGoodEndpoint *string)
+	Delete(service *v1.Service, id string) error
+	SetInstanceEndpointsStatus(service *v1.Service, state bool) error
+}
+
+func NewEndpointWorker(sm *Manager, provider epProvider) EndpointWorker {
+	if sm.config.EnableRoutingTable {
+		return NewRoutingTable(sm, provider)
+	}
+	if sm.config.EnableBGP {
+		return NewBGP(sm, provider)
+	}
+	return &Generic{
+		sm:       sm,
+		provider: provider,
+	}
+}
+
+type Generic struct {
+	sm       *Manager
+	provider epProvider
+}
+
+func (g *Generic) ProcessInstance(_ context.Context, _ *v1.Service, _ *bool) error {
+	return nil
+}
+
+func (g *Generic) Clear(lastKnownGoodEndpoint *string, service *v1.Service, cancel context.CancelFunc, leaderElectionActive *bool) {
+	g.clearEgress(lastKnownGoodEndpoint, service, cancel, leaderElectionActive)
+}
+
+func (g *Generic) clearEgress(lastKnownGoodEndpoint *string, service *v1.Service, cancel context.CancelFunc, leaderElectionActive *bool) {
+	if *lastKnownGoodEndpoint != "" {
+		log.Warn("existing endpoint has been removed, no remaining endpoints for leaderElection", "provider", g.provider.getLabel(), "endpoint", lastKnownGoodEndpoint)
+		if err := g.sm.TeardownEgress(*lastKnownGoodEndpoint, service.Spec.LoadBalancerIP, service.Namespace, service.Annotations); err != nil {
+			log.Error("error removing redundant egress rules", "err", err)
+		}
+
+		*lastKnownGoodEndpoint = "" // reset endpoint
+		if g.sm.config.EnableServicesElection || g.sm.config.EnableLeaderElection {
+			cancel() // stop services watcher
+		}
+		*leaderElectionActive = false
+	}
+}
+
+func (g *Generic) GetEndpoints(_ *v1.Service, id string) ([]string, error) {
+	return g.getLocalEndpoints(id)
+}
+
+func (g *Generic) getLocalEndpoints(id string) ([]string, error) {
+	// Build endpoints
+	var endpoints []string
+	var err error
+	if endpoints, err = g.provider.getLocalEndpoints(id, g.sm.config); err != nil {
+		return nil, fmt.Errorf("[%s] error getting local endpoints: %w", g.provider.getLabel(), err)
+	}
+
+	return endpoints, nil
+}
+
+func (g *Generic) getAllEndpoints(service *v1.Service, id string) ([]string, error) {
+	// Build endpoints
+	var err error
+	var endpoints []string
+	if !g.sm.config.EnableLeaderElection && !g.sm.config.EnableServicesElection &&
+		service.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeCluster {
+		if endpoints, err = g.provider.getAllEndpoints(); err != nil {
+			return nil, fmt.Errorf("[%s] error getting all endpoints: %w", g.provider.getLabel(), err)
+		}
+	} else {
+		if endpoints, err = g.provider.getLocalEndpoints(id, g.sm.config); err != nil {
+			return nil, fmt.Errorf("[%s] error getting local endpoints: %w", g.provider.getLabel(), err)
+		}
+	}
+
+	return endpoints, nil
+}
+
+func (g *Generic) RemoveEgress(_ *v1.Service, _ *string) {
+}
+
+func (g *Generic) Delete(_ *v1.Service, _ string) error {
+	return nil
+}
+
+func (g *Generic) SetInstanceEndpointsStatus(_ *v1.Service, _ bool) error {
+	return nil
+}

--- a/pkg/manager/endpoints_routing_table.go
+++ b/pkg/manager/endpoints_routing_table.go
@@ -1,0 +1,140 @@
+package manager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"syscall"
+
+	log "log/slog"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+type RoutingTable struct {
+	Generic
+}
+
+func NewRoutingTable(sm *Manager, provider epProvider) EndpointWorker {
+	return &RoutingTable{
+		Generic: Generic{
+			sm:       sm,
+			provider: provider,
+		},
+	}
+}
+
+func (rt *RoutingTable) ProcessInstance(ctx context.Context, service *v1.Service, leaderElectionActive *bool) error {
+	instance, err := rt.sm.findServiceInstanceWithTimeout(ctx, service)
+	if err != nil {
+		log.Error("error finding instance", "service", service.UID, "provider", rt.provider.getLabel(), "err", err)
+	}
+	if instance != nil {
+		for _, cluster := range instance.clusters {
+			for i := range cluster.Network {
+				err := cluster.Network[i].AddRoute(false)
+				if err != nil {
+					if errors.Is(err, syscall.EEXIST) {
+						// If route exists try to update it if necessary
+						isUpdated, err := cluster.Network[i].UpdateRoutes()
+						if err != nil {
+							return fmt.Errorf("[%s] error updating existing routes: %w", rt.provider.getLabel(), err)
+						}
+						if isUpdated {
+							log.Debug("updated route", "provider", rt.provider.getLabel(), "ip", cluster.Network[i].IP())
+						}
+					} else {
+						// If other error occurs, return error
+						return fmt.Errorf("[%s] error adding route: %s", rt.provider.getLabel(), err.Error())
+					}
+				} else {
+					log.Info("added route", "provider",
+						rt.provider.getLabel(), "ip", cluster.Network[i].IP(), "service name", service.Name, "namespace", service.Namespace, "interface", cluster.Network[i].Interface(), "tableID", rt.sm.config.RoutingTableID)
+					configuredLocalRoutes.Store(string(service.UID), true)
+					*leaderElectionActive = true
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (rt *RoutingTable) Clear(lastKnownGoodEndpoint *string, service *v1.Service, cancel context.CancelFunc, leaderElectionActive *bool) {
+	if !rt.sm.config.EnableServicesElection && !rt.sm.config.EnableLeaderElection {
+		// If routing table mode is enabled - routes should be deleted
+		if errs := rt.sm.clearRoutes(service); len(errs) == 0 {
+			configuredLocalRoutes.Store(string(service.UID), false)
+		} else {
+			for _, err := range errs {
+				log.Error("error while clearing routes", "err", err)
+			}
+		}
+	}
+
+	rt.clearEgress(lastKnownGoodEndpoint, service, cancel, leaderElectionActive)
+}
+
+func (rt *RoutingTable) GetEndpoints(service *v1.Service, id string) ([]string, error) {
+	return rt.getAllEndpoints(service, id)
+}
+
+func (rt *RoutingTable) RemoveEgress(service *v1.Service, lastKnownGoodEndpoint *string) {
+	if err := rt.sm.TeardownEgress(*lastKnownGoodEndpoint, service.Spec.LoadBalancerIP,
+		service.Namespace, service.Annotations); err != nil {
+		log.Warn("removing redundant egress rules", "err", err)
+	}
+}
+
+func (rt *RoutingTable) Delete(service *v1.Service, id string) error {
+	// When no-leader-elecition mode
+	if !rt.sm.config.EnableServicesElection && !rt.sm.config.EnableLeaderElection {
+		// find all existing local endpoints
+		endpoints, err := rt.GetEndpoints(service, id)
+		if err != nil {
+			return fmt.Errorf("[%s] error getting endpoints: %w", rt.provider.getLabel(), err)
+		}
+
+		// If there were local endpoints deleted
+		if len(endpoints) > 0 {
+			rt.deleteAction(service)
+		}
+	}
+
+	return nil
+}
+
+func (rt *RoutingTable) deleteAction(service *v1.Service) {
+	rt.sm.clearRoutes(service)
+}
+
+func (sm *Manager) clearRoutes(service *v1.Service) []error {
+	errs := []error{}
+	if instance := sm.findServiceInstance(service); instance != nil {
+		for _, cluster := range instance.clusters {
+			for i := range cluster.Network {
+				route := cluster.Network[i].PrepareRoute()
+				// check if route we are about to delete is not referenced by more than one service
+				if sm.countRouteReferences(route) <= 1 {
+					err := cluster.Network[i].DeleteRoute()
+					if err != nil && !errors.Is(err, syscall.ESRCH) {
+						log.Error("failed to delete route", "ip", cluster.Network[i].IP(), "err", err)
+						errs = append(errs, err)
+					}
+					log.Debug("deleted route", "ip",
+						cluster.Network[i].IP(), "service name", service.Name, "namespace", service.Namespace, "interface", cluster.Network[i].Interface(), "tableID", sm.config.RoutingTableID)
+				}
+			}
+		}
+	}
+	return errs
+}
+
+func (rt *RoutingTable) SetInstanceEndpointsStatus(service *v1.Service, state bool) error {
+	instance := rt.sm.findServiceInstance(service)
+	if instance == nil {
+		return fmt.Errorf("failed to find instance for service %s/%s", service.Namespace, service.Name)
+	}
+	instance.HasEndpoints = state
+	return nil
+}

--- a/pkg/manager/endpoints_routing_table.go
+++ b/pkg/manager/endpoints_routing_table.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"syscall"
 
 	log "log/slog"
@@ -24,34 +25,41 @@ func NewRoutingTable(sm *Manager, provider epProvider) EndpointWorker {
 	}
 }
 
-func (rt *RoutingTable) ProcessInstance(ctx context.Context, service *v1.Service, leaderElectionActive *bool) error {
-	instance, err := rt.sm.findServiceInstanceWithTimeout(ctx, service)
-	if err != nil {
-		log.Error("error finding instance", "service", service.UID, "provider", rt.provider.getLabel(), "err", err)
-	}
+func (rt *RoutingTable) ProcessInstance(svcCtx *serviceContext, service *v1.Service, leaderElectionActive *bool) error {
+	instance := rt.sm.findServiceInstance(service)
 	if instance != nil {
-		for _, cluster := range instance.clusters {
+		for _, cluster := range instance.Clusters {
 			for i := range cluster.Network {
-				err := cluster.Network[i].AddRoute(false)
-				if err != nil {
-					if errors.Is(err, syscall.EEXIST) {
-						// If route exists try to update it if necessary
-						isUpdated, err := cluster.Network[i].UpdateRoutes()
-						if err != nil {
-							return fmt.Errorf("[%s] error updating existing routes: %w", rt.provider.getLabel(), err)
-						}
-						if isUpdated {
-							log.Debug("updated route", "provider", rt.provider.getLabel(), "ip", cluster.Network[i].IP())
+				if !svcCtx.isNetworkConfigured(cluster.Network[i].IP()) && cluster.Network[i].HasEndpoints() {
+					err := cluster.Network[i].AddRoute(false)
+					if err != nil {
+						if errors.Is(err, syscall.EEXIST) {
+							// If route exists, but protocol is not set (e.g. the route was created by the older version
+							// of kube-vip) try to update it if necessary
+							isUpdated, err := cluster.Network[i].UpdateRoutes()
+							if err != nil {
+								return fmt.Errorf("[%s] error updating existing routes: %w", rt.provider.getLabel(), err)
+							}
+							if isUpdated {
+								log.Info("updated route", "provider",
+									rt.provider.getLabel(), "ip", cluster.Network[i].IP(), "service name", service.Name, "namespace",
+									service.Namespace, "interface", cluster.Network[i].Interface(), "tableID", rt.sm.config.RoutingTableID)
+							} else {
+								log.Info("route already present", "provider",
+									rt.provider.getLabel(), "ip", cluster.Network[i].IP(), "service name", service.Name, "namespace",
+									service.Namespace, "interface", cluster.Network[i].Interface(), "tableID", rt.sm.config.RoutingTableID)
+							}
+						} else {
+							// If other error occurs, return error
+							return fmt.Errorf("[%s] error adding route: %s", rt.provider.getLabel(), err.Error())
 						}
 					} else {
-						// If other error occurs, return error
-						return fmt.Errorf("[%s] error adding route: %s", rt.provider.getLabel(), err.Error())
+						log.Info("added route", "provider",
+							rt.provider.getLabel(), "ip", cluster.Network[i].IP(), "service name", service.Name, "namespace",
+							service.Namespace, "interface", cluster.Network[i].Interface(), "tableID", rt.sm.config.RoutingTableID)
+						svcCtx.configuredNetworks.Store(cluster.Network[i].IP(), cluster.Network[i])
+						*leaderElectionActive = true
 					}
-				} else {
-					log.Info("added route", "provider",
-						rt.provider.getLabel(), "ip", cluster.Network[i].IP(), "service name", service.Name, "namespace", service.Namespace, "interface", cluster.Network[i].Interface(), "tableID", rt.sm.config.RoutingTableID)
-					configuredLocalRoutes.Store(string(service.UID), true)
-					*leaderElectionActive = true
 				}
 			}
 		}
@@ -60,11 +68,10 @@ func (rt *RoutingTable) ProcessInstance(ctx context.Context, service *v1.Service
 	return nil
 }
 
-func (rt *RoutingTable) Clear(lastKnownGoodEndpoint *string, service *v1.Service, cancel context.CancelFunc, leaderElectionActive *bool) {
+func (rt *RoutingTable) Clear(svcCtx *serviceContext, lastKnownGoodEndpoint *string, service *v1.Service, cancel context.CancelFunc, leaderElectionActive *bool) {
 	if !rt.sm.config.EnableServicesElection && !rt.sm.config.EnableLeaderElection {
-		// If routing table mode is enabled - routes should be deleted
 		if errs := rt.sm.clearRoutes(service); len(errs) == 0 {
-			configuredLocalRoutes.Store(string(service.UID), false)
+			svcCtx.configuredNetworks.Clear()
 		} else {
 			for _, err := range errs {
 				log.Error("error while clearing routes", "err", err)
@@ -111,7 +118,7 @@ func (rt *RoutingTable) deleteAction(service *v1.Service) {
 func (sm *Manager) clearRoutes(service *v1.Service) []error {
 	errs := []error{}
 	if instance := sm.findServiceInstance(service); instance != nil {
-		for _, cluster := range instance.clusters {
+		for _, cluster := range instance.Clusters {
 			for i := range cluster.Network {
 				route := cluster.Network[i].PrepareRoute()
 				// check if route we are about to delete is not referenced by more than one service
@@ -130,11 +137,22 @@ func (sm *Manager) clearRoutes(service *v1.Service) []error {
 	return errs
 }
 
-func (rt *RoutingTable) SetInstanceEndpointsStatus(service *v1.Service, state bool) error {
+func (rt *RoutingTable) SetInstanceEndpointsStatus(service *v1.Service, endpoints []string) error {
 	instance := rt.sm.findServiceInstance(service)
 	if instance == nil {
 		return fmt.Errorf("failed to find instance for service %s/%s", service.Namespace, service.Name)
 	}
-	instance.HasEndpoints = state
+	for _, c := range instance.Clusters {
+		for n := range c.Network {
+			// if there are no endpoints set HasEndpoints false just in case
+			if len(endpoints) < 1 {
+				c.Network[n].SetHasEndpoints(false)
+			}
+			// check if endpoint are available and are of same IP family as service
+			if len(endpoints) > 0 && ((net.ParseIP(c.Network[n].IP()).To4() == nil) == (net.ParseIP(endpoints[0]).To4() == nil)) {
+				c.Network[n].SetHasEndpoints(true)
+			}
+		}
+	}
 	return nil
 }

--- a/pkg/manager/watch_endpoints.go
+++ b/pkg/manager/watch_endpoints.go
@@ -187,6 +187,8 @@ func (sm *Manager) watchEndpoint(svcCtx *serviceContext, id string, service *v1.
 
 	ch := rw.ResultChan()
 
+	epProcessor := NewEndpointProcessor(sm, provider)
+
 	var lastKnownGoodEndpoint string
 	for event := range ch {
 		activeEndpointAnnotation := activeEndpoint
@@ -194,272 +196,16 @@ func (sm *Manager) watchEndpoint(svcCtx *serviceContext, id string, service *v1.
 		switch event.Type {
 
 		case watch.Added, watch.Modified:
-
-			if err = provider.loadObject(event.Object, cancel); err != nil {
-				return fmt.Errorf("[%s] error loading k8s object: %w", provider.getLabel(), err)
+			restart, err := epProcessor.AddModify(ctx, event, cancel, &lastKnownGoodEndpoint, service, id, &leaderElectionActive)
+			if restart {
+				continue
+			} else if err != nil {
+				return fmt.Errorf("[%s] error while processing add/modify event: %w", provider.getLabel(), err)
 			}
-
-			if sm.config.EnableEndpointSlices && provider.getProtocol() == string(discoveryv1.AddressTypeIPv6) {
-				activeEndpointAnnotation = activeEndpointIPv6
-			}
-
-			// Build endpoints
-			var endpoints []string
-			if (sm.config.EnableBGP || sm.config.EnableRoutingTable) && !sm.config.EnableLeaderElection && !sm.config.EnableServicesElection &&
-				service.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeCluster {
-				if endpoints, err = provider.getAllEndpoints(); err != nil {
-					return fmt.Errorf("[%s] error getting all endpoints: %w", provider.getLabel(), err)
-				}
-			} else {
-				if endpoints, err = provider.getLocalEndpoints(id, sm.config); err != nil {
-					return fmt.Errorf("[%s] error getting local endpoints: %w", provider.getLabel(), err)
-				}
-			}
-
-			if sm.config.EnableRoutingTable {
-				instance := sm.findServiceInstance(service)
-				if err != nil {
-					log.Error("failed to find the instance", "service", service.UID, "provider", provider.getLabel(), "err", err)
-				}
-				if instance == nil {
-					log.Error("failed to find the instance", "service", service.UID, "provider", provider.getLabel())
-				} else {
-					for _, c := range instance.Clusters {
-						for n := range c.Network {
-							// if there are no endpoints set HasEndpoints false just in case
-							if len(endpoints) < 1 {
-								c.Network[n].SetHasEndpoints(false)
-							}
-							// check if endpoint are available and are of same IP family as service
-							if len(endpoints) > 0 && ((net.ParseIP(c.Network[n].IP()).To4() == nil) == (net.ParseIP(endpoints[0]).To4() == nil)) {
-								c.Network[n].SetHasEndpoints(true)
-							}
-						}
-					}
-				}
-			}
-
-			// Find out if we have any local endpoints
-			// if out endpoint is empty then populate it
-			// if not, go through the endpoints and see if ours still exists
-			// If we have a local endpoint then begin the leader Election, unless it's already running
-			//
-
-			// Check that we have local endpoints
-			if len(endpoints) != 0 {
-				// Ignore IPv4
-				if service.Annotations[egressIPv6] == "true" && net.ParseIP(endpoints[0]).To4() != nil {
-					continue
-				}
-
-				// if we haven't populated one, then do so
-				if lastKnownGoodEndpoint != "" {
-
-					// check out previous endpoint exists
-					stillExists := false
-
-					for x := range endpoints {
-						if endpoints[x] == lastKnownGoodEndpoint {
-							stillExists = true
-						}
-					}
-					// If the last endpoint no longer exists, we cancel our leader Election, and set another endpoint as last known good
-					if !stillExists {
-						if sm.config.EnableRoutingTable {
-							if err := sm.TeardownEgress(lastKnownGoodEndpoint, service.Spec.LoadBalancerIP,
-								service.Namespace, service.Annotations); err != nil {
-								log.Warn("removing redundant egress rules", "err", err)
-							}
-						}
-						if leaderElectionActive && (sm.config.EnableServicesElection || sm.config.EnableLeaderElection) {
-							log.Warn(" existing endpoint has been removed, restarting leaderElection", "provider", provider.getLabel(), "endpoint", lastKnownGoodEndpoint)
-							// Stop the existing leaderElection
-							cancel()
-							// disable last leaderElection flag
-							leaderElectionActive = false
-						}
-						// Set our active endpoint to an existing one
-						lastKnownGoodEndpoint = endpoints[0]
-					}
-				} else {
-					lastKnownGoodEndpoint = endpoints[0]
-				}
-
-				if !leaderElectionActive && sm.config.EnableServicesElection {
-					go func() {
-						leaderContext, cancel = context.WithCancel(svcCtx.ctx)
-
-						// This is a blocking function, that will restart (in the event of failure)
-						for {
-							// if the context isn't cancelled restart
-							if leaderContext.Err() != context.Canceled {
-								leaderElectionActive = true
-								err := sm.StartServicesLeaderElection(leaderContext, service)
-								if err != nil {
-									log.Error(err.Error())
-								}
-								leaderElectionActive = false
-							} else {
-								leaderElectionActive = false
-								break
-							}
-						}
-					}()
-				}
-
-				// There are local endpoints available on the node
-				if !sm.config.EnableServicesElection && !sm.config.EnableLeaderElection {
-					// If routing table mode is enabled - routes should be added per node
-					if sm.config.EnableRoutingTable {
-						instance := sm.findServiceInstance(service)
-						if instance != nil {
-							for _, cluster := range instance.Clusters {
-								for i := range cluster.Network {
-									if !svcCtx.isNetworkConfigured(cluster.Network[i].IP()) && cluster.Network[i].HasEndpoints() {
-										err := cluster.Network[i].AddRoute(false)
-										if err != nil {
-											if errors.Is(err, syscall.EEXIST) {
-												// If route exists, but protocol is not set (e.g. the route was created by the older version
-												// of kube-vip) try to update it if necessary
-												isUpdated, err := cluster.Network[i].UpdateRoutes()
-												if err != nil {
-													return fmt.Errorf("[%s] error updating existing routes: %w", provider.getLabel(), err)
-												}
-												if isUpdated {
-													log.Info("updated route", "provider",
-														provider.getLabel(), "ip", cluster.Network[i].IP(), "service name", service.Name, "namespace", service.Namespace, "interface", cluster.Network[i].Interface(), "tableID", sm.config.RoutingTableID)
-												} else {
-													log.Info("route already present", "provider",
-														provider.getLabel(), "ip", cluster.Network[i].IP(), "service name", service.Name, "namespace", service.Namespace, "interface", cluster.Network[i].Interface(), "tableID", sm.config.RoutingTableID)
-												}
-											} else {
-												// If other error occurs, return error
-												return fmt.Errorf("[%s] error adding route: %s", provider.getLabel(), err.Error())
-											}
-										} else {
-											log.Info("added route", "provider",
-												provider.getLabel(), "ip", cluster.Network[i].IP(), "service name", service.Name, "namespace", service.Namespace, "interface", cluster.Network[i].Interface(), "tableID", sm.config.RoutingTableID)
-											svcCtx.configuredNetworks.Store(cluster.Network[i].IP(), cluster.Network[i])
-											leaderElectionActive = true
-										}
-									}
-								}
-							}
-						}
-					}
-
-					// If BGP mode is enabled - hosts should be added per node
-					if sm.config.EnableBGP {
-						if instance := sm.findServiceInstance(service); instance != nil {
-							for _, cluster := range instance.Clusters {
-								for i := range cluster.Network {
-									if !svcCtx.isNetworkConfigured(cluster.Network[i].IP()) {
-										network := cluster.Network[i]
-										if err != nil {
-											log.Error("error formatting address with subnet mask", "err", err)
-										}
-										log.Debug("attempting to advertise BGP service", "provider", provider.getLabel(), "ip", network.CIDR())
-										err = sm.bgpServer.AddHost(network.CIDR())
-										if err != nil {
-											log.Error("error adding BGP host", "provider", provider.getLabel(), "err", err)
-										} else {
-											log.Info("added BGP host", "provider",
-												provider.getLabel(), "ip", network.CIDR(), "service name", service.Name, "namespace", service.Namespace)
-											svcCtx.configuredNetworks.Store(cluster.Network[i].IP(), cluster.Network[i])
-											leaderElectionActive = true
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			} else {
-				// There are no local endpoints
-				if !sm.config.EnableServicesElection && !sm.config.EnableLeaderElection {
-					// If routing table mode is enabled - routes should be deleted
-					if sm.config.EnableRoutingTable {
-						if errs := sm.clearRoutes(service); len(errs) == 0 {
-							svcCtx.configuredNetworks.Clear()
-						} else {
-							for _, err := range errs {
-								log.Error("error while clearing routes", "err", err)
-							}
-						}
-					}
-
-					// If BGP mode is enabled - routes should be deleted
-					if sm.config.EnableBGP {
-						if instance := sm.findServiceInstance(service); instance != nil {
-							for _, cluster := range instance.Clusters {
-								for i := range cluster.Network {
-									network := cluster.Network[i]
-									err = sm.bgpServer.DelHost(network.CIDR())
-									if err != nil {
-										log.Error("[endpoint] deleting BGP host", "provider", provider.getLabel(), "ip", network.CIDR(), "err", err)
-									} else {
-										log.Info("[endpoint] deleted BGP host", "provider",
-											provider.getLabel(), "ip", network.CIDR(), "service name", service.Name, "namespace", service.Namespace)
-
-										svcCtx.configuredNetworks.Delete(cluster.Network[i].IP())
-										leaderElectionActive = false
-									}
-								}
-							}
-						}
-					}
-				}
-
-				// If there are no local endpoints, and we had one then remove it and stop the leaderElection
-				if lastKnownGoodEndpoint != "" {
-					log.Warn("existing endpoint has been removed, no remaining endpoints for leaderElection", "provider", provider.getLabel(), "endpoint", lastKnownGoodEndpoint)
-					if err := sm.TeardownEgress(lastKnownGoodEndpoint, service.Spec.LoadBalancerIP, service.Namespace, service.Annotations); err != nil {
-						log.Error("error removing redundant egress rules", "err", err)
-					}
-
-					lastKnownGoodEndpoint = "" // reset endpoint
-					if sm.config.EnableServicesElection || sm.config.EnableLeaderElection {
-						cancel() // stop services watcher
-					}
-					leaderElectionActive = false
-				}
-			}
-			// Set the service accordingly
-			if service.Annotations[egress] == "true" {
-				service.Annotations[activeEndpointAnnotation] = lastKnownGoodEndpoint
-			}
-
-			log.Debug("watcher", "provider",
-				provider.getLabel(), "service name", service.Name, "namespace", service.Namespace, "endpoints", len(endpoints), "last endpoint", lastKnownGoodEndpoint, "active leader election", leaderElectionActive)
 
 		case watch.Deleted:
-			// When no-leader-elecition mode
-			if !sm.config.EnableServicesElection && !sm.config.EnableLeaderElection {
-				// find all existing local endpoints
-				var endpoints []string
-				if (sm.config.EnableBGP || sm.config.EnableRoutingTable) && !sm.config.EnableLeaderElection && !sm.config.EnableServicesElection &&
-					service.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeCluster {
-					if endpoints, err = provider.getAllEndpoints(); err != nil {
-						return fmt.Errorf("[%s] error getting all endpoints: %w", provider.getLabel(), err)
-					}
-				} else {
-					if endpoints, err = provider.getLocalEndpoints(id, sm.config); err != nil {
-						return fmt.Errorf("[%s] error getting all endpoints: %w", provider.getLabel(), err)
-					}
-				}
-
-				// If there were local endpoints deleted
-				if len(endpoints) > 0 {
-					// Delete all routes in routing table mode
-					if sm.config.EnableRoutingTable {
-						sm.clearRoutes(service)
-					}
-
-					// Delete all hosts in BGP mode
-					if sm.config.EnableBGP {
-						sm.clearBGPHosts(service)
-					}
-				}
+			if err := epProcessor.Delete(service, id); err != nil {
+				return fmt.Errorf("[%s] error while processing delete event: %w", provider.getLabel(), err)
 			}
 
 			// Close the goroutine that will end the retry watcher, then exit the endpoint watcher function
@@ -478,47 +224,12 @@ func (sm *Manager) watchEndpoint(svcCtx *serviceContext, id string, service *v1.
 	return nil //nolint:govet
 }
 
-func (sm *Manager) clearRoutes(service *v1.Service) []error {
-	errs := []error{}
-	if instance := sm.findServiceInstance(service); instance != nil {
-		for _, cluster := range instance.Clusters {
-			for i := range cluster.Network {
-				route := cluster.Network[i].PrepareRoute()
-				// check if route we are about to delete is not referenced by more than one service
-				if sm.countRouteReferences(route) <= 1 {
-					err := cluster.Network[i].DeleteRoute()
-					if err != nil && !errors.Is(err, syscall.ESRCH) {
-						log.Error("failed to delete route", "ip", cluster.Network[i].IP(), "err", err)
-						errs = append(errs, err)
-					}
-					log.Debug("deleted route", "ip",
-						cluster.Network[i].IP(), "service name", service.Name, "namespace", service.Namespace, "interface", cluster.Network[i].Interface(), "tableID", sm.config.RoutingTableID)
-				}
-			}
-		}
+func storeConfiguredNetwork(svcUID string, network vip.Network) {
+	if _, exists := configuredNetworks[svcUID]; !exists {
+		configuredNetworks[svcUID] = make(map[string]vip.Network)
 	}
-	return errs
-}
 
-func (sm *Manager) clearBGPHosts(service *v1.Service) {
-	if instance := sm.findServiceInstance(service); instance != nil {
-		sm.clearBGPHostsByInstance(instance)
-	}
-}
-
-func (sm *Manager) clearBGPHostsByInstance(instance *cluster.Instance) {
-	for _, cluster := range instance.Clusters {
-		for i := range cluster.Network {
-			network := cluster.Network[i]
-			err := sm.bgpServer.DelHost(network.CIDR())
-			if err != nil {
-				log.Error("[endpoint] error deleting BGP host", "err", err)
-			} else {
-				log.Debug("[endpoint] deleted BGP host", "ip",
-					network.CIDR(), "service name", instance.ServiceSnapshot.Name, "namespace", instance.ServiceSnapshot.Namespace)
-			}
-		}
-	}
+	configuredNetworks[svcUID][network.IP()] = network
 }
 
 func (svcCtx *serviceContext) isNetworkConfigured(ip string) bool {

--- a/pkg/manager/watch_services.go
+++ b/pkg/manager/watch_services.go
@@ -326,7 +326,7 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 
 			if sm.config.EnableLeaderElection && !sm.config.EnableServicesElection {
 				if sm.config.EnableBGP {
-					sm.clearBGPHosts(svc)
+					sm.ClearBGPHosts(svc)
 				} else if sm.config.EnableRoutingTable {
 					sm.clearRoutes(svc)
 				}

--- a/pkg/vip/arp.go
+++ b/pkg/vip/arp.go
@@ -135,9 +135,7 @@ func sendARP(iface *net.Interface, m *arpMessage) error {
 		Halen:    m.hardwareAddressLength,
 	}
 	target := ethernetBroadcast
-	for i := 0; i < len(target); i++ { //nolint
-		ll.Addr[i] = target[i]
-	}
+	copy(ll.Addr[:], target)
 
 	b, err := m.bytes()
 	if err != nil {

--- a/testing/e2e/ip.go
+++ b/testing/e2e/ip.go
@@ -20,7 +20,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-	"github.com/vishvananda/netlink"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -224,24 +223,4 @@ func (so *SecureOffset) Get() uint {
 	defer so.mu.Unlock()
 	so.value++
 	return uint(so.value - 1)
-}
-
-func getNetwork(link netlink.Link, family int) (*net.IP, *net.IPNet, error) {
-	addrs, err := netlink.AddrList(link, family)
-	if err != nil {
-		return nil, nil, fmt.Errorf("netlink: failed to get addresses for link %q: %w", link.Attrs().Name, err)
-	}
-	if len(addrs) > 0 {
-		for _, a := range addrs {
-			if a.Scope == int(netlink.SCOPE_UNIVERSE) {
-				ip, cidr, err := net.ParseCIDR(a.IPNet.String())
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to parse CIDR: %w", err)
-				}
-				return &ip, cidr, nil
-			}
-		}
-	}
-
-	return nil, nil, nil
 }

--- a/testing/services/pkg/deployment/services.go
+++ b/testing/services/pkg/deployment/services.go
@@ -62,6 +62,7 @@ func (config *TestConfig) StartServiceTest(ctx context.Context, clientset *kuber
 			errs = append(errs, err)
 		}
 	}
+
 	if config.LocalDeploy {
 		// Failover tests
 		err = config.LocalDeployment(ctx, clientset)
@@ -72,7 +73,7 @@ func (config *TestConfig) StartServiceTest(ctx context.Context, clientset *kuber
 	}
 
 	if config.Egress {
-		// Failover tests
+		// Egress test
 		err = config.EgressDeployment(ctx, clientset)
 		if err != nil {
 			slog.Error(err)
@@ -81,7 +82,7 @@ func (config *TestConfig) StartServiceTest(ctx context.Context, clientset *kuber
 	}
 
 	if config.EgressIPv6 {
-		// Failover tests
+		// Egress v6 tests
 		err = config.Egressv6Deployment(ctx, clientset)
 		if err != nil {
 			slog.Error(err)
@@ -90,7 +91,7 @@ func (config *TestConfig) StartServiceTest(ctx context.Context, clientset *kuber
 	}
 
 	if config.DualStack {
-		// Failover tests
+		// Dualstack tests
 		err = config.DualStackDeployment(ctx, clientset)
 		if err != nil {
 			slog.Error(err)

--- a/testing/services/pkg/deployment/tests.go
+++ b/testing/services/pkg/deployment/tests.go
@@ -308,7 +308,7 @@ func (config *TestConfig) LocalDeployment(ctx context.Context, clientset *kubern
 }
 
 func (config *TestConfig) EgressDeployment(ctx context.Context, clientset *kubernetes.Clientset) error {
-	// pod Failover tests
+	// egress test
 
 	var err error
 	defer func() error {
@@ -382,7 +382,7 @@ func (config *TestConfig) EgressDeployment(ctx context.Context, clientset *kuber
 }
 
 func (config *TestConfig) Egressv6Deployment(ctx context.Context, clientset *kubernetes.Clientset) error {
-	// pod Failover tests
+	// egress v6 test
 
 	var err error
 	defer func() error {


### PR DESCRIPTION
This PR moves code from the `manager/endpoint_watcher.go` to separate entity and additional interfaces. This is mostly just a first step and an example for achieving better readability of the code as I started discussion about his topic here: #1102 

Instead of just one big event loop I've decided to move that code to separate entity `Processor` in `manager/endpoints.go`. I've also moved some code to separate functions as I believe it's easier to understand that.

 `Processor` uses interfaces `EndpointWorker` which can be instantiated into `Generic`, `BGP` or `RoutingTable` depending on the kube-vip's mode. This eliminates the need for  the mode-related conditional statements. Additionally any change that is relevant only to one of the modes will not affect any other mode.
 
Next steps for this would be to move this code to separate package and then do the same for `services_watcher.go`.