### PR TITLE
Improved global lease

### DIFF
--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -10,26 +10,40 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/bgp"
 	"github.com/kube-vip/kube-vip/pkg/election"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 
 	log "log/slog"
 )
 
 // StartCluster - Begins a running instance of the Leader Election cluster
-func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config, sm *election.Manager, bgpServer *bgp.Server) error {
+func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config,
+	em *election.Manager, bgpServer *bgp.Server, leaseMgr *lease.Manager) error {
 	var err error
 
-	log.Info("cluster membership", "namespace", c.Namespace, "lock", c.LeaseName, "id", c.NodeName)
+	ns, leaseName := lease.NamespaceName(c.LeaseName, c)
 
-	// use a Go context so we can tell the leaderelection code when we
-	// want to step down
-	leaderCtx, leaderCancel := context.WithCancel(ctx)
-	defer leaderCancel()
+	leaseID := lease.NewID(c.LeaderElectionType, ns, leaseName)
 
-	// use a Go context so we can tell the arp loop code when we
-	// want to step down
-	clusterCtx, clusterCancel := context.WithCancel(ctx)
-	defer clusterCancel()
+	log.Info("cluster membership", "namespace", leaseID.Namespace(), "lock", leaseID.Name(), "id", c.NodeName)
+
+	objectName := lease.ObjectName(leaseID, "cp")
+	objLease, newLease, sharedLease := leaseMgr.Add(leaseID, objectName)
+
+	// Start a goroutine that will delete the lease when the service context is cancelled.
+	// This is important for proper cleanup when a service is deleted - it ensures that
+	// the lease context (svcLease.Ctx) gets cancelled, which causes RunOrDie to return.
+	// Without this, RunOrDie would continue running until leadership is naturally lost.
+	go func() {
+		<-objLease.Ctx.Done()
+		leaseMgr.Delete(leaseID, objectName)
+	}()
+
+	if !newLease {
+		log.Debug("this election was already done, waiting for it to finish", "lease", leaseName)
+		<-objLease.Ctx.Done()
+		return nil
+	}
 
 	// listen for interrupts or the Linux SIGTERM signal and cancel
 	// our context, which the leader election code will observe and
@@ -58,7 +72,7 @@ func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config, sm 
 
 		log.Info("Received termination, signaling cluster shutdown")
 		// Cancel the leader context, which will in turn cancel the leadership
-		leaderCancel()
+		objLease.Cancel()
 	}()
 
 	// (attempt to) Remove the virtual IP, in case it already exists
@@ -92,118 +106,157 @@ func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config, sm 
 		}
 	}
 
+	// this object is sharing lease with another object
+	if sharedLease {
+		log.Debug("this election was already done, shared lease", "lease", leaseName)
+		// wait for leader election to start or context to be done
+		select {
+		case <-objLease.Started:
+		case <-objLease.Ctx.Done():
+			// Lease was cancelled (e.g., leader election ended), return immediately
+			// This allows the restart loop to create a fresh lease
+			log.Debug("lease context cancelled before leader election started", "lease", leaseName)
+			return fmt.Errorf("lease %q context cancelled before leader election started", leaseName)
+		}
+
+		cluster.OnStartedLeading(c, objLease, em, bgpServer, signalChan, sharedLease)
+
+		log.Debug("cluster waiting for leader context done", "lease", leaseName)
+		// wait for leaderelection to be finished
+		<-objLease.Ctx.Done()
+
+		cluster.OnStoppedLeading(c, objLease, bgpServer, signalChan)
+
+		return nil
+	}
+
 	run := &election.RunConfig{
 		Config:           c,
-		LeaseID:          c.NodeName,
-		LeaseName:        c.LeaseName,
-		Namespace:        c.Namespace,
+		LeaseID:          leaseID,
 		LeaseAnnotations: c.LeaseAnnotations,
-		Mgr:              sm,
+		Mgr:              em,
 		OnStartedLeading: func(context.Context) { //nolint TODO: potential clean code
-			// When we become leader, ensure we can take over VIPs even if they're preserved on other nodes
-			if c.PreserveVIPOnLeadershipLoss {
-				log.Info("Becoming leader with VIP preservation enabled - ensuring VIP takeover")
-				// Force add the VIPs (this will work even if they exist due to the precheck logic)
-				for i := range cluster.Network {
-					added, err := cluster.Network[i].AddIP(true, false)
-					if err != nil {
-						log.Error("failed to ensure VIP on leader takeover", "vip", cluster.Network[i].IP(), "err", err)
-					} else if added {
-						log.Info("took over VIP as new leader", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
-					} else {
-						log.Info("VIP already configured on interface", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
-					}
-				}
-			}
-
-			// Start ARP advertisements now that we have leadership
-			log.Info("Start ARP/NDP advertisement")
-			go cluster.arpMgr.StartAdvertisement(clusterCtx)
-
-			// As we're leading lets start the vip service
-			err := cluster.vipService(clusterCtx, c, sm, bgpServer, leaderCancel)
-			if err != nil {
-				log.Error("starting VIP service on leader", "err", err)
-				signalChan <- syscall.SIGINT
-			}
+			cluster.OnStartedLeading(c, objLease, em, bgpServer, signalChan, sharedLease)
 		},
 		OnStoppedLeading: func() {
-			// we can do cleanup here
-			log.Info("This node is becoming a follower within the cluster")
-
-			// Stop the cluster context if it is running
-			clusterCancel()
-
-			// Stop the BGP server
-			if bgpServer != nil {
-				err := bgpServer.Close()
-				if err != nil {
-					log.Warn("close BGP server", "err", err)
-				}
-			}
-
-			// Handle VIP cleanup based on configuration
-			if c.PreserveVIPOnLeadershipLoss {
-				// For IPv6, we must remove VIPs immediately to avoid DAD failures on the new leader
-				// IPv6 Duplicate Address Detection will fail if the new leader tries to add an IP that is still present on this node's interface
-				// We need to check each VIP individually and only remove IPv6 VIPs
-				for i := range cluster.Network {
-					if utils.IsIPv6(cluster.Network[i].IP()) {
-						log.Info("Removing IPv6 VIP immediately (required to prevent DAD failures on new leader)", "ip", cluster.Network[i].IP())
-						deleted, err := cluster.Network[i].DeleteIP()
-						if err != nil {
-							log.Warn("delete VIP", "err", err)
-						}
-						if deleted {
-							log.Info("deleted address", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
-						}
-					} else {
-						log.Info("Preserving IPv4 VIP address on interface, only stopped ARP broadcasting", "ip", cluster.Network[i].IP())
-					}
-				}
-			} else {
-				// Legacy behavior: delete VIP addresses on leadership loss
-				log.Info("Deleting VIP addresses on leadership loss (legacy behavior)")
-				for i := range cluster.Network {
-					deleted, err := cluster.Network[i].DeleteIP()
-					if err != nil {
-						log.Warn("delete VIP", "err", err)
-					}
-					if deleted {
-						log.Info("deleted address", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
-					}
-				}
-			}
-
-			log.Error("lost leadership, restarting kube-vip")
-			signalChan <- syscall.SIGINT
+			cluster.OnStoppedLeading(c, objLease, bgpServer, signalChan)
 		},
 		OnNewLeader: func(identity string) {
-			// we're notified when new leader elected
-			log.Info("New leader", "leader", identity)
-
-			// If we're not the new leader and we have VIPs preserved from previous leadership,
-			// we need to clean them up to avoid conflicts.
-			if identity != c.NodeName && c.PreserveVIPOnLeadershipLoss {
-				log.Info("Cleaning up preserved VIPs as another node became leader", "new_leader", identity)
-				for i := range cluster.Network {
-					deleted, err := cluster.Network[i].DeleteIP()
-					if err != nil {
-						log.Warn("failed to cleanup preserved VIP", "vip", cluster.Network[i].IP(), "err", err)
-					}
-					if deleted {
-						log.Info("cleaned up preserved VIP to avoid conflict", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface(), "new_leader", identity)
-					} else {
-						log.Debug("VIP was not present on this node", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
-					}
-				}
-			}
+			cluster.OnNewLeader(identity, c)
 		},
 	}
 
-	if err := election.RunOrDie(leaderCtx, run, c); err != nil {
+	if err := election.RunOrDie(objLease.Ctx, run, c); err != nil {
+		objLease.Cancel()
 		return fmt.Errorf("leaderelection failed: %w", err)
 	}
 
 	return nil
+}
+
+func (cluster *Cluster) OnStartedLeading(c *kubevip.Config, objLease *lease.Lease,
+	em *election.Manager, bgpServer *bgp.Server, signalChan chan os.Signal, isShared bool) {
+	// When we become leader, ensure we can take over VIPs even if they're preserved on other nodes
+	if !isShared {
+		close(objLease.Started)
+	}
+
+	if c.PreserveVIPOnLeadershipLoss {
+		log.Info("Becoming leader with VIP preservation enabled - ensuring VIP takeover")
+		// Force add the VIPs (this will work even if they exist due to the precheck logic)
+		for i := range cluster.Network {
+			added, err := cluster.Network[i].AddIP(true, false)
+			if err != nil {
+				log.Error("failed to ensure VIP on leader takeover", "vip", cluster.Network[i].IP(), "err", err)
+			} else if added {
+				log.Info("took over VIP as new leader", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
+			} else {
+				log.Info("VIP already configured on interface", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
+			}
+		}
+	}
+
+	// As we're leading lets start the vip service
+	err := cluster.vipService(objLease.Ctx, c, em, bgpServer, objLease.Cancel)
+	if err != nil {
+		log.Error("starting VIP service on leader", "err", err)
+		signalChan <- syscall.SIGINT
+	}
+}
+
+func (cluster *Cluster) OnStoppedLeading(c *kubevip.Config, objLease *lease.Lease,
+	bgpServer *bgp.Server, signalChan chan os.Signal) {
+	// we can do cleanup here
+	log.Info("This node is becoming a follower within the cluster")
+
+	// Stop the cluster context if it is running
+	objLease.Cancel()
+
+	// Stop the BGP server
+	if bgpServer != nil {
+		err := bgpServer.Close()
+		if err != nil {
+			log.Warn("close BGP server", "err", err)
+		}
+	}
+
+	// Handle VIP cleanup based on configuration
+	if c.PreserveVIPOnLeadershipLoss {
+		// For IPv6, we must remove VIPs immediately to avoid DAD failures on the new leader
+		// IPv6 Duplicate Address Detection will fail if the new leader tries to add an IP that is still present on this node's interface
+		// We need to check each VIP individually and only remove IPv6 VIPs
+		for i := range cluster.Network {
+			if utils.IsIPv6(cluster.Network[i].IP()) {
+				log.Info("Removing IPv6 VIP immediately (required to prevent DAD failures on new leader)", "ip", cluster.Network[i].IP())
+				deleted, err := cluster.Network[i].DeleteIP()
+				if err != nil {
+					log.Warn("delete VIP", "err", err)
+				}
+				if deleted {
+					log.Info("deleted address", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
+				}
+			} else {
+				log.Info("Preserving IPv4 VIP address on interface, only stopped ARP broadcasting", "ip", cluster.Network[i].IP())
+			}
+		}
+	} else {
+		// Legacy behavior: delete VIP addresses on leadership loss
+		log.Info("Deleting VIP addresses on leadership loss (legacy behavior)")
+		for i := range cluster.Network {
+			deleted, err := cluster.Network[i].DeleteIP()
+			if err != nil {
+				log.Warn("delete VIP", "err", err)
+			}
+			if deleted {
+				log.Info("deleted address", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
+			}
+		}
+	}
+
+	log.Error("lost leadership, restarting kube-vip")
+	signalChan <- syscall.SIGINT
+}
+
+func (cluster *Cluster) OnNewLeader(identity string, c *kubevip.Config) {
+	// we're notified when new leader elected
+	log.Info("New leader", "leader", identity)
+
+	// If we're not the new leader and we have VIPs preserved from previous leadership,
+	// we need to clean them up to avoid conflicts.
+	if identity != c.NodeName && c.PreserveVIPOnLeadershipLoss {
+		log.Info("Cleaning up preserved VIPs as another node became leader", "new_leader", identity)
+		for i := range cluster.Network {
+			deleted, err := cluster.Network[i].DeleteIP()
+			if err != nil {
+				log.Warn("failed to cleanup preserved VIP", "vip", cluster.Network[i].IP(), "err", err)
+			}
+			if deleted {
+				log.Info("cleaned up preserved VIP to avoid conflict", "IP", cluster.Network[i].IP(),
+					"interface", cluster.Network[i].Interface(), "new_leader", identity)
+			} else {
+				log.Debug("VIP was not present on this node", "IP", cluster.Network[i].IP(),
+					"interface", cluster.Network[i].Interface())
+			}
+		}
+	}
 }

--- a/pkg/endpoints/endpoints_generic.go
+++ b/pkg/endpoints/endpoints_generic.go
@@ -70,7 +70,10 @@ func (g *generic) clearEgress(lastKnownGoodEndpoint *string, service *v1.Service
 
 		*lastKnownGoodEndpoint = "" // reset endpoint
 		if g.config.EnableServicesElection || g.config.EnableLeaderElection {
-			g.leaseMgr.Delete(service)
+			leaseNamespace, leaseName := lease.ServiceName(service)
+			id := lease.NewID(g.config.LeaderElectionType, leaseNamespace, leaseName)
+			objectName := lease.ServiceNamespacedName(service)
+			g.leaseMgr.Delete(id, objectName)
 		}
 	}
 }

--- a/pkg/lease/lease_test.go
+++ b/pkg/lease/lease_test.go
@@ -21,6 +21,16 @@ func createTestService(name, namespace string, annotations map[string]string) *v
 	}
 }
 
+func getSvcID(svc *v1.Service) ID {
+	namespace, name := ServiceName(svc)
+	id := NewID("kubernetes", namespace, name)
+	return id
+}
+
+func getSvcData(svc *v1.Service) (ID, string) {
+	return getSvcID(svc), ServiceNamespacedName(svc)
+}
+
 const serviceLeaseAnnotation = kubevip.ServiceLease
 
 // TestManager_Add_NewLease tests adding a new service with a new lease
@@ -28,7 +38,7 @@ func TestManager_Add_NewLease(t *testing.T) {
 	mgr := NewManager()
 	svc := createTestService("test-svc", "default", nil)
 
-	lease, isNew, isShared := mgr.Add(svc)
+	lease, isNew, isShared := mgr.Add(getSvcData(svc))
 
 	if !isNew {
 		t.Error("expected isNew to be true for first Add")
@@ -55,8 +65,8 @@ func TestManager_Add_ExistingLease(t *testing.T) {
 	mgr := NewManager()
 	svc := createTestService("test-svc", "default", nil)
 
-	lease1, isNew1, isShared1 := mgr.Add(svc)
-	lease2, isNew2, isShared2 := mgr.Add(svc)
+	lease1, isNew1, isShared1 := mgr.Add(getSvcData(svc))
+	lease2, isNew2, isShared2 := mgr.Add(getSvcData(svc))
 
 	if !isNew1 {
 		t.Error("expected first Add to return isNew=true")
@@ -81,21 +91,21 @@ func TestManager_Delete_DecrementCounter(t *testing.T) {
 	svc := createTestService("test-svc", "default", nil)
 
 	// Add twice (simulating two services sharing the lease)
-	mgr.Add(svc)
-	mgr.Add(svc)
+	mgr.Add(getSvcData(svc))
+	mgr.Add(getSvcData(svc))
 
 	// Delete once - should not remove the lease
-	mgr.Delete(svc)
+	mgr.Delete(getSvcData(svc))
 
-	lease := mgr.Get(svc)
+	lease := mgr.Get(getSvcID(svc))
 	if lease != nil {
 		t.Error("expected lease to be removed after first delete if same service was processed twice")
 	}
 
 	// Delete again - should remove the lease
-	mgr.Delete(svc)
+	mgr.Delete(getSvcData(svc))
 
-	lease = mgr.Get(svc)
+	lease = mgr.Get(getSvcID(svc))
 	if lease != nil {
 		t.Error("expected lease to be removed")
 	}
@@ -106,7 +116,7 @@ func TestManager_Delete_CancelsContext(t *testing.T) {
 	mgr := NewManager()
 	svc := createTestService("test-svc", "default", nil)
 
-	lease, _, _ := mgr.Add(svc)
+	lease, _, _ := mgr.Add(getSvcData(svc))
 
 	// Verify context is not cancelled
 	select {
@@ -117,7 +127,7 @@ func TestManager_Delete_CancelsContext(t *testing.T) {
 	}
 
 	// Delete the lease
-	mgr.Delete(svc)
+	mgr.Delete(getSvcData(svc))
 
 	// Verify context is cancelled
 	select {
@@ -134,11 +144,11 @@ func TestManager_Add_AfterDelete_CreatesNewLease(t *testing.T) {
 	svc := createTestService("test-svc", "default", nil)
 
 	// Add and delete
-	lease1, _, _ := mgr.Add(svc)
-	mgr.Delete(svc)
+	lease1, _, _ := mgr.Add(getSvcData(svc))
+	mgr.Delete(getSvcData(svc))
 
 	// Add again - should create new lease
-	lease2, isNew, _ := mgr.Add(svc)
+	lease2, isNew, _ := mgr.Add(getSvcData(svc))
 
 	if !isNew {
 		t.Error("expected isNew to be true after delete and re-add")
@@ -154,8 +164,8 @@ func TestManager_Add_DifferentServices(t *testing.T) {
 	svc1 := createTestService("svc1", "default", nil)
 	svc2 := createTestService("svc2", "default", nil)
 
-	lease1, isNew1, _ := mgr.Add(svc1)
-	lease2, isNew2, _ := mgr.Add(svc2)
+	lease1, isNew1, _ := mgr.Add(getSvcData(svc1))
+	lease2, isNew2, _ := mgr.Add(getSvcData(svc2))
 
 	if !isNew1 || !isNew2 {
 		t.Error("expected both adds to return isNew=true")
@@ -171,8 +181,8 @@ func TestManager_Add_SameNameDifferentNamespace(t *testing.T) {
 	svc1 := createTestService("test-svc", "namespace1", nil)
 	svc2 := createTestService("test-svc", "namespace2", nil)
 
-	lease1, isNew1, _ := mgr.Add(svc1)
-	lease2, isNew2, _ := mgr.Add(svc2)
+	lease1, isNew1, _ := mgr.Add(getSvcData(svc1))
+	lease2, isNew2, _ := mgr.Add(getSvcData(svc2))
 
 	if !isNew1 || !isNew2 {
 		t.Error("expected both adds to return isNew=true")
@@ -195,7 +205,7 @@ func TestManager_ConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			mgr.Add(svc)
+			mgr.Add(getSvcData(svc))
 		}()
 	}
 	wg.Wait()
@@ -205,13 +215,13 @@ func TestManager_ConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			mgr.Delete(svc)
+			mgr.Delete(getSvcData(svc))
 		}()
 	}
 	wg.Wait()
 
 	// After all deletes, lease should be gone
-	lease := mgr.Get(svc)
+	lease := mgr.Get(getSvcID(svc))
 	if lease != nil {
 		t.Error("expected lease to be removed after all concurrent deletes")
 	}
@@ -248,16 +258,17 @@ func TestLease_StartedChannel(t *testing.T) {
 func TestGetName_WithoutAnnotation(t *testing.T) {
 	svc := createTestService("my-service", "my-namespace", nil)
 
-	name, id := GetName(svc)
+	namespace, name := ServiceName(svc)
+	id := NewID("kubernetes", namespace, name)
 
 	expectedName := "kubevip-my-service"
-	expectedID := "kubevip-my-service/my-namespace"
+	expectedID := "my-namespace/kubevip-my-service"
 
-	if name != expectedName {
-		t.Errorf("expected name %q, got %q", expectedName, name)
+	if id.Name() != expectedName {
+		t.Errorf("expected name %q, got %q", expectedName, id.Name())
 	}
-	if id != expectedID {
-		t.Errorf("expected id %q, got %q", expectedID, id)
+	if id.NamespacedName() != expectedID {
+		t.Errorf("expected id %q, got %q", expectedID, id.NamespacedName())
 	}
 }
 
@@ -267,16 +278,103 @@ func TestGetName_WithAnnotation(t *testing.T) {
 		serviceLeaseAnnotation: "shared-lease",
 	})
 
-	name, id := GetName(svc)
+	namespace, name := ServiceName(svc)
+	id := NewID("kubernetes", namespace, name)
 
 	expectedName := "shared-lease"
-	expectedID := "shared-lease/my-namespace"
+	expectedID := "my-namespace/shared-lease"
 
-	if name != expectedName {
-		t.Errorf("expected name %q, got %q", expectedName, name)
+	if id.Name() != expectedName {
+		t.Errorf("expected name %q, got %q", expectedName, id.Name())
 	}
-	if id != expectedID {
-		t.Errorf("expected id %q, got %q", expectedID, id)
+	if id.NamespacedName() != expectedID {
+		t.Errorf("expected id %q, got %q", expectedID, id.NamespacedName())
+	}
+}
+
+// TestGetName_WithAnnotation tests with a shared lease annotation
+func TestGetName_WithAnnotationAndOverriddenNamespace(t *testing.T) {
+	svc := createTestService("my-service", "my-namespace", map[string]string{
+		serviceLeaseAnnotation: "other-namespace/shared-lease",
+	})
+
+	namespace, name := ServiceName(svc)
+	id := NewID("kubernetes", namespace, name)
+
+	expectedName := "shared-lease"
+	expectedID := "other-namespace/shared-lease"
+	expectedNamespace := "other-namespace"
+
+	if id.Name() != expectedName {
+		t.Errorf("expected name %q, got %q", expectedName, id.Name())
+	}
+	if id.NamespacedName() != expectedID {
+		t.Errorf("expected id %q, got %q", expectedID, id.NamespacedName())
+	}
+	if id.Namespace() != expectedNamespace {
+		t.Errorf("expected namespace %q, got %q", expectedNamespace, id.Namespace())
+	}
+}
+
+// TestGetName_WithoutAnnotation_Etcd tests with no annotation
+func TestGetName_WithoutAnnotation_etcd(t *testing.T) {
+	svc := createTestService("my-service", "my-namespace", nil)
+
+	namespace, name := ServiceName(svc)
+	id := NewID("etcd", namespace, name)
+
+	expectedName := "kubevip-my-service"
+	expectedID := "my-namespace-kubevip-my-service"
+
+	if id.Name() != expectedName {
+		t.Errorf("expected name %q, got %q", expectedName, id.Name())
+	}
+	if id.NamespacedName() != expectedID {
+		t.Errorf("expected id %q, got %q", expectedID, id.NamespacedName())
+	}
+}
+
+// TestGetName_WithAnnotation_Etcd tests with a shared lease annotation
+func TestGetName_WithAnnotation_Etcd(t *testing.T) {
+	svc := createTestService("my-service", "my-namespace", map[string]string{
+		serviceLeaseAnnotation: "shared-lease",
+	})
+
+	namespace, name := ServiceName(svc)
+	id := NewID("etcd", namespace, name)
+
+	expectedName := "shared-lease"
+	expectedID := "my-namespace-shared-lease"
+
+	if id.Name() != expectedName {
+		t.Errorf("expected name %q, got %q", expectedName, id.Name())
+	}
+	if id.NamespacedName() != expectedID {
+		t.Errorf("expected id %q, got %q", expectedID, id.NamespacedName())
+	}
+}
+
+// TestGetName_WithAnnotation_Etcd tests with a shared lease annotation
+func TestGetName_WithAnnotationAndOverriddenNamespace_Etcd(t *testing.T) {
+	svc := createTestService("my-service", "my-namespace", map[string]string{
+		serviceLeaseAnnotation: "other-namespace/shared-lease",
+	})
+
+	namespace, name := ServiceName(svc)
+	id := NewID("etcd", namespace, name)
+
+	expectedName := "shared-lease"
+	expectedID := "other-namespace-shared-lease"
+	expectedNamespace := "other-namespace"
+
+	if id.Name() != expectedName {
+		t.Errorf("expected name %q, got %q", expectedName, id.Name())
+	}
+	if id.NamespacedName() != expectedID {
+		t.Errorf("expected id %q, got %q", expectedID, id.NamespacedName())
+	}
+	if id.Namespace() != expectedNamespace {
+		t.Errorf("expected namespace %q, got %q", expectedNamespace, id.Namespace())
 	}
 }
 
@@ -284,12 +382,12 @@ func TestGetName_WithAnnotation(t *testing.T) {
 // leadership is lost and the restartable service watcher tries to restart
 // the leader election. This test verifies that after deleting the lease,
 // a new lease can be created.
-func TestManager_LeaderElectionRestartScenario(t *testing.T) {
+func TestManager_LeaderElectionRestartScenario_etcd(t *testing.T) {
 	mgr := NewManager()
 	svc := createTestService("traefik", "traefik", nil)
 
 	// Simulate first leader election start
-	lease1, isNew1, isShared1 := mgr.Add(svc)
+	lease1, isNew1, isShared1 := mgr.Add(getSvcData(svc))
 	if !isNew1 {
 		t.Fatal("expected first add to return isNew=true")
 	}
@@ -302,15 +400,15 @@ func TestManager_LeaderElectionRestartScenario(t *testing.T) {
 
 	// Simulate leadership lost - the leader election function should delete the lease
 	// This is the fix: delete the lease when RunOrDie returns
-	mgr.Delete(svc)
+	mgr.Delete(getSvcData(svc))
 
 	// Verify lease is removed
-	if mgr.Get(svc) != nil {
+	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease to be removed after delete")
 	}
 
 	// Simulate restartable service watcher calling StartServicesLeaderElection again
-	lease2, isNew2, isShared2 := mgr.Add(svc)
+	lease2, isNew2, isShared2 := mgr.Add(getSvcData(svc))
 	if !isNew2 {
 		t.Fatal("expected second add after delete to return isNew=true")
 	}
@@ -345,7 +443,7 @@ func TestManager_CommonLeaseScenario(t *testing.T) {
 	svc2 := createTestService("svc2", "default", sharedLeaseAnnotations)
 
 	// First service gets a new lease
-	lease1, isNew1, isShared1 := mgr.Add(svc1)
+	lease1, isNew1, isShared1 := mgr.Add(getSvcData(svc1))
 	if !isNew1 {
 		t.Error("expected first add to return isNew=true")
 	}
@@ -357,7 +455,7 @@ func TestManager_CommonLeaseScenario(t *testing.T) {
 	close(lease1.Started)
 
 	// Second service should get the same lease
-	lease2, isNew2, isShared2 := mgr.Add(svc2)
+	lease2, isNew2, isShared2 := mgr.Add(getSvcData(svc2))
 	if !isNew2 {
 		t.Error("expected second add with same lease name to return isNew=true")
 	}
@@ -369,14 +467,14 @@ func TestManager_CommonLeaseScenario(t *testing.T) {
 	}
 
 	// Delete first service - lease should still exist
-	mgr.Delete(svc1)
-	if mgr.Get(svc1) == nil {
+	mgr.Delete(getSvcData(svc1))
+	if mgr.Get(getSvcID(svc1)) == nil {
 		t.Error("expected lease to still exist after first delete")
 	}
 
 	// Delete second service - lease should be removed
-	mgr.Delete(svc2)
-	if mgr.Get(svc1) != nil {
+	mgr.Delete(getSvcData(svc2))
+	if mgr.Get(getSvcID(svc2)) != nil {
 		t.Error("expected lease to be removed after all services deleted")
 	}
 }
@@ -389,7 +487,7 @@ func TestManager_RaceCondition_LeaseExistsBeforeDelete(t *testing.T) {
 	svc := createTestService("traefik", "traefik", nil)
 
 	// Simulate first leader election start
-	lease1, isNew1, isShared1 := mgr.Add(svc)
+	lease1, isNew1, isShared1 := mgr.Add(getSvcData(svc))
 	if !isNew1 {
 		t.Fatal("expected first add to return isNew=true")
 	}
@@ -402,7 +500,7 @@ func TestManager_RaceCondition_LeaseExistsBeforeDelete(t *testing.T) {
 
 	// Simulate a second goroutine calling Add BEFORE the first goroutine's defer deletes the lease
 	// This is the race condition scenario
-	lease2, isNew2, isShared2 := mgr.Add(svc)
+	lease2, isNew2, isShared2 := mgr.Add(getSvcData(svc))
 	if isNew2 {
 		t.Error("expected second add before delete to return isNew=false")
 	}
@@ -422,16 +520,16 @@ func TestManager_RaceCondition_LeaseExistsBeforeDelete(t *testing.T) {
 	}
 
 	// Now the first goroutine's defer deletes the lease
-	mgr.Delete(svc)
+	mgr.Delete(getSvcData(svc))
 
 	// The lease should not still exist because same service was processed twice, so we do not increment the counter
-	if mgr.Get(svc) != nil {
+	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease tonot exist")
 	}
 
 	// Second delete does nothing
-	mgr.Delete(svc)
-	if mgr.Get(svc) != nil {
+	mgr.Delete(getSvcData(svc))
+	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease to not exist")
 	}
 }
@@ -443,7 +541,7 @@ func TestManager_NonCommonLease_MultipleAdds(t *testing.T) {
 	svc := createTestService("traefik", "traefik", nil) // No common lease annotation
 
 	// First Add
-	lease1, isNew1, isShared1 := mgr.Add(svc)
+	lease1, isNew1, isShared1 := mgr.Add(getSvcData(svc))
 	if !isNew1 {
 		t.Error("expected first add to return isNew=true")
 	}
@@ -455,7 +553,7 @@ func TestManager_NonCommonLease_MultipleAdds(t *testing.T) {
 	close(lease1.Started)
 
 	// Second Add (simulating another goroutine or restart attempt)
-	lease2, isNew2, isShared2 := mgr.Add(svc)
+	lease2, isNew2, isShared2 := mgr.Add(getSvcData(svc))
 	if isNew2 {
 		t.Error("expected second add to return isNew=false")
 	}
@@ -467,7 +565,7 @@ func TestManager_NonCommonLease_MultipleAdds(t *testing.T) {
 	}
 
 	// Third Add
-	lease3, isNew3, isShared3 := mgr.Add(svc)
+	lease3, isNew3, isShared3 := mgr.Add(getSvcData(svc))
 	if isNew3 {
 		t.Error("expected third add to return isNew=false")
 	}
@@ -479,18 +577,18 @@ func TestManager_NonCommonLease_MultipleAdds(t *testing.T) {
 	}
 
 	// Need one delete to remove the lease, another delete runs do nothing
-	mgr.Delete(svc)
-	if mgr.Get(svc) != nil {
+	mgr.Delete(getSvcData(svc))
+	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease to be deleted")
 	}
 
-	mgr.Delete(svc)
-	if mgr.Get(svc) != nil {
+	mgr.Delete(getSvcData(svc))
+	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease to be deleted")
 	}
 
-	mgr.Delete(svc)
-	if mgr.Get(svc) != nil {
+	mgr.Delete(getSvcData(svc))
+	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease to be deleted")
 	}
 }
@@ -503,7 +601,7 @@ func TestManager_LeaseContextCancelledBeforeStarted(t *testing.T) {
 	svc := createTestService("traefik", "traefik", nil)
 
 	// First Add
-	lease1, isNew1, isShared1 := mgr.Add(svc)
+	lease1, isNew1, isShared1 := mgr.Add(getSvcData(svc))
 	if !isNew1 {
 		t.Fatal("expected first add to return isNew=true")
 	}
@@ -512,7 +610,7 @@ func TestManager_LeaseContextCancelledBeforeStarted(t *testing.T) {
 	}
 
 	// Second Add before Started is closed
-	lease2, isNew2, isShared2 := mgr.Add(svc)
+	lease2, isNew2, isShared2 := mgr.Add(getSvcData(svc))
 	if isNew2 {
 		t.Error("expected second add to return isNew=false")
 	}
@@ -540,10 +638,10 @@ func TestManager_LeaseContextCancelledBeforeStarted(t *testing.T) {
 	}
 
 	// Delete should still work
-	mgr.Delete(svc)
-	mgr.Delete(svc)
+	mgr.Delete(getSvcData(svc))
+	mgr.Delete(getSvcData(svc))
 
-	if mgr.Get(svc) != nil {
+	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease to be removed")
 	}
 }
@@ -555,21 +653,21 @@ func TestManager_RestartAfterLeaseContextCancelled(t *testing.T) {
 	svc := createTestService("traefik", "traefik", nil)
 
 	// First Add
-	lease1, _, _ := mgr.Add(svc)
+	lease1, _, _ := mgr.Add(getSvcData(svc))
 
 	// Cancel context before Started is closed
 	lease1.Cancel()
 
 	// Delete the lease
-	mgr.Delete(svc)
+	mgr.Delete(getSvcData(svc))
 
 	// Verify lease is gone
-	if mgr.Get(svc) != nil {
+	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease to be removed after delete")
 	}
 
 	// Add again - should create new lease
-	lease2, isNew2, isShared2 := mgr.Add(svc)
+	lease2, isNew2, isShared2 := mgr.Add(getSvcData(svc))
 	if !isNew2 {
 		t.Error("expected new lease after delete")
 	}
@@ -602,7 +700,7 @@ func TestManager_NonCommonLease_WaitForLeaseContextDone(t *testing.T) {
 	svc := createTestService("egress-service", "default", nil) // Non-common lease
 
 	// First Add - simulates the first leader election starting
-	lease1, isNew1, isShared1 := mgr.Add(svc)
+	lease1, isNew1, isShared1 := mgr.Add(getSvcData(svc))
 	if !isNew1 {
 		t.Fatal("expected first add to return isNew=true")
 	}
@@ -615,7 +713,7 @@ func TestManager_NonCommonLease_WaitForLeaseContextDone(t *testing.T) {
 
 	// Second Add - simulates another goroutine trying to start leader election
 	// This should return isNew=false
-	lease2, isNew2, isShared2 := mgr.Add(svc)
+	lease2, isNew2, isShared2 := mgr.Add(getSvcData(svc))
 	if isNew2 {
 		t.Error("expected second add to return isNew=false")
 	}
@@ -659,11 +757,11 @@ func TestManager_NonCommonLease_WaitForLeaseContextDone(t *testing.T) {
 	}
 
 	// Now simulate the first leader election ending (defer deletes the lease)
-	mgr.Delete(svc)
+	mgr.Delete(getSvcData(svc))
 
 	// The lease context should now be cancelled (because counter went to 0)
 	// But we added twice, so we need to delete twice
-	mgr.Delete(svc)
+	mgr.Delete(getSvcData(svc))
 
 	// Now the goroutine should have completed
 	select {
@@ -674,7 +772,7 @@ func TestManager_NonCommonLease_WaitForLeaseContextDone(t *testing.T) {
 	}
 
 	// Verify lease is removed
-	if mgr.Get(svc) != nil {
+	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease to be removed")
 	}
 }
@@ -688,7 +786,7 @@ func TestManager_NonCommonLease_SpinLoopPrevention(t *testing.T) {
 	svc := createTestService("egress-service", "default", nil) // Non-common lease
 
 	// First Add - leader election starts
-	lease1, isNew1, isShared1 := mgr.Add(svc)
+	lease1, isNew1, isShared1 := mgr.Add(getSvcData(svc))
 	if !isNew1 {
 		t.Fatal("expected first add to return isNew=true")
 	}
@@ -705,7 +803,7 @@ func TestManager_NonCommonLease_SpinLoopPrevention(t *testing.T) {
 
 	go func() {
 		for i := 0; i < 100; i++ {
-			lease, isNew, isShared := mgr.Add(svc)
+			lease, isNew, isShared := mgr.Add(getSvcData(svc))
 			addCount++
 			if isNew {
 				// This shouldn't happen while the first lease exists
@@ -741,8 +839,8 @@ func TestManager_NonCommonLease_SpinLoopPrevention(t *testing.T) {
 		t.Errorf("expected 100 adds, got %d", addCount)
 	}
 
-	mgr.Delete(svc)
-	if mgr.Get(svc) != nil {
+	mgr.Delete(getSvcData(svc))
+	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease to be removed after first delete")
 	}
 }
@@ -755,11 +853,11 @@ func TestManager_NonCommonLease_ServiceContextCancellation(t *testing.T) {
 	svc := createTestService("egress-service", "default", nil)
 
 	// First Add - leader election starts
-	lease1, _, _ := mgr.Add(svc)
+	lease1, _, _ := mgr.Add(getSvcData(svc))
 	close(lease1.Started)
 
 	// Second Add - returns isNew=false
-	lease2, isNew2, isShared2 := mgr.Add(svc)
+	lease2, isNew2, isShared2 := mgr.Add(getSvcData(svc))
 	if isNew2 {
 		t.Error("expected isNew=false")
 	}

--- a/pkg/manager/worker/worker.go
+++ b/pkg/manager/worker/worker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/bgp"
 	"github.com/kube-vip/kube-vip/pkg/election"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/networkinterface"
 	"github.com/kube-vip/kube-vip/pkg/services"
 	"github.com/prometheus/client_golang/prometheus"
@@ -19,9 +20,9 @@ import (
 type Worker interface {
 	Configure(context.Context) error
 	InitControlPlane() error
-	StartControlPlane(context.Context, *election.Manager, string, string)
+	StartControlPlane(context.Context, *election.Manager)
 	ConfigureServices()
-	StartServices(ctx context.Context, id string) error
+	StartServices(ctx context.Context) error
 	Name() string
 }
 
@@ -29,26 +30,26 @@ func New(arpMgr *arp.Manager, intfMgr *networkinterface.Manager,
 	config *kubevip.Config, closing *atomic.Bool, signalChan chan os.Signal,
 	svcProcessor *services.Processor, mutex *sync.Mutex, clientSet *kubernetes.Clientset,
 	bgpServer *bgp.Server, bgpSessionInfoGauge *prometheus.GaugeVec,
-	electionMgr *election.Manager) Worker {
+	electionMgr *election.Manager, leaseMgr *lease.Manager) Worker {
 	if config.EnableARP {
 		return NewARP(arpMgr, intfMgr, config, closing, signalChan,
-			svcProcessor, mutex, clientSet, electionMgr)
+			svcProcessor, mutex, clientSet, electionMgr, leaseMgr)
 	}
 
 	if config.EnableBGP {
 		return NewBGP(arpMgr, intfMgr, config, closing, signalChan,
 			svcProcessor, mutex, clientSet, bgpServer, bgpSessionInfoGauge,
-			electionMgr)
+			electionMgr, leaseMgr)
 	}
 
 	if config.EnableRoutingTable {
 		return NewTable(arpMgr, intfMgr, config, closing, signalChan,
-			svcProcessor, mutex, clientSet, electionMgr)
+			svcProcessor, mutex, clientSet, electionMgr, leaseMgr)
 	}
 
 	if config.EnableWireguard {
 		return NewWireGuard(arpMgr, intfMgr, config, closing, signalChan,
-			svcProcessor, mutex, clientSet, electionMgr)
+			svcProcessor, mutex, clientSet, electionMgr, leaseMgr)
 	}
 
 	return nil

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -68,7 +68,7 @@ type labelManager interface {
 func NewServicesProcessor(config *kubevip.Config, bgpServer *bgp.Server,
 	clientSet *kubernetes.Clientset, rwClientSet *kubernetes.Clientset, shutdownChan chan struct{},
 	intfMgr *networkinterface.Manager, arpMgr *arp.Manager, nodeLabelManager labelManager,
-	electionMgr *election.Manager) *Processor {
+	electionMgr *election.Manager, leaseMgr *lease.Manager) *Processor {
 	lbClassFilterFunc := lbClassFilter
 	if config.LoadBalancerClassLegacyHandling {
 		lbClassFilterFunc = lbClassFilterLegacy
@@ -91,7 +91,7 @@ func NewServicesProcessor(config *kubevip.Config, bgpServer *bgp.Server,
 
 		intfMgr:          intfMgr,
 		arpMgr:           arpMgr,
-		leaseMgr:         lease.NewManager(),
+		leaseMgr:         leaseMgr,
 		nodeLabelManager: nodeLabelManager,
 		electionMgr:      electionMgr,
 	}


### PR DESCRIPTION
This PR should help with #464 

It introduces common global lease (based on previously introduced common lease for services). Now both CP and services (global and per service leader election) can share leases.

Configuration (assuming `kube-vip` is running in `kube-system` namespace:

- When `svc_election: false`

```
- name: vip_leasename
  value: plndr-common-lock
- name: svc_leasename
  value: plndr-common-lock
```

If `vip_leasename` and `svc_leasename` are the same, both CP and Services will use the same lease (so would run on just one node).


- When `svc_election: true`

Service can use any lease known to kube-vip. Eg. let's assume that the configured lease is:

```
- name: vip_leasename
  value: plndr-cp-lock
```

if service is deployed in the same namespace as kube-vip, one can just provide the name of the lease to the service:
For example 
```
annotations:
  kube-vip.io/leaseName: "plndr-cp-lock"
```

will tie service in `kube-system` namespace to control plane lease (`plndr-cp-lock`) in the same namespace.

Additionally **cross-namespace** leases are supported. Example - service in namespace `default` can be tied to the CP lock in `kube-system` namespace with:

```
annotations:
   kube-vip.io/leaseName: "kube-system/plndr-cp-lock"
```

Similarly, namespace can be selected for 'global' leases like:

```
- name: vip_leasename
  value: some-namespace/plndr-cp-lock
- name: svc_leasename
  value: some-namespace/plndr-svc-lock
```