### PR TITLE
Fixed leaderelection retry on error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ e2e-tests129-bgp:
 
 e2e-tests129: e2e-tests129-arp e2e-tests129-rt e2e-tests129-bgp
 
-service-tests: 
+service-tests:
 	$(MAKE) -C testing/e2e/e2e dockerLocal
 	E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run ./testing/services -Services -simple -deployments -leaderActive -leaderFailover -localDeploy -egress -egressIPv6 -dualStack
 

--- a/pkg/endpoints/endpoints_bgp.go
+++ b/pkg/endpoints/endpoints_bgp.go
@@ -63,7 +63,7 @@ func (b *BGP) clear(svcCtx *servicecontext.Context, lastKnownGoodEndpoint *strin
 		}
 	}
 
-	b.clearEgress(lastKnownGoodEndpoint, service, svcCtx.Cancel)
+	b.clearEgress(lastKnownGoodEndpoint, service)
 }
 
 func (b *BGP) getEndpoints(service *v1.Service, id string) ([]string, error) {

--- a/pkg/endpoints/endpoints_routing_table.go
+++ b/pkg/endpoints/endpoints_routing_table.go
@@ -78,7 +78,7 @@ func (rt *RoutingTable) clear(svcCtx *servicecontext.Context, lastKnownGoodEndpo
 		}
 	}
 
-	rt.clearEgress(lastKnownGoodEndpoint, service, svcCtx.Cancel)
+	rt.clearEgress(lastKnownGoodEndpoint, service)
 }
 
 func (rt *RoutingTable) getEndpoints(service *v1.Service, id string) ([]string, error) {

--- a/pkg/lease/lease_test.go
+++ b/pkg/lease/lease_test.go
@@ -28,7 +28,7 @@ func TestManager_Add_NewLease(t *testing.T) {
 	mgr := NewManager()
 	svc := createTestService("test-svc", "default", nil)
 
-	lease, isNew := mgr.Add(svc)
+	lease, isNew, isShared := mgr.Add(svc)
 
 	if !isNew {
 		t.Error("expected isNew to be true for first Add")
@@ -45,6 +45,9 @@ func TestManager_Add_NewLease(t *testing.T) {
 	if lease.Started == nil {
 		t.Error("expected lease Started channel to be non-nil")
 	}
+	if isShared {
+		t.Error("expected isShared to be false for first Add")
+	}
 }
 
 // TestManager_Add_ExistingLease tests adding a service with an existing lease
@@ -52,8 +55,8 @@ func TestManager_Add_ExistingLease(t *testing.T) {
 	mgr := NewManager()
 	svc := createTestService("test-svc", "default", nil)
 
-	lease1, isNew1 := mgr.Add(svc)
-	lease2, isNew2 := mgr.Add(svc)
+	lease1, isNew1, isShared1 := mgr.Add(svc)
+	lease2, isNew2, isShared2 := mgr.Add(svc)
 
 	if !isNew1 {
 		t.Error("expected first Add to return isNew=true")
@@ -63,6 +66,12 @@ func TestManager_Add_ExistingLease(t *testing.T) {
 	}
 	if lease1 != lease2 {
 		t.Error("expected same lease to be returned for same service")
+	}
+	if isShared1 {
+		t.Error("expected isShared to be false for first Add")
+	}
+	if !isShared2 {
+		t.Error("expected isShared to be true for first Add")
 	}
 }
 
@@ -79,8 +88,8 @@ func TestManager_Delete_DecrementCounter(t *testing.T) {
 	mgr.Delete(svc)
 
 	lease := mgr.Get(svc)
-	if lease == nil {
-		t.Error("expected lease to still exist after first delete")
+	if lease != nil {
+		t.Error("expected lease to be removed after first delete if same service was processed twice")
 	}
 
 	// Delete again - should remove the lease
@@ -88,7 +97,7 @@ func TestManager_Delete_DecrementCounter(t *testing.T) {
 
 	lease = mgr.Get(svc)
 	if lease != nil {
-		t.Error("expected lease to be removed after second delete")
+		t.Error("expected lease to be removed")
 	}
 }
 
@@ -97,7 +106,7 @@ func TestManager_Delete_CancelsContext(t *testing.T) {
 	mgr := NewManager()
 	svc := createTestService("test-svc", "default", nil)
 
-	lease, _ := mgr.Add(svc)
+	lease, _, _ := mgr.Add(svc)
 
 	// Verify context is not cancelled
 	select {
@@ -125,11 +134,11 @@ func TestManager_Add_AfterDelete_CreatesNewLease(t *testing.T) {
 	svc := createTestService("test-svc", "default", nil)
 
 	// Add and delete
-	lease1, _ := mgr.Add(svc)
+	lease1, _, _ := mgr.Add(svc)
 	mgr.Delete(svc)
 
 	// Add again - should create new lease
-	lease2, isNew := mgr.Add(svc)
+	lease2, isNew, _ := mgr.Add(svc)
 
 	if !isNew {
 		t.Error("expected isNew to be true after delete and re-add")
@@ -145,8 +154,8 @@ func TestManager_Add_DifferentServices(t *testing.T) {
 	svc1 := createTestService("svc1", "default", nil)
 	svc2 := createTestService("svc2", "default", nil)
 
-	lease1, isNew1 := mgr.Add(svc1)
-	lease2, isNew2 := mgr.Add(svc2)
+	lease1, isNew1, _ := mgr.Add(svc1)
+	lease2, isNew2, _ := mgr.Add(svc2)
 
 	if !isNew1 || !isNew2 {
 		t.Error("expected both adds to return isNew=true")
@@ -162,8 +171,8 @@ func TestManager_Add_SameNameDifferentNamespace(t *testing.T) {
 	svc1 := createTestService("test-svc", "namespace1", nil)
 	svc2 := createTestService("test-svc", "namespace2", nil)
 
-	lease1, isNew1 := mgr.Add(svc1)
-	lease2, isNew2 := mgr.Add(svc2)
+	lease1, isNew1, _ := mgr.Add(svc1)
+	lease2, isNew2, _ := mgr.Add(svc2)
 
 	if !isNew1 || !isNew2 {
 		t.Error("expected both adds to return isNew=true")
@@ -271,50 +280,6 @@ func TestGetName_WithAnnotation(t *testing.T) {
 	}
 }
 
-// TestUsesCommon tests the common lease detection
-func TestUsesCommon(t *testing.T) {
-	tests := []struct {
-		name        string
-		annotations map[string]string
-		expected    bool
-	}{
-		{
-			name:        "no annotation",
-			annotations: nil,
-			expected:    false,
-		},
-		{
-			name:        "empty annotations",
-			annotations: map[string]string{},
-			expected:    false,
-		},
-		{
-			name: "with service-lease annotation",
-			annotations: map[string]string{
-				serviceLeaseAnnotation: "shared-lease",
-			},
-			expected: true,
-		},
-		{
-			name: "with other annotation",
-			annotations: map[string]string{
-				"some-other-annotation": "value",
-			},
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			svc := createTestService("test-svc", "default", tt.annotations)
-			result := UsesCommon(svc)
-			if result != tt.expected {
-				t.Errorf("UsesCommon() = %v, expected %v", result, tt.expected)
-			}
-		})
-	}
-}
-
 // TestManager_LeaderElectionRestartScenario simulates the bug scenario where
 // leadership is lost and the restartable service watcher tries to restart
 // the leader election. This test verifies that after deleting the lease,
@@ -324,9 +289,12 @@ func TestManager_LeaderElectionRestartScenario(t *testing.T) {
 	svc := createTestService("traefik", "traefik", nil)
 
 	// Simulate first leader election start
-	lease1, isNew1 := mgr.Add(svc)
+	lease1, isNew1, isShared1 := mgr.Add(svc)
 	if !isNew1 {
 		t.Fatal("expected first add to return isNew=true")
+	}
+	if isShared1 {
+		t.Fatal("expected first add to return isShared=false")
 	}
 
 	// Simulate leadership acquired - close Started channel
@@ -342,9 +310,12 @@ func TestManager_LeaderElectionRestartScenario(t *testing.T) {
 	}
 
 	// Simulate restartable service watcher calling StartServicesLeaderElection again
-	lease2, isNew2 := mgr.Add(svc)
+	lease2, isNew2, isShared2 := mgr.Add(svc)
 	if !isNew2 {
 		t.Fatal("expected second add after delete to return isNew=true")
+	}
+	if isShared2 {
+		t.Fatal("expected second add after delete to return isShared2=false")
 	}
 
 	// Verify we got a new lease with a fresh Started channel
@@ -374,18 +345,24 @@ func TestManager_CommonLeaseScenario(t *testing.T) {
 	svc2 := createTestService("svc2", "default", sharedLeaseAnnotations)
 
 	// First service gets a new lease
-	lease1, isNew1 := mgr.Add(svc1)
+	lease1, isNew1, isShared1 := mgr.Add(svc1)
 	if !isNew1 {
 		t.Error("expected first add to return isNew=true")
+	}
+	if isShared1 {
+		t.Error("expected first add to return isShared=false")
 	}
 
 	// Simulate first service starting leadership
 	close(lease1.Started)
 
 	// Second service should get the same lease
-	lease2, isNew2 := mgr.Add(svc2)
-	if isNew2 {
-		t.Error("expected second add with same lease name to return isNew=false")
+	lease2, isNew2, isShared2 := mgr.Add(svc2)
+	if !isNew2 {
+		t.Error("expected second add with same lease name to return isNew=true")
+	}
+	if !isShared2 {
+		t.Error("expected second add with same lease name to return isShared=true")
 	}
 	if lease1 != lease2 {
 		t.Error("expected same lease for services with same lease annotation")
@@ -412,9 +389,12 @@ func TestManager_RaceCondition_LeaseExistsBeforeDelete(t *testing.T) {
 	svc := createTestService("traefik", "traefik", nil)
 
 	// Simulate first leader election start
-	lease1, isNew1 := mgr.Add(svc)
+	lease1, isNew1, isShared1 := mgr.Add(svc)
 	if !isNew1 {
 		t.Fatal("expected first add to return isNew=true")
+	}
+	if isShared1 {
+		t.Fatal("expected first add to return isShared=false")
 	}
 
 	// Simulate leadership acquired - close Started channel
@@ -422,9 +402,12 @@ func TestManager_RaceCondition_LeaseExistsBeforeDelete(t *testing.T) {
 
 	// Simulate a second goroutine calling Add BEFORE the first goroutine's defer deletes the lease
 	// This is the race condition scenario
-	lease2, isNew2 := mgr.Add(svc)
+	lease2, isNew2, isShared2 := mgr.Add(svc)
 	if isNew2 {
 		t.Error("expected second add before delete to return isNew=false")
+	}
+	if !isShared2 {
+		t.Error("expected second add before delete to return isShared=true")
 	}
 	if lease1 != lease2 {
 		t.Error("expected same lease to be returned")
@@ -441,15 +424,15 @@ func TestManager_RaceCondition_LeaseExistsBeforeDelete(t *testing.T) {
 	// Now the first goroutine's defer deletes the lease
 	mgr.Delete(svc)
 
-	// The lease should still exist because the second Add incremented the counter
-	if mgr.Get(svc) == nil {
-		t.Error("expected lease to still exist after first delete (counter was incremented)")
+	// The lease should not still exist because same service was processed twice, so we do not increment the counter
+	if mgr.Get(svc) != nil {
+		t.Error("expected lease tonot exist")
 	}
 
-	// Second delete removes the lease
+	// Second delete does nothing
 	mgr.Delete(svc)
 	if mgr.Get(svc) != nil {
-		t.Error("expected lease to be removed after second delete")
+		t.Error("expected lease to not exist")
 	}
 }
 
@@ -460,46 +443,55 @@ func TestManager_NonCommonLease_MultipleAdds(t *testing.T) {
 	svc := createTestService("traefik", "traefik", nil) // No common lease annotation
 
 	// First Add
-	lease1, isNew1 := mgr.Add(svc)
+	lease1, isNew1, isShared1 := mgr.Add(svc)
 	if !isNew1 {
 		t.Error("expected first add to return isNew=true")
+	}
+	if isShared1 {
+		t.Error("expected first add to return isShared=false")
 	}
 
 	// Close Started to simulate leadership acquired
 	close(lease1.Started)
 
 	// Second Add (simulating another goroutine or restart attempt)
-	lease2, isNew2 := mgr.Add(svc)
+	lease2, isNew2, isShared2 := mgr.Add(svc)
 	if isNew2 {
 		t.Error("expected second add to return isNew=false")
+	}
+	if !isShared2 {
+		t.Error("expected second add to return isShared=true")
 	}
 	if lease1 != lease2 {
 		t.Error("expected same lease")
 	}
 
 	// Third Add
-	lease3, isNew3 := mgr.Add(svc)
+	lease3, isNew3, isShared3 := mgr.Add(svc)
 	if isNew3 {
 		t.Error("expected third add to return isNew=false")
+	}
+	if !isShared3 {
+		t.Error("expected third add to return isShared=true")
 	}
 	if lease1 != lease3 {
 		t.Error("expected same lease")
 	}
 
-	// Need 3 deletes to remove the lease
+	// Need one delete to remove the lease, another delete runs do nothing
 	mgr.Delete(svc)
-	if mgr.Get(svc) == nil {
-		t.Error("expected lease to exist after first delete")
-	}
-
-	mgr.Delete(svc)
-	if mgr.Get(svc) == nil {
-		t.Error("expected lease to exist after second delete")
+	if mgr.Get(svc) != nil {
+		t.Error("expected lease to be deleted")
 	}
 
 	mgr.Delete(svc)
 	if mgr.Get(svc) != nil {
-		t.Error("expected lease to be removed after third delete")
+		t.Error("expected lease to be deleted")
+	}
+
+	mgr.Delete(svc)
+	if mgr.Get(svc) != nil {
+		t.Error("expected lease to be deleted")
 	}
 }
 
@@ -511,15 +503,21 @@ func TestManager_LeaseContextCancelledBeforeStarted(t *testing.T) {
 	svc := createTestService("traefik", "traefik", nil)
 
 	// First Add
-	lease1, isNew1 := mgr.Add(svc)
+	lease1, isNew1, isShared1 := mgr.Add(svc)
 	if !isNew1 {
 		t.Fatal("expected first add to return isNew=true")
 	}
+	if isShared1 {
+		t.Fatal("expected first add to return isShared=false")
+	}
 
 	// Second Add before Started is closed
-	lease2, isNew2 := mgr.Add(svc)
+	lease2, isNew2, isShared2 := mgr.Add(svc)
 	if isNew2 {
 		t.Error("expected second add to return isNew=false")
+	}
+	if !isShared2 {
+		t.Error("expected second add to return isShared=true")
 	}
 
 	// Verify Started is not closed yet
@@ -557,7 +555,7 @@ func TestManager_RestartAfterLeaseContextCancelled(t *testing.T) {
 	svc := createTestService("traefik", "traefik", nil)
 
 	// First Add
-	lease1, _ := mgr.Add(svc)
+	lease1, _, _ := mgr.Add(svc)
 
 	// Cancel context before Started is closed
 	lease1.Cancel()
@@ -571,9 +569,12 @@ func TestManager_RestartAfterLeaseContextCancelled(t *testing.T) {
 	}
 
 	// Add again - should create new lease
-	lease2, isNew2 := mgr.Add(svc)
+	lease2, isNew2, isShared2 := mgr.Add(svc)
 	if !isNew2 {
 		t.Error("expected new lease after delete")
+	}
+	if isShared2 {
+		t.Error("expected add after to return isShared=false")
 	}
 
 	// Verify new lease has fresh context and Started channel
@@ -601,9 +602,12 @@ func TestManager_NonCommonLease_WaitForLeaseContextDone(t *testing.T) {
 	svc := createTestService("egress-service", "default", nil) // Non-common lease
 
 	// First Add - simulates the first leader election starting
-	lease1, isNew1 := mgr.Add(svc)
+	lease1, isNew1, isShared1 := mgr.Add(svc)
 	if !isNew1 {
 		t.Fatal("expected first add to return isNew=true")
+	}
+	if isShared1 {
+		t.Fatal("expected first add to return isShared=false")
 	}
 
 	// Simulate leadership acquired
@@ -611,9 +615,12 @@ func TestManager_NonCommonLease_WaitForLeaseContextDone(t *testing.T) {
 
 	// Second Add - simulates another goroutine trying to start leader election
 	// This should return isNew=false
-	lease2, isNew2 := mgr.Add(svc)
+	lease2, isNew2, isShared2 := mgr.Add(svc)
 	if isNew2 {
 		t.Error("expected second add to return isNew=false")
+	}
+	if !isShared2 {
+		t.Error("expected second add to return isShared=true")
 	}
 	if lease1 != lease2 {
 		t.Error("expected same lease to be returned")
@@ -681,9 +688,12 @@ func TestManager_NonCommonLease_SpinLoopPrevention(t *testing.T) {
 	svc := createTestService("egress-service", "default", nil) // Non-common lease
 
 	// First Add - leader election starts
-	lease1, isNew1 := mgr.Add(svc)
+	lease1, isNew1, isShared1 := mgr.Add(svc)
 	if !isNew1 {
 		t.Fatal("expected first add to return isNew=true")
+	}
+	if isShared1 {
+		t.Fatal("expected first add to return isShared1=false")
 	}
 	close(lease1.Started)
 
@@ -695,11 +705,16 @@ func TestManager_NonCommonLease_SpinLoopPrevention(t *testing.T) {
 
 	go func() {
 		for i := 0; i < 100; i++ {
-			lease, isNew := mgr.Add(svc)
+			lease, isNew, isShared := mgr.Add(svc)
 			addCount++
 			if isNew {
 				// This shouldn't happen while the first lease exists
 				t.Error("unexpected isNew=true")
+				break
+			}
+			if !isShared {
+				// This shouldn't happen while the first lease exists
+				t.Error("unexpected isShared=false")
 				break
 			}
 			// In the fixed code, we would block here on lease.Ctx.Done()
@@ -726,18 +741,9 @@ func TestManager_NonCommonLease_SpinLoopPrevention(t *testing.T) {
 		t.Errorf("expected 100 adds, got %d", addCount)
 	}
 
-	// The lease counter should be 101 (1 original + 100 from loop)
-	// We need 101 deletes to remove the lease
-	for i := 0; i < 100; i++ {
-		mgr.Delete(svc)
-	}
-	if mgr.Get(svc) == nil {
-		t.Error("expected lease to still exist after 100 deletes")
-	}
-
 	mgr.Delete(svc)
 	if mgr.Get(svc) != nil {
-		t.Error("expected lease to be removed after 101 deletes")
+		t.Error("expected lease to be removed after first delete")
 	}
 }
 
@@ -749,13 +755,16 @@ func TestManager_NonCommonLease_ServiceContextCancellation(t *testing.T) {
 	svc := createTestService("egress-service", "default", nil)
 
 	// First Add - leader election starts
-	lease1, _ := mgr.Add(svc)
+	lease1, _, _ := mgr.Add(svc)
 	close(lease1.Started)
 
 	// Second Add - returns isNew=false
-	lease2, isNew2 := mgr.Add(svc)
+	lease2, isNew2, isShared2 := mgr.Add(svc)
 	if isNew2 {
 		t.Error("expected isNew=false")
+	}
+	if !isShared2 {
+		t.Error("expected isShared=true")
 	}
 
 	// Create a simulated service context

--- a/pkg/servicecontext/servicecontext.go
+++ b/pkg/servicecontext/servicecontext.go
@@ -3,6 +3,9 @@ package servicecontext
 import (
 	"context"
 	"sync"
+	"sync/atomic"
+
+	"github.com/kube-vip/kube-vip/pkg/lease"
 )
 
 type Context struct {
@@ -11,6 +14,8 @@ type Context struct {
 	IsActive           bool
 	IsWatched          bool
 	ConfiguredNetworks sync.Map
+	Lease              *lease.Lease
+	HasEndpoints       atomic.Bool
 }
 
 func New(ctx context.Context) *Context {

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -216,6 +216,12 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 					}
 
 					go func() {
+						defer func() {
+							if svcCtx != nil {
+								svcCtx.IsWatched = false
+							}
+						}()
+
 						if svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal {
 							// Add Endpoint or EndpointSlices watcher
 							var provider providers.Provider
@@ -240,6 +246,12 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 				}
 
 				go func() {
+					defer func() {
+						if svcCtx != nil {
+							svcCtx.IsWatched = false
+						}
+					}()
+
 					if svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeCluster {
 						// Add Endpoint watcher
 						var provider providers.Provider
@@ -256,7 +268,6 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 				// We're now watching this service
 				svcCtx.IsWatched = true
 			} else {
-
 				go func() {
 					for {
 						select {
@@ -271,10 +282,10 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 								if err != nil {
 									log.Error(err.Error())
 								}
+								log.Info("(svcs) restartable service watcher done", "uid", svc.UID)
 							}
 						}
 					}
-
 				}()
 			}
 		} else {

--- a/pkg/services/watch_endpoints.go
+++ b/pkg/services/watch_endpoints.go
@@ -49,7 +49,7 @@ func (p *Processor) watchEndpoint(svcCtx *servicecontext.Context, id string, ser
 
 	ch := rw.ResultChan()
 
-	epProcessor := endpoints.NewEndpointProcessor(p.config, provider, p.bgpServer, &p.ServiceInstances)
+	epProcessor := endpoints.NewEndpointProcessor(p.config, provider, p.bgpServer, &p.ServiceInstances, p.leaseMgr)
 
 	var lastKnownGoodEndpoint string
 	for event := range ch {

--- a/testing/e2e/e2e_bgp_test.go
+++ b/testing/e2e/e2e_bgp_test.go
@@ -636,7 +636,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
 			)
 
-			DescribeTable("only stops advertising route if it was referenced by multiple services and all of them were delete while using common lease",
+			DescribeTable("only stops advertising route if it was referenced by multiple services and all of them were deleted while using common lease",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					testBGP(offset, utils.IPv6Family, api.Family_AFI_IP6, []corev1.IPFamily{corev1.IPv6Protocol}, svcName,
 						trafficPolicy, client, 2, gobgpClient, defaultFixedNexthopv6, "common-lease")


### PR DESCRIPTION
This PR should fix #1377 

It turned out that election and service context were not properly handled in case of election failure.

Additionally, this should fix an issue reported in the same thread about not electing a leader for service when endpoint moves from one node to another.