### PR TITLE
feat: Add leaderElection retry logic

### DIFF
--- a/pkg/leaderelection/retry.go
+++ b/pkg/leaderelection/retry.go
@@ -1,0 +1,242 @@
+package leaderelection
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	log "log/slog"
+
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+// RetryableLeaderElection wraps the k8s leader election with retry logic
+type RetryableLeaderElection struct {
+	config      leaderelection.LeaderElectionConfig
+	maxRetries  int
+	retryDelays []time.Duration
+}
+
+// NewRetryableLeaderElection creates a new retryable leader election wrapper
+func NewRetryableLeaderElection(config leaderelection.LeaderElectionConfig) *RetryableLeaderElection {
+	return &RetryableLeaderElection{
+		config:      config,
+		maxRetries:  2,
+		retryDelays: []time.Duration{1 * time.Second, 2 * time.Second},
+	}
+}
+
+// isRetryableError checks if an error is one that we should retry
+func isRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errStr := strings.ToLower(err.Error())
+
+	// Check for certain error patterns that indicate a retryable failure
+	retryablePatterns := []string{
+		"context deadline exceeded",
+		"client.timeout exceeded while awaiting headers",
+		"client rate limiter wait returned an error",
+		"timed out waiting for the condition",
+		"connection refused",
+		"connection reset by peer",
+		"no such host",
+		"temporary failure in name resolution",
+		"i/o timeout",
+		"network is unreachable",
+		"the object has been modified; please apply your changes to the latest version",
+		"operation cannot be fulfilled",
+		"resource version conflict",
+		"conflict",
+	}
+
+	for _, pattern := range retryablePatterns {
+		if strings.Contains(errStr, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isOptimisticLockError checks if an error is specifically an optimistic locking conflict
+func isOptimisticLockError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errStr := strings.ToLower(err.Error())
+
+	// Check for optimistic locking conflict patterns
+	optimisticLockPatterns := []string{
+		"the object has been modified; please apply your changes to the latest version",
+		"operation cannot be fulfilled",
+		"resource version conflict",
+	}
+
+	for _, pattern := range optimisticLockPatterns {
+		if strings.Contains(errStr, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// RetryableResourceLock wraps a resource lock to add retry logic
+type RetryableResourceLock struct {
+	resourcelock.Interface
+	retryable                        *RetryableLeaderElection
+	lastUpdateWasOptimisticLockError bool
+}
+
+// Get wraps the original Get with retry logic
+func (r *RetryableResourceLock) Get(ctx context.Context) (*resourcelock.LeaderElectionRecord, []byte, error) {
+	for attempt := 0; attempt <= r.retryable.maxRetries; attempt++ {
+		if attempt > 0 {
+			delay := r.retryable.retryDelays[attempt-1]
+			log.Info("retrying lease Get operation", "attempt", attempt, "delay", delay, "lock", r.Interface.Describe())
+			select {
+			case <-ctx.Done():
+				return nil, nil, ctx.Err()
+			case <-time.After(delay):
+				// Continue with retry
+			}
+		}
+
+		record, raw, err := r.Interface.Get(ctx)
+		if err != nil && isRetryableError(err) && attempt < r.retryable.maxRetries {
+			log.Warn("retryable error in lease Get operation", "err", err, "attempt", attempt+1, "lock", r.Interface.Describe())
+			continue
+		}
+		return record, raw, err
+	}
+	return nil, nil, context.DeadlineExceeded
+}
+
+// Create wraps the original Create with retry logic
+func (r *RetryableResourceLock) Create(ctx context.Context, ler resourcelock.LeaderElectionRecord) error {
+	for attempt := 0; attempt <= r.retryable.maxRetries; attempt++ {
+		if attempt > 0 {
+			delay := r.retryable.retryDelays[attempt-1]
+			log.Info("retrying lease Create operation", "attempt", attempt, "delay", delay, "lock", r.Interface.Describe())
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+				// Continue with retry
+			}
+		}
+
+		err := r.Interface.Create(ctx, ler)
+		if err != nil && isRetryableError(err) && attempt < r.retryable.maxRetries {
+			log.Warn("retryable error in lease Create operation", "err", err, "attempt", attempt+1, "lock", r.Interface.Describe())
+			continue
+		}
+		return err
+	}
+	return context.DeadlineExceeded
+}
+
+// Update wraps the original Update with retry logic
+func (r *RetryableResourceLock) Update(ctx context.Context, ler resourcelock.LeaderElectionRecord) error {
+	for attempt := 0; attempt <= r.retryable.maxRetries; attempt++ {
+		if attempt > 0 {
+			// Use shorter delays for optimistic locking conflicts
+			var delay time.Duration
+			if attempt-1 < len(r.retryable.retryDelays) {
+				delay = r.retryable.retryDelays[attempt-1]
+			} else {
+				delay = r.retryable.retryDelays[len(r.retryable.retryDelays)-1]
+			}
+
+			// For optimistic lock conflicts, use shorter delays
+			if r.lastUpdateWasOptimisticLockError {
+				delay = delay / 4 // Use shorter delay for conflicts since it's not a network failure
+			}
+
+			log.Info("retrying lease Update operation", "attempt", attempt, "delay", delay, "lock", r.Interface.Describe())
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+				// Continue with retry
+			}
+		}
+
+		// For optimistic lock errors, try to refresh the lease record first
+		currentLer := ler
+		if attempt > 0 && r.lastUpdateWasOptimisticLockError {
+			if latest, _, err := r.Interface.Get(ctx); err == nil && latest != nil {
+				log.Info("refreshing lease record before retry", "attempt", attempt, "lock", r.Interface.Describe())
+				// Update the lease record with latest data but keep our identity and timing
+				currentLer = *latest
+				currentLer.HolderIdentity = ler.HolderIdentity
+				currentLer.RenewTime = ler.RenewTime
+				currentLer.AcquireTime = ler.AcquireTime
+			}
+		}
+
+		err := r.Interface.Update(ctx, currentLer)
+		r.lastUpdateWasOptimisticLockError = isOptimisticLockError(err)
+
+		if err != nil && isRetryableError(err) && attempt < r.retryable.maxRetries {
+			if r.lastUpdateWasOptimisticLockError {
+				log.Warn("optimistic lock conflict in lease Update operation", "err", err, "attempt", attempt+1, "lock", r.Interface.Describe())
+			} else {
+				log.Warn("retryable error in lease Update operation", "err", err, "attempt", attempt+1, "lock", r.Interface.Describe())
+			}
+			continue
+		}
+		return err
+	}
+	return context.DeadlineExceeded
+}
+
+// RunWithRetry runs leader election with retry logic for API client errors
+func (r *RetryableLeaderElection) RunWithRetry(ctx context.Context) {
+	// Create a retryable resource lock wrapper
+	retryableLock := &RetryableResourceLock{
+		Interface: r.config.Lock,
+		retryable: r,
+	}
+
+	// Create a modified config with the retryable lock
+	wrappedConfig := r.config
+	wrappedConfig.Lock = retryableLock
+
+	// Wrap the callbacks to add logging and retry detection
+	originalCallbacks := r.config.Callbacks
+	wrappedConfig.Callbacks = leaderelection.LeaderCallbacks{
+		OnStartedLeading: func(ctx context.Context) {
+			log.Info("started leading with retry wrapper", "lock", retryableLock.Interface.Describe())
+			originalCallbacks.OnStartedLeading(ctx)
+		},
+		OnStoppedLeading: func() {
+			log.Info("stopped leading with retry wrapper", "lock", retryableLock.Interface.Describe())
+			originalCallbacks.OnStoppedLeading()
+		},
+		OnNewLeader: func(identity string) {
+			log.Info("new leader elected with retry wrapper", "leader", identity, "lock", retryableLock.Interface.Describe())
+			originalCallbacks.OnNewLeader(identity)
+		},
+	}
+
+	// Run the leader election with the wrapped lock
+	leaderelection.RunOrDie(ctx, wrappedConfig)
+}
+
+// RunOrDieWithRetry is a function that runs leader election with retries
+func RunOrDieWithRetry(ctx context.Context, config leaderelection.LeaderElectionConfig) {
+	retryable := NewRetryableLeaderElection(config)
+	retryable.RunWithRetry(ctx)
+}
+
+// RunWithRetryFunc is a function that creates and runs retryable leader election
+func RunWithRetryFunc(ctx context.Context, config leaderelection.LeaderElectionConfig) {
+	retryable := NewRetryableLeaderElection(config)
+	retryable.RunWithRetry(ctx)
+}

--- a/pkg/leaderelection/retry_test.go
+++ b/pkg/leaderelection/retry_test.go
@@ -1,0 +1,219 @@
+package leaderelection
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+// MockResourceLock is a test implementation of resourcelock.Interface
+type MockResourceLock struct {
+	getCallCount    int
+	createCallCount int
+	updateCallCount int
+	shouldFail      bool
+	failureError    error
+}
+
+func (m *MockResourceLock) Get(ctx context.Context) (*resourcelock.LeaderElectionRecord, []byte, error) {
+	m.getCallCount++
+	if m.shouldFail {
+		return nil, nil, m.failureError
+	}
+	return &resourcelock.LeaderElectionRecord{}, []byte("test"), nil
+}
+
+func (m *MockResourceLock) Create(ctx context.Context, ler resourcelock.LeaderElectionRecord) error {
+	m.createCallCount++
+	if m.shouldFail {
+		return m.failureError
+	}
+	return nil
+}
+
+func (m *MockResourceLock) Update(ctx context.Context, ler resourcelock.LeaderElectionRecord) error {
+	m.updateCallCount++
+	if m.shouldFail {
+		return m.failureError
+	}
+	return nil
+}
+
+func (m *MockResourceLock) RecordEvent(string) {}
+
+func (m *MockResourceLock) Identity() string {
+	return "test-identity"
+}
+
+func (m *MockResourceLock) Describe() string {
+	return "test-lock"
+}
+
+func TestRetryableResourceLock_Get_Success(t *testing.T) {
+	mock := &MockResourceLock{shouldFail: false}
+	retryable := &RetryableLeaderElection{
+		maxRetries:  2,
+		retryDelays: []time.Duration{10 * time.Millisecond, 20 * time.Millisecond},
+	}
+
+	wrapper := &RetryableResourceLock{
+		Interface: mock,
+		retryable: retryable,
+	}
+
+	ctx := context.Background()
+	_, _, err := wrapper.Get(ctx)
+
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	if mock.getCallCount != 1 {
+		t.Errorf("Expected 1 call to Get, got %d", mock.getCallCount)
+	}
+}
+
+func TestRetryableResourceLock_Get_RetryOnRetryableError(t *testing.T) {
+	mock := &MockResourceLock{
+		shouldFail:   true,
+		failureError: errors.New("client rate limiter Wait returned an error: context deadline exceeded"),
+	}
+	retryable := &RetryableLeaderElection{
+		maxRetries:  2,
+		retryDelays: []time.Duration{10 * time.Millisecond, 20 * time.Millisecond},
+	}
+
+	wrapper := &RetryableResourceLock{
+		Interface: mock,
+		retryable: retryable,
+	}
+
+	ctx := context.Background()
+	_, _, err := wrapper.Get(ctx)
+
+	// Should have retried the maximum number of times plus the initial attempt
+	expectedCalls := 1 + retryable.maxRetries
+	if mock.getCallCount != expectedCalls {
+		t.Errorf("Expected %d calls to Get, got %d", expectedCalls, mock.getCallCount)
+	}
+
+	// Should still return an error after all retries
+	if err == nil {
+		t.Error("Expected an error after all retries failed")
+	}
+}
+
+func TestRetryableResourceLock_Update_RetryOnRetryableError(t *testing.T) {
+	mock := &MockResourceLock{
+		shouldFail:   true,
+		failureError: errors.New("net/http: request canceled (Client.Timeout exceeded while awaiting headers)"),
+	}
+	retryable := &RetryableLeaderElection{
+		maxRetries:  2,
+		retryDelays: []time.Duration{10 * time.Millisecond, 20 * time.Millisecond},
+	}
+
+	wrapper := &RetryableResourceLock{
+		Interface: mock,
+		retryable: retryable,
+	}
+
+	ctx := context.Background()
+	err := wrapper.Update(ctx, resourcelock.LeaderElectionRecord{})
+
+	// Should have retried the maximum number of times plus the initial attempt
+	expectedCalls := 1 + retryable.maxRetries
+	if mock.updateCallCount != expectedCalls {
+		t.Errorf("Expected %d calls to Update, got %d", expectedCalls, mock.updateCallCount)
+	}
+
+	// Should still return an error after all retries
+	if err == nil {
+		t.Error("Expected an error after all retries failed")
+	}
+}
+
+func TestRetryableResourceLock_NoRetryOnNonRetryableError(t *testing.T) {
+	mock := &MockResourceLock{
+		shouldFail:   true,
+		failureError: errors.New("permission denied"),
+	}
+	retryable := &RetryableLeaderElection{
+		maxRetries:  2,
+		retryDelays: []time.Duration{10 * time.Millisecond, 20 * time.Millisecond},
+	}
+
+	wrapper := &RetryableResourceLock{
+		Interface: mock,
+		retryable: retryable,
+	}
+
+	ctx := context.Background()
+	err := wrapper.Update(ctx, resourcelock.LeaderElectionRecord{})
+
+	// Should not retry for non-retryable errors
+	if mock.updateCallCount != 1 {
+		t.Errorf("Expected 1 call to Update, got %d", mock.updateCallCount)
+	}
+
+	// Should return the original error
+	if err == nil {
+		t.Error("Expected an error")
+	}
+}
+
+func TestIsRetryableError(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "context deadline exceeded",
+			err:      errors.New("context deadline exceeded"),
+			expected: true,
+		},
+		{
+			name:     "client rate limiter error",
+			err:      errors.New("client rate limiter Wait returned an error: context deadline exceeded"),
+			expected: true,
+		},
+		{
+			name:     "timeout exceeded",
+			err:      errors.New("Client.Timeout exceeded while awaiting headers"),
+			expected: true,
+		},
+		{
+			name:     "connection refused",
+			err:      errors.New("connection refused"),
+			expected: true,
+		},
+		{
+			name:     "non-retryable error",
+			err:      errors.New("permission denied"),
+			expected: false,
+		},
+		{
+			name:     "timed out waiting",
+			err:      errors.New("timed out waiting for the condition"),
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isRetryableError(tc.err)
+			if result != tc.expected {
+				t.Errorf("Expected %v for error %q, got %v", tc.expected, tc.err, result)
+			}
+		})
+	}
+}

--- a/pkg/manager/manager_wireguard.go
+++ b/pkg/manager/manager_wireguard.go
@@ -6,9 +6,10 @@ import (
 
 	log "log/slog"
 
+	"github.com/kube-vip/kube-vip/pkg/leaderelection"
 	"github.com/kube-vip/kube-vip/pkg/wireguard"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/leaderelection"
+	k8sleaderelection "k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 )
 
@@ -76,8 +77,8 @@ func (sm *Manager) startWireguard(id string) error {
 			},
 		}
 
-		// start the leader election code loop
-		leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+		// start the leader election code loop with retry logic
+		leaderelection.RunOrDieWithRetry(ctx, k8sleaderelection.LeaderElectionConfig{
 			Lock: lock,
 			// IMPORTANT: you MUST ensure that any code you have that
 			// is protected by the lease must terminate **before**
@@ -89,7 +90,7 @@ func (sm *Manager) startWireguard(id string) error {
 			LeaseDuration:   time.Duration(sm.config.LeaseDuration) * time.Second,
 			RenewDeadline:   time.Duration(sm.config.RenewDeadline) * time.Second,
 			RetryPeriod:     time.Duration(sm.config.RetryPeriod) * time.Second,
-			Callbacks: leaderelection.LeaderCallbacks{
+			Callbacks: k8sleaderelection.LeaderCallbacks{
 				OnStartedLeading: func(ctx context.Context) {
 					err = sm.svcProcessor.ServicesWatcher(ctx, sm.svcProcessor.SyncServices)
 					if err != nil {


### PR DESCRIPTION
Currently if there is any failure in communications when trying to get or check the leader, kubevip immediately fails. This causes the service to remove the vip and restart which can cause a short outage This makes kube-vip much more reliable before failing when running in unstable or unreliable networks.

Instead of failing, if leader election fails for "retryable" conditions, then try up to 2 additional times for a total of 3 before failing. 

- attempt 1
- sleep 1s before attempt 2
- sleep 2s before attempt 3

if the error is something like a etcd lease update or conflict, then try much faster.
- attempt 1
- sleep 250ms before attempt 2
- sleep 500ms before attempt 3