### PR TITLE
Fixed service-tests + minor changes

### DIFF
--- a/pkg/manager/servicesLeader.go
+++ b/pkg/manager/servicesLeader.go
@@ -78,7 +78,6 @@ func (sm *Manager) StartServicesLeaderElection(ctx context.Context, service *v1.
 	}
 
 	svcCtx.isActive = true
-	// activeService[string(service.UID)] = true
 
 	// start the leader election code loop
 	leaderelection.RunOrDie(childCtx, leaderelection.LeaderElectionConfig{
@@ -112,7 +111,6 @@ func (sm *Manager) StartServicesLeaderElection(ctx context.Context, service *v1.
 				}
 				// Mark this service is inactive
 				svcCtx.isActive = false
-				// activeService[string(service.UID)] = false
 			},
 			OnNewLeader: func(identity string) {
 				// we're notified when new leader elected

--- a/pkg/manager/servicesLeader.go
+++ b/pkg/manager/servicesLeader.go
@@ -77,7 +77,7 @@ func (sm *Manager) StartServicesLeaderElection(ctx context.Context, service *v1.
 		return fmt.Errorf("failed to get context for service %q with UID %q: nil context", service.Name, service.UID)
 	}
 
-	svcCtx.IsActive = true
+	svcCtx.isActive = true
 	// activeService[string(service.UID)] = true
 
 	// start the leader election code loop
@@ -105,13 +105,13 @@ func (sm *Manager) StartServicesLeaderElection(ctx context.Context, service *v1.
 			OnStoppedLeading: func() {
 				// we can do cleanup here
 				log.Info("leadership lost", "service", service.Name, "leader", sm.config.NodeName)
-				if svcCtx.IsActive {
+				if svcCtx.isActive {
 					if err := sm.deleteService(service.UID); err != nil {
 						log.Error("service deletion", "err", err)
 					}
 				}
 				// Mark this service is inactive
-				svcCtx.IsActive = false
+				svcCtx.isActive = false
 				// activeService[string(service.UID)] = false
 			},
 			OnNewLeader: func(identity string) {

--- a/pkg/manager/watch_services.go
+++ b/pkg/manager/watch_services.go
@@ -32,7 +32,7 @@ type serviceContext struct {
 	configuredNetworks sync.Map
 }
 
-func NewServiceContext(ctx context.Context) *serviceContext {
+func newServiceContext(ctx context.Context) *serviceContext {
 	svcCtx, svcCancel := context.WithCancel(ctx)
 	return &serviceContext{
 		ctx:    svcCtx,
@@ -191,7 +191,7 @@ func (sm *Manager) servicesWatcher(ctx context.Context, serviceFunc func(context
 				log.Debug("(svcs) has been added/modified with addresses", "service name", svc.Name, "ip", cluster.FetchServiceAddresses(svc))
 
 				if svcCtx == nil {
-					svcCtx = NewServiceContext(ctx)
+					svcCtx = newServiceContext(ctx)
 					services.Store(svc.UID, svcCtx)
 				}
 
@@ -395,7 +395,7 @@ func (sm *Manager) lbClassFilter(svc *v1.Service) bool {
 
 func (svcCtx *serviceContext) hasConfiguredNetworks() bool {
 	cnt := 0
-	svcCtx.configuredNetworks.Range(func(key any, value any) bool {
+	svcCtx.configuredNetworks.Range(func(_ any, _ any) bool {
 		cnt++
 		return cnt < 1
 	})

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+
+rm -f logs.txt
+
+for i in $(seq 1 100);
+do
+  echo "RUN $i"
+  GOMAXPROCS=4 make e2e-tests129
+  if [[ "$?" -ne 0 ]]; then 
+    echo "FAILED AT RUN $i"
+    break
+  fi
+done

--- a/testing/services/main.go
+++ b/testing/services/main.go
@@ -43,6 +43,8 @@ func main() {
 	flag.BoolVar(&t.RetainCluster, "retain", false, "Retain the cluster")
 	flag.StringVar(&t.KindVersionImage, "kindImage", "", "The image to use for the kind nodes e.g. (kindest/node:v1.21.14)")
 	flag.BoolVar(&existing, "existing", false, "Use an existing cluster")
+	flag.BoolVar(&t.IPv6, "ipv6", false, "Perform an IPv6-only test")
+	flag.StringVar(&t.DockerNIC, "networkInterface", "br-", "Selects networking interface to use")
 
 	flag.BoolVar(&t.Cilium, "cilium", false, "Use cilium as a CNI")
 
@@ -50,9 +52,6 @@ func main() {
 
 	slog.Infof("🔬 beginning e2e tests, image: [%s] DualStack [%t]", t.ImagePath, t.DualStack)
 
-	// if !t.ignoreDualStack {
-	// 	t.Dualstack = true
-	// }
 	t.Affinity = os.Getenv("NODE_TOLERATE")
 
 	t.DeploymentName = "kube-vip-deploy"
@@ -134,7 +133,7 @@ func main() {
 			}
 		}
 
-		t.StartServiceTest(ctx, clientset)
+		errs := t.StartServiceTest(ctx, clientset)
+		os.Exit(len(errs))
 	}
-
 }

--- a/testing/services/pkg/deployment/kind.go
+++ b/testing/services/pkg/deployment/kind.go
@@ -3,11 +3,13 @@ package deployment
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"os/exec"
 	"strings"
 	"time"
 
 	"github.com/gookit/slog"
+	"github.com/vishvananda/netlink"
 	kindconfigv1alpha4 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 	"sigs.k8s.io/kind/pkg/cluster"
 	"sigs.k8s.io/kind/pkg/cmd"
@@ -15,6 +17,11 @@ import (
 )
 
 var provider *cluster.Provider
+
+const (
+	defaultIPv4Pool = "172.18.100.10-172.18.100.30"
+	defaultIPv6Pool = "fd34:70db:8529:1e3d:0000:0000:0000:0010-fd34:70db:8529:1e3d:0000:0000:0000:0030"
+)
 
 type kubevipManifestValues struct {
 	ControlPlaneVIP string
@@ -39,13 +46,12 @@ func (config *TestConfig) CreateKind() error {
 		},
 	}
 
-	if config.IPv6 {
-		// Change Networking Family
-		clusterConfig.Networking.IPFamily = kindconfigv1alpha4.IPv6Family
-	}
 	if config.DualStack {
-		// Change Networking Family
 		clusterConfig.Networking.IPFamily = kindconfigv1alpha4.DualStackFamily
+	} else {
+		if config.IPv6 || !config.Egress && config.EgressIPv6 {
+			clusterConfig.Networking.IPFamily = kindconfigv1alpha4.IPv6Family
+		}
 	}
 
 	if config.Cilium {
@@ -140,10 +146,51 @@ func (config *TestConfig) CreateKind() error {
 			}
 		}
 
-		globalRange := "172.18.100.10-172.18.100.30"
-		if config.IPv6 {
-			globalRange = "fd34:70db:8529:1e3d:0000:0000:0000:0010-fd34:70db:8529:1e3d:0000:0000:0000:0030"
+		ipv4Pool := defaultIPv4Pool
+		ipv6Pool := defaultIPv6Pool
+
+		var ipv4Net *net.IPNet
+		var ipv6Net *net.IPNet
+
+		links, err := netlink.LinkList()
+		if err != nil {
+			return fmt.Errorf("netlink: failed to list links: %w", err)
 		}
+
+		for _, link := range links {
+			if strings.Contains(link.Attrs().Name, config.DockerNIC) {
+				_, ipv4Net, err = getNetwork(link, netlink.FAMILY_V4)
+				if err != nil {
+					return fmt.Errorf("failed to get IPv4 network: %w", err)
+				}
+				if ipv4Net == nil {
+					return fmt.Errorf("failed to find IPv4 network on the docker interface")
+				}
+
+				ipv4Pool = generateRange(ipv4Net)
+
+				_, ipv6Net, err = getNetwork(link, netlink.FAMILY_V6)
+				if err != nil {
+					return fmt.Errorf("failed to get IPv6 network: %w", err)
+				}
+				if ipv6Net == nil {
+					return fmt.Errorf("failed to find IPv6 network on the docker interface")
+				}
+
+				ipv6Pool = generateRange(ipv6Net)
+			}
+		}
+
+		globalRange := ipv4Pool
+		if config.IPv6 {
+			globalRange = ipv6Pool
+		}
+
+		if config.DualStack {
+			globalRange = fmt.Sprintf("%s,%s", ipv4Pool, ipv6Pool)
+		}
+
+		slog.Infof("Cloud provider's range: %s", globalRange)
 
 		cmd := exec.Command("kubectl", "create", "configmap", "--namespace", "kube-system", "kubevip", "--from-literal", "range-global="+globalRange)
 		if _, err := cmd.CombinedOutput(); err != nil {
@@ -161,6 +208,43 @@ func (config *TestConfig) CreateKind() error {
 		time.Sleep(time.Second * 5)
 	}
 	return nil
+}
+
+func getNetwork(link netlink.Link, family int) (*net.IP, *net.IPNet, error) {
+	addrs, err := netlink.AddrList(link, family)
+	if err != nil {
+		return nil, nil, fmt.Errorf("netlink: failed to get addresses for link %q: %w", link.Attrs().Name, err)
+	}
+	if len(addrs) > 0 {
+		for _, a := range addrs {
+			if a.Scope == int(netlink.SCOPE_UNIVERSE) {
+				ip, cidr, err := net.ParseCIDR(a.IPNet.String())
+				if err != nil {
+					return nil, nil, fmt.Errorf("failed to parse CIDR: %w", err)
+				}
+				return &ip, cidr, nil
+			}
+		}
+	}
+
+	return nil, nil, nil
+}
+
+func generateRange(network *net.IPNet) string {
+	if network.IP.To4() != nil {
+		parts := strings.Split(network.IP.String(), ".")
+		p1 := fmt.Sprintf("%s.%s.100.10", parts[0], parts[1])
+		p2 := fmt.Sprintf("%s.%s.100.100", parts[0], parts[1])
+		return fmt.Sprintf("%s-%s", p1, p2)
+	}
+
+	if network.IP.To16() != nil {
+		parts := strings.Split(network.IP.String(), ":")
+		p1 := fmt.Sprintf("%s:%s:%s:%s:0000:0000:0100:0010", parts[0], parts[1], parts[2], parts[3])
+		p2 := fmt.Sprintf("%s:%s:%s:%s:0000:0000:0100:0100", parts[0], parts[1], parts[2], parts[3])
+		return fmt.Sprintf("%s-%s", p1, p2)
+	}
+	return ""
 }
 
 func DeleteKind() error {

--- a/testing/services/pkg/deployment/kubernetes.go
+++ b/testing/services/pkg/deployment/kubernetes.go
@@ -297,7 +297,6 @@ func (s *Service) CreateService(ctx context.Context, clientset *kubernetes.Clien
 		// We need to inspect the event and get ResourceVersion out of it
 		switch event.Type {
 		case watch.Added, watch.Modified:
-			// slog.Debugf("Endpoints for service [%s] have been Created or modified", s.service.ServiceName)
 			svc, ok := event.Object.(*v1.Service)
 			if !ok {
 				slog.Fatalf("unable to parse Kubernetes services from API watcher")


### PR DESCRIPTION
This PR introduces 2 changes:

1. It moves `configuredRoutes` maps into `serviceContext` struct. This is rather minor change that might simplify some things - like e.g. instead of remembering to delete the value from the `configuredRoutes` map it is sufficient to delete the service whatsoever sometimes. Additionally fixed some encapsulation.

2. It fixes the `service-tests` target. It turned out that there were a few issues in the tests (e.g. incorrect local address was found so the test server was reachable from the kind cluster, resulting in no traffic to/from loadbalancer/egress etc.). All tests should work fine now. Also, if any issue will occur the test will now explicitly fail in the CI.

Important info:

When running the `service-tests` target the test will try to find an interface with the name starting with `br-` (as used by default by docker/kind). This should be sufficient for the CI. However, if you have multiple docker networks on your dev machine you'll have to use `-networkInterface <interface-name>` flag to explicitly specify the interface to be used.