### PR TITLE
fix: align CLI lease flag defaults with Kubernetes client-go defaults (15/10/2)

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -81,9 +81,9 @@ func init() {
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableLeaderElection, "leaderElection", false, "Use the Kubernetes leader election mechanism for clustering")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.LeaderElectionType, "leaderElectionType", "kubernetes", "Defines the backend to run the leader election: kubernetes or etcd. Defaults to kubernetes.")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.LeaseName, "leaseName", "plndr-cp-lock", "Name of the lease that is used for leader election")
-	kubeVipCmd.PersistentFlags().IntVar(&initConfig.LeaseDuration, "leaseDuration", 5, "Length of time (in seconds) a Kubernetes leader lease can be held for")
-	kubeVipCmd.PersistentFlags().IntVar(&initConfig.RenewDeadline, "leaseRenewDuration", 3, "Length of time (in seconds) a Kubernetes leader can attempt to renew its lease")
-	kubeVipCmd.PersistentFlags().IntVar(&initConfig.RetryPeriod, "leaseRetry", 1, "Length of time (in seconds) the LeaderElector clients should wait between tries of actions")
+	kubeVipCmd.PersistentFlags().IntVar(&initConfig.LeaseDuration, "leaseDuration", 15, "Length of time (in seconds) a Kubernetes leader lease can be held for")
+	kubeVipCmd.PersistentFlags().IntVar(&initConfig.RenewDeadline, "leaseRenewDuration", 10, "Length of time (in seconds) a Kubernetes leader can attempt to renew its lease")
+	kubeVipCmd.PersistentFlags().IntVar(&initConfig.RetryPeriod, "leaseRetry", 2, "Length of time (in seconds) the LeaderElector clients should wait between tries of actions")
 
 	// BGP flags
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableBGP, "bgp", false, "This will enable BGP support within kube-vip")


### PR DESCRIPTION
## Summary

The CLI flag defaults for leader election lease parameters (`--leaseDuration`,
`--leaseRenewDuration`, `--leaseRetry`) are currently set to `5/3/1` seconds,
which is significantly more aggressive than the Kubernetes client-go defaults of
`15/10/2` seconds.

This causes VIP instability (flapping, split-brain) when the API server
experiences even minor latency spikes (e.g., slow etcd disk I/O, brief network
hiccups), because the leader cannot renew its lease within the tight 3-second
deadline.

## Changes

- `cmd/kube-vip.go`: Change CLI flag defaults from `5/3/1` to `15/10/2`

## Why 15/10/2?

These are the [Kubernetes client-go leader election defaults](https://github.com/kubernetes/client-go/blob/f0b431a6e0bfce3c7c1d10b223d46875df3d1c29/tools/leaderelection/leaderelection.go#L128),
and also match the values already used as fallback defaults in
`pkg/kubevip/config_generator.go` (with a TODO comment referencing this exact
client-go link).

The kube-vip documentation Flags page also states the defaults as `15/10/2`,
but the actual CLI defaults were `5/3/1` — this PR resolves that inconsistency.