### PR TITLE
Fix IP refresh when using FQDN for VIP

### DIFF
--- a/pkg/arp/arp.go
+++ b/pkg/arp/arp.go
@@ -169,7 +169,7 @@ func ensureIPAndSendGratuitous(instance *Instance) {
 			log.Info("deleted and recreating address with NODAD flag to skip DAD", "IP", ipString, "interface", iface)
 			// Re-add immediately without DAD check since we're recovering from DADFAILED
 			// The AddIP function will set IFA_F_NODAD flag for IPv6 addresses when skipDAD=true
-			if _, err := instance.network.AddIP(false, true, vip.NoLifetime); err != nil {
+			if _, err := instance.network.AddIP(false, true); err != nil {
 				log.Error("failed to recreate address after DADFAILED", "IP", ipString, "interface", iface, "err", err)
 			} else {
 				log.Info("successfully recreated address after DADFAILED recovery", "IP", ipString, "interface", iface)
@@ -180,7 +180,7 @@ func ensureIPAndSendGratuitous(instance *Instance) {
 	}
 
 	// Normal case: add IP with precheck and normal DAD process
-	if added, err := instance.network.AddIP(true, false, vip.NoLifetime); err != nil {
+	if added, err := instance.network.AddIP(true, false); err != nil {
 		log.Warn(err.Error())
 	} else if added {
 		log.Warn("Re-applied the VIP configuration", "ip", ipString, "interface", iface)

--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -17,7 +17,6 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/loadbalancer"
 	"github.com/kube-vip/kube-vip/pkg/utils"
-	"github.com/kube-vip/kube-vip/pkg/vip"
 
 	log "log/slog"
 
@@ -180,7 +179,7 @@ func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config, sm 
 				log.Info("Becoming leader with VIP preservation enabled - ensuring VIP takeover")
 				// Force add the VIPs (this will work even if they exist due to the precheck logic)
 				for i := range cluster.Network {
-					added, err := cluster.Network[i].AddIP(true, false, vip.NoLifetime)
+					added, err := cluster.Network[i].AddIP(true, false)
 					if err != nil {
 						log.Error("failed to ensure VIP on leader takeover", "vip", cluster.Network[i].IP(), "err", err)
 					} else if added {

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -82,7 +82,7 @@ func (cluster *Cluster) vipService(ctx context.Context, c *kubevip.Config, sm *M
 
 		if !c.EnableRoutingTable {
 			// Normal VIP addition, use skipDAD=false for normal DAD process
-			if _, err = network.AddIP(false, false, vip.NoLifetime); err != nil {
+			if _, err = network.AddIP(false, false); err != nil {
 				log.Error(err.Error())
 			}
 		}
@@ -207,7 +207,7 @@ func (cluster *Cluster) vipService(ctx context.Context, c *kubevip.Config, sm *M
 					if entry.Check() {
 						log.Debug("entry.Check() true")
 						// Normal VIP addition with precheck, use skipDAD=false for normal DAD process
-						_, err = network.AddIP(true, false, vip.NoLifetime)
+						_, err = network.AddIP(true, false)
 						if err != nil {
 							log.Error("error adding address", "err", err)
 						}
@@ -347,7 +347,7 @@ func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip
 		}
 
 		// Normal VIP addition, use skipDAD=false for normal DAD process
-		if _, err = network.AddIP(false, false, vip.NoLifetime); err != nil {
+		if _, err = network.AddIP(false, false); err != nil {
 			log.Warn(err.Error())
 		} else {
 			log.Info("successful add IP")

--- a/pkg/vip/address.go
+++ b/pkg/vip/address.go
@@ -37,7 +37,7 @@ const (
 
 // Network is an interface that enable managing operations for a given IP
 type Network interface {
-	AddIP(precheck bool, skipDAD bool, minLiftime int) (bool, error)
+	AddIP(precheck bool, skipDAD bool, minLifetime ...int) (bool, error)
 	AddRoute(precheck bool) error
 	DeleteIP() (bool, error)
 	DeleteRoute() error
@@ -361,7 +361,7 @@ func (configurator *network) UpdateRoutes() (bool, error) {
 // AddIP - Add an IP address to the interface
 // precheck: if true, check if the IP already exists before adding
 // skipDAD: if true, set IFA_F_NODAD flag for IPv6 addresses to skip Duplicate Address Detection
-func (configurator *network) AddIP(precheck bool, skipDAD bool, minLifetime int) (bool, error) {
+func (configurator *network) AddIP(precheck bool, skipDAD bool, minLifetime ...int) (bool, error) {
 	configurator.link.Lock.Lock()
 	defer configurator.link.Lock.Unlock()
 	var existing *netlink.Addr
@@ -372,7 +372,13 @@ func (configurator *network) AddIP(precheck bool, skipDAD bool, minLifetime int)
 		}
 	}
 
-	if existing != nil && existing.ValidLft > minLifetime {
+	lifetime := NoLifetime
+
+	if len(minLifetime) > 0 {
+		lifetime = minLifetime[0]
+	}
+
+	if existing != nil && existing.ValidLft > lifetime {
 		return false, nil
 	}
 


### PR DESCRIPTION
This PR should fix #1389 

It seems that in case of CP without leader election in BGP mode the `vipService` function did not wait for the exit signal, so the DNS context was cancelled with defer of the parent function which resulted in IP updater being stopped.

Additionally, IP updater is refreshing the IP every 3 seconds, which might result in IP being deleted for a while (max 3 seconds) if lifetime expires. I have added a threshold to the `AddIP`, so if the valid lifetime is lower than the threshold the IP will be refreshed so there should be no situation when IP is deleted even for a while.