### PR TITLE
WIP: Add node labels with per service leader election

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/k8s"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/networkinterface"
+	"github.com/kube-vip/kube-vip/pkg/node"
 	"github.com/kube-vip/kube-vip/pkg/services"
 	"github.com/kube-vip/kube-vip/pkg/upnp"
 	"github.com/kube-vip/kube-vip/pkg/utils"
@@ -66,6 +67,9 @@ type Manager struct {
 
 	// This tracks VIPs and performs ARP/NDP advertisement.
 	arpMgr *arp.Manager
+
+	// This tracks node labels and performs label management
+	nodeLabelManager *node.Manager
 }
 
 // New will create a new managing object
@@ -187,6 +191,12 @@ func New(configMap string, config *kubevip.Config) (*Manager, error) {
 	intfMgr := networkinterface.NewManager()
 	arpMgr := arp.NewManager(config)
 
+	// if node labeling is enabled, then we need to create a node label manager
+	var nodeLabelManager *node.Manager
+	if config.EnableNodeLabeling {
+		nodeLabelManager = node.NewManager(config, clientset)
+	}
+
 	var bgpServer *bgp.Server
 	if config.EnableBGP {
 		bgpServer, err = bgp.NewBGPServer(&config.BGPConfig)
@@ -195,7 +205,7 @@ func New(configMap string, config *kubevip.Config) (*Manager, error) {
 		}
 	}
 
-	svcProcessor := services.NewServicesProcessor(config, bgpServer, clientset, rwClientSet, shutdownChan, intfMgr, arpMgr)
+	svcProcessor := services.NewServicesProcessor(config, bgpServer, clientset, rwClientSet, shutdownChan, intfMgr, arpMgr, nodeLabelManager)
 
 	return &Manager{
 		clientSet:   clientset,
@@ -214,12 +224,13 @@ func New(configMap string, config *kubevip.Config) (*Manager, error) {
 			Name:      "bgp_session_info",
 			Help:      "Display state of session by setting metric for label value with current state to 1",
 		}, []string{"state", "peer"}),
-		signalChan:   signalChan,
-		shutdownChan: shutdownChan,
-		svcProcessor: svcProcessor,
-		intfMgr:      intfMgr,
-		arpMgr:       arpMgr,
-		bgpServer:    bgpServer,
+		signalChan:       signalChan,
+		shutdownChan:     shutdownChan,
+		svcProcessor:     svcProcessor,
+		intfMgr:          intfMgr,
+		arpMgr:           arpMgr,
+		bgpServer:        bgpServer,
+		nodeLabelManager: nodeLabelManager,
 	}, nil
 }
 
@@ -256,6 +267,11 @@ func (sm *Manager) Start() error {
 				log.Error("healthcheck", "unable to start", err)
 			}
 		}()
+	}
+
+	if sm.nodeLabelManager != nil {
+		// on exit, clean up the node labels
+		defer sm.nodeLabelManager.CleanUpLabels(10 * time.Second)
 	}
 
 	// If BGP is enabled then we start a server instance that will broadcast VIPs

--- a/pkg/node/manager.go
+++ b/pkg/node/manager.go
@@ -1,0 +1,137 @@
+package node
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	log "log/slog"
+
+	"github.com/kube-vip/kube-vip/pkg/instance"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// labelName is the name of the label that will be added to the node
+	// it is prefix for the label key before "/"
+	labelName = "service-provided.kube-vip.io"
+)
+
+// labelOperation is the operation to perform on the node labels
+type labelOperation string
+
+// labelOperation constants
+const (
+	labelOperationRemove labelOperation = "remove"
+	labelOperationAdd    labelOperation = "add"
+)
+
+// Manager is the label manager for the node
+type Manager struct {
+	// nodeName is the name of the node to manage
+	nodeName string
+
+	// clientSet is the Kubernetes client set to use
+	clientSet *kubernetes.Clientset
+}
+
+// NewManager creates a new Label Manager for the given node
+func NewManager(config *kubevip.Config, clientSet *kubernetes.Clientset) *Manager {
+	return &Manager{
+		nodeName:  config.NodeName,
+		clientSet: clientSet,
+	}
+}
+
+// AddLabel a new label to the node
+func (m *Manager) AddLabel(ctx context.Context, svc *corev1.Service) error {
+	labelKey, labelValue := generateNodeLabelKeyValue(svc)
+	return m.patchNode(ctx, labelOperationAdd, map[string]string{labelKey: labelValue})
+}
+
+// RemoveLabel a label from the node
+func (m *Manager) RemoveLabel(ctx context.Context, svc *corev1.Service) error {
+	labelKey, _ := generateNodeLabelKeyValue(svc)
+	return m.patchNode(ctx, labelOperationRemove, map[string]string{labelKey: ""})
+}
+
+// clean up the node labels
+func (m *Manager) CleanUpLabels(timeout time.Duration) error {
+	log.Debug("cleaning up labels for node", "node", m.nodeName, "timeout", timeout)
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	// get the node
+	node, err := m.clientSet.CoreV1().Nodes().Get(ctx, m.nodeName, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "failed to get node %s", m.nodeName)
+	}
+
+	// collect all labels with the prefix to remove
+	labels := map[string]string{}
+	for k := range node.Labels {
+		if strings.HasPrefix(k, labelName) {
+			labels[k] = ""
+		}
+	}
+
+	if len(labels) == 0 {
+		log.Debug("no labels to remove for node", "node", m.nodeName)
+		return nil
+	}
+
+	// patch the node with the labels to remove
+	return m.patchNode(ctx, labelOperationRemove, labels)
+}
+
+// generateNodeLabelKeyValue generates a label key and value for the given service
+func generateNodeLabelKeyValue(svc *corev1.Service) (string, string) {
+	addresses := instance.FetchServiceAddresses(svc)
+	return fmt.Sprintf("%s/%s.%s", labelName, svc.Name, svc.Namespace), strings.Join(addresses, ",")
+}
+
+// patchNode patches the node with the given labels
+func (m *Manager) patchNode(ctx context.Context, operation labelOperation, labels map[string]string) error {
+	type patchStringLabel struct {
+		Op    string `json:"op"`
+		Path  string `json:"path"`
+		Value string `json:"value"`
+	}
+
+	patchLabels := []patchStringLabel{}
+	// generate the patch
+	for k, v := range labels {
+		patchLabels = append(patchLabels, patchStringLabel{
+			Op: string(operation),
+			// replace all slashes with ~1
+			Path:  fmt.Sprintf("/metadata/labels/%s", strings.ReplaceAll(k, "/", "~1")),
+			Value: v,
+		})
+	}
+
+	patchData, err := json.Marshal(patchLabels)
+	if err != nil {
+		log.Debug("node patch marshaling failed", "err", err, "labels", labels, "patch", patchLabels)
+		return errors.Wrapf(err, "node patch marshaling failed for labels %v", labels)
+	}
+
+	// patch node
+	node, err := m.clientSet.CoreV1().Nodes().Patch(ctx,
+		m.nodeName, types.JSONPatchType, patchData, metav1.PatchOptions{})
+	if err != nil {
+		log.Debug("node patching failed", "err", err, "patchData", patchData)
+		return errors.Wrapf(err, "node patching failed with patch %s", string(patchData))
+	}
+
+	log.Debug("updated", "node", m.nodeName, "labels", node.Labels)
+
+	return nil
+}

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -46,11 +46,20 @@ type Processor struct {
 
 	intfMgr *networkinterface.Manager
 	arpMgr  *arp.Manager
+
+	// nodeLabelManager is the manager for the node labels
+	nodeLabelManager labelManager
+}
+
+// labelManager is the interface for the node label manager to add/remove labels
+type labelManager interface {
+	AddLabel(ctx context.Context, svc *v1.Service) error
+	RemoveLabel(ctx context.Context, svc *v1.Service) error
 }
 
 func NewServicesProcessor(config *kubevip.Config, bgpServer *bgp.Server,
 	clientSet *kubernetes.Clientset, rwClientSet *kubernetes.Clientset, shutdownChan chan struct{},
-	intfMgr *networkinterface.Manager, arpMgr *arp.Manager) *Processor {
+	intfMgr *networkinterface.Manager, arpMgr *arp.Manager, nodeLabelManager labelManager) *Processor {
 	lbClassFilterFunc := lbClassFilter
 	if config.LoadBalancerClassLegacyHandling {
 		lbClassFilterFunc = lbClassFilterLegacy
@@ -71,8 +80,9 @@ func NewServicesProcessor(config *kubevip.Config, bgpServer *bgp.Server,
 			Help:      "Count all events fired by the service watcher categorised by event type",
 		}, []string{"type"}),
 
-		intfMgr: intfMgr,
-		arpMgr:  arpMgr,
+		intfMgr:          intfMgr,
+		arpMgr:           arpMgr,
+		nodeLabelManager: nodeLabelManager,
 	}
 }
 

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -42,6 +42,15 @@ func (p *Processor) SyncServices(ctx context.Context, svc *v1.Service) error {
 	action := p.getServiceInstanceAction(svc)
 	switch action {
 	case ActionDelete:
+		// remove the label from the node before deleting the service
+		if p.nodeLabelManager != nil {
+			log.Debug("[service] delete label", "namespace", svc.Namespace, "name", svc.Name)
+			// remove the label from the node
+			if err := p.nodeLabelManager.RemoveLabel(ctx, svc); err != nil {
+				return fmt.Errorf("error removing label from node: %w", err)
+			}
+		}
+
 		log.Debug("[service] delete", "namespace", svc.Namespace, "name", svc.Name)
 		if err := p.deleteService(svc.UID); err != nil {
 			return fmt.Errorf("error deleting service %s/%s: %w", svc.Namespace, svc.Name, err)
@@ -50,6 +59,15 @@ func (p *Processor) SyncServices(ctx context.Context, svc *v1.Service) error {
 		log.Debug("[service] add", "namespace", svc.Namespace, "name", svc.Name)
 		if err := p.addService(ctx, svc); err != nil {
 			return fmt.Errorf("error adding service %s/%s: %w", svc.Namespace, svc.Name, err)
+		}
+
+		// add the label to the node after adding the service
+		if p.nodeLabelManager != nil {
+			log.Debug("[service] add label", "namespace", svc.Namespace, "name", svc.Name)
+			// add the label to the node
+			if err := p.nodeLabelManager.AddLabel(ctx, svc); err != nil {
+				return fmt.Errorf("error adding label to node: %w", err)
+			}
 		}
 	case ActionNone:
 		log.Debug("[service] no action", "namespace", svc.Namespace, "name", svc.Name)


### PR DESCRIPTION
this fixes #1234 
Label nodes with following flags:
        - name: svc_election
          value: "true"
        - name: enable_node_labeling
          value: "true"
Node label template:
service-provided.kube-vip.io/<service-name>.<service-namespace>: "<service IPs if any>"
On kube-vip shutdown all these labels removed from the node.