### PR TITLE
Replace invalid verb "endpoints" with "update"

### DIFF
--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -100,7 +100,7 @@ func GenerateRole(c *Config, role bool) *applyRbacV1.RoleApplyConfiguration {
 			{
 				APIGroups: []string{""},
 				Resources: []string{"services", "endpoints"},
-				Verbs:     []string{"list", "get", "watch", "endpoints"},
+				Verbs:     []string{"list", "get", "watch", "update"},
 			},
 			{
 				APIGroups: []string{""},


### PR DESCRIPTION
As written, the RBAC manifest generator produces a rule that looks like:

```yaml
- apiGroups:
  - ""
  resources:
  - services
  - endpoints
  verbs:
  - list
  - get
  - watch
  - endpoints
```

The very last line of this snippet, "endpoints", doesn't seem correct. This can be checked with the command `kubectl api-resources --verbs=endpoints`, which will show all resource types for which `endpoints` is a valid verb. In my cluster none exist. Based on the hand-written manifest published [here](https://github.com/kube-vip/website/blob/main/content/manifests/rbac.yaml#L19), I think this is supposed to be "update". This PR adjusts the RBAC manifest generation accordingly.