### PR TITLE
Configurable DHCP retry

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -135,6 +135,8 @@ func init() {
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.ServicesLeaseName, "servicesLeaseName", "plndr-svcs-lock", "Name of the lease that is used for leader election for services (in arp mode)")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.DNSMode, "dnsMode", "first", "Name of the mode that DNS lookup will be performed (first, ipv4, ipv6, dual)")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.DHCPMode, "dhcpMode", "", "Mode DHCP resolving will use to obtain IP addresses (ipv4, ipv6, dual)")
+	kubeVipCmd.PersistentFlags().UintVar(&initConfig.DHCPBackoffAttempts, "dhcpBackoffAttempts", kubevip.DefaultDHCPBackoffAttempts,
+		fmt.Sprintf("number of times DHCP client will try to obtain an IP address (defaults to: %d, 0 for unlimited retries)", kubevip.DefaultDHCPBackoffAttempts))
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.DisableServiceUpdates, "disableServiceUpdates", false, "If true, kube-vip will process services as usual, but will not update service's Status.LoadBalancer.Ingress slice")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableEndpoints, "enableEndpoints", false, "If enabled, kube-vip will only advertise services, but will use the (deprecated since v1.33) endpoints for IP addresses")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.LoInterfaceGlobalScope, "loInterfaceGlobalScope", false, "If true, kube-vip will set global scope when using the lo interface, otherwise a host scope will be used by default")

--- a/pkg/cluster/clusterDDNS.go
+++ b/pkg/cluster/clusterDDNS.go
@@ -12,8 +12,8 @@ import (
 // during runtime if IP changes, startDDNS don't have to do reconfigure because
 // dnsUpdater already have the functionality to keep trying resolve the IP
 // and update the VIP configuration if it changes
-func (cluster *Cluster) StartDDNS(ctx context.Context, network vip.Network) error {
-	ddnsMgr := vip.NewDDNSManager(network)
+func (cluster *Cluster) StartDDNS(ctx context.Context, network vip.Network, backoffAttempts uint) error {
+	ddnsMgr := vip.NewDDNSManager(network, backoffAttempts)
 	ip, err := ddnsMgr.Start(ctx)
 	if err != nil {
 		return err

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -50,7 +50,7 @@ func (cluster *Cluster) vipService(ctxArp, ctxDNS context.Context, c *kubevip.Co
 		network := cluster.Network[i]
 
 		if network.IsDDNS() {
-			if err := cluster.StartDDNS(ctxDNS, cluster.Network[i]); err != nil {
+			if err := cluster.StartDDNS(ctxDNS, cluster.Network[i], c.DHCPBackoffAttempts); err != nil {
 				log.Error("failed to start DDNS", "err", err)
 			}
 		}
@@ -290,7 +290,7 @@ func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip
 
 				// start the DDNS if requested
 				log.Debug("(svcs) start DDNS", "name", network.DNSName())
-				if err := cluster.StartDDNS(ctxDDNS, cluster.Network[i]); err != nil {
+				if err := cluster.StartDDNS(ctxDDNS, cluster.Network[i], c.DHCPBackoffAttempts); err != nil {
 					log.Error("failed to start DDNS", "err", err)
 				}
 

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -392,6 +392,18 @@ func ParseEnvironment(c *Config) error {
 		}
 	}
 
+	// DHCP backoff attempts
+	env = os.Getenv(dhcpBackoffAttempts)
+	if env != "" {
+		tmp, err := strconv.ParseInt(env, 10, 32)
+		if err != nil {
+			return err
+		}
+		if tmp >= 0 {
+			c.DHCPBackoffAttempts = uint(tmp)
+		}
+	}
+
 	// Disable updates for services (status.LoadBalancer.Ingress will not be updated)
 	env = os.Getenv(disableServiceUpdates)
 	if env != "" {
@@ -891,9 +903,14 @@ func mergeConfigValues(baseConfig, fileConfig *Config) {
 		baseConfig.DNSMode = fileConfig.DNSMode
 	}
 
-	// DHCP configuration
+	// DHCP configuration - mode
 	if baseConfig.DHCPMode == "" && fileConfig.DHCPMode != "" {
 		baseConfig.DHCPMode = fileConfig.DHCPMode
+	}
+
+	// DHCP configuration - backoff attempts
+	if baseConfig.DHCPBackoffAttempts == DefaultDHCPBackoffAttempts && fileConfig.DHCPBackoffAttempts != DefaultDHCPBackoffAttempts {
+		baseConfig.DHCPBackoffAttempts = fileConfig.DHCPBackoffAttempts
 	}
 
 	// Health check configuration

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -215,6 +215,9 @@ const (
 	// dhcpMode defines mode that DHCP lookup will be performed with (ipv4, ipv6, dual)
 	dhcpMode = "dhcp_mode"
 
+	// dhcpBackoffAttempts defines how many times DHCP client will try to obtain an IP address
+	dhcpBackoffAttempts = "dhcp_backoff_attempts"
+
 	// disableServiceUpdates disables service updating
 	disableServiceUpdates = "disable_service_updates"
 

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -266,6 +266,17 @@ func generatePodSpec(c *Config, image, imageVersion string, inCluster bool) *cor
 		newEnvironment = append(newEnvironment, dhcpModeSelector...)
 	}
 
+	if c.DHCPBackoffAttempts != DefaultDHCPBackoffAttempts {
+		// build environment variables
+		dhcpBackoff := []corev1.EnvVar{
+			{
+				Name:  dhcpBackoffAttempts,
+				Value: strconv.FormatUint(uint64(c.DHCPBackoffAttempts), 10),
+			},
+		}
+		newEnvironment = append(newEnvironment, dhcpBackoff...)
+	}
+
 	// If we're doing the hybrid mode
 	if c.EnableControlPlane {
 		cp := []corev1.EnvVar{

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -199,6 +199,9 @@ type Config struct {
 
 	// ConfigFile defines the path to a JSON/YAML configuration file
 	ConfigFile string `yaml:"configFile"`
+
+	// DHCPBackoffAttempts defaines how many times will DHCP client try to obtain address (unlimited when 0)
+	DHCPBackoffAttempts uint `yaml:"dhcpBackoffAttempts"`
 }
 
 // KubernetesLeaderElection defines all of the settings for Kubernetes KubernetesLeaderElection

--- a/pkg/kubevip/constants.go
+++ b/pkg/kubevip/constants.go
@@ -2,4 +2,6 @@ package kubevip
 
 const (
 	LBClassName = "kube-vip.io/kube-vip-class"
+
+	DefaultDHCPBackoffAttempts = 3
 )

--- a/pkg/vip/ddns.go
+++ b/pkg/vip/ddns.go
@@ -18,20 +18,22 @@ type DDNSManager interface {
 }
 
 type ddnsManager struct {
-	network Network
+	network         Network
+	backoffAttempts uint
 }
 
 // NewDDNSManager returns a newly created Dynamic DNS manager
-func NewDDNSManager(network Network) DDNSManager {
+func NewDDNSManager(network Network, backoffAttempts uint) DDNSManager {
 	return &ddnsManager{
-		network: network,
+		network:         network,
+		backoffAttempts: backoffAttempts,
 	}
 }
 
 // Start will start the dhcpclient routine to keep the lease
 // and return the IP it got from DHCP
 func (ddns *ddnsManager) Start(ctx context.Context) (string, error) {
-	client, err := NewDHCPClient(ddns.network)
+	client, err := NewDHCPClient(ddns.network, ddns.backoffAttempts)
 	if err != nil {
 		return "", fmt.Errorf("unable to create DHCP client: %w", err)
 	}

--- a/pkg/vip/dhcp.go
+++ b/pkg/vip/dhcp.go
@@ -17,7 +17,7 @@ type DHCPClient interface {
 	WithHostName(hostname string) DHCPClient
 }
 
-func NewDHCPClient(network Network) (DHCPClient, error) {
+func NewDHCPClient(network Network, backoffAttempts uint) (DHCPClient, error) {
 	interfaceName := network.Interface()
 	iface, err := net.InterfaceByName(interfaceName)
 	if err != nil {
@@ -27,12 +27,12 @@ func NewDHCPClient(network Network) (DHCPClient, error) {
 	var client DHCPClient
 
 	if strings.EqualFold(network.DHCPFamily(), utils.IPv6Family) {
-		client, err = NewDHCPv6Client(iface, nil, false, "")
+		client, err = NewDHCPv6Client(iface, nil, false, "", backoffAttempts)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create DHCP client: %w", err)
 		}
 	} else {
-		client = NewDHCPv4Client(iface, false, "")
+		client = NewDHCPv4Client(iface, false, "", backoffAttempts)
 	}
 
 	return client, nil


### PR DESCRIPTION
This PR adds new config flag to configure number of retries (attempts) DHCP client will use to obtain IP address from the server. The default value (3) was not changed.

Can be configured with env variable `dhcp_backoff_attempts`, or CLI flag `dhcpBackoffAttempts`.

If set to `0` the number of attempts will be unlimited.

With this #1214 can be closed I think.