### PR TITLE
Move this error to a warning

### DIFF
--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -285,7 +285,7 @@ func (p *Processor) deleteService(uid types.UID) error {
 	if !found {
 		// TODO: - fix UX
 		// return fmt.Errorf("unable to find/stop service [%s]", uid)
-		log.Error("unable to find/stop service", "uid", uid)
+		log.Warn("unable to find/stop service", "uid", uid)
 		return nil
 	}
 


### PR DESCRIPTION
This currently creates an error, however a deleted service that we aren't monitoring should largely be a warning.