### PR TITLE
Fixed preserveVipOnLeadershipLoss setting in manifest generation

### DIFF
--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -302,9 +302,6 @@ func ParseEnvironment(c *Config) error {
 			return err
 		}
 		c.PreserveVIPOnLeadershipLoss = b
-	} else {
-		// Default to false for backward compatibility
-		c.PreserveVIPOnLeadershipLoss = false
 	}
 
 	// Wireguard Mode

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -594,6 +594,16 @@ func generatePodSpec(c *Config, image, imageVersion string, inCluster bool) *cor
 		}
 	}
 
+	if c.PreserveVIPOnLeadershipLoss {
+		preserveVIPOnLeadershipLoss := []corev1.EnvVar{
+			{
+				Name:  vipPreserveOnLeadershipLoss,
+				Value: strconv.FormatBool(c.PreserveVIPOnLeadershipLoss),
+			},
+		}
+		newEnvironment = append(newEnvironment, preserveVIPOnLeadershipLoss...)
+	}
+
 	newManifest := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",


### PR DESCRIPTION
This PR should fix #1369 

`preserveVipOnLeadershipLoss` was not set in config generator. Additionally it was being overridden with default `false` if CLI arguments were used instead of ENV variables.