### PR TITLE
Fixed endpointslices handling in dualstack clusters

### DIFF
--- a/pkg/endpoints/endpoints_routing_table.go
+++ b/pkg/endpoints/endpoints_routing_table.go
@@ -124,10 +124,14 @@ func (rt *RoutingTable) setInstanceEndpointsStatus(service *v1.Service, endpoint
 				// if there are no endpoints set HasEndpoints false just in case
 				if len(endpoints) < 1 {
 					c.Network[n].SetHasEndpoints(false)
-				}
-				// check if endpoint are available and are of same IP family as service
-				if len(endpoints) > 0 && ((net.ParseIP(c.Network[n].IP()).To4() == nil) == (net.ParseIP(endpoints[0]).To4() == nil)) {
-					c.Network[n].SetHasEndpoints(true)
+				} else {
+					// check if endpoint are available and are of same IP family as service
+					for _, ep := range endpoints {
+						if (net.ParseIP(c.Network[n].IP()).To4() == nil) == (net.ParseIP(ep).To4() == nil) {
+							c.Network[n].SetHasEndpoints(true)
+							break
+						}
+					}
 				}
 			}
 		}

--- a/pkg/endpoints/providers/endpoints.go
+++ b/pkg/endpoints/providers/endpoints.go
@@ -131,7 +131,3 @@ func (ep *Endpoints) UpdateServiceAnnotation(endpoint string, _ string, service 
 func (ep *Endpoints) GetLabel() string {
 	return ep.label
 }
-
-func (ep *Endpoints) GetProtocol() string {
-	return ""
-}

--- a/pkg/endpoints/providers/interface.go
+++ b/pkg/endpoints/providers/interface.go
@@ -18,5 +18,4 @@ type Provider interface {
 	GetLabel() string
 	UpdateServiceAnnotation(string, string, *v1.Service, *kubernetes.Clientset) error
 	LoadObject(runtime.Object, context.CancelFunc) error
-	GetProtocol() string
 }

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -333,9 +333,9 @@ func (p *Processor) Delete(event watch.Event) (bool, error) {
 		}
 
 		// Calls the cancel function of the context
-		log.Warn("(svcs) The load balancer was deleted, cancelling context")
+		log.Warn("(svcs) The load balancer was deleted, cancelling context", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
 		svcCtx.Cancel()
-		log.Warn("(svcs) waiting for load balancer to finish")
+		log.Warn("(svcs) waiting for load balancer to finish", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
 		<-svcCtx.Ctx.Done()
 		p.svcMap.Delete(svc.UID)
 	}


### PR DESCRIPTION
While working on #1375 I have found an issue with handling of endpointslices in dualstack clusters. Sometimes when IPv4 and IPv6 endpointslices were updated one after another the last known good endpoint was changed from IPv4 to IPv6 or the other way around which resulted in cancelling leader context. For this reason BGP test failed randomly. I think that should be fixed now.

Now instead of using common object IPv4 and IPv6 endpoints are processed separately and the last known good endpoint is not being lost if not deleted.