### PR TITLE
Fixed an issue with default gateway interface retrieval in multi-path…

### DIFF
--- a/pkg/vip/util.go
+++ b/pkg/vip/util.go
@@ -25,18 +25,18 @@ func getHostName(dnsName string) string {
 }
 
 // GetDefaultGatewayInterface return default gateway interface link
-func GetDefaultGatewayInterface() (*net.Interface, error) {
+func GetDefaultGatewayInterface() (iface *net.Interface, err error) {
 	// Attempt IPv4 first (usually the default)
-	if iface, err := getDefaultRoute(syscall.AF_INET); err == nil {
+	if iface, err = getDefaultRoute(syscall.AF_INET); err == nil {
 		return iface, nil
 	}
 
-	// If the IPv6 default route is not found, then attempt IPv6.
-	if iface, err := getDefaultRoute(syscall.AF_INET6); err == nil {
+	// If the IPv4 default route is not found, then attempt IPv6 default route.
+	if iface, err = getDefaultRoute(syscall.AF_INET6); err == nil {
 		return iface, nil
 	}
 
-	return nil, errors.New("unable to find interface with default route")
+	return nil, fmt.Errorf("unable to find interface with default route: %w", err)
 }
 
 // getDefaultRoute attempts to find the default route for the specified address family.
@@ -69,7 +69,7 @@ func getDefaultRoute(family int) (*net.Interface, error) {
 		}
 
 		if idx > 0 {
-			return net.InterfaceByIndex(idx), nil
+			return net.InterfaceByIndex(idx)
 		}
 	}
 	return nil, errors.New("default route not found")


### PR DESCRIPTION
I replace default route to multi-path for testing:
```
# ip -j -6 route show ::/0
[{"dst":"default","metric":1024,"flags":[],"pref":"medium","nexthops":[{"gateway":"2242::192:168:242:254","dev":"ens3","weight":1,"flags":[]},{"gateway":"fe80::aaaa:bbbb:cccc:dddd","dev":"ens3","weight":1,"flags":[]}]}]
```
After the modification, VIP can work normally as expected.

```log
# kubectl  -nkube-system logs infra-kube-vip-7kw6c 
2025/12/29 03:05:47 INFO kube-vip.io version=v1.0.3 build=ba7a71bc5fd70f767a39fae2482c6f3c0d98215d
2025/12/29 03:05:47 INFO starting namespace=kube-system Mode=ARP "Control Plane"=false Services=true
2025/12/29 03:05:47 INFO No interface is specified for VIP in config, auto-detecting default Interface
2025/12/29 03:05:47 INFO prometheus HTTP server started
2025/12/29 03:05:47 INFO kube-vip bind interface=ens3
2025/12/29 03:05:47 WARN Node name is missing from the config, fall back to hostname
2025/12/29 03:05:47 INFO using node name name=mgmtnode-31
2025/12/29 03:05:47 INFO Starting Kube-vip Manager with the ARP engine
2025/12/29 03:05:47 INFO Start ARP/NDP advertisement
2025/12/29 03:05:47 INFO beginning services leadership namespace=kube-system "lock name"=plndr-svcs-lock id=mgmtnode-31
2025/12/29 03:05:47 INFO [ARP manager] starting ARP/NDP advertisement
I1229 03:05:47.456956       1 leaderelection.go:257] attempting to acquire leader lease kube-system/plndr-svcs-lock...
I1229 03:05:47.501213       1 leaderelection.go:271] successfully acquired lease kube-system/plndr-svcs-lock
2025/12/29 03:05:47 INFO (svcs) starting services watcher for all namespaces
2025/12/29 03:05:47 INFO NewInstance used instanceAddresses=[2242::192:168:242:30] instanceHostnames=[]
2025/12/29 03:05:47 INFO (svcs) adding VIP ip=2242::192:168:242:30 interface=ens3 namespace=cloud name=vnc
2025/12/29 03:05:47 INFO successful add IP
2025/12/29 03:05:47 INFO layer 2 broadcaster starting IP=2242::192:168:242:30 device=ens3
2025/12/29 03:05:47 INFO [ARP manager] inserting ARP/NDP instance name=2242::192:168:242:30/128-ens3
2025/12/29 03:05:47 INFO [service] service=vnc namespace=cloud "synchronised in"=74ms
2025/12/29 03:05:47 INFO NewInstance used instanceAddresses=[2242::192:168:242:30] instanceHostnames=[]
2025/12/29 03:05:47 INFO (svcs) adding VIP ip=2242::192:168:242:30 interface=ens3 namespace=kube-system name=infra-chrony-lb
2025/12/29 03:05:47 INFO successful add IP
2025/12/29 03:05:47 INFO layer 2 broadcaster starting IP=2242::192:168:242:30 device=ens3
2025/12/29 03:05:47 INFO [service] service=infra-chrony-lb namespace=kube-system "synchronised in"=12ms
2025/12/29 03:05:47 INFO NewInstance used instanceAddresses=[2242::192:168:242:30] instanceHostnames=[]
2025/12/29 03:05:47 INFO (svcs) adding VIP ip=2242::192:168:242:30 interface=ens3 namespace=kube-system name=traefik
2025/12/29 03:05:47 INFO successful add IP
2025/12/29 03:05:47 INFO layer 2 broadcaster starting IP=2242::192:168:242:30 device=ens3
2025/12/29 03:05:47 INFO [service] service=traefik namespace=kube-system "synchronised in"=44ms
2025/12/29 03:05:50 INFO Broadcasting NDP update ip=2242::192:168:242:30 hwaddr="RT\x00-\xa2\xcb" interface=ens3
2025/12/29 03:05:53 INFO Broadcasting NDP update ip=2242::192:168:242:30 hwaddr="RT\x00-\xa2\xcb" interface=ens3
2025/12/29 03:05:56 INFO Broadcasting NDP update ip=2242::192:168:242:30 hwaddr="RT\x00-\xa2\xcb" interface=ens3
```

Fixed: #1371 