### PR TITLE
Reverted missing change from #623

### DIFF
--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -83,7 +83,7 @@ func (cluster *Cluster) vipService(ctx context.Context, c *kubevip.Config, sm *M
 		if !c.EnableRoutingTable {
 			// Normal VIP addition, use skipDAD=false for normal DAD process
 			if _, err = network.AddIP(false, false); err != nil {
-				log.Error(err.Error())
+				return fmt.Errorf("failed to add IP address %s: %w", network.IP(), err)
 			}
 		}
 


### PR DESCRIPTION
PR #623 introduced restart of kube-vip when VIP for control plane cannot be added. This was lost in the meantime, so I have reintroduced this behaviour.