### PR TITLE
Fixed BGP clear deadlock

### DIFF
--- a/pkg/manager/services.go
+++ b/pkg/manager/services.go
@@ -300,7 +300,7 @@ func (sm *Manager) deleteService(uid types.UID) error {
 		}
 		for i := range serviceInstance.VIPConfigs {
 			if serviceInstance.VIPConfigs[i].EnableBGP {
-				sm.clearBGPHosts(serviceInstance.ServiceSnapshot)
+				sm.clearBGPHostsByInstance(serviceInstance)
 			}
 		}
 


### PR DESCRIPTION
As I am currently working on BGP e2e-tests I found that some current changes created a deadlock when trying to remove BGP routes upon service deletion. This should be fixed with this small PR.