### PR TITLE
Added logs as CI artifact

### DIFF
--- a/.github/workflows/ci-pull-request.yaml
+++ b/.github/workflows/ci-pull-request.yaml
@@ -9,8 +9,10 @@ jobs:
       matrix:
         mode: ["arp", "rt", "bgp"]
       fail-fast: true
-      max-parallel: 1
     steps:
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H-%M')"
       - name: Ensure fs wont cause issues
         run: sudo sysctl fs.inotify.max_user_instances=8192 &&  sudo sysctl fs.inotify.max_user_watches=524288
       - name: Checkout code
@@ -24,21 +26,33 @@ jobs:
       - name: Run Manifest generation tests
         run: make manifest-test
       - name: Run ARP mode tests v1.29.0 onwards
-        run: make e2e-tests129-arp
+        run: E2E_KEEP_LOGS=true make e2e-tests129-arp
         if: matrix.mode== 'arp'
       - name: Run RT mode tests v1.29.0 onwards
-        run: make e2e-tests129-rt
+        run: E2E_KEEP_LOGS=true make e2e-tests129-rt
         if: matrix.mode== 'rt'
       - name: Get GoBGP binaries
         run: make get-gobgp
         if: matrix.mode== 'bgp'
       - name: Run BGP mode tests v1.29.0 onwards
-        run: sudo -E PATH=$PATH DOCKER_API_VERSION=1.48 make e2e-tests129-bgp
+        run: sudo -E PATH=$PATH DOCKER_API_VERSION=1.48 E2E_KEEP_LOGS=true make e2e-tests129-bgp
         if: matrix.mode== 'bgp'
+      - name: Change log directory permissions
+        run: sudo chmod -R 755 /tmp/kube-vip-test-${{ matrix.mode }}*
+        if: matrix.mode== 'bgp'
+      - name: Save logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-test-logs-${{ matrix.mode }}-${{ steps.date.outputs.date }}
+          path: /tmp/kube-vip-test-${{ matrix.mode }}*
+        if: always()
   service-e2e-tests:
     runs-on: ubuntu-latest
     name: E2E service tests
     steps:
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H-%M')"
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install Go
@@ -48,4 +62,10 @@ jobs:
       - name: Build image with iptables
         run: make dockerx86ActionIPTables
       - name: Run tests
-        run: DOCKERTAG=action make service-tests
+        run: DOCKERTAG=action E2E_KEEP_LOGS=true make service-tests
+      - name: Save logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: services-test-logs-${{ steps.date.outputs.date }}
+          path: /tmp/kube-vip-services*
+        if: always()

--- a/pkg/etcd/election.go
+++ b/pkg/etcd/election.go
@@ -221,7 +221,7 @@ func (m *member) tryToBeLeader(ctx context.Context) {
 
 func (m *member) resignOnCancel(ctx context.Context) {
 	<-ctx.Done()
-	if err := m.election.Resign(m.client.Ctx()); err != nil {
+	if err := m.election.Resign(m.client.Ctx()); err != nil && !errors.Is(err, context.Canceled) {
 		log.Error("Failed to resign after the context was canceled", "err", err)
 	}
 }

--- a/testing/e2e/ip.go
+++ b/testing/e2e/ip.go
@@ -154,14 +154,18 @@ func CheckIPAddressPresence(ip string, container string, expected bool) bool {
 	cmd.Stdout = cmdOut
 	cmd.Stderr = cmdErr
 	if err := cmd.Run(); err != nil {
+		By(fmt.Sprintf("contianer %q interfaces error: %s", container, cmdErr.String()))
 		return false
 	}
+
+	By(fmt.Sprintf("contianer %q interfaces:\n %s", container, cmdOut.String()))
 
 	return strings.Contains(cmdOut.String(), ip) == expected
 }
 
 func CheckIPAddressPresenceByLease(name, namespace, ip string, client kubernetes.Interface, expected bool) bool {
 	container := GetLeaseHolder(name, namespace, client)
+	By("Lease: " + container)
 	if container == "" {
 		return false
 	}
@@ -201,7 +205,7 @@ func GetLeaseHolder(name, namespace string, client kubernetes.Interface) string 
 		var err error
 		lease, err = client.CoordinationV1().Leases(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		return err
-	}, "300s").ShouldNot(HaveOccurred())
+	}, "120s", "1s").ShouldNot(HaveOccurred())
 
 	Expect(lease).ToNot(BeNil())
 	return *lease.Spec.HolderIdentity

--- a/testing/e2e/kube-vip-bgp.yaml.tmpl
+++ b/testing/e2e/kube-vip-bgp.yaml.tmpl
@@ -4,6 +4,8 @@ kind: Pod
 metadata:
   name: kube-vip
   namespace: kube-system
+  labels:
+    app: kube-vip
 spec:
   containers:
   - name: kube-vip

--- a/testing/e2e/kube-vip-hostname.yaml.tmpl
+++ b/testing/e2e/kube-vip-hostname.yaml.tmpl
@@ -4,6 +4,8 @@ kind: Pod
 metadata:
   name: kube-vip
   namespace: kube-system
+  labels:
+    app: kube-vip
 spec:
   containers:
   - name: kube-vip

--- a/testing/e2e/kube-vip-routing-table.yaml.tmpl
+++ b/testing/e2e/kube-vip-routing-table.yaml.tmpl
@@ -4,6 +4,8 @@ kind: Pod
 metadata:
   name: kube-vip
   namespace: kube-system
+  labels:
+    app: kube-vip
 spec:
   containers:
   - name: kube-vip

--- a/testing/e2e/kube-vip.yaml.tmpl
+++ b/testing/e2e/kube-vip.yaml.tmpl
@@ -4,6 +4,8 @@ kind: Pod
 metadata:
   name: kube-vip
   namespace: kube-system
+  labels:
+    app: kube-vip
 spec:
   containers:
   - name: kube-vip

--- a/testing/e2e/logs.go
+++ b/testing/e2e/logs.go
@@ -1,0 +1,129 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func GetLogs(ctx context.Context, client kubernetes.Interface, tempDirPath string) error {
+	if os.Getenv("E2E_KEEP_LOGS") != "true" {
+		if err := os.RemoveAll(tempDirPath); err != nil {
+			return fmt.Errorf("failed to remove temporary directory %q: %w", tempDirPath, err)
+		}
+		return nil
+	}
+
+	intCtx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel()
+
+	path := filepath.Join(tempDirPath, "pods.json")
+	fpods, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create file %q: %w", path, err)
+	}
+	defer fpods.Close()
+
+	// list pods
+	pods, err := client.CoreV1().Pods("").List(intCtx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get pods: %w", err)
+	}
+	data, err := json.Marshal(pods)
+	if err != nil {
+		return fmt.Errorf("failed to marshal pods data: %w", err)
+	}
+	if _, err := fpods.Write(data); err != nil {
+		return fmt.Errorf("failed to save pods: %w", err)
+	}
+
+	// list services
+	path = filepath.Join(tempDirPath, "services.json")
+	fsvcs, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create file %q: %w", path, err)
+	}
+	defer fpods.Close()
+
+	svcs, err := client.CoreV1().Services("").List(intCtx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get pods: %w", err)
+	}
+	data, err = json.Marshal(svcs)
+	if err != nil {
+		return fmt.Errorf("failed to marshal pods data: %w", err)
+	}
+	if _, err := fsvcs.Write(data); err != nil {
+		return fmt.Errorf("failed to save pods: %w", err)
+	}
+
+	// list leases
+	path = filepath.Join(tempDirPath, "leases.json")
+	fleases, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create file %q: %w", path, err)
+	}
+	defer fpods.Close()
+
+	leases, err := client.CoordinationV1().Leases("").List(intCtx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get leases: %w", err)
+	}
+	data, err = json.Marshal(leases)
+	if err != nil {
+		return fmt.Errorf("failed to marshal leases data: %w", err)
+	}
+	if _, err := fleases.Write(data); err != nil {
+		return fmt.Errorf("failed to save leases: %w", err)
+	}
+
+	// get kube-vip pods
+	listOptions := metav1.ListOptions{
+		LabelSelector: "app=kube-vip",
+	}
+
+	kvpods, err := client.CoreV1().Pods("").List(intCtx, listOptions)
+	if err != nil {
+		return fmt.Errorf("failed to list pods: %w", err)
+	}
+
+	for _, pod := range kvpods.Items {
+		if pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		req := client.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{})
+		podLogs, err := req.Stream(intCtx)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("reading request stream: %w", err)
+		}
+		defer podLogs.Close()
+
+		buf := new(bytes.Buffer)
+		_, err = io.Copy(buf, podLogs)
+		if err != nil {
+			return fmt.Errorf("failed to copy logs to buffer: %w", err)
+		}
+
+		path := filepath.Join(tempDirPath, fmt.Sprintf("%s-%s.log", pod.Namespace, pod.Name))
+		err = os.WriteFile(path, buf.Bytes(), 0600)
+		if err != nil {
+			return fmt.Errorf("failed to write the log file %q: %w", path, err)
+		}
+	}
+
+	return nil
+}

--- a/testing/services/main.go
+++ b/testing/services/main.go
@@ -59,6 +59,12 @@ func main() {
 	t.ServiceName = "kube-vip-service"
 	t.LeaderName = "kube-vip-deploy-leader"
 
+	var err error
+	t.TempDirPath, err = os.MkdirTemp("", "kube-vip-services")
+	if err != nil {
+		slog.Fatal(err)
+	}
+
 	if t.ControlPlane {
 		err := t.CreateKind()
 		if !t.RetainCluster {

--- a/testing/services/pkg/deployment/kubernetes.go
+++ b/testing/services/pkg/deployment/kubernetes.go
@@ -44,18 +44,21 @@ func (d *Deployment) CreateKVDs(ctx context.Context, clientset *kubernetes.Clien
 			Namespace: "kube-system",
 			Labels: map[string]string{
 				"app.kubernetes.io/name": "kube-vip-ds",
+				"app":                    "kube-vip",
 			},
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app.kubernetes.io/name": "kube-vip-ds",
+					"app":                    "kube-vip",
 				},
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"app.kubernetes.io/name": "kube-vip-ds",
+						"app":                    "kube-vip",
 					},
 				},
 				Spec: v1.PodSpec{


### PR DESCRIPTION
This PR introduces logs gathering for the CI + some minor fixes as I am trying to stabilize the CI tests.
Logs of all kube-vip pods + kube-vip-cloud-controller pods (if used) + json list of services, leases and pods are currently being saved.

I have re-enabled parallel test execution as I would like to gather some more logs of CI errors.