### PR TITLE
Fixed nil pointer reference when endpoints serving condition is not set

### DIFF
--- a/pkg/endpoints/providers/endpointslices.go
+++ b/pkg/endpoints/providers/endpointslices.go
@@ -71,7 +71,7 @@ func (ep *Endpointslices) GetAllEndpoints() ([]string, error) {
 func (ep *Endpointslices) GetLocalEndpoints(id string, _ *kubevip.Config) ([]string, error) {
 	var localEndpoints []string
 	for _, endpoint := range ep.endpoints.Endpoints {
-		if !*endpoint.Conditions.Serving {
+		if endpoint.Conditions.Serving == nil || !*endpoint.Conditions.Serving {
 			continue
 		}
 		for _, address := range endpoint.Addresses {


### PR DESCRIPTION
This should fix #1258 

It turned out that it might happen that kube-vip will get an endpointslice in between apiserver creates it and sets `Conditions.Serving`. This should fix such an issue.