### PR TITLE
fix: s/endoints/endpoints/ in RBAC manifest generation code

### DIFF
--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -100,7 +100,7 @@ func GenerateRole(c *Config, role bool) *applyRbacV1.RoleApplyConfiguration {
 			{
 				APIGroups: []string{""},
 				Resources: []string{"services", "endpoints"},
-				Verbs:     []string{"list", "get", "watch", "endoints"},
+				Verbs:     []string{"list", "get", "watch", "endpoints"},
 			},
 			{
 				APIGroups: []string{""},


### PR DESCRIPTION
While moving over to using the RBAC manifest generator, this stood out as a clear typo.