### PR TITLE
Fixed route deletion issue when 2 services referenced same endpoint

### DIFF
--- a/pkg/manager/instance.go
+++ b/pkg/manager/instance.go
@@ -30,6 +30,7 @@ type Instance struct {
 	dhcpInterfaceIP     string
 	dhcpHostname        string
 	dhcpClient          *vip.DHCPClient
+	HasEndpoints        bool
 
 	// External Gateway IP the service is forwarded from
 	upnpGatewayIPs []string

--- a/testing/e2e/etcd/kube-etcd-vip.yaml.tmpl
+++ b/testing/e2e/etcd/kube-etcd-vip.yaml.tmpl
@@ -32,7 +32,7 @@ spec:
     - name: cp_enable
       value: "true"
     - name: vip_loglevel
-      value: "5"
+      value: "-4"
     - name: vip_nodename
       valueFrom:
         fieldRef:

--- a/testing/services/pkg/deployment/kubernetes.go
+++ b/testing/services/pkg/deployment/kubernetes.go
@@ -92,7 +92,7 @@ func (d *Deployment) CreateKVDs(ctx context.Context, clientset *kubernetes.Clien
 								},
 								{
 									Name:  "vip_loglevel",
-									Value: "5",
+									Value: "-4",
 								},
 								{
 									Name:  "egress_withnftables",
@@ -323,6 +323,7 @@ func (s *Service) CreateService(ctx context.Context, clientset *kubernetes.Clien
 		for _, lbAddress := range loadBalancerAddresses {
 			err = httpTest(lbAddress)
 			if err != nil {
+				slog.Infof("web retrieval err: %s", err.Error())
 				return "", nil, fmt.Errorf("web retrieval timeout ")
 
 			}


### PR DESCRIPTION
Recently we have discovered that kube-vip was unable to remove local-endpoint related route if 2 services referenced same pod (endpoint) and pod was deleted and recreated on another node. This should be fixed by this change.

Same happened if there were 2 services referencing same endpoint present on route cleareance at kube-vip start. That should be fixed as well.