### PR TITLE
Bumped e2e test kubernetes version to 1.35.0

### DIFF
--- a/.github/workflows/ci-pull-request.yaml
+++ b/.github/workflows/ci-pull-request.yaml
@@ -25,17 +25,17 @@ jobs:
         run: make dockerx86Local
       - name: Run Manifest generation tests
         run: make manifest-test
-      - name: Run ARP mode tests v1.29.0 onwards
-        run: E2E_KEEP_LOGS=true make e2e-tests129-arp
+      - name: Run ARP mode tests
+        run: E2E_KEEP_LOGS=true make e2e-tests-arp
         if: matrix.mode== 'arp'
-      - name: Run RT mode tests v1.29.0 onwards
-        run: E2E_KEEP_LOGS=true make e2e-tests129-rt
+      - name: Run RT mode tests
+        run: E2E_KEEP_LOGS=true make e2e-tests-rt
         if: matrix.mode== 'rt'
       - name: Get GoBGP binaries
         run: make get-gobgp
         if: matrix.mode== 'bgp'
-      - name: Run BGP mode tests v1.29.0 onwards
-        run: sudo -E PATH=$PATH DOCKER_API_VERSION=1.48 E2E_KEEP_LOGS=true make e2e-tests129-bgp
+      - name: Run BGP mode tests
+        run: sudo -E PATH=$PATH DOCKER_API_VERSION=1.48 E2E_KEEP_LOGS=true make e2e-tests-bgp
         if: matrix.mode== 'bgp'
       - name: Change log directory permissions
         run: sudo chmod -R 755 /tmp/kube-vip-test-${{ matrix.mode }}*

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -75,7 +75,12 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			if configPath == "" {
 				configPath = "/etc/kubernetes/admin.conf"
 			}
-			_, v129 = os.LookupEnv("V129")
+			v129 = true
+			if v129env, v129set := os.LookupEnv("V129"); v129set {
+				var err error
+				v129, err = strconv.ParseBool(v129env)
+				Expect(err).ToNot(HaveOccurred())
+			}
 			curDir, err := os.Getwd()
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
As per @Cellebyte request I've bumped the kubernetes version used in the e2e test to 1.35.0.

1.35.0 was selected arbitrarily as the most up-to-date version available, but we can change that of course. This can be also set 'on the go' with `K8S_VERSION` env variable
.
Deleted the targets `e2e-test129*` but kept the `V129` variable (and the according code) for now as true by default, if anyone would like to test with something older for any reason, but I believe that we might as well delete this as versions older than 1.32 has already reached theirs EOLs.