### PR TITLE
Added context inheritance for services

### DIFF
--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -201,7 +201,10 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 		log.Debug("(svcs) has been added/modified with addresses", "service name", svc.Name, "ips", ips, "hostnames", hostnames)
 
 		if svcCtx == nil {
-			svcCtx = servicecontext.New(ctx)
+			ns, name := lease.ServiceName(svc)
+			leaseID := lease.NewID(p.config.LeaderElectionType, ns, name)
+			lease := p.leaseMgr.Add(ctx, leaseID)
+			svcCtx = servicecontext.New(lease.Ctx)
 			p.svcMap.Store(svc.UID, svcCtx)
 		}
 


### PR DESCRIPTION
Currently `serviceContext` uses `context.Background()` as a parent context. This PR adds inheritance for `serviceContext` so the context for services is created as a child of either global context or election context if per-service election is enabled. This should lead to better context cancellation in case of e.g. kube-vip's shutdown.