### PR TITLE
Fixed actions failure when whoami image cannot be loaded

### DIFF
--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -1244,10 +1244,15 @@ func prepareCluster(ctx context.Context, tempDirPath, clusterNameSuffix, k8sImag
 	}
 
 	By(withTimestamp("loading local docker image to kind cluster"))
-	e2e.LoadDockerImageToKind(logger, manifestValues.ImagePath, clusterName)
+	Expect(e2e.LoadDockerImageToKind(logger, manifestValues.ImagePath, clusterName)).To(Succeed())
 
 	By(withTimestamp("loading traefik/whoami image to kind cluster"))
-	e2e.LoadDockerImageToKind(logger, "ghcr.io/traefik/whoami:v1.11", clusterName)
+	if err := e2e.LoadDockerImageToKind(logger, "ghcr.io/traefik/whoami:v1.11", clusterName); err != nil {
+		By(withTimestamp(fmt.Sprintf(
+			"failed to load image ghcr.io/traefik/whoami:v1.11 into kind cluster, image will be downloaded after pod deployment, error: %s",
+			err.Error(),
+		)))
+	}
 
 	return clusterName, client, cfg
 }

--- a/testing/e2e/etcd/cluster.go
+++ b/testing/e2e/etcd/cluster.go
@@ -54,10 +54,12 @@ func CreateCluster(ctx context.Context, spec *ClusterSpec) *Cluster {
 	c.initKindCluster()
 
 	c.Logger.Printf("Loading kube-vip image into nodes")
-	e2e.LoadDockerImageToKind(spec.Logger, spec.KubeVIPImage, spec.Name)
+	Expect(e2e.LoadDockerImageToKind(spec.Logger, spec.KubeVIPImage, spec.Name)).To(Succeed())
 
 	c.Logger.Printf("Loading traefik image into nodes")
-	e2e.LoadDockerImageToKind(spec.Logger, "ghcr.io/traefik/whoami:v1.11", spec.Name)
+	if err := e2e.LoadDockerImageToKind(spec.Logger, "ghcr.io/traefik/whoami:v1.11", spec.Name); err != nil {
+		c.Logger.Warnf("failed to load image ghcr.io/traefik/whoami:v1.11 into kind cluster, image will be downloaded after pod deployment, error: %s", err.Error())
+	}
 
 	c.Logger.Printf("Starting etcd cluster")
 	c.initEtcd(ctx)

--- a/testing/e2e/kind.go
+++ b/testing/e2e/kind.go
@@ -51,10 +51,10 @@ func NodeIPv4(node nodes.Node) string {
 	return ip
 }
 
-func LoadDockerImageToKind(logger kindlog.Logger, imagePath, clusterName string) {
+func LoadDockerImageToKind(logger kindlog.Logger, imagePath, clusterName string) error {
 	loadImageCmd := load.NewCommand(logger, cmd.StandardIOStreams())
 	loadImageCmd.SetArgs([]string{"--name", clusterName, imagePath})
-	Expect(loadImageCmd.Execute()).To(Succeed())
+	return loadImageCmd.Execute()
 }
 
 func RunInNode(node nodes.Node, command string, args ...string) {


### PR DESCRIPTION
This PR should mitigate recent issue where `traefik/whoami` cannot be loaded into cluster in Github Actions. If image cannot be loaded k8s should download it when the pod starts (old e2e tests behaviour).