### PR TITLE
Updated go version to 1.24.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM golang:1.24.2-alpine3.20 as dev
+FROM golang:1.24.4-alpine3.22 as dev
 RUN apk add --no-cache git ca-certificates make
 RUN adduser -D appuser
 COPY . /src/

--- a/Dockerfile_iptables
+++ b/Dockerfile_iptables
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM golang:1.24.2-alpine3.20 as dev
+FROM golang:1.24.4-alpine3.22 as dev
 RUN apk add --no-cache git make
 RUN adduser -D appuser
 COPY . /src/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kube-vip/kube-vip
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/cloudflare/ipvs v0.11.0


### PR DESCRIPTION
In another PR trivy reporst that there is a vurnerability in go 1.24.2, therefore updating to 1.24.4

```
┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬──────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                        Title                         │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼──────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-22874 │ HIGH     │ fixed  │ v1.24.2           │ 1.23.10, 1.24.4 │ crypto/x509: Usage of ExtKeyUsageAny disables policy │
│         │                │          │        │                   │                 │ validation in crypto/x509                            │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-22874           │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴──────────────────────────────────────────────────────┘
```