### PR TITLE
Now dumps kubernetes configuration of services and endpointslices

### DIFF
--- a/pkg/manager/manager_dump.go
+++ b/pkg/manager/manager_dump.go
@@ -138,7 +138,7 @@ func (sm *Manager) dumpServicesSection() {
 						}
 						vipConfigs += cfg.IP
 					}
-					fmt.Printf("Name=%s, Addresses=%s\n", svcList.Items[x].Name, vipConfigs)
+					fmt.Printf("Name=%s, UUID=%s, Addresses=%s\n", svcList.Items[x].Name, string(svcList.Items[x].UID), vipConfigs)
 				}
 				fmt.Println()
 			}


### PR DESCRIPTION
Is now added to the debug output:

```
--- KUBERNETES CONFIGURATION (SERVICES/ENDPOINTSLICES) ---
Service Configuration:
Name=hpeocsnf, UUID=16021e3b-4bcd-4e43-b39c-f2953f42f3b6, Addresses=
Name=kube-vip-service, UUID=af9bc4aa-5500-4d1f-a29b-b3d1f5ae09ff, Addresses=172.18.100.10
Name=kubernetes, UUID=16fa12ed-96ca-4299-b618-922e4f1cd655, Addresses=
Name=kube-dns, UUID=b025a94e-959b-476b-bff2-303252c09070, Addresses=

EndpointSlice Configuration (note endpoint names have -XXXXX prefixed):
  Endpoint Slice Name: kube-vip-service-lsbft
        Node: services-worker2, Target Pod:kube-vip-deploy-84c4c85769-4xbvc, Addresses: 10.244.1.7
        Node: services-worker, Target Pod:kube-vip-deploy-84c4c85769-gpttl, Addresses: 10.244.2.6
        Node: services-worker, Target Pod:kube-vip-deploy-84c4c85769-2b76l, Addresses: 10.244.2.7
        Node: services-worker, Target Pod:kube-vip-deploy-84c4c85769-4bs6b, Addresses: 10.244.2.5
        Node: services-worker2, Target Pod:kube-vip-deploy-84c4c85769-qmzwb, Addresses: 10.244.1.8
  Endpoint Slice Name: kubernetes
        Node: Unknown, Target Pod:Unknown, Addresses: 172.18.0.3
  Endpoint Slice Name: kube-dns-nn6cv
        Node: services-control-plane, Target Pod:coredns-668d6bf9bc-7cnkf, Addresses: 10.244.0.3
        Node: services-control-plane, Target Pod:coredns-668d6bf9bc-nx7kp, Addresses: 10.244.0.2
```