### PR TITLE
Removed insecure client use in E2E tests

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -2,8 +2,6 @@ package backend
 
 import (
 	"fmt"
-	"os"
-	"strconv"
 	"time"
 
 	log "log/slog"
@@ -52,22 +50,6 @@ func (e *Entry) Check() bool {
 			log.Error("create k8s REST config", "err", err)
 			return false
 		}
-	}
-
-	// This insecure client was introduced for more straightforward e2e-test implementation.
-	// Should be only used for test purposes.
-	useInescure := false
-	if value, isSet := os.LookupEnv("E2E_INSECURE_CLIENT"); isSet {
-		useInescure, err = strconv.ParseBool(value)
-		if err != nil {
-			log.Error("failed to parse E2E_INSECURE_CLIENT env value, setting value to 'false' explicitly", "err", err)
-			useInescure = false
-		}
-	}
-
-	if useInescure {
-		config.Insecure = true
-		config.CAData = []byte{}
 	}
 
 	client, err = k8s.NewClientset(config)

--- a/testing/e2e/e2e_bgp_test.go
+++ b/testing/e2e/e2e_bgp_test.go
@@ -91,10 +91,13 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 
 			tempDirPath, err = os.MkdirTemp("", "kube-vip-test")
 			Expect(err).NotTo(HaveOccurred())
-			localIPv4, err = deployment.GetLocalIPv4(networkInterface)
+			v4addr, _, err := deployment.GetLocalIPv4(networkInterface)
 			Expect(err).ToNot(HaveOccurred())
-			localIPv6, err = deployment.GetLocalIPv6(networkInterface)
+			localIPv4 = v4addr.String()
+
+			v6addr, _, err := deployment.GetLocalIPv6(networkInterface)
 			Expect(err).ToNot(HaveOccurred())
+			localIPv6 = v6addr.String()
 
 			goBGPConfig := &e2e.BGPPeerValues{
 				AS: goBGPAS,
@@ -478,7 +481,7 @@ func setupEnv(tempDirPath, cpVIP, clusterName *string, manifestValues *e2e.Kubev
 
 	By(manifestValues.BGPPeers)
 
-	*clusterName, *client = prepareCluster(*tempDirPath, clusterNameSuffix, k8sImagePath, v129, kubeVIPBGPManifestTemplate, logger, manifestValues, networking, nodesNumber)
+	*clusterName, *client = prepareCluster(*tempDirPath, clusterNameSuffix, k8sImagePath, v129, kubeVIPBGPManifestTemplate, logger, manifestValues, networking, nodesNumber, nil)
 
 	container := fmt.Sprintf("%s-control-plane", *clusterName)
 

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -44,6 +44,11 @@ const (
 	dsNamespace = "default"
 )
 
+const testJSON = `
+- op: add
+  path: "/apiServer/certSANs/-"
+  value: `
+
 var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 	if Mode == ModeARP {
 		var (
@@ -105,7 +110,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 					EnableEndpointslices: "false",
 				}
 
-				clusterName, _ = prepareCluster(tempDirPath, "ipv4", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 3)
+				clusterName, _ = prepareCluster(tempDirPath, "ipv4", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 3, nil)
 			})
 
 			AfterAll(func() {
@@ -140,7 +145,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 					EnableEndpointslices: "false",
 				}
 
-				clusterName, client = prepareCluster(tempDirPath, "svc-ipv4", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 1)
+				clusterName, client = prepareCluster(tempDirPath, "svc-ipv4", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil)
 			})
 
 			AfterAll(func() {
@@ -190,7 +195,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 					EnableEndpointslices: "false",
 				}
 
-				clusterName, client = prepareCluster(tempDirPath, "svc-el-ipv4", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 1)
+				clusterName, client = prepareCluster(tempDirPath, "svc-el-ipv4", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil)
 			})
 
 			AfterAll(func() {
@@ -229,7 +234,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 					EnableEndpointslices: "false",
 				}
 
-				clusterName, _ = prepareCluster(tempDirPath, "ipv6", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 3)
+				clusterName, _ = prepareCluster(tempDirPath, "ipv6", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 3, nil)
 			})
 
 			AfterAll(func() {
@@ -264,7 +269,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 					EnableEndpointslices: "false",
 				}
 
-				clusterName, client = prepareCluster(tempDirPath, "svc-ipv6", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 1)
+				clusterName, client = prepareCluster(tempDirPath, "svc-ipv6", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil)
 			})
 
 			AfterAll(func() {
@@ -313,7 +318,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 					EnableEndpointslices: "false",
 				}
 
-				clusterName, client = prepareCluster(tempDirPath, "svc-el-ipv6", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 1)
+				clusterName, client = prepareCluster(tempDirPath, "svc-el-ipv6", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil)
 			})
 
 			AfterAll(func() {
@@ -352,7 +357,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 					EnableEndpointslices: "true",
 				}
 
-				clusterName, _ = prepareCluster(tempDirPath, "ds-ipv4", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 3)
+				clusterName, _ = prepareCluster(tempDirPath, "ds-ipv4", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 3, nil)
 			})
 
 			AfterAll(func() {
@@ -387,7 +392,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 					EnableEndpointslices: "true",
 				}
 
-				clusterName, client = prepareCluster(tempDirPath, "ds-svc-ipv4", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 1)
+				clusterName, client = prepareCluster(tempDirPath, "ds-svc-ipv4", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil)
 			})
 
 			AfterAll(func() {
@@ -436,7 +441,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 					EnableEndpointslices: "true",
 				}
 
-				clusterName, client = prepareCluster(tempDirPath, "ds-svc-el-ipv4", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 1)
+				clusterName, client = prepareCluster(tempDirPath, "ds-svc-el-ipv4", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil)
 			})
 
 			AfterAll(func() {
@@ -477,7 +482,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 					EnableEndpointslices: "true",
 				}
 
-				clusterName, _ = prepareCluster(tempDirPath, "ds-ipv6", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 3)
+				clusterName, _ = prepareCluster(tempDirPath, "ds-ipv6", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 3, nil)
 			})
 
 			AfterAll(func() {
@@ -514,7 +519,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 					EnableEndpointslices: "true",
 				}
 
-				clusterName, client = prepareCluster(tempDirPath, "ds-svc-ipv6", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 1)
+				clusterName, client = prepareCluster(tempDirPath, "ds-svc-ipv6", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil)
 			})
 
 			AfterAll(func() {
@@ -565,7 +570,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 					EnableEndpointslices: "true",
 				}
 
-				clusterName, client = prepareCluster(tempDirPath, "ds-svc-el-ipv6", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 1)
+				clusterName, client = prepareCluster(tempDirPath, "ds-svc-el-ipv6", k8sImagePath, v129, kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil)
 			})
 
 			AfterAll(func() {
@@ -604,7 +609,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 					EnableEndpointslices: "false",
 				}
 
-				clusterName, _ = prepareCluster(tempDirPath, "ipv4-hostname", k8sImagePath, v129, kubeVIPHostnameManifestTemplate, logger, manifestValues, networking, 3)
+				clusterName, _ = prepareCluster(tempDirPath, "ipv4-hostname", k8sImagePath, v129, kubeVIPHostnameManifestTemplate, logger, manifestValues, networking, 3, nil)
 			})
 
 			AfterAll(func() {
@@ -835,7 +840,8 @@ func checkIPAddressByLease(name, namespace, lbAddress string, expected bool, cli
 
 func prepareCluster(tempDirPath, clusterNameSuffix, k8sImagePath string,
 	v129 bool, kubeVIPManifestTemplate *template.Template, logger log.Logger,
-	manifestValues *e2e.KubevipManifestValues, networking *kindconfigv1alpha4.Networking, nodesNum int) (string, kubernetes.Interface) {
+	manifestValues *e2e.KubevipManifestValues, networking *kindconfigv1alpha4.Networking, nodesNum int,
+	addSAN *san) (string, kubernetes.Interface) {
 
 	manifestPath := filepath.Join(tempDirPath, fmt.Sprintf("kube-vip-%s.yaml", clusterNameSuffix))
 
@@ -848,6 +854,24 @@ func prepareCluster(tempDirPath, clusterNameSuffix, k8sImagePath string,
 		Networking: *networking,
 		Nodes:      []kindconfigv1alpha4.Node{},
 	}
+
+	kubeadmPatches := []kindconfigv1alpha4.PatchJSON6902{}
+
+	if addSAN != nil {
+		for i := 0; i < 64; i++ {
+			(*addSAN.ip)[len(*addSAN.ip)-1]++
+			if addSAN.ipnet.Contains(*addSAN.ip) {
+				kubeadmPatches = append(kubeadmPatches, kindconfigv1alpha4.PatchJSON6902{
+					Group:   "kubeadm.k8s.io",
+					Version: "v1beta3",
+					Kind:    "ClusterConfiguration",
+					Patch:   testJSON + addSAN.ip.String(),
+				})
+			}
+		}
+	}
+
+	clusterConfig.KubeadmConfigPatchesJSON6902 = kubeadmPatches
 
 	for range nodesNum {
 		nodeConfig := kindconfigv1alpha4.Node{

--- a/testing/e2e/kube-vip-routing-table.yaml.tmpl
+++ b/testing/e2e/kube-vip-routing-table.yaml.tmpl
@@ -46,8 +46,6 @@ spec:
       value: "{{ .SvcElectionEnable }}"
     - name: enable_endpointslices
       value: "{{ .EnableEndpointslices }}"
-    - name: E2E_INSECURE_CLIENT
-      value: "true"
     image: "{{ .ImagePath }}"
     imagePullPolicy: Never
     securityContext:

--- a/testing/services/pkg/deployment/services.go
+++ b/testing/services/pkg/deployment/services.go
@@ -377,32 +377,32 @@ func handleRequest(conn net.Conn) {
 	conn.Close()
 }
 
-func GetLocalIP(ifName string, family int) (string, error) {
+func GetLocalIP(ifName string, family int) (*net.IP, *net.IPNet, error) {
 	links, err := netlink.LinkList()
 	if err != nil {
-		return "", fmt.Errorf("netlink: failed to list links: %w", err)
+		return nil, nil, fmt.Errorf("netlink: failed to list links: %w", err)
 	}
 
 	for _, link := range links {
 		if strings.Contains(link.Attrs().Name, ifName) {
-			ip, _, err := getNetwork(link, family)
+			ip, ipnet, err := getNetwork(link, family)
 			if err != nil {
-				return "", fmt.Errorf("failed to get IPv4 address: %w", err)
+				return nil, nil, fmt.Errorf("failed to get IPv4 address: %w", err)
 			}
 			if ip == nil {
-				return "", fmt.Errorf("failed to find IPv4 address on the interface %q", ifName)
+				return nil, nil, fmt.Errorf("failed to find IPv4 address on the interface %q", ifName)
 			}
-			return ip.String(), nil
+			return ip, ipnet, nil
 		}
 	}
 
-	return "", nil
+	return nil, nil, nil
 }
 
-func GetLocalIPv4(ifName string) (string, error) {
+func GetLocalIPv4(ifName string) (*net.IP, *net.IPNet, error) {
 	return GetLocalIP(ifName, netlink.FAMILY_V4)
 }
 
-func GetLocalIPv6(ifName string) (string, error) {
+func GetLocalIPv6(ifName string) (*net.IP, *net.IPNet, error) {
 	return GetLocalIP(ifName, netlink.FAMILY_V6)
 }

--- a/testing/services/pkg/deployment/tests.go
+++ b/testing/services/pkg/deployment/tests.go
@@ -337,10 +337,11 @@ func (config *TestConfig) EgressDeployment(ctx context.Context, clientset *kuber
 	}
 
 	// Find this machines IP address
-	deploy.address, err = GetLocalIPv4(config.DockerNIC)
+	addr, _, err := GetLocalIPv4(config.DockerNIC)
 	if err != nil {
 		return fmt.Errorf("unable to detect local IP address: %w", err)
 	}
+	deploy.address = addr.String()
 	if deploy.address == "" {
 		return fmt.Errorf("unable to detect local IP address")
 	}
@@ -411,10 +412,11 @@ func (config *TestConfig) Egressv6Deployment(ctx context.Context, clientset *kub
 	}
 
 	// Find this machines IP address
-	deploy.address, err = GetLocalIPv6(config.DockerNIC)
+	addr, _, err := GetLocalIPv6(config.DockerNIC)
 	if err != nil {
 		return fmt.Errorf("unable to detect local IP address: %w", err)
 	}
+	deploy.address = addr.String()
 	if deploy.address == "" {
 		return fmt.Errorf("unable to detect local IP address")
 	}


### PR DESCRIPTION
This PR is a folloup to #1206 

It removes insecure client altogether in favor of adding additional certSANs to the kind cluster. 63 addresses (or less, if the address will fall out of the docker's interface CIDR)  will be added to the certs starting from the docker bridge address.
In case that there are many docker bridges (or other interfaces named `br-XXX`) the network interface for RT tests has to be provided with NETWORK_INTERFACE=<name> env variable similar to what's described in #1188