### PR TITLE
Support specifying UPNP lease duration as annotation on a service.

### DIFF
--- a/pkg/kubevip/annotations.go
+++ b/pkg/kubevip/annotations.go
@@ -57,6 +57,9 @@ const (
 	// Enable UPNP on a Service
 	UpnpEnabled = "kube-vip.io/forwardUPNP"
 
+	// Set the UPNP lease duration for a specific service using duration format (e.g., "30s", "1h")
+	UpnpLeaseDuration = "kube-vip.io/upnp-lease-duration"
+
 	RPFilter = "kube-vip.io/rp_filter" // Set the return path filter for a specific service interface
 
 	ServiceLease = "kube-vip.io/leaseName"

--- a/pkg/services/services_test.go
+++ b/pkg/services/services_test.go
@@ -1,0 +1,68 @@
+package services
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kube-vip/kube-vip/pkg/instance"
+)
+
+// Test_upnpLeaseDurationForService tests whether the default lease duration is used, and whether the annotation
+// overrides it correctly.
+//
+// For simplicity, this table driven test does not cover all edge cases (passing in nil instance, nil service snapshot,
+// nil annotations, etc).
+func Test_upnpLeaseDurationForService(t *testing.T) {
+	const annotation = "kube-vip.io/upnp-lease-duration" // Validating value of kubevip.UpnpLeaseDuration.
+	tcs := []struct {
+		name        string
+		annotations map[string]string
+		want        int // in seconds
+	}{
+		{
+			name:        "No annotation uses default",
+			annotations: map[string]string{},
+			want:        3600,
+		},
+		{
+			name: "Valid annotation overrides default",
+			annotations: map[string]string{
+				annotation: "2h",
+			},
+			want: 7200,
+		},
+		{
+			name: "Valid short annotation overrides default",
+			annotations: map[string]string{
+				annotation: "30m",
+			},
+			want: 1800,
+		},
+		{
+			name: "Invalid annotation uses default",
+			annotations: map[string]string{
+				annotation: "invalid-duration",
+			},
+			want: 3600,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			i := &instance.Instance{
+				ServiceSnapshot: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: tc.annotations,
+					},
+				},
+			}
+			gotDuration := upnpLeaseDurationForService(i)
+			got := int(gotDuration.Seconds())
+			if got != tc.want {
+				t.Errorf("upnpLeaseDurationForService(%+v) = %v, want %v", tc.annotations, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The annotation `kube-vip.io/upnp-lease-duration` takes in a duration where the string is parseable by `time.ParseDuration`.

There is no new configuration option that would allow setting this globally, since this new feature is most helpful in limited cases (such as incorrect implementations that have trouble with certain values).

There is a minimal test added for the value returned by the new private helper `upnpLeaseDurationForService`. Due to a lack of dependency injection in `service.Processor`'s `upnpMap`, it is infeasible to add a more complete test at this time, to check what would be passed, exactly, into `AddPinholeCtx` and `AddPortMapping`.



Fixes: #1349