### PR TITLE
Issue 1201 - uniquely identify a service lease combining namespace + service name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ kind-quick:
 	kubectl create configmap --namespace kube-system kubevip --from-literal range-global=172.18.100.10-172.18.100.30
 	kubectl apply -f https://raw.githubusercontent.com/kube-vip/kube-vip-cloud-provider/main/manifest/kube-vip-cloud-controller.yaml
 	kind load docker-image --name kube-vip $(REPOSITORY)/$(TARGET):$(DOCKERTAG)
-	docker run --network host --rm $(REPOSITORY)/$(TARGET):$(DOCKERTAG) manifest daemonset --services --inCluster --arp --servicesElection --interface  eth0 | kubectl apply -f -
+	docker run --network host --rm $(REPOSITORY)/$(TARGET):$(DOCKERTAG) manifest daemonset --services --inCluster --arp --servicesElection --interface  eth0 | sed 's|image:.*$ |image: $(REPOSITORY)/$(TARGET):$(DOCKERTAG)|'| kubectl apply -f -
 
 kind-reload:
 	kind load docker-image $(REPOSITORY)/$(TARGET):$(DOCKERTAG) --name kube-vip

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -45,7 +45,8 @@ func (p *Processor) StartServicesWatchForLeaderElection(ctx context.Context) err
 
 // The startServicesWatchForLeaderElection function will start a services watcher, the
 func (p *Processor) StartServicesLeaderElection(ctx context.Context, service *v1.Service) error {
-	serviceLease := fmt.Sprintf("kubevip-%s-%s", service.Namespace, service.Name)
+	serviceLease := fmt.Sprintf("kubevip-%s", service.Name)
+	serviceLeaseId := fmt.Sprintf("kubevip-%s/%s", serviceLease, service.Namespace)
 	log.Info("new leader election", "service", service.Name, "namespace", service.Namespace, "lock_name", serviceLease, "host_id", p.config.NodeName)
 	// we use the Lease lock type since edits to Leases are less common
 	// and fewer objects in the cluster watch "all Leases".
@@ -62,12 +63,12 @@ func (p *Processor) StartServicesLeaderElection(ctx context.Context, service *v1
 	childCtx, childCancel := context.WithCancel(ctx)
 	defer childCancel()
 
-	if _, ok := svcLocks[serviceLease]; !ok {
-		svcLocks[serviceLease] = new(sync.Mutex)
+	if _, ok := svcLocks[serviceLeaseId]; !ok {
+		svcLocks[serviceLeaseId] = new(sync.Mutex)
 	}
 
-	svcLocks[serviceLease].Lock()
-	defer svcLocks[serviceLease].Unlock()
+	svcLocks[serviceLeaseId].Lock()
+	defer svcLocks[serviceLeaseId].Unlock()
 
 	svcCtx, err := p.getServiceContext(service.UID)
 	if err != nil {

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -46,7 +46,7 @@ func (p *Processor) StartServicesWatchForLeaderElection(ctx context.Context) err
 // The startServicesWatchForLeaderElection function will start a services watcher, the
 func (p *Processor) StartServicesLeaderElection(ctx context.Context, service *v1.Service) error {
 	serviceLease := fmt.Sprintf("kubevip-%s", service.Name)
-	serviceLeaseId := fmt.Sprintf("%s/%s", serviceLease, service.Namespace)
+	serviceLeaseID := fmt.Sprintf("%s/%s", serviceLease, service.Namespace)
 	log.Info("new leader election", "service", service.Name, "namespace", service.Namespace, "lock_name", serviceLease, "host_id", p.config.NodeName)
 	// we use the Lease lock type since edits to Leases are less common
 	// and fewer objects in the cluster watch "all Leases".
@@ -63,12 +63,12 @@ func (p *Processor) StartServicesLeaderElection(ctx context.Context, service *v1
 	childCtx, childCancel := context.WithCancel(ctx)
 	defer childCancel()
 
-	if _, ok := svcLocks[serviceLeaseId]; !ok {
-		svcLocks[serviceLeaseId] = new(sync.Mutex)
+	if _, ok := svcLocks[serviceLeaseID]; !ok {
+		svcLocks[serviceLeaseID] = new(sync.Mutex)
 	}
 
-	svcLocks[serviceLeaseId].Lock()
-	defer svcLocks[serviceLeaseId].Unlock()
+	svcLocks[serviceLeaseID].Lock()
+	defer svcLocks[serviceLeaseID].Unlock()
 
 	svcCtx, err := p.getServiceContext(service.UID)
 	if err != nil {

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -45,7 +45,7 @@ func (p *Processor) StartServicesWatchForLeaderElection(ctx context.Context) err
 
 // The startServicesWatchForLeaderElection function will start a services watcher, the
 func (p *Processor) StartServicesLeaderElection(ctx context.Context, service *v1.Service) error {
-	serviceLease := fmt.Sprintf("kubevip-%s", service.Name)
+	serviceLease := fmt.Sprintf("kubevip-%s-%s", service.Namespace, service.Name)
 	log.Info("new leader election", "service", service.Name, "namespace", service.Namespace, "lock_name", serviceLease, "host_id", p.config.NodeName)
 	// we use the Lease lock type since edits to Leases are less common
 	// and fewer objects in the cluster watch "all Leases".

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -46,7 +46,7 @@ func (p *Processor) StartServicesWatchForLeaderElection(ctx context.Context) err
 // The startServicesWatchForLeaderElection function will start a services watcher, the
 func (p *Processor) StartServicesLeaderElection(ctx context.Context, service *v1.Service) error {
 	serviceLease := fmt.Sprintf("kubevip-%s", service.Name)
-	serviceLeaseId := fmt.Sprintf("kubevip-%s/%s", serviceLease, service.Namespace)
+	serviceLeaseId := fmt.Sprintf("%s/%s", serviceLease, service.Namespace)
 	log.Info("new leader election", "service", service.Name, "namespace", service.Namespace, "lock_name", serviceLease, "host_id", p.config.NodeName)
 	// we use the Lease lock type since edits to Leases are less common
 	// and fewer objects in the cluster watch "all Leases".


### PR DESCRIPTION
This PR fixes [this issue](https://github.com/kube-vip/kube-vip/issues/1201) by adding namespace to uniquely identify a service lease, instead of merely relying on the service name.