### PR TITLE
Improved global lease

### DIFF
--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/etcd"
 	"github.com/kube-vip/kube-vip/pkg/k8s"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/loadbalancer"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 
@@ -93,20 +94,36 @@ func NewManager(path string, inCluster bool, port int) (*Manager, error) {
 }
 
 // StartCluster - Begins a running instance of the Leader Election cluster
-func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config, sm *Manager, bgpServer *bgp.Server) error {
+func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config,
+	sm *Manager, bgpServer *bgp.Server, leaseMgr *lease.Manager) error {
 	var err error
 
-	log.Info("cluster membership", "namespace", c.Namespace, "lock", c.LeaseName, "id", c.NodeName)
+	ns, leaseName := lease.NamespaceName(c.LeaseName, c)
 
-	// use a Go context so we can tell the leaderelection code when we
-	// want to step down
-	leaderCtx, leaderCancel := context.WithCancel(ctx)
-	defer leaderCancel()
+	log.Info("cluster membership", "namespace", ns, "lock", leaseName, "id", c.NodeName)
 
-	// use a Go context so we can tell the arp loop code when we
-	// want to step down
-	clusterCtx, clusterCancel := context.WithCancel(ctx)
-	defer clusterCancel()
+	leaseID := fmt.Sprintf("%s/%s", ns, leaseName)
+	objectName := fmt.Sprintf("%s-cp", leaseID)
+	objLease, newLease, sharedLease := leaseMgr.Add(leaseID, objectName)
+
+	if !newLease {
+		log.Debug("this election was alreadty done, waiting for it to finish", "lease", leaseName)
+		select {
+		case <-ctx.Done():
+		case <-objLease.Ctx.Done():
+		}
+		leaseMgr.Delete(leaseID, objectName)
+		return nil
+	}
+
+	// Start a goroutine that will delete the lease when the service context is cancelled.
+	// This is important for proper cleanup when a service is deleted - it ensures that
+	// the lease context (svcLease.Ctx) gets cancelled, which causes RunOrDie to return.
+	// Without this, RunOrDie would continue running until leadership is naturally lost.
+	go func() {
+		<-ctx.Done()
+		leaseMgr.Delete(leaseID, objectName)
+	}()
 
 	// listen for interrupts or the Linux SIGTERM signal and cancel
 	// our context, which the leader election code will observe and
@@ -134,8 +151,7 @@ func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config, sm 
 		}
 
 		log.Info("Received termination, signaling cluster shutdown")
-		// Cancel the leader context, which will in turn cancel the leadership
-		leaderCancel()
+		objLease.Cancel()
 	}()
 
 	// (attempt to) Remove the virtual IP, in case it already exists
@@ -169,11 +185,95 @@ func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config, sm 
 		}
 	}
 
+	// this object is sharing lease with another object
+	if sharedLease {
+		log.Debug("this election was alreadty done, shared lease", "lease", leaseName)
+		// wait for leader election to start or context to be done
+		select {
+		case <-objLease.Started:
+		case <-objLease.Ctx.Done():
+			// Lease was cancelled (e.g., leader election ended), return immediately
+			// This allows the restart loop to create a fresh lease
+			log.Debug("lease context cancelled before leader election started", "lease", leaseName)
+			return fmt.Errorf("lease %q context cancelled before leader election started", leaseName)
+		}
+
+		// When we become leader, ensure we can take over VIPs even if they're preserved on other nodes
+		if c.PreserveVIPOnLeadershipLoss {
+			log.Info("Becoming leader with VIP preservation enabled - ensuring VIP takeover")
+			// Force add the VIPs (this will work even if they exist due to the precheck logic)
+			for i := range cluster.Network {
+				added, err := cluster.Network[i].AddIP(true, false)
+				if err != nil {
+					log.Error("failed to ensure VIP on leader takeover", "vip", cluster.Network[i].IP(), "err", err)
+				} else if added {
+					log.Info("took over VIP as new leader", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
+				} else {
+					log.Info("VIP already configured on interface", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
+				}
+			}
+		}
+
+		// Start ARP advertisements now that we have leadership
+		log.Info("Start ARP/NDP advertisement")
+		go cluster.arpMgr.StartAdvertisement(ctx)
+
+		// As we're leading lets start the vip service
+		err := cluster.vipService(ctx, c, sm, bgpServer, objLease.Cancel)
+		if err != nil {
+			log.Error("starting VIP service on leader", "err", err)
+			signalChan <- syscall.SIGINT
+		}
+
+		log.Debug("cluster waiting for leader context done", "lease", leaseName)
+		// wait for leaderelection to be finished
+		<-objLease.Ctx.Done()
+
+		// Handle VIP cleanup based on configuration
+		if c.PreserveVIPOnLeadershipLoss {
+			// For IPv6, we must remove VIPs immediately to avoid DAD failures on the new leader
+			// IPv6 Duplicate Address Detection will fail if the new leader tries to add an IP that is still present on this node's interface
+			// We need to check each VIP individually and only remove IPv6 VIPs
+			for i := range cluster.Network {
+				if utils.IsIPv6(cluster.Network[i].IP()) {
+					log.Info("Removing IPv6 VIP immediately (required to prevent DAD failures on new leader)", "ip", cluster.Network[i].IP())
+					deleted, err := cluster.Network[i].DeleteIP()
+					if err != nil {
+						log.Warn("delete VIP", "err", err)
+					}
+					if deleted {
+						log.Info("deleted address", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
+					}
+				} else {
+					log.Info("Preserving IPv4 VIP address on interface, only stopped ARP broadcasting", "ip", cluster.Network[i].IP())
+				}
+			}
+		} else {
+			// Legacy behavior: delete VIP addresses on leadership loss
+			log.Info("Deleting VIP addresses on leadership loss (legacy behavior)")
+			for i := range cluster.Network {
+				log.Info("Deleting VIP addresses on leadership loss (legacy behavior)", "i", i, "IP", cluster.Network[i].IP())
+				deleted, err := cluster.Network[i].DeleteIP()
+				if err != nil {
+					log.Warn("delete VIP", "err", err)
+				}
+				if deleted {
+					log.Info("deleted address", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
+				}
+			}
+		}
+
+		return nil
+	}
+
 	run := &runConfig{
-		config:  c,
-		leaseID: c.NodeName,
-		sm:      sm,
-		onStartedLeading: func(context.Context) { //nolint TODO: potential clean code
+		config:    c,
+		leaseID:   c.NodeName,
+		leaseName: leaseName,
+		namespace: ns,
+		sm:        sm,
+		onStartedLeading: func(context.Context) {
+			close(objLease.Started)
 			// When we become leader, ensure we can take over VIPs even if they're preserved on other nodes
 			if c.PreserveVIPOnLeadershipLoss {
 				log.Info("Becoming leader with VIP preservation enabled - ensuring VIP takeover")
@@ -192,10 +292,10 @@ func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config, sm 
 
 			// Start ARP advertisements now that we have leadership
 			log.Info("Start ARP/NDP advertisement")
-			go cluster.arpMgr.StartAdvertisement(clusterCtx)
+			go cluster.arpMgr.StartAdvertisement(objLease.Ctx)
 
 			// As we're leading lets start the vip service
-			err := cluster.vipService(clusterCtx, c, sm, bgpServer, leaderCancel)
+			err := cluster.vipService(objLease.Ctx, c, sm, bgpServer, objLease.Cancel)
 			if err != nil {
 				log.Error("starting VIP service on leader", "err", err)
 				signalChan <- syscall.SIGINT
@@ -204,9 +304,6 @@ func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config, sm 
 		onStoppedLeading: func() {
 			// we can do cleanup here
 			log.Info("This node is becoming a follower within the cluster")
-
-			// Stop the cluster context if it is running
-			clusterCancel()
 
 			// Stop the BGP server
 			if bgpServer != nil {
@@ -239,6 +336,7 @@ func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config, sm 
 				// Legacy behavior: delete VIP addresses on leadership loss
 				log.Info("Deleting VIP addresses on leadership loss (legacy behavior)")
 				for i := range cluster.Network {
+					log.Info("Deleting VIP addresses on leadership loss (legacy behavior)", "i", i, "IP", cluster.Network[i].IP())
 					deleted, err := cluster.Network[i].DeleteIP()
 					if err != nil {
 						log.Warn("delete VIP", "err", err)
@@ -277,9 +375,9 @@ func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config, sm 
 
 	switch c.LeaderElectionType {
 	case "kubernetes", "":
-		cluster.runKubernetesLeaderElectionOrDie(leaderCtx, run)
+		cluster.runKubernetesLeaderElectionOrDie(objLease.Ctx, run)
 	case "etcd":
-		if err := cluster.runEtcdLeaderElectionOrDie(leaderCtx, run); err != nil {
+		if err := cluster.runEtcdLeaderElectionOrDie(objLease.Ctx, run); err != nil {
 			return err
 		}
 	default:
@@ -290,9 +388,11 @@ func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config, sm 
 }
 
 type runConfig struct {
-	config  *kubevip.Config
-	leaseID string
-	sm      *Manager
+	config    *kubevip.Config
+	leaseID   string
+	leaseName string
+	namespace string
+	sm        *Manager
 
 	// onStartedLeading is called when this member starts leading.
 	onStartedLeading func(context.Context)
@@ -309,8 +409,8 @@ func (cluster *Cluster) runKubernetesLeaderElectionOrDie(ctx context.Context, ru
 	// and fewer objects in the cluster watch "all Leases".
 	lock := &resourcelock.LeaseLock{
 		LeaseMeta: metav1.ObjectMeta{
-			Name:        run.config.LeaseName,
-			Namespace:   run.config.Namespace,
+			Name:        run.leaseName,
+			Namespace:   run.namespace,
 			Annotations: run.config.LeaseAnnotations,
 		},
 		Client: run.sm.KubernetesClient.CoordinationV1(),
@@ -343,7 +443,7 @@ func (cluster *Cluster) runKubernetesLeaderElectionOrDie(ctx context.Context, ru
 func (cluster *Cluster) runEtcdLeaderElectionOrDie(ctx context.Context, run *runConfig) error {
 	if err := etcd.RunElectionOrDie(ctx, &etcd.LeaderElectionConfig{
 		EtcdConfig:           etcd.ClientConfig{Client: run.sm.EtcdClient},
-		Name:                 run.config.LeaseName,
+		Name:                 fmt.Sprintf("%s-%s", run.namespace, run.leaseName),
 		MemberID:             run.leaseID,
 		LeaseDurationSeconds: int64(run.config.LeaseDuration),
 		Callbacks: etcd.LeaderCallbacks{

--- a/pkg/endpoints/endpoints_generic.go
+++ b/pkg/endpoints/endpoints_generic.go
@@ -70,7 +70,9 @@ func (g *generic) clearEgress(lastKnownGoodEndpoint *string, service *v1.Service
 
 		*lastKnownGoodEndpoint = "" // reset endpoint
 		if g.config.EnableServicesElection || g.config.EnableLeaderElection {
-			g.leaseMgr.Delete(service)
+			_, svcLeaseID, _ := lease.ServiceName(service)
+			objectName := lease.ServiceNamespacedName(service)
+			g.leaseMgr.Delete(svcLeaseID, objectName)
 		}
 	}
 }

--- a/pkg/manager/manager_arp.go
+++ b/pkg/manager/manager_arp.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"context"
+	"fmt"
 	"syscall"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 
 	"github.com/kube-vip/kube-vip/pkg/cluster"
 	"github.com/kube-vip/kube-vip/pkg/iptables"
+	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/vip"
 )
 
@@ -46,7 +48,7 @@ func (sm *Manager) startARP(ctx context.Context, id string) error {
 		}
 
 		go func() {
-			err := cpCluster.StartCluster(arpCtx, sm.config, clusterManager, nil)
+			err := cpCluster.StartCluster(arpCtx, sm.config, clusterManager, nil, sm.leaseMgr)
 			if err != nil {
 				log.Error("starting control plane", "err", err)
 			}
@@ -73,18 +75,99 @@ func (sm *Manager) startARP(ctx context.Context, id string) error {
 				return err
 			}
 		} else {
-			ns, err := returnNameSpace()
-			if err != nil {
-				log.Warn("unable to auto-detect namespace, dropping to config", "namespace", sm.config.Namespace)
-				ns = sm.config.Namespace
+			ns, leaseName := lease.NamespaceName(sm.config.ServicesLeaseName, sm.config)
+
+			log.Info("beginning services leadership", "namespace", ns, "lock name", leaseName, "id", id)
+
+			leaseID := fmt.Sprintf("%s/%s", ns, leaseName)
+			objectName := fmt.Sprintf("%s-svc", leaseID)
+
+			objLease, newLease, sharedLease := sm.leaseMgr.Add(leaseID, objectName)
+
+			// this service was already processed so we do not need to do anything
+			if !newLease {
+				log.Debug("this election was already done, waiting for it to finish", "lease", leaseName)
+				// Wait for either the service context or lease context to be done
+				select {
+				case <-ctx.Done():
+					// Service was deleted
+					sm.leaseMgr.Delete(leaseID, objectName)
+				case <-objLease.Ctx.Done():
+					// Leader election ended (leadership lost or context cancelled)
+				}
+				return nil
 			}
 
-			log.Info("beginning services leadership", "namespace", ns, "lock name", sm.config.ServicesLeaseName, "id", id)
+			// Start a goroutine that will delete the lease when the service context is cancelled.
+			// This is important for proper cleanup when a service is deleted - it ensures that
+			// the lease context (svcLease.Ctx) gets cancelled, which causes RunOrDie to return.
+			// Without this, RunOrDie would continue running until leadership is naturally lost.
+			go func() {
+				<-ctx.Done()
+				sm.leaseMgr.Delete(leaseID, objectName)
+			}()
+
+			// this object is sharing lease with another object
+			if sharedLease {
+				log.Debug("this election was already done, shared lease", "lease", leaseName)
+				// wait for leader election to start or context to be done
+				select {
+				case <-objLease.Started:
+				case <-objLease.Ctx.Done():
+					// Lease was cancelled (e.g., leader election ended), return immediately
+					// This allows the restart loop to create a fresh lease
+					log.Debug("lease context cancelled before leader election started", "lease", leaseName)
+					return nil
+				}
+
+				err = sm.svcProcessor.ServicesWatcher(ctx, sm.svcProcessor.SyncServices)
+				if err != nil {
+					log.Error("service watcher", "err", err)
+					if !sm.closing.Load() {
+						sm.signalChan <- syscall.SIGINT
+					}
+					objLease.Cancel()
+				}
+
+				log.Debug("waiting for context to finish", "lease", leaseName)
+				// Block until context is cancelled
+				<-ctx.Done()
+
+				log.Debug("waiting for lease to finish", "lease", leaseName)
+				// wait for leaderelection to be finished
+				<-objLease.Ctx.Done()
+
+				// we can do cleanup here
+				sm.mutex.Lock()
+				defer sm.mutex.Unlock()
+				log.Info("leader lost", "lease", leaseName)
+				sm.svcProcessor.Stop()
+
+				log.Error("lost services leadership, restarting kube-vip")
+				if !sm.closing.Load() {
+					sm.signalChan <- syscall.SIGINT
+				}
+
+				return nil
+			}
+
+			// For new leases (not shared), ensure cleanup when the leader election ends
+			// This is critical for the restartable service watcher to be able to restart
+			// the leader election after leadership loss
+			defer func() {
+				// Delete the lease from the manager so subsequent calls can create a fresh lease
+				// This handles the case where leader election ends due to:
+				// 1. Leadership loss (e.g., network timeout)
+				// 2. Context cancellation
+				// 3. Any other reason RunOrDie returns
+				sm.leaseMgr.Delete(leaseID, objectName)
+			}()
+
 			// we use the Lease lock type since edits to Leases are less common
 			// and fewer objects in the cluster watch "all Leases".
 			lock := &resourcelock.LeaseLock{
 				LeaseMeta: metav1.ObjectMeta{
-					Name:      sm.config.ServicesLeaseName,
+					Name:      leaseName,
 					Namespace: ns,
 				},
 				Client: sm.clientSet.CoordinationV1(),
@@ -108,6 +191,7 @@ func (sm *Manager) startARP(ctx context.Context, id string) error {
 				RetryPeriod:     time.Duration(sm.config.RetryPeriod) * time.Second,
 				Callbacks: leaderelection.LeaderCallbacks{
 					OnStartedLeading: func(ctx context.Context) {
+						close(objLease.Started)
 						err = sm.svcProcessor.ServicesWatcher(ctx, sm.svcProcessor.SyncServices)
 						if err != nil {
 							log.Error("service watcher", "err", err)

--- a/pkg/manager/manager_bgp.go
+++ b/pkg/manager/manager_bgp.go
@@ -77,7 +77,7 @@ func (sm *Manager) startBGP(ctx context.Context) error {
 
 		go func() {
 			if sm.config.EnableLeaderElection {
-				err = cpCluster.StartCluster(bgpCtx, sm.config, clusterManager, sm.bgpServer)
+				err = cpCluster.StartCluster(bgpCtx, sm.config, clusterManager, sm.bgpServer, sm.leaseMgr)
 			} else {
 				err = cpCluster.StartVipService(bgpCtx, sm.config, clusterManager, sm.bgpServer)
 			}

--- a/pkg/manager/manager_table.go
+++ b/pkg/manager/manager_table.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/cluster"
 	"github.com/kube-vip/kube-vip/pkg/endpoints"
 	"github.com/kube-vip/kube-vip/pkg/iptables"
+	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/vip"
 	"github.com/vishvananda/netlink"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,13 +79,6 @@ func (sm *Manager) startTableMode(ctx context.Context, id string) error {
 	}
 
 	if sm.config.EnableServices {
-		log.Debug("starting Services")
-		ns, err := returnNameSpace()
-		if err != nil {
-			log.Warn("unable to auto-detect namespace", "dropping to", sm.config.Namespace)
-			ns = sm.config.Namespace
-		}
-
 		// Start a services watcher (all kube-vip pods will watch services), upon a new service
 		// a lock based upon that service is created that they will all leaderElection on
 		if sm.config.EnableServicesElection {
@@ -94,13 +88,99 @@ func (sm *Manager) startTableMode(ctx context.Context, id string) error {
 				return err
 			}
 		} else if sm.config.EnableLeaderElection {
+			ns, leaseName := lease.NamespaceName(sm.config.ServicesLeaseName, sm.config)
 
-			log.Info("beginning services leadership", "namespace", ns, "lock name", plunderLock, "id", id)
+			log.Info("beginning services leadership", "namespace", ns, "lock name", leaseName, "id", id)
+
+			leaseID := fmt.Sprintf("%s/%s", ns, leaseName)
+			objectName := fmt.Sprintf("%s-svc", leaseID)
+
+			objLease, newLease, sharedLease := sm.leaseMgr.Add(leaseID, objectName)
+
+			// this service was already processed so we do not need to do anything
+			if !newLease {
+				log.Debug("this election was already done, waiting for it to finish", "lease", leaseName)
+				// Wait for either the service context or lease context to be done
+				select {
+				case <-ctx.Done():
+					// Service was deleted
+					sm.leaseMgr.Delete(leaseID, objectName)
+				case <-objLease.Ctx.Done():
+					// Leader election ended (leadership lost or context cancelled)
+				}
+				return nil
+			}
+
+			// Start a goroutine that will delete the lease when the service context is cancelled.
+			// This is important for proper cleanup when a service is deleted - it ensures that
+			// the lease context (svcLease.Ctx) gets cancelled, which causes RunOrDie to return.
+			// Without this, RunOrDie would continue running until leadership is naturally lost.
+			go func() {
+				<-ctx.Done()
+				sm.leaseMgr.Delete(leaseID, objectName)
+			}()
+
+			// this object is sharing lease with another object
+			if sharedLease {
+				log.Debug("this election was already done, shared lease", "lease", leaseName)
+				// wait for leader election to start or context to be done
+				select {
+				case <-objLease.Started:
+				case <-objLease.Ctx.Done():
+					// Lease was cancelled (e.g., leader election ended), return immediately
+					// This allows the restart loop to create a fresh lease
+					log.Debug("lease context cancelled before leader election started", "lease", leaseName)
+					return nil
+				}
+
+				err = sm.svcProcessor.ServicesWatcher(ctx, sm.svcProcessor.SyncServices)
+				if err != nil {
+					log.Error("service watcher", "err", err)
+					if !sm.closing.Load() {
+						sm.signalChan <- syscall.SIGINT
+					}
+					objLease.Cancel()
+				}
+
+				log.Debug("waiting for context to finish", "lease", leaseName)
+				// Block until context is cancelled
+				<-ctx.Done()
+
+				log.Debug("waiting for lease to finish", "lease", leaseName)
+				// wait for leaderelection to be finished
+				<-objLease.Ctx.Done()
+
+				// we can do cleanup here
+				sm.mutex.Lock()
+				defer sm.mutex.Unlock()
+				log.Info("leader lost", "lease", leaseName)
+				sm.svcProcessor.Stop()
+
+				log.Error("lost services leadership, restarting kube-vip")
+				if !sm.closing.Load() {
+					sm.signalChan <- syscall.SIGINT
+				}
+
+				return nil
+			}
+
+			// For new leases (not shared), ensure cleanup when the leader election ends
+			// This is critical for the restartable service watcher to be able to restart
+			// the leader election after leadership loss
+			defer func() {
+				// Delete the lease from the manager so subsequent calls can create a fresh lease
+				// This handles the case where leader election ends due to:
+				// 1. Leadership loss (e.g., network timeout)
+				// 2. Context cancellation
+				// 3. Any other reason RunOrDie returns
+				sm.leaseMgr.Delete(leaseID, objectName)
+			}()
+
 			// we use the Lease lock type since edits to Leases are less common
 			// and fewer objects in the cluster watch "all Leases".
 			lock := &resourcelock.LeaseLock{
 				LeaseMeta: metav1.ObjectMeta{
-					Name:      plunderLock,
+					Name:      leaseName,
 					Namespace: ns,
 				},
 				Client: sm.clientSet.CoordinationV1(),
@@ -123,6 +203,7 @@ func (sm *Manager) startTableMode(ctx context.Context, id string) error {
 				RetryPeriod:     time.Duration(sm.config.RetryPeriod) * time.Second,
 				Callbacks: leaderelection.LeaderCallbacks{
 					OnStartedLeading: func(ctx context.Context) {
+						close(objLease.Started)
 						err = sm.svcProcessor.ServicesWatcher(ctx, sm.svcProcessor.SyncServices)
 						if err != nil {
 							log.Error(err.Error())

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -64,7 +64,7 @@ type labelManager interface {
 
 func NewServicesProcessor(config *kubevip.Config, bgpServer *bgp.Server,
 	clientSet *kubernetes.Clientset, rwClientSet *kubernetes.Clientset, shutdownChan chan struct{},
-	intfMgr *networkinterface.Manager, arpMgr *arp.Manager, nodeLabelManager labelManager) *Processor {
+	intfMgr *networkinterface.Manager, arpMgr *arp.Manager, nodeLabelManager labelManager, leaseMgr *lease.Manager) *Processor {
 	lbClassFilterFunc := lbClassFilter
 	if config.LoadBalancerClassLegacyHandling {
 		lbClassFilterFunc = lbClassFilterLegacy
@@ -87,7 +87,7 @@ func NewServicesProcessor(config *kubevip.Config, bgpServer *bgp.Server,
 
 		intfMgr:          intfMgr,
 		arpMgr:           arpMgr,
-		leaseMgr:         lease.NewManager(),
+		leaseMgr:         leaseMgr,
 		nodeLabelManager: nodeLabelManager,
 	}
 }


### PR DESCRIPTION
This PR should help with #464

Separated from #1405 - this PR should incorporate all changes that are related to global lease, but is based on the current `main`. Other changes that were added to original #1405 and are dependent on #1395 will be added later depending on which PR will be merged first, if any.

It introduces common global lease (based on previously introduced common lease for services). Now both CP and services (global and per service leader election) can share leases.

Configuration (assuming `kube-vip` is running in `kube-system` namespace:

- When `svc_election: false`

```
- name: vip_leasename
  value: plndr-common-lock
- name: svc_leasename
  value: plndr-common-lock
```

If `vip_leasename` and `svc_leasename` are the same, both CP and Services will use the same lease (so would run on just one node).


- When `svc_election: true`

Service can use any lease known to kube-vip. Eg. let's assume that the configured lease is:

```
- name: vip_leasename
  value: plndr-cp-lock
```

if service is deployed in the same namespace as kube-vip, one can just provide the name of the lease to the service:
For example 
```
annotations:
  kube-vip.io/leaseName: "plndr-cp-lock"
```

will tie service in `kube-system` namespace to control plane lease (`plndr-cp-lock`) in the same namespace.

Additionally **cross-namespace** leases are supported. Example - service in namespace `default` can be tied to the CP lock in `kube-system` namespace with:

```
annotations:
   kube-vip.io/leaseName: "kube-system/plndr-cp-lock"
```