### PR TITLE
Add annotation to service when using BGP and not just ARP

### DIFF
--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -443,8 +443,8 @@ func (p *Processor) updateStatus(i *instance.Instance) error {
 			currentServiceCopy.Annotations = make(map[string]string)
 		}
 
-		// If we're using ARP then we can only broadcast the VIP from one place, add an annotation to the service
-		if p.config.EnableARP {
+		// If we're using ARP then we can only broadcast the VIP from one place, also useful for other software when running BGP, add an annotation to the service
+		if p.config.EnableARP || p.config.EnableBGP {
 			// Add the current host
 			currentServiceCopy.Annotations[kubevip.VipHost] = p.config.NodeName
 		}


### PR DESCRIPTION
Also add annotation to the service when using BGP and not just ARP to faciliate
using kube-vip to allow for high availability ciliumegressgatewaypolicies.cilium.io using for example https://github.com/angeloxx/cilium-haegress-operator