### PR TITLE
Added pre-pull for testing images + some minor e2e tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,20 +133,25 @@ integration-tests:
 	go test -tags=integration,e2e -v ./pkg/etcd
 
 e2e-tests:
+	docker pull ghcr.io/traefik/whoami:v1.11
 	GOMAXPROCS=4 E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v -p ./testing/e2e ./testing/e2e/etcd
 
 e2e-tests129-arp:
+	docker pull ghcr.io/traefik/whoami:v1.11
 	GOMAXPROCS=4 TEST_MODE=arp V129=true K8S_IMAGE_PATH=kindest/node:v1.29.0 E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v -p ./testing/e2e
 
 e2e-tests129-rt:
+	docker pull ghcr.io/traefik/whoami:v1.11
 	GOMAXPROCS=4 TEST_MODE=rt V129=true K8S_IMAGE_PATH=kindest/node:v1.29.0 E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v -p ./testing/e2e
 
 e2e-tests129-bgp:
+	docker pull ghcr.io/traefik/whoami:v1.11
 	GOMAXPROCS=4 TEST_MODE=bgp V129=true K8S_IMAGE_PATH=kindest/node:v1.29.0 E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v -p ./testing/e2e
 
 e2e-tests129: e2e-tests129-arp e2e-tests129-rt e2e-tests129-bgp
 
-service-tests:
+service-tests: 
+	$(MAKE) -C testing/e2e/e2e dockerLocal
 	E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run ./testing/services -Services -simple -deployments -leaderActive -leaderFailover -localDeploy -egress -egressIPv6 -dualStack
 
 trivy: dockerx86ActionIPTables

--- a/pkg/etcd/election_test.go
+++ b/pkg/etcd/election_test.go
@@ -59,7 +59,7 @@ func TestRunElectionWithMemberIDCollision(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
-		time.Sleep(time.Millisecond * 50) // make sure the first one becomes leader
+		time.Sleep(time.Millisecond * 100) // make sure the first one becomes leader
 		g.Expect(etcd.RunElection(ctx, config)).Should(MatchError(ContainSubstring("creating lease")))
 	}()
 

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -333,9 +333,9 @@ func (p *Processor) Delete(event watch.Event) (bool, error) {
 		}
 
 		// Calls the cancel function of the context
-		log.Warn("(svcs) The load balancer was deleted, cancelling context")
+		log.Warn("(svcs) The load balancer was deleted, cancelling context", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
 		svcCtx.Cancel()
-		log.Warn("(svcs) waiting for load balancer to finish")
+		log.Warn("(svcs) waiting for load balancer to finish", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
 		<-svcCtx.Ctx.Done()
 		p.svcMap.Delete(svc.UID)
 	}

--- a/testing/e2e/e2e/Dockerfile
+++ b/testing/e2e/e2e/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM golang:1.20-alpine as dev
+FROM golang:1.25.5-alpine3.23 as dev
 RUN apk add --no-cache git ca-certificates
 RUN adduser -D appuser
 COPY . /src/

--- a/testing/e2e/e2e/Makefile
+++ b/testing/e2e/e2e/Makefile
@@ -47,6 +47,10 @@ fmt:
 docker:
 	# @docker buildx build  --platform linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x --push -t $(REPOSITORY)/$(TARGET):$(DOCKERTAG) .
 	@docker buildx build  --platform linux/amd64 --push -t $(REPOSITORY)/$(TARGET):$(DOCKERTAG) .
+	@echo New Multi Architecture Docker image created and pushed
+
+dockerLocal:
+	@docker buildx build  --platform linux/amd64 -t $(REPOSITORY)/$(TARGET):$(VERSION) .
 	@echo New Multi Architecture Docker image created
 
 simplify:

--- a/testing/e2e/e2e/go.mod
+++ b/testing/e2e/e2e/go.mod
@@ -1,3 +1,3 @@
 module github.com/kube-vip/kube-vip/testing/e2e/servicesClient
 
-go 1.19
+go 1.25.5

--- a/testing/e2e/e2e_bgp_test.go
+++ b/testing/e2e/e2e_bgp_test.go
@@ -1107,7 +1107,7 @@ func checkGoBGPPaths(ctx context.Context, client api.GobgpApiClient, family *api
 			return fmt.Errorf("expected %d paths, but found %d", expectedPaths, len(paths))
 		}
 		return nil
-	}, "360s", "1s").ShouldNot(HaveOccurred())
+	}, "30s", "1s").ShouldNot(HaveOccurred())
 	return paths
 }
 
@@ -1128,12 +1128,15 @@ func getGoBGPPaths(ctx context.Context, client api.GobgpApiClient, family *api.F
 	rib := make([]*api.Destination, 0)
 	for {
 		r, err := stream.Recv()
-		if err == io.EOF {
-			break
-		} else if err != nil {
+		if err != nil && err != io.EOF {
 			return nil, err
 		}
-		rib = append(rib, r.Destination)
+		if r != nil {
+			rib = append(rib, r.Destination)
+		}
+		if err != nil && err == io.EOF {
+			break
+		}
 	}
 
 	return rib, nil

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -1237,6 +1237,9 @@ func prepareCluster(tempDirPath, clusterNameSuffix, k8sImagePath string,
 	By(withTimestamp("loading local docker image to kind cluster"))
 	e2e.LoadDockerImageToKind(logger, manifestValues.ImagePath, clusterName)
 
+	By(withTimestamp("loading traefik/whoami image to kind cluster"))
+	e2e.LoadDockerImageToKind(logger, "ghcr.io/traefik/whoami:v1.11", clusterName)
+
 	return clusterName, client, cfg
 }
 

--- a/testing/e2e/etcd/cluster.go
+++ b/testing/e2e/etcd/cluster.go
@@ -56,6 +56,9 @@ func CreateCluster(ctx context.Context, spec *ClusterSpec) *Cluster {
 	c.Logger.Printf("Loading kube-vip image into nodes")
 	e2e.LoadDockerImageToKind(spec.Logger, spec.KubeVIPImage, spec.Name)
 
+	c.Logger.Printf("Loading traefik image into nodes")
+	e2e.LoadDockerImageToKind(spec.Logger, "ghcr.io/traefik/whoami:v1.11", spec.Name)
+
 	c.Logger.Printf("Starting etcd cluster")
 	c.initEtcd(ctx)
 

--- a/testing/services/pkg/deployment/kind.go
+++ b/testing/services/pkg/deployment/kind.go
@@ -116,6 +116,14 @@ func (config *TestConfig) CreateKind() error {
 		if err != nil {
 			return err
 		}
+
+		loadE2EImageCmd := load.NewCommand(cmd.NewLogger(), cmd.StandardIOStreams())
+		loadE2EImageCmd.SetArgs([]string{"--name", "services", "docker.io/plndr/e2e:0.0.1"})
+		err = loadE2EImageCmd.Execute()
+		if err != nil {
+			return err
+		}
+
 		nodes, err := provider.ListNodes("services")
 		if err != nil {
 			return err

--- a/testing/services/pkg/deployment/services.go
+++ b/testing/services/pkg/deployment/services.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gookit/slog"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/utils"
 	"github.com/kube-vip/kube-vip/testing/e2e"
 	"github.com/vishvananda/netlink"
 
@@ -508,14 +509,20 @@ func GetLocalIP(ifName string, family int) (*net.IP, *net.IPNet, error) {
 		return nil, nil, fmt.Errorf("netlink: failed to list links: %w", err)
 	}
 
+	famStr := utils.IPv4Family
+
+	if family == netlink.FAMILY_V6 {
+		famStr = utils.IPv6Family
+	}
+
 	for _, link := range links {
 		if strings.Contains(link.Attrs().Name, ifName) {
 			ip, ipnet, err := getNetwork(link, family)
 			if err != nil {
-				return nil, nil, fmt.Errorf("failed to get IPv4 address: %w", err)
+				return nil, nil, fmt.Errorf("failed to get %s address: %w", famStr, err)
 			}
 			if ip == nil {
-				return nil, nil, fmt.Errorf("failed to find IPv4 address on the interface %q", ifName)
+				return nil, nil, fmt.Errorf("failed to find %s address on the interface %q", famStr, ifName)
 			}
 			return ip, ipnet, nil
 		}


### PR DESCRIPTION
While working on #1375 I've tried to run the tests in a loop and I believe I've hit some rate limits for `traefik/whoami` image. This image is pulled for every cluster (node) created in the e2e tests. Decided to try to pull it once before the test and load it to into the kind cluster.

Additionally added a local build of `plndr/e2e` image to the e2e tests so the image is built and loaded instead of being pulled. At this point it turned out that the `log` package in the code was changed to `slog`, but the code was not updated, so fixed that and additionally bumped go version to `1.25.5` same as main `kub-vip` image.