### PR TITLE
Fixed service deletion when service leader election is enabled

### DIFF
--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -41,7 +41,7 @@ const (
 )
 
 func (p *Processor) SyncServices(ctx context.Context, svc *v1.Service) error {
-	log.Debug("[STARTING] Service Sync", "namespace", svc.Namespace, "name", svc.Name)
+	log.Debug("[STARTING] Service Sync", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
 
 	// Iterate through the synchronising services
 
@@ -126,7 +126,7 @@ func (p *Processor) getServiceInstanceAction(svc *v1.Service) ServiceInstanceAct
 		}
 	}
 	if len(addresses) > 0 || len(hostnames) > 0 {
-		log.Debug("no matching service instance found", "service", svc.Name, "namespace", svc.Namespace, "addresses", addresses, "hostnames", hostnames)
+		log.Debug("no matching service instance found", "service", svc.Name, "namespace", svc.Namespace, "uid", svc.UID, "addresses", addresses, "hostnames", hostnames)
 		return ActionAdd // If no matching instance is found, we need to add a new service instance
 	}
 	return ActionNone
@@ -161,7 +161,7 @@ func (p *Processor) addService(ctx context.Context, svc *v1.Service) error {
 	}
 
 	for x := range newService.VIPConfigs {
-		log.Debug("starting loadbalancer for service", "name", svc.Name, "namespace", svc.Namespace)
+		log.Debug("starting loadbalancer for service", "name", svc.Name, "namespace", svc.Namespace, "uid", svc.UID)
 		newService.Clusters[x].StartLoadBalancerService(ctx, newService.VIPConfigs[x], p.bgpServer, svc.Name, p.CountRouteReferences)
 	}
 
@@ -329,7 +329,7 @@ func (p *Processor) deleteService(uid types.UID) error {
 	var serviceInstance *instance.Instance
 	found := false
 	for x := range p.ServiceInstances {
-		log.Debug("[service] lookup", "target UID", uid, "found UID ", p.ServiceInstances[x].ServiceSnapshot.UID, "name", p.ServiceInstances[x].ServiceSnapshot.Name, "namespace", p.ServiceInstances[x].ServiceSnapshot.Namespace)
+		log.Debug("[service] lookup", "target UID", uid, "found UID", p.ServiceInstances[x].ServiceSnapshot.UID, "name", p.ServiceInstances[x].ServiceSnapshot.Name, "namespace", p.ServiceInstances[x].ServiceSnapshot.Namespace)
 		// Add the running services to the new array
 		if p.ServiceInstances[x].ServiceSnapshot.UID != uid {
 			updatedInstances = append(updatedInstances, p.ServiceInstances[x])
@@ -354,7 +354,7 @@ func (p *Processor) deleteService(uid types.UID) error {
 		}
 	}
 
-	// Determine if this this VIP is shared with other loadbalancers
+	// Determine if this VIP is shared with other loadbalancers
 	shared := false
 	vipSet := make(map[string]interface{})
 	for x := range updatedInstances {

--- a/testing/e2e/e2e_bgp_test.go
+++ b/testing/e2e/e2e_bgp_test.go
@@ -402,7 +402,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 		})
 
-		Describe("kube-vip DualStack services BGP mode functionality with MP-BGP IPv4 over IPv6 - fixed nexthop", Ordered, func() {
+		Describe("kube-vip DualStack services BGP mode functionality with MP-BGP IPv4 over IPv6 - auto_sourceif nexthop, auto source interface", Ordered, func() {
 			var (
 				cpVIP          string
 				clusterName    string
@@ -457,7 +457,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 		})
 
-		Describe("kube-vip IPv4 services BGP mode functionality", Ordered, func() {
+		Describe("kube-vip IPv4 services BGP mode functionality, with service election", Ordered, func() {
 			var (
 				cpVIP          string
 				clusterName    string
@@ -521,7 +521,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 		})
 
-		Describe("kube-vip IPv6 services BGP mode functionality", Ordered, func() {
+		Describe("kube-vip IPv6 services BGP mode functionality, with service election", Ordered, func() {
 			var (
 				cpVIP          string
 				clusterName    string
@@ -583,7 +583,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 		})
 
-		Describe("kube-vip DualStack services BGP mode functionality with MP-BGP IPv6 over IPv4 - fixed nexthop", Ordered, func() {
+		Describe("kube-vip DualStack services BGP mode functionality with MP-BGP IPv6 over IPv4 - fixed nexthop, with service election", Ordered, func() {
 			var (
 				cpVIP          string
 				clusterName    string
@@ -645,7 +645,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 		})
 
-		Describe("kube-vip DualStack services BGP mode functionality with MP-BGP IPv4 over IPv6 - fixed nexthop", Ordered, func() {
+		Describe("kube-vip DualStack services BGP mode functionality with MP-BGP IPv4 over IPv6 - fixed nexthop, with service election", Ordered, func() {
 			var (
 				cpVIP          string
 				clusterName    string
@@ -707,7 +707,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 		})
 
-		Describe("kube-vip DualStack services BGP mode functionality with MP-BGP IPv6 over IPv4 - auto_sourceif nexthop", Ordered, func() {
+		Describe("kube-vip DualStack services BGP mode functionality with MP-BGP IPv6 over IPv4 - auto_sourceif nexthop, with service election", Ordered, func() {
 			var (
 				cpVIP          string
 				clusterName    string
@@ -770,7 +770,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 		})
 
-		Describe("kube-vip DualStack services BGP mode functionality with MP-BGP IPv4 over IPv6 - fixed nexthop", Ordered, func() {
+		Describe("kube-vip DualStack services BGP mode functionality with MP-BGP IPv4 over IPv6 - auto_sourceif nexthop, with service election", Ordered, func() {
 			var (
 				cpVIP          string
 				clusterName    string


### PR DESCRIPTION
This PR fixes #1287 

It turned out that the issue described by @Cellebyte did occur not only for dualstack services, but all -  kube-vip tried to delete the service in two codepaths if service election was enabled. I've changed where service is tagged as inactive and in what circumstances should be delete called, so the `unable to find/stop service` log should not be displayed now.

Additionally added  service's UID to some logs to ease service tracking a bit and updated the titles of BGP e2e tests to be more distinguishable. 