### PR TITLE
fix for layer 3 issues with not added ip 

### DIFF
--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -181,7 +181,7 @@ func (cluster *Cluster) vipService(ctxArp, ctxDNS context.Context, c *kubevip.Co
 				}
 
 				for entry := range *backendMap {
-					log.Debug("entry.Check() for entry:", entry)
+					log.Debug("entry.Check() for entry", "entry", entry)
 					if entry.Check() {
 						log.Debug("entry.Check() true")
 						_, err = network.AddIP(true)
@@ -283,7 +283,7 @@ func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip
 		if err != nil {
 			log.Warn("attempted to clean existing VIP", "err", err)
 		}
-		log.Debug("c.EnableRoutingTable:", c.EnableRoutingTable, " c.EnableLeaderElection ", c.EnableLeaderElection, " c.EnableServicesElection ", c.EnableServicesElection)
+		log.Debug("config flags", "enable_routing_table", c.EnableRoutingTable, "enable_leader_election", c.EnableLeaderElection, "enable_services_election", c.EnableServicesElection)
 
 		if c.EnableRoutingTable && (c.EnableLeaderElection || c.EnableServicesElection) {
 			err = network.AddRoute(false)


### PR DESCRIPTION
fix for [issue 1243](https://github.com/kube-vip/kube-vip/issues/1243).

for cp_enable=true and svc_enable=true issue:
just change the order of start up because cp code is not threading.

for ip issue:
just change if causes which might be the problem.