### PR TITLE
Added waitgroups

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	log "log/slog"
@@ -302,14 +303,19 @@ var kubeVipManager = &cobra.Command{
 		// Welome messages
 		log.Info("kube-vip.io", "version", Release.Version, "build", Release.Build)
 
+		wg := sync.WaitGroup{}
+		defer wg.Wait()
+
 		// create main manager context
 		ctx, cancel := context.WithCancel(cmd.Context())
 		defer cancel()
 
 		// start prometheus server
 		if initConfig.PrometheusHTTPServer != "" {
-			go servePrometheusHTTPServer(ctx, PrometheusHTTPServerConfig{
-				Addr: initConfig.PrometheusHTTPServer,
+			wg.Go(func() {
+				servePrometheusHTTPServer(ctx, PrometheusHTTPServerConfig{
+					Addr: initConfig.PrometheusHTTPServer,
+				})
 			})
 		}
 
@@ -393,13 +399,13 @@ var kubeVipManager = &cobra.Command{
 				initConfig.Interface = defaultIF.Name
 				log.Info("kube-vip bind", "interface", initConfig.Interface)
 
-				go func() {
+				wg.Go(func() {
 					if err := vip.MonitorDefaultInterface(ctx, defaultIF); err != nil {
 
 						log.Error("interface monitor", "err", err)
 						return
 					}
-				}()
+				})
 			}
 		}
 		// Perform a check on the state of the interface
@@ -458,18 +464,18 @@ func servePrometheusHTTPServer(ctx context.Context, config PrometheusHTTPServerC
 		ReadHeaderTimeout: 2 * time.Second,
 	}
 
-	go func() {
+	wg := sync.WaitGroup{}
+
+	wg.Go(func() {
 		if err = srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Error("prometheus HTTP server", "err", err)
 			return
 		}
-	}()
+	})
 
 	log.Info("prometheus HTTP server started")
 
 	<-ctx.Done()
-
-	log.Info("prometheus HTTP server stopped")
 
 	// create prometheus shutdown context (independent of other contexts)
 	ctxShutDown, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -485,6 +491,10 @@ func servePrometheusHTTPServer(ctx context.Context, config PrometheusHTTPServerC
 	if err == http.ErrServerClosed {
 		err = nil
 	}
+
+	log.Info("prometheus HTTP server stopped")
+
+	wg.Wait()
 }
 
 func GenerateCidrRange(address string, dnsMode string) (string, error) {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -34,8 +34,10 @@ func InitCluster(c *kubevip.Config, disableVIP bool, intfMgr *networkinterface.M
 	}
 	// Initialise the Cluster structure
 	newCluster := &Cluster{
-		Network: networks,
-		arpMgr:  arpMgr,
+		Network:   networks,
+		arpMgr:    arpMgr,
+		completed: make(chan bool),
+		stop:      make(chan bool),
 	}
 
 	log.Debug("service security", "enabled", c.EnableServiceSecurity)

--- a/pkg/cluster/clusterDDNS.go
+++ b/pkg/cluster/clusterDDNS.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"sync"
 
 	"github.com/kube-vip/kube-vip/pkg/vip"
 )
@@ -12,9 +13,9 @@ import (
 // during runtime if IP changes, startDDNS don't have to do reconfigure because
 // dnsUpdater already have the functionality to keep trying resolve the IP
 // and update the VIP configuration if it changes
-func (cluster *Cluster) StartDDNS(ctx context.Context, network vip.Network, backoffAttempts uint) error {
+func (cluster *Cluster) StartDDNS(ctx context.Context, network vip.Network, backoffAttempts uint, wg *sync.WaitGroup) error {
 	ddnsMgr := vip.NewDDNSManager(network, backoffAttempts)
-	ip, err := ddnsMgr.Start(ctx)
+	ip, err := ddnsMgr.Start(ctx, wg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 
 	"github.com/kube-vip/kube-vip/pkg/bgp"
@@ -19,7 +20,6 @@ import (
 // StartCluster - Begins a running instance of the Leader Election cluster
 func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config,
 	em *election.Manager, bgpServer *bgp.Server, leaseMgr *lease.Manager) error {
-	var err error
 
 	ns, leaseName := lease.NamespaceName(c.LeaseName, c)
 
@@ -31,14 +31,17 @@ func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config,
 	objLease := leaseMgr.Add(ctx, leaseID)
 	isNew := objLease.Add(objectName)
 
+	wg := sync.WaitGroup{}
+	defer wg.Wait()
+
 	// Start a goroutine that will delete the lease when the service context is cancelled.
 	// This is important for proper cleanup when a service is deleted - it ensures that
 	// the lease context (svcLease.Ctx) gets cancelled, which causes RunOrDie to return.
 	// Without this, RunOrDie would continue running until leadership is naturally lost.
-	go func() {
+	wg.Go(func() {
 		<-objLease.Ctx.Done()
 		leaseMgr.Delete(leaseID, objectName)
-	}()
+	})
 
 	if !isNew {
 		log.Debug("this election was already done, waiting for it to finish", "lease", leaseName)
@@ -56,16 +59,7 @@ func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config,
 	// Add Notification for SIGTERM (sent from Kubernetes)
 	signal.Notify(signalChan, syscall.SIGTERM)
 
-	if cluster.completed == nil {
-		cluster.completed = make(chan bool, 1)
-		defer close(cluster.completed)
-	}
-
-	if cluster.stop == nil {
-		cluster.stop = make(chan bool, 1)
-	}
-
-	go func() {
+	wg.Go(func() {
 		select {
 		case <-signalChan:
 		case <-cluster.stop:
@@ -74,7 +68,7 @@ func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config,
 		log.Info("Received termination, signaling cluster shutdown")
 		// Cancel the leader context, which will in turn cancel the leadership
 		objLease.Cancel()
-	}()
+	})
 
 	// (attempt to) Remove the virtual IP, in case it already exists
 
@@ -85,25 +79,6 @@ func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config,
 		}
 		if deleted {
 			log.Info("deleted address", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
-		}
-	}
-
-	// Defer a function to check if the bgpServer has been created and if so attempt to close it
-	defer func() {
-		if bgpServer != nil {
-			bgpServer.Close()
-		}
-	}()
-
-	if c.EnableBGP && bgpServer == nil {
-		// Lets start BGP
-		log.Info("Starting the BGP server to advertise VIP routes to VGP peers")
-		bgpServer, err = bgp.NewBGPServer(c.BGPConfig)
-		if err != nil {
-			log.Error("new BGP server", "err", err)
-		}
-		if err := bgpServer.Start(ctx, nil); err != nil {
-			log.Error("starting BGP server", "err", err)
 		}
 	}
 
@@ -188,7 +163,7 @@ func (cluster *Cluster) OnStartedLeading(c *kubevip.Config, objLease *lease.Leas
 	}
 
 	// As we're leading lets start the vip service
-	err := cluster.vipService(objLease.Ctx, c, em, bgpServer, objLease.Cancel)
+	err := cluster.vipService(objLease.Ctx, c, em, bgpServer, objLease.Cancel, signalChan)
 	if err != nil {
 		log.Error("starting VIP service on leader", "err", err)
 		signalChan <- syscall.SIGINT
@@ -202,14 +177,6 @@ func (cluster *Cluster) OnStoppedLeading(c *kubevip.Config, objLease *lease.Leas
 
 	// Stop the cluster context if it is running
 	objLease.Cancel()
-
-	// Stop the BGP server
-	if bgpServer != nil {
-		err := bgpServer.Close()
-		if err != nil {
-			log.Warn("close BGP server", "err", err)
-		}
-	}
 
 	// Handle VIP cleanup based on configuration
 	if c.PreserveVIPOnLeadershipLoss {
@@ -245,7 +212,6 @@ func (cluster *Cluster) OnStoppedLeading(c *kubevip.Config, objLease *lease.Leas
 	}
 
 	log.Error("lost leadership, restarting kube-vip")
-	signalChan <- syscall.SIGINT
 }
 
 func (cluster *Cluster) OnNewLeader(identity string, c *kubevip.Config) {

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -7,7 +7,6 @@ import (
 	"io/fs"
 	"net"
 	"os"
-	"os/signal"
 	"strings"
 	"sync"
 	"syscall"
@@ -30,42 +29,26 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func (cluster *Cluster) vipService(ctx context.Context, c *kubevip.Config, sm *election.Manager, bgpServer *bgp.Server, cancelLeaderElection context.CancelFunc) error {
+func (cluster *Cluster) vipService(ctx context.Context, c *kubevip.Config, sm *election.Manager, bgpServer *bgp.Server, cancelLeaderElection context.CancelFunc, signalChan chan os.Signal) error {
 	var err error
 
-	// listen for interrupts or the Linux SIGTERM signal and cancel
-	// our context, which the leader election code will observe and
-	// step down
-	signalChan := make(chan os.Signal, 1)
-	// Add Notification for Userland interrupt
-	signal.Notify(signalChan, syscall.SIGINT)
+	defer close(cluster.completed)
 
-	// Add Notification for SIGTERM (sent from Kubernetes)
-	signal.Notify(signalChan, syscall.SIGTERM)
+	var wg sync.WaitGroup
+	defer wg.Wait()
 
-	shouldClose := false
-	if cluster.completed == nil {
-		cluster.completed = make(chan bool, 1)
-		shouldClose = true
-	}
-
-	go func() {
+	wg.Go(func() {
 		<-ctx.Done()
 		signalChan <- syscall.SIGINT
-		if shouldClose {
-			defer close(cluster.completed)
-		}
-	}()
+	})
 
 	loadbalancers := []*loadbalancer.IPVSLoadBalancer{}
-
-	var arpWG sync.WaitGroup
 
 	for i := range cluster.Network {
 		network := cluster.Network[i]
 
 		if network.IsDDNS() {
-			if err := cluster.StartDDNS(ctx, cluster.Network[i], c.DHCPBackoffAttempts); err != nil {
+			if err := cluster.StartDDNS(ctx, cluster.Network[i], c.DHCPBackoffAttempts, &wg); err != nil {
 				log.Error("failed to start DDNS", "err", err)
 			}
 		}
@@ -78,7 +61,9 @@ func (cluster *Cluster) vipService(ctx context.Context, c *kubevip.Config, sm *e
 		if network.IsDNS() {
 			log.Info("starting the DNS updater", "address", network.DNSName())
 			ipUpdater := vip.NewIPUpdater(network)
-			ipUpdater.Run(ctx)
+			wg.Go(func() {
+				ipUpdater.Run(ctx)
+			})
 		}
 
 		if !c.EnableRoutingTable {
@@ -98,12 +83,12 @@ func (cluster *Cluster) vipService(ctx context.Context, c *kubevip.Config, sm *e
 		}
 
 		if c.EnableLoadBalancer {
-			lb, err := loadbalancer.NewIPVSLB(network.IP(), c.LoadBalancerPort, c.LoadBalancerForwardingMethod, c.BackendHealthCheckInterval, c.Interface, cancelLeaderElection, signalChan)
+			lb, err := loadbalancer.NewIPVSLB(network.IP(), c.LoadBalancerPort, c.LoadBalancerForwardingMethod, c.BackendHealthCheckInterval, c.Interface, cancelLeaderElection, signalChan, &wg)
 			if err != nil {
 				return fmt.Errorf("creating IPVS LoadBalance: %w", err)
 			}
 
-			go func() {
+			wg.Go(func() {
 				err = sm.NodeWatcher(ctx, lb, c.Port)
 				if err != nil {
 					log.Error("Error watching node labels", "err", err)
@@ -111,14 +96,15 @@ func (cluster *Cluster) vipService(ctx context.Context, c *kubevip.Config, sm *e
 						signalChan <- syscall.SIGINT
 					}
 				}
-			}()
+			})
 
 			loadbalancers = append(loadbalancers, lb)
 		}
 
 		if c.EnableARP {
-			arpWG.Add(1)
-			go cluster.layer2Update(ctx, network, c, &arpWG)
+			wg.Go(func() {
+				cluster.layer2Update(ctx, network, c)
+			})
 		}
 	}
 
@@ -182,10 +168,10 @@ func (cluster *Cluster) vipService(ctx context.Context, c *kubevip.Config, sm *e
 		stop := make(chan struct{})
 
 		// will wait for system interrupt and will send stop signal to backend watch
-		go func() {
+		wg.Go(func() {
 			<-signalChan
 			stop <- struct{}{}
-		}()
+		})
 
 		backend.Watch(func() {
 			for i := range cluster.Network {
@@ -259,10 +245,6 @@ func (cluster *Cluster) vipService(ctx context.Context, c *kubevip.Config, sm *e
 		}, c.BackendHealthCheckInterval, stop)
 	}
 
-	if c.EnableARP {
-		arpWG.Wait()
-	}
-
 	if c.EnableBGP {
 		<-signalChan
 	}
@@ -293,43 +275,39 @@ func getNodeIPs(ctx context.Context, nodename string, client *kubernetes.Clients
 }
 
 // StartLoadBalancerService will start a VIP instance and leave it for kube-proxy to handle
-func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip.Config, bgp *bgp.Server, name string, CountRouteReferences func(*netlink.Route) int) error {
+func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip.Config, bgp *bgp.Server, name string, CountRouteReferences func(*netlink.Route) int, wg *sync.WaitGroup) error {
 	// use a Go context so we can tell the arp loop code when we
 	// want to step down
 	//nolint
-	ctxArp, cancelArp := context.WithCancel(ctx)
+	lbCtx, lbCancel := context.WithCancel(ctx)
 
-	cluster.stop = make(chan bool, 1)
-	cluster.completed = make(chan bool, 1)
+	var lbWg sync.WaitGroup
 
-	var arpWG sync.WaitGroup
-
-	log.Debug("StartLoadBalancerService", "networks", len(cluster.Network))
 	for i := range cluster.Network {
 		network := cluster.Network[i]
 
 		if network.IsDDNS() {
 			ddnsReady := make(chan struct{})
-			go func() {
+			lbWg.Go(func() {
 				ctxDDNS, ddnsCancel := context.WithCancel(ctx)
 				defer ddnsCancel()
 
 				// start the DDNS if requested
 				log.Debug("(svcs) start DDNS", "name", network.DNSName())
-				if err := cluster.StartDDNS(ctxDDNS, cluster.Network[i], c.DHCPBackoffAttempts); err != nil {
+				if err := cluster.StartDDNS(ctxDDNS, cluster.Network[i], c.DHCPBackoffAttempts, &lbWg); err != nil {
 					log.Error("failed to start DDNS", "err", err)
 				}
 
 				close(ddnsReady)
 				<-cluster.stop
-			}()
+			})
 			<-ddnsReady
 		}
 
 		log.Debug("current ip to process", "ip", network.IP(), "mask", c.VIPSubnet)
 		if err := network.SetMask(c.VIPSubnet); err != nil {
 			log.Error("failed to set mask", "subnet", c.VIPSubnet, "err", err)
-			cancelArp()
+			lbCancel()
 			return utils.NewPanicError(fmt.Sprintf("failed to set mask for subnet %q: %s", c.VIPSubnet, err.Error()))
 		}
 		_, err := network.DeleteIP()
@@ -355,8 +333,9 @@ func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip
 		}
 
 		if c.EnableARP {
-			arpWG.Add(1)
-			go cluster.layer2Update(ctxArp, network, c, &arpWG)
+			lbWg.Go(func() {
+				cluster.layer2Update(lbCtx, network, c)
+			})
 		}
 
 		if c.EnableBGP && (c.EnableLeaderElection || c.EnableServicesElection) {
@@ -369,7 +348,9 @@ func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip
 		}
 	}
 
-	go func() {
+	wg.Go(func() {
+		defer close(cluster.completed)
+
 		for i := range cluster.Network {
 			network := cluster.Network[i]
 
@@ -380,15 +361,17 @@ func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip
 			if network.IsDNS() {
 				log.Info("(svcs) starting the DNS updater", "address", network.DNSName(), "ip", network.IP())
 				ipUpdater := vip.NewIPUpdater(network)
-				ipUpdater.Run(ctxDNS)
+				wg.Go(func() {
+					ipUpdater.Run(ctxDNS)
+				})
 			}
 		}
 
 		<-cluster.stop
-		// Stop the Arp context if it is running
-		cancelArp()
+		// Stop the loadbalancer context if it is running
+		lbCancel()
 
-		arpWG.Wait() // wait for all cluster ARP/NDP to be finished
+		lbWg.Wait() // wait for all cluster ARP/NDP to be finished
 
 		log.Info("[LOADBALANCER] Stopping load balancers", "name", name)
 
@@ -404,7 +387,6 @@ func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip
 				}
 			}
 
-			close(cluster.completed)
 			return
 		}
 		for i := range cluster.Network {
@@ -441,16 +423,13 @@ func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip
 				}
 			}
 		}
-
-		close(cluster.completed)
-	}()
+	})
 
 	return nil
 }
 
 // Layer2Update, handles the creation of the
-func (cluster *Cluster) layer2Update(ctx context.Context, network vip.Network, c *kubevip.Config, arpWG *sync.WaitGroup) {
-	defer arpWG.Done()
+func (cluster *Cluster) layer2Update(ctx context.Context, network vip.Network, c *kubevip.Config) {
 	var ndp *vip.NdpResponder
 	var err error
 	ipString := network.IP()

--- a/pkg/cluster/singleNode.go
+++ b/pkg/cluster/singleNode.go
@@ -3,73 +3,10 @@ package cluster
 import (
 	"context"
 
-	log "log/slog"
-
 	"github.com/kube-vip/kube-vip/pkg/bgp"
 	"github.com/kube-vip/kube-vip/pkg/election"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
-	"github.com/kube-vip/kube-vip/pkg/vip"
 )
-
-// StartSingleNode will start a single node cluster
-func (cluster *Cluster) StartSingleNode(c *kubevip.Config, disableVIP bool) error {
-	// Start kube-vip as a single node server
-
-	// TODO - Split all this code out as a separate function
-	log.Info("Starting kube-vip as a single node cluster")
-
-	log.Info("This node is assuming leadership of the cluster")
-
-	cluster.stop = make(chan bool, 1)
-	cluster.completed = make(chan bool, 1)
-
-	for i := range cluster.Network {
-		if !disableVIP {
-			deleted, err := cluster.Network[i].DeleteIP()
-			if err != nil {
-				log.Warn("Attempted to clean existing VIP", "err", err)
-			}
-			if deleted {
-				log.Info("deleted address", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
-			}
-
-			// Normal VIP addition for single node, use skipDAD=false for normal DAD process
-			_, err = cluster.Network[i].AddIP(false, false, 0)
-			if err != nil {
-				log.Warn(err.Error())
-			}
-
-		}
-
-		if c.EnableARP {
-			// Gratuitous ARP, will broadcast to new MAC <-> IP
-			err := vip.ARPSendGratuitous(cluster.Network[i].IP(), c.Interface)
-			if err != nil {
-				log.Warn(err.Error())
-			}
-		}
-	}
-
-	go func() {
-		<-cluster.stop
-
-		if !disableVIP {
-			for i := range cluster.Network {
-				log.Info("[VIP] Releasing the VIP", "address", cluster.Network[i].IP())
-				deleted, err := cluster.Network[i].DeleteIP()
-				if err != nil {
-					log.Warn(err.Error())
-				}
-				if deleted {
-					log.Info("deleted address", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
-				}
-			}
-		}
-		close(cluster.completed)
-	}()
-	log.Info("Started Load Balancer and Virtual IP")
-	return nil
-}
 
 func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, sm *election.Manager, bgp *bgp.Server) error {
 	// use a Go context so we can tell the arp loop code when we
@@ -77,5 +14,5 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 	clusterCtx, clusterCancel := context.WithCancel(ctx)
 	defer clusterCancel()
 
-	return cluster.vipService(clusterCtx, c, sm, bgp, nil)
+	return cluster.vipService(clusterCtx, c, sm, bgp, nil, sm.SignalChan)
 }

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 
 	log "log/slog"
 
@@ -40,7 +41,7 @@ func NewEndpointProcessor(config *kubevip.Config, provider providers.Provider, b
 
 func (p *Processor) AddOrModify(svcCtx *servicecontext.Context, event watch.Event,
 	lastKnownGoodEndpoint *string, service *v1.Service, id string,
-	serviceFunc func(*servicecontext.Context, *v1.Service) error) (bool, error) {
+	serviceFunc func(*servicecontext.Context, *v1.Service, *sync.WaitGroup) error, wg *sync.WaitGroup) (bool, error) {
 
 	var err error
 	if err = p.provider.LoadObject(event.Object, svcCtx.Cancel); err != nil {
@@ -73,9 +74,9 @@ func (p *Processor) AddOrModify(svcCtx *servicecontext.Context, event watch.Even
 		svcCtx.HasEndpoints.Store(true)
 		// start leader election if it's enabled and not already started
 		if !svcCtx.IsActive && p.config.EnableServicesElection {
-			go func() {
-				startLeaderElection(svcCtx, service, serviceFunc)
-			}()
+			wg.Go(func() {
+				startLeaderElection(svcCtx, service, serviceFunc, wg)
+			})
 		}
 
 		// There are local endpoints available on the node
@@ -158,14 +159,14 @@ func (p *Processor) updateAnnotations(service *v1.Service, lastKnownGoodEndpoint
 	}
 }
 
-func startLeaderElection(svcCtx *servicecontext.Context, service *v1.Service, serviceFunc func(*servicecontext.Context, *v1.Service) error) {
+func startLeaderElection(svcCtx *servicecontext.Context, service *v1.Service, serviceFunc func(*servicecontext.Context, *v1.Service, *sync.WaitGroup) error, wg *sync.WaitGroup) {
 	// This is a blocking function, that will restart (in the event of failure)
 	for {
 		select {
 		case <-svcCtx.Ctx.Done():
 			return
 		default:
-			err := serviceFunc(svcCtx, service)
+			err := serviceFunc(svcCtx, service, wg)
 			if err != nil {
 				log.Error(err.Error())
 			}

--- a/pkg/etcd/election_test.go
+++ b/pkg/etcd/election_test.go
@@ -108,7 +108,7 @@ func TestRunElectionWithTwoMembersAndReelection(t *testing.T) {
 		LeaseDurationSeconds: 1,
 	}
 
-	member1Ctx, _ := context.WithCancel(ctx)
+	member1Ctx, cancelMember1 := context.WithCancel(ctx)
 	member2Ctx, cancelMember2 := context.WithCancel(ctx)
 
 	config1 := configBase
@@ -124,6 +124,7 @@ func TestRunElectionWithTwoMembersAndReelection(t *testing.T) {
 		log.Println("Losing the leadership on purpose by stopping renewing the lease")
 		g.Expect(cliMember1.Lease.Close()).To(Succeed())
 		log.Println("Member1 leases closed")
+		cancelMember1()
 	}
 
 	config2 := configBase
@@ -152,6 +153,7 @@ func TestRunElectionWithTwoMembersAndReelection(t *testing.T) {
 	}()
 
 	wg.Wait()
+
 }
 
 func baseCallbacksForName(name string) etcd.LeaderCallbacks {

--- a/pkg/loadbalancer/ipvs.go
+++ b/pkg/loadbalancer/ipvs.go
@@ -59,7 +59,8 @@ type IPVSLoadBalancer struct {
 	family              ipvs.AddressFamily
 }
 
-func NewIPVSLB(address string, port uint16, forwardingMethod string, backendHealthCheckInterval int, networkInterface string, leaderCancel context.CancelFunc, signal chan os.Signal) (*IPVSLoadBalancer, error) {
+func NewIPVSLB(address string, port uint16, forwardingMethod string, backendHealthCheckInterval int, networkInterface string,
+	leaderCancel context.CancelFunc, signal chan os.Signal, wg *sync.WaitGroup) (*IPVSLoadBalancer, error) {
 	log.Info("Starting IPVS LoadBalancer", "address", address)
 
 	// Create IPVS client
@@ -148,7 +149,9 @@ func NewIPVSLB(address string, port uint16, forwardingMethod string, backendHeal
 		family:              family,
 	}
 
-	go lb.healthCheck()
+	wg.Go(func() {
+		lb.healthCheck()
+	})
 
 	// Return our created load-balancer
 	return lb, nil

--- a/pkg/manager/worker/arp.go
+++ b/pkg/manager/worker/arp.go
@@ -33,9 +33,11 @@ func NewARP(arpMgr *arp.Manager, intfMgr *networkinterface.Manager,
 	}
 }
 
-func (a *ARP) Configure(ctx context.Context) error {
+func (a *ARP) Configure(ctx context.Context, wg *sync.WaitGroup) error {
 	log.Info("Start ARP/NDP advertisement Global")
-	go a.arpMgr.StartAdvertisement(ctx)
+	wg.Go(func() {
+		a.arpMgr.StartAdvertisement(ctx)
+	})
 	return nil
 }
 

--- a/pkg/manager/worker/bgp.go
+++ b/pkg/manager/worker/bgp.go
@@ -41,7 +41,7 @@ func NewBGP(arpMgr *arp.Manager, intfMgr *networkinterface.Manager,
 	}
 }
 
-func (b *BGP) Configure(ctx context.Context) error {
+func (b *BGP) Configure(ctx context.Context, _ *sync.WaitGroup) error {
 	var err error
 	if b.bgpServer == nil {
 		b.bgpServer, err = bgp.NewBGPServer(b.config.BGPConfig)
@@ -72,6 +72,13 @@ func (b *BGP) Configure(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (b *BGP) Cleanup() {
+	// Defer a function to check if the bgpServer has been created and if so attempt to close it
+	if b.bgpServer != nil {
+		b.bgpServer.Close()
+	}
 }
 
 func (b *BGP) StartControlPlane(ctx context.Context, electionManager *election.Manager) {

--- a/pkg/manager/worker/common.go
+++ b/pkg/manager/worker/common.go
@@ -83,6 +83,10 @@ func (c *Common) ServicesNoLeader(ctx context.Context) error {
 	return nil
 }
 
+func (c *Common) Cleanup() {
+	// NOT IMPLEMENTED
+}
+
 func (c *Common) OnStartedLeading(ctx context.Context) {
 	err := c.svcProcessor.ServicesWatcher(ctx, c.svcProcessor.SyncServices)
 	if err != nil {

--- a/pkg/manager/worker/table.go
+++ b/pkg/manager/worker/table.go
@@ -37,17 +37,17 @@ func NewTable(arpMgr *arp.Manager, intfMgr *networkinterface.Manager,
 	}
 }
 
-func (t *Table) Configure(ctx context.Context) error {
+func (t *Table) Configure(ctx context.Context, wg *sync.WaitGroup) error {
 	log.Info("destination for routes", "table", t.config.RoutingTableID, "protocol", t.config.RoutingProtocol)
 
 	if t.config.CleanRoutingTable {
-		go func() {
+		wg.Go(func() {
 			// we assume that after 10s all services should be configured so we can delete redundant routes
 			time.Sleep(time.Second * 10)
 			if err := t.cleanRoutes(); err != nil {
 				log.Error("error checking for old routes", "err", err)
 			}
-		}()
+		})
 	}
 
 	if t.config.EgressClean {

--- a/pkg/manager/worker/wireguard.go
+++ b/pkg/manager/worker/wireguard.go
@@ -42,7 +42,7 @@ func NewWireGuard(arpMgr *arp.Manager, intfMgr *networkinterface.Manager,
 	}
 }
 
-func (w *WireGuard) Configure(ctx context.Context) error {
+func (w *WireGuard) Configure(ctx context.Context, _ *sync.WaitGroup) error {
 	log.Info("reading wireguard tunnel configurations from Kubernetes secret")
 	tunnelMgr := wireguard.NewTunnelManager()
 	err := tunnelMgr.LoadConfigurationsFromSecret(ctx, w.clientSet, w.config.Namespace, "wireguard")

--- a/pkg/manager/worker/worker.go
+++ b/pkg/manager/worker/worker.go
@@ -18,12 +18,13 @@ import (
 )
 
 type Worker interface {
-	Configure(context.Context) error
+	Configure(context.Context, *sync.WaitGroup) error
 	InitControlPlane() error
 	StartControlPlane(context.Context, *election.Manager)
 	ConfigureServices()
 	StartServices(ctx context.Context) error
 	Name() string
+	Cleanup()
 }
 
 func New(arpMgr *arp.Manager, intfMgr *networkinterface.Manager,

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	log "log/slog"
 
@@ -25,7 +26,6 @@ func (p *Processor) StartServicesWatchForLeaderElection(ctx context.Context) err
 				for i := range cluster.Network {
 					_ = cluster.Network[i].DeleteRoute()
 				}
-				cluster.Stop()
 			}
 		}
 	}
@@ -36,7 +36,7 @@ func (p *Processor) StartServicesWatchForLeaderElection(ctx context.Context) err
 }
 
 // The startServicesWatchForLeaderElection function will start a services watcher, the
-func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, service *v1.Service) error {
+func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, service *v1.Service, _ *sync.WaitGroup) error {
 	if svcCtx == nil {
 		return fmt.Errorf("no context context for service %q with UID %q: nil context", service.Name, service.UID)
 	}
@@ -72,14 +72,17 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 		svcLease.Unlock()
 	}()
 
+	wg := sync.WaitGroup{}
+	defer wg.Wait()
+
 	// Start a goroutine that will delete the lease when the service context is cancelled.
 	// This is important for proper cleanup when a service is deleted - it ensures that
 	// the lease context (svcLease.Ctx) gets cancelled, which causes RunOrDie to return.
 	// Without this, RunOrDie would continue running until leadership is naturally lost.
-	go func() {
+	wg.Go(func() {
 		<-svcCtx.Ctx.Done()
 		p.leaseMgr.Delete(id, objectName)
-	}()
+	})
 
 	// this service is sharing lease with another service
 	if svcLease.Elected.Load() {
@@ -97,7 +100,7 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 
 		// Common lease handling: sync the service and wait for context cancellation
 		if !svcCtx.IsActive {
-			if err := p.SyncServices(svcCtx, service); err != nil {
+			if err := p.SyncServices(svcCtx, service, &wg); err != nil {
 				log.Error("service sync", "err", err, "uid", service.UID)
 				svcLease.Cancel()
 			}
@@ -150,7 +153,7 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 			// Mark this service as active (as we've started leading)
 			// we run this in background as it's blocking
 			svcCtx.IsActive = true
-			if err := p.SyncServices(svcCtx, service); err != nil {
+			if err := p.SyncServices(svcCtx, service, &wg); err != nil {
 				log.Error("service sync", "uid", service.UID, "err", err)
 				svcLease.Cancel()
 			}
@@ -161,7 +164,7 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 			log.Info("leadership lost", "service", service.Name, "uid", service.UID, "leader", p.config.NodeName)
 			if svcCtx.IsActive {
 				log.Debug("deleting service due to lost leadership", "uid", service.UID)
-				if err := p.deleteService(svcCtx.Ctx, service.UID); err != nil {
+				if err := p.deleteService(svcLease.Ctx, service.UID); err != nil {
 					log.Error("service deletion", "err", err)
 				}
 			}

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -102,7 +102,7 @@ func NewServicesProcessor(config *kubevip.Config, bgpServer *bgp.Server,
 	}
 }
 
-func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceFunc func(*servicecontext.Context, *v1.Service) error) (bool, error) {
+func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceFunc func(*servicecontext.Context, *v1.Service, *sync.WaitGroup) error, wg *sync.WaitGroup) (bool, error) {
 	// log.Debugf("Endpoints for service [%s] have been Created or modified", s.service.ServiceName)
 	svc, ok := event.Object.(*v1.Service)
 	if !ok {
@@ -217,7 +217,7 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 		// This is independent of leader election settings (which are for control plane HA)
 		if p.config.EnableWireguard && !svcCtx.IsWatched {
 			// Call serviceFunc first to set up the WireGuard tunnel
-			err = serviceFunc(svcCtx, svc)
+			err = serviceFunc(svcCtx, svc, wg)
 			if err != nil {
 				log.Error(err.Error())
 				if errors.Is(err, &utils.PanicError{}) {
@@ -225,7 +225,7 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 				}
 			}
 
-			go func() {
+			wg.Go(func() {
 				defer func() {
 					if svcCtx != nil {
 						svcCtx.IsWatched = false
@@ -242,7 +242,7 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 				if err = p.watchEndpoint(svcCtx, p.config.NodeName, svc, provider); err != nil {
 					log.Error(err.Error())
 				}
-			}()
+			})
 
 			svcCtx.IsWatched = true
 		} else if p.config.EnableServicesElection || // Service Election
@@ -256,7 +256,7 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 				if !svcCtx.IsWatched {
 					// background the endpoint watcher
 					if (p.config.EnableRoutingTable || p.config.EnableBGP) && (!p.config.EnableLeaderElection && !p.config.EnableServicesElection) {
-						err = serviceFunc(svcCtx, svc)
+						err = serviceFunc(svcCtx, svc, wg)
 						if err != nil {
 							log.Error(err.Error())
 							if errors.Is(err, &utils.PanicError{}) {
@@ -265,7 +265,7 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 						}
 					}
 
-					go func() {
+					wg.Go(func() {
 						defer func() {
 							if svcCtx != nil {
 								svcCtx.IsWatched = false
@@ -284,13 +284,13 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 								log.Error(err.Error())
 							}
 						}
-					}()
+					})
 
 					// We're now watching this service
 					svcCtx.IsWatched = true
 				}
 			} else if (p.config.EnableBGP || p.config.EnableRoutingTable) && (!p.config.EnableLeaderElection && !p.config.EnableServicesElection) {
-				err = serviceFunc(svcCtx, svc)
+				err = serviceFunc(svcCtx, svc, wg)
 				if err != nil {
 					log.Error(err.Error())
 					if errors.Is(err, &utils.PanicError{}) {
@@ -298,7 +298,7 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 					}
 				}
 
-				go func() {
+				wg.Go(func() {
 					defer func() {
 						if svcCtx != nil {
 							svcCtx.IsWatched = false
@@ -317,11 +317,11 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 							log.Error(err.Error())
 						}
 					}
-				}()
+				})
 				// We're now watching this service
 				svcCtx.IsWatched = true
 			} else {
-				go func() {
+				wg.Go(func() {
 					for {
 						select {
 						case <-svcCtx.Ctx.Done():
@@ -330,7 +330,7 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 						default:
 							if !svcCtx.IsActive {
 								log.Info("(svcs) restartable service watcher starting", "uid", svc.UID)
-								err = serviceFunc(svcCtx, svc)
+								err = serviceFunc(svcCtx, svc, wg)
 								if err != nil {
 									log.Error(err.Error())
 									if errors.Is(err, &utils.PanicError{}) {
@@ -341,11 +341,11 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 							}
 						}
 					}
-				}()
+				})
 			}
 		} else {
 			// Increment the waitGroup before the service Func is called (Done is completed in there)
-			err = serviceFunc(svcCtx, svc)
+			err = serviceFunc(svcCtx, svc, wg)
 			if err != nil {
 				log.Error(err.Error())
 				if errors.Is(err, &utils.PanicError{}) {

--- a/pkg/vip/dns.go
+++ b/pkg/vip/dns.go
@@ -31,36 +31,35 @@ func NewIPUpdater(vip Network) IPUpdater {
 
 // Run runs the IP updater
 func (d *ipUpdater) Run(ctx context.Context) {
-	go func(ctx context.Context) {
-		for {
-			select {
-			case <-ctx.Done():
-				log.Info("stop ipUpdater")
-				return
-			default:
-				mode := "ipv4"
-				if utils.IsIPv6(d.vip.IP()) {
-					mode = "ipv6"
-				}
 
-				ip, err := utils.LookupHost(d.vip.DNSName(), mode, true)
-				if err != nil {
-					log.Warn("cannot lookup", "name", d.vip.DNSName(), "err", err)
-					// fallback to renewing the existing IP
-					ip = []string{d.vip.IP()}
-				}
-
-				if err := d.vip.SetIP(ip[0]); err != nil {
-					log.Error("setting IP", "address", ip, "err", err)
-				}
-
-				// Normal VIP addition for DNS, use skipDAD=false for normal DAD process
-				if _, err := d.vip.AddIP(true, false, defaultInterval); err != nil {
-					log.Error("error adding virtual IP", "err", err)
-				}
-
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("stop ipUpdater")
+			return
+		default:
+			mode := "ipv4"
+			if utils.IsIPv6(d.vip.IP()) {
+				mode = "ipv6"
 			}
-			time.Sleep(defaultInterval * time.Second)
+
+			ip, err := utils.LookupHost(d.vip.DNSName(), mode, true)
+			if err != nil {
+				log.Warn("cannot lookup", "name", d.vip.DNSName(), "err", err)
+				// fallback to renewing the existing IP
+				ip = []string{d.vip.IP()}
+			}
+
+			if err := d.vip.SetIP(ip[0]); err != nil {
+				log.Error("setting IP", "address", ip, "err", err)
+			}
+
+			// Normal VIP addition for DNS, use skipDAD=false for normal DAD process
+			if _, err := d.vip.AddIP(true, false, defaultInterval); err != nil {
+				log.Error("error adding virtual IP", "err", err)
+			}
+
 		}
-	}(ctx)
+		time.Sleep(defaultInterval * time.Second)
+	}
 }

--- a/testing/e2e/e2e_bgp_ds_test.go
+++ b/testing/e2e/e2e_bgp_ds_test.go
@@ -1,0 +1,233 @@
+//go:build e2e
+// +build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"os"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	kindconfigv1alpha4 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
+	"sigs.k8s.io/kind/pkg/log"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kube-vip/kube-vip/pkg/utils"
+	"github.com/kube-vip/kube-vip/testing/e2e"
+)
+
+var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() {
+	if Mode == ModeBGP {
+		var (
+			logger          log.Logger
+			imagePath       string
+			k8sImagePath    string
+			configPath      string
+			tempDirPathRoot string
+		)
+
+		ctx, cancel := context.WithCancel(context.TODO())
+
+		BeforeEach(func() {
+			klog.SetOutput(GinkgoWriter)
+			logger = e2e.TestLogger{}
+
+			imagePath = os.Getenv("E2E_IMAGE_PATH")    // Path to kube-vip image
+			configPath = os.Getenv("CONFIG_PATH")      // path to the api server config
+			k8sImagePath = os.Getenv("K8S_IMAGE_PATH") // path to the kubernetes image (version for kind)
+			if configPath == "" {
+				configPath = "/etc/kubernetes/admin.conf"
+			}
+		})
+
+		BeforeAll(func() {
+			var err error
+			tempDirPathRoot, err = os.MkdirTemp("", "kube-vip-test-arp")
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+
+		AfterAll(func() {
+			if os.Getenv("E2E_KEEP_LOGS") != "true" {
+				Expect(os.RemoveAll(tempDirPathRoot)).To(Succeed())
+			}
+			cancel()
+		})
+
+		Describe("kube-vip BGP functionality", Ordered, func() {
+			var (
+				client      kubernetes.Interface
+				clusterName string
+				tempDirPath string
+			)
+
+			BeforeAll(func() {
+				networking := &kindconfigv1alpha4.Networking{
+					IPFamily: kindconfigv1alpha4.IPv4Family,
+				}
+
+				var err error
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				Expect(err).NotTo(HaveOccurred())
+
+				clusterName, client, _ = prepareClusterForDS(ctx, tempDirPath, "bgp-ds", imagePath, k8sImagePath,
+					logger, networking, 1, nil, 1)
+			})
+
+			AfterAll(func() {
+				Eventually(func() error {
+					return e2e.GetLogs(ctx, client, tempDirPath)
+				}, "60s", "5s").Should(Succeed())
+				cleanupCluster(clusterName, ConfigMtx, logger)
+			})
+
+			It(clusterName+" exits gracefully when only control plane is enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "true",
+					VipElectionEnable:    "false",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "false",
+					SvcElectionEnable:    "false",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+					BGPPeers:             "127.0.0.1:1::false",
+					BGPAS:                2,
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv4Family, clusterName)
+			})
+
+			It(clusterName+" exits gracefully when only control plane is enabled with leader election", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "true",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "false",
+					SvcElectionEnable:    "false",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+					BGPPeers:             "127.0.0.1:1::false",
+					BGPAS:                2,
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv4Family, clusterName)
+			})
+
+			It(clusterName+" exits gracefully when only services are enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "false",
+					VipElectionEnable:    "false",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "false",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+					BGPPeers:             "127.0.0.1:1::false",
+					BGPAS:                2,
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv4Family, clusterName)
+			})
+
+			It(clusterName+" exits gracefully when only services are enabled with leader election", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "false",
+					VipElectionEnable:    "false",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "true",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+					BGPPeers:             "127.0.0.1:1::false",
+					BGPAS:                2,
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv4Family, clusterName)
+			})
+
+			It(clusterName+" exits gracefully when control plane services are enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "true",
+					VipElectionEnable:    "false",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "false",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+					BGPPeers:             "127.0.0.1:1::false",
+					BGPAS:                2,
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv4Family, clusterName)
+			})
+
+			It(clusterName+" exits gracefully when control plane w/ leader election and services w/o leader election are enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "true",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "false",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+					BGPPeers:             "127.0.0.1:1::false",
+					BGPAS:                2,
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv4Family, clusterName)
+			})
+
+			It(clusterName+" exits gracefully when control plane w/o leader election and services w/ leader election are enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "true",
+					VipElectionEnable:    "false",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "true",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+					BGPPeers:             "127.0.0.1:1::false",
+					BGPAS:                2,
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv4Family, clusterName)
+			})
+
+			It(clusterName+" exits gracefully when control plane and services w/ leader election are enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "true",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "true",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+					BGPPeers:             "127.0.0.1:1::false",
+					BGPAS:                2,
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv4Family, clusterName)
+			})
+
+		})
+	}
+})

--- a/testing/e2e/e2e_bgp_test.go
+++ b/testing/e2e/e2e_bgp_test.go
@@ -1078,25 +1078,6 @@ func newGoBGPClient(address string, port uint32) (api.GobgpApiClient, error) {
 }
 
 func checkGoBGPPaths(ctx context.Context, client api.GobgpApiClient, family *api.Family, prefixes []*api.TableLookupPrefix, expectedPaths int) []*api.Destination {
-	// ticker := time.NewTicker(time.Second)
-	// defer ticker.Stop()
-	// to := time.NewTimer(time.Second * 180)
-	// defer to.Stop()
-	// for {
-	// 	select {
-	// 	case <-to.C:
-	// 		return nil
-	// 	case <-ticker.C:
-	// 		paths, err := getGoBGPPaths(ctx, client, family, prefixes)
-	// 		if err != nil {
-	// 			return nil
-	// 		}
-	// 		if len(paths) == expectedPaths {
-	// 			return paths
-	// 		}
-	// 	}
-	// }
-
 	var paths []*api.Destination
 	Eventually(func() error {
 		var err error

--- a/testing/e2e/e2e_ds_test.go
+++ b/testing/e2e/e2e_ds_test.go
@@ -1,0 +1,813 @@
+//go:build e2e
+// +build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	kindconfigv1alpha4 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
+	"sigs.k8s.io/kind/pkg/log"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kube-vip/kube-vip/pkg/utils"
+	"github.com/kube-vip/kube-vip/testing/e2e"
+)
+
+var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular pod", Ordered, func() {
+	if Mode == ModeARP {
+		var (
+			logger          log.Logger
+			imagePath       string
+			k8sImagePath    string
+			configPath      string
+			tempDirPathRoot string
+		)
+
+		ctx, cancel := context.WithCancel(context.TODO())
+
+		BeforeEach(func() {
+			klog.SetOutput(GinkgoWriter)
+			logger = e2e.TestLogger{}
+
+			imagePath = os.Getenv("E2E_IMAGE_PATH")    // Path to kube-vip image
+			configPath = os.Getenv("CONFIG_PATH")      // path to the api server config
+			k8sImagePath = os.Getenv("K8S_IMAGE_PATH") // path to the kubernetes image (version for kind)
+			if configPath == "" {
+				configPath = "/etc/kubernetes/admin.conf"
+			}
+		})
+
+		BeforeAll(func() {
+			var err error
+			tempDirPathRoot, err = os.MkdirTemp("", "kube-vip-test-arp")
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+
+		AfterAll(func() {
+			if os.Getenv("E2E_KEEP_LOGS") != "true" {
+				Expect(os.RemoveAll(tempDirPathRoot)).To(Succeed())
+			}
+			cancel()
+		})
+
+		Describe("kube-vip IPv4 functionality, vip_leaderelection=true", Ordered, func() {
+			var (
+				client      kubernetes.Interface
+				clusterName string
+				tempDirPath string
+			)
+
+			BeforeAll(func() {
+				networking := &kindconfigv1alpha4.Networking{
+					IPFamily: kindconfigv1alpha4.IPv4Family,
+				}
+
+				var err error
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				Expect(err).NotTo(HaveOccurred())
+
+				clusterName, client, _ = prepareClusterForDS(ctx, tempDirPath, "ipv4-ds", imagePath, k8sImagePath,
+					logger, networking, 1, nil, 1)
+			})
+
+			AfterAll(func() {
+				Eventually(func() error {
+					return e2e.GetLogs(ctx, client, tempDirPath)
+				}, "60s", "5s").Should(Succeed())
+				cleanupCluster(clusterName, ConfigMtx, logger)
+			})
+
+			It(clusterName+" deletes all IPv4 addresses on exit when only control plane is enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "true",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "false",
+					SvcElectionEnable:    "false",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv4Family, clusterName)
+			})
+
+			It(clusterName+" deletes all IPv4 addresses on exit when only services are enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "false",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "false",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv4Family, clusterName)
+			})
+
+			It(clusterName+" deletes all IPv4 addresses on exit when only services with per-service leaderelection are enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "false",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "true",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv4Family, clusterName)
+			})
+
+			It(clusterName+" deletes all IPv4 addresses on exit when control-plane and services are enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "true",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "false",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv4Family, clusterName)
+			})
+
+			It(clusterName+" deletes all IPv4 addresses on exit when ontrol plane and services with per-service leaderelection are enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "true",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "true",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv4Family, clusterName)
+			})
+		})
+
+		Describe("kube-vip IPv6 functionality, vip_leaderelection=true", Ordered, func() {
+			var (
+				client      kubernetes.Interface
+				clusterName string
+				tempDirPath string
+			)
+
+			BeforeAll(func() {
+				networking := &kindconfigv1alpha4.Networking{
+					IPFamily: kindconfigv1alpha4.IPv6Family,
+				}
+
+				var err error
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				Expect(err).NotTo(HaveOccurred())
+
+				clusterName, client, _ = prepareClusterForDS(ctx, tempDirPath, "ipv6-ds", imagePath, k8sImagePath,
+					logger, networking, 1, nil, 1)
+			})
+
+			AfterAll(func() {
+				Eventually(func() error {
+					return e2e.GetLogs(ctx, client, tempDirPath)
+				}, "60s", "5s").Should(Succeed())
+				cleanupCluster(clusterName, ConfigMtx, logger)
+			})
+
+			It(clusterName+" deletes all IPv6 addresses on exit when only control plane is enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "true",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "false",
+					SvcElectionEnable:    "false",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv6Family, clusterName)
+			})
+
+			It(clusterName+" deletes all IPv6 addresses on exit when only services are enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "false",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "false",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv6Family, clusterName)
+			})
+
+			It(clusterName+" deletes all IPv6 addresses on exit when only services with per-service leaderelection are enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "false",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "true",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv6Family, clusterName)
+			})
+
+			It(clusterName+" deletes all IPv6 addresses on exit when control-plane and services are enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "true",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "false",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv6Family, clusterName)
+			})
+
+			It(clusterName+" deletes all IPv6 addresses on exit when ontrol plane and services with per-service leaderelection are enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "true",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "true",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv6Family, clusterName)
+			})
+		})
+
+		Describe("kube-vip DualStack functionality, vip_leaderelection=true", Ordered, func() {
+			var (
+				client      kubernetes.Interface
+				clusterName string
+				tempDirPath string
+			)
+
+			BeforeAll(func() {
+				networking := &kindconfigv1alpha4.Networking{
+					IPFamily: kindconfigv1alpha4.DualStackFamily,
+				}
+
+				var err error
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				Expect(err).NotTo(HaveOccurred())
+
+				clusterName, client, _ = prepareClusterForDS(ctx, tempDirPath, "ipdual-ds", imagePath, k8sImagePath,
+					logger, networking, 1, nil, 1)
+			})
+
+			AfterAll(func() {
+				Eventually(func() error {
+					return e2e.GetLogs(ctx, client, tempDirPath)
+				}, "60s", "5s").Should(Succeed())
+				cleanupCluster(clusterName, ConfigMtx, logger)
+			})
+
+			It(clusterName+" deletes all addresses on exit when only control plane is enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "true",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "false",
+					SvcElectionEnable:    "false",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.DualFamily, clusterName)
+			})
+
+			It(clusterName+" deletes all addresses on exit when only services are enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "false",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "false",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.DualFamily, clusterName)
+			})
+
+			It(clusterName+" deletes all addresses on exit when only services with per-service leaderelection are enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "false",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "true",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.DualFamily, clusterName)
+			})
+
+			It(clusterName+" deletes all addresses on exit when control-plane and services are enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "true",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "false",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.DualFamily, clusterName)
+			})
+
+			It(clusterName+" deletes all addresses on exit when ontrol plane and services with per-service leaderelection are enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "true",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "true",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.DualFamily, clusterName)
+			})
+		})
+	}
+})
+
+func testDsArp(ctx context.Context, manifestValues *e2e.KubevipManifestValues, client kubernetes.Interface, family, clusterName string) {
+
+	cpEnable, err := strconv.ParseBool(manifestValues.ControlPlaneEnable)
+	Expect(err).ToNot(HaveOccurred())
+
+	svcEnable, err := strconv.ParseBool(manifestValues.SvcEnable)
+	Expect(err).ToNot(HaveOccurred())
+
+	vipElection, err := strconv.ParseBool(manifestValues.VipElectionEnable)
+	Expect(err).ToNot(HaveOccurred())
+
+	svcElection, err := strconv.ParseBool(manifestValues.SvcElectionEnable)
+	Expect(err).ToNot(HaveOccurred())
+
+	vipUseLease, svcUseLease, svcPerServiceElection := false, false, false
+
+	switch manifestValues.Mode {
+	case ModeARP:
+		vipUseLease = true
+		svcUseLease = true
+		svcPerServiceElection = svcElection
+	case ModeRT:
+		if vipElection || svcElection {
+			svcUseLease = true
+		}
+		if svcElection {
+			svcPerServiceElection = true
+		}
+	case ModeBGP:
+		if vipElection {
+			vipUseLease = true
+		}
+		if svcElection {
+			svcUseLease = true
+			svcPerServiceElection = true
+		}
+	}
+
+	genFam := family
+	if family == utils.DualFamily {
+		genFam = e2e.DualstackFamily
+	}
+
+	if cpEnable {
+		manifestValues.ControlPlaneVIP = e2e.GenerateVIP(genFam, SOffset.Get())
+	}
+
+	createKubeVipDS(ctx, "kube-vip", "kube-system", manifestValues, client)
+
+	families := []corev1.IPFamily{}
+	switch family {
+	case utils.IPv4Family:
+		families = []corev1.IPFamily{corev1.IPv4Protocol}
+	case utils.IPv6Family:
+		families = []corev1.IPFamily{corev1.IPv6Protocol}
+	case utils.DualFamily:
+		families = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
+	}
+
+	var cpVips, svcVips, services []string
+	var cpHost, svcHost, svcVip string
+
+	if cpEnable {
+		if vipUseLease {
+			cpHost = e2e.GetLeaseHolder(ctx, "plndr-cp-lock", "kube-system", client)
+			By(withTimestamp("control plane lease holder: " + cpHost))
+		} else {
+			cpHost = fmt.Sprintf("%s-control-plane", clusterName)
+		}
+
+		cpVips = strings.Split(manifestValues.ControlPlaneVIP, ",")
+		for _, addr := range cpVips {
+			By(withTimestamp("checking control plane address was added: " + addr))
+			Expect(checkIPAddress(addr, cpHost, true)).To(BeTrue())
+		}
+	}
+
+	if svcEnable {
+		leaseName := "plndr-svcs-lock"
+		leaseNamespace := "kube-system"
+
+		svcVip = e2e.GenerateVIP(genFam, SOffset.Get())
+		var leases []string
+		services, leases = createTestServiceForDS(ctx, "test-svc", svcVip, leaseName,
+			corev1.ServiceExternalTrafficPolicyCluster, client, svcElection, families, 1)
+
+		if svcUseLease {
+			if svcPerServiceElection {
+				Expect(leases).ToNot(BeEmpty())
+				leaseName = leases[0]
+				leaseNamespace = dsNamespace
+			}
+			svcHost = e2e.GetLeaseHolder(ctx, leaseName, leaseNamespace, client)
+			By(withTimestamp(fmt.Sprintf("services lease %s/%s holder: %s", leaseNamespace, leaseName, svcHost)))
+		} else {
+			svcHost = fmt.Sprintf("%s-control-plane", clusterName)
+		}
+
+		svcVips = strings.Split(svcVip, ",")
+
+		for _, addr := range svcVips {
+			By(withTimestamp("checking address was added: " + addr))
+			Expect(checkIPAddress(addr, svcHost, true)).To(BeTrue())
+		}
+	}
+
+	pods, err := client.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{LabelSelector: "app=kube-vip"})
+	Expect(err).ToNot(HaveOccurred())
+	Expect(len(pods.Items)).To(Equal(1))
+
+	removeKubeVipDS(ctx, client)
+
+	// check if kube-vip pod gets deleted within 10s
+	Eventually(func() error {
+		_, err := client.CoreV1().Pods("kube-system").Get(ctx, pods.Items[0].Name, metav1.GetOptions{})
+		return err
+	}, "10s", "200ms").ShouldNot(Succeed())
+
+	if cpEnable && manifestValues.Mode == ModeARP {
+		for _, addr := range cpVips {
+			By(withTimestamp("checking CP address was removed: " + addr))
+			Expect(checkIPAddress(addr, cpHost, false)).To(BeTrue())
+		}
+	}
+
+	if svcEnable {
+		if manifestValues.Mode == ModeARP {
+			for _, addr := range svcVips {
+				By(withTimestamp("checking service address was removed: " + addr))
+				Expect(checkIPAddress(addr, svcHost, false)).To(BeTrue())
+			}
+		}
+
+		for _, svc := range services {
+			By(withTimestamp("deleting service: " + svc))
+			Expect(client.CoreV1().Services(dsNamespace).Delete(ctx, svc, metav1.DeleteOptions{})).To(Succeed())
+			time.Sleep(time.Second)
+		}
+	}
+}
+
+func createKubeVipDS(ctx context.Context, name, namespace string, manifestValues *e2e.KubevipManifestValues, client kubernetes.Interface) {
+	labels := make(map[string]string)
+	labels["app"] = name
+	d := v1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: v1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      "node-role.kubernetes.io/control-plane",
+							Operator: corev1.TolerationOpExists,
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+						{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: corev1.TolerationOpExists,
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:            name,
+							Args:            []string{"manager", "--prometheusHTTPServer", ""},
+							Image:           manifestValues.ImagePath,
+							ImagePullPolicy: corev1.PullNever,
+							Env: []corev1.EnvVar{
+								{
+									Name:  "vip_loglevel",
+									Value: "-4",
+								},
+								{
+									Name:  "vip_interface",
+									Value: "eth0",
+								},
+								{
+									Name:  "vip_leaderelection",
+									Value: manifestValues.VipElectionEnable,
+								},
+								{
+									Name:  "address",
+									Value: manifestValues.ControlPlaneVIP,
+								},
+								{
+									Name:  "vip_leaseduration",
+									Value: "5",
+								},
+								{
+									Name:  "vip_renewdeadline",
+									Value: "3",
+								},
+								{
+									Name:  "vip_retryperiod",
+									Value: "1",
+								},
+								{
+									Name:  "cp_enable",
+									Value: manifestValues.ControlPlaneEnable,
+								},
+								{
+									Name: "vip_nodename",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "spec.nodeName",
+										},
+									},
+								},
+								{
+									Name:  "svc_enable",
+									Value: manifestValues.SvcEnable,
+								},
+								{
+									Name:  "svc_election",
+									Value: manifestValues.SvcElectionEnable,
+								},
+								{
+									Name:  "enable_node_labeling",
+									Value: manifestValues.EnableNodeLabeling,
+								},
+								{
+									Name:  "enable_endpointslices",
+									Value: manifestValues.EnableEndpointslices,
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								Capabilities: &corev1.Capabilities{
+									Add: []corev1.Capability{
+										"NET_ADMIN",
+										"NET_RAW",
+									},
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "kubeconfig",
+									MountPath: "/etc/kubernetes/admin.conf",
+								},
+							},
+						},
+					},
+					HostAliases: []corev1.HostAlias{
+						{
+							Hostnames: []string{"kubernetes"},
+							IP:        "127.0.0.1",
+						},
+					},
+					HostNetwork: true,
+					Volumes: []corev1.Volume{
+						{
+							Name: "kubeconfig",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: manifestValues.ConfigPath,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var modeEnv []corev1.EnvVar
+
+	switch manifestValues.Mode {
+	case "rt":
+		modeEnv = append(modeEnv, corev1.EnvVar{
+			Name:  "vip_routingtable",
+			Value: "true",
+		})
+	case "bgp":
+		modeEnv = append(modeEnv,
+			corev1.EnvVar{
+				Name:  "bgp_enable",
+				Value: "true",
+			},
+			corev1.EnvVar{
+				Name:  "bgp_routerid",
+				Value: "2.2.2.2",
+			},
+			corev1.EnvVar{
+				Name:  "bgp_as",
+				Value: fmt.Sprintf("%d", manifestValues.BGPAS),
+			},
+			corev1.EnvVar{
+				Name:  "bgp_peers",
+				Value: manifestValues.BGPPeers,
+			},
+		)
+	case "wireguard":
+		modeEnv = append(modeEnv, corev1.EnvVar{
+			Name:  "vip_wireguard",
+			Value: "true",
+		})
+	default:
+		modeEnv = append(modeEnv, corev1.EnvVar{
+			Name:  "vip_arp",
+			Value: "true",
+		})
+	}
+
+	d.Spec.Template.Spec.Containers[0].Env = append(d.Spec.Template.Spec.Containers[0].Env, modeEnv...)
+
+	By(withTimestamp("creating kube-vip's daemonset"))
+	_, err := client.AppsV1().DaemonSets(namespace).Create(ctx, &d, metav1.CreateOptions{})
+	Expect(err).ToNot(HaveOccurred())
+
+	Eventually(func() error {
+		return dsStarted(ctx, name, namespace, client)
+	}, "300s").Should(Succeed())
+}
+
+func removeKubeVipDS(ctx context.Context, client kubernetes.Interface) {
+	By(withTimestamp("removing kube-vip's daemonset"))
+	Eventually(func() error {
+		return client.AppsV1().DaemonSets("kube-system").Delete(ctx, "kube-vip", metav1.DeleteOptions{})
+	}, "300s", "200ms").Should(Succeed())
+}
+
+func prepareClusterForDS(ctx context.Context, tempDirPath, clusterNameSuffix, kvImagePath, k8sImagePath string, logger log.Logger,
+	networking *kindconfigv1alpha4.Networking, nodesNum int,
+	addSAN *san, dsNumber int) (string, kubernetes.Interface, *rest.Config) {
+
+	clusterConfig := kindconfigv1alpha4.Cluster{
+		Networking: *networking,
+		Nodes:      []kindconfigv1alpha4.Node{},
+	}
+
+	kubeadmPatches := []kindconfigv1alpha4.PatchJSON6902{}
+
+	if addSAN != nil {
+		for range 64 {
+			(*addSAN.ip)[len(*addSAN.ip)-1]++
+			if addSAN.ipnet.Contains(*addSAN.ip) {
+				kubeadmPatches = append(kubeadmPatches, kindconfigv1alpha4.PatchJSON6902{
+					Group:   "kubeadm.k8s.io",
+					Version: "v1beta3",
+					Kind:    "ClusterConfiguration",
+					Patch:   testJSON + addSAN.ip.String(),
+				})
+			}
+		}
+	}
+
+	clusterConfig.KubeadmConfigPatchesJSON6902 = kubeadmPatches
+
+	for range nodesNum {
+		nodeConfig := kindconfigv1alpha4.Node{
+			Role: kindconfigv1alpha4.ControlPlaneRole,
+		}
+		// Override the kind image version
+		if k8sImagePath != "" {
+			nodeConfig.Image = k8sImagePath
+		}
+		clusterConfig.Nodes = append(clusterConfig.Nodes, nodeConfig)
+	}
+
+	clusterName := fmt.Sprintf("%s-%s", filepath.Base(tempDirPath), clusterNameSuffix)
+
+	By(withTimestamp("creating a kind cluster with multiple control plane nodes"))
+	client, cfg, err := createKindCluster(logger, &clusterConfig, clusterName)
+	Expect(err).ToNot(HaveOccurred())
+
+	By(withTimestamp("loading local docker image to kind cluster"))
+	Expect(e2e.LoadDockerImageToKind(logger, kvImagePath, clusterName)).To(Succeed())
+
+	By(withTimestamp("loading traefik/whoami image to kind cluster"))
+	if err := e2e.LoadDockerImageToKind(logger, "ghcr.io/traefik/whoami:v1.11", clusterName); err != nil {
+		By(withTimestamp(fmt.Sprintf(
+			"failed to load image ghcr.io/traefik/whoami:v1.11 into kind cluster, image will be downloaded after pod deployment, error: %s",
+			err.Error(),
+		)))
+	}
+
+	By(withTimestamp("creating test daemonset"))
+	for i := range dsNumber {
+		tmpDsName := dsName
+		if i > 0 {
+			tmpDsName = fmt.Sprintf("%s-%d", dsName, i)
+		}
+		createTestDS(ctx, tmpDsName, dsNamespace, client, 80+i)
+	}
+
+	return clusterName, client, cfg
+}
+
+func createTestServiceForDS(ctx context.Context, svcName, lbAddress, leaseName string, trafficPolicy corev1.ServiceExternalTrafficPolicy,
+	client kubernetes.Interface, serviceElection bool, ipFamily []corev1.IPFamily, numberOfServices int) ([]string, []string) {
+	services := []string{}
+	leases := []string{}
+	for i := range numberOfServices {
+		services = append(services, fmt.Sprintf("%s-%d", svcName, i))
+		if serviceElection {
+			leases = append(leases, fmt.Sprintf("kubevip-%s-%d", svcName, i))
+		} else {
+			leases = append(leases, leaseName)
+		}
+
+	}
+
+	for _, svc := range services {
+		createTestService(ctx, svc, dsNamespace, dsName, lbAddress,
+			client, corev1.IPFamilyPolicyPreferDualStack, ipFamily, trafficPolicy, "", 80)
+		time.Sleep(time.Second)
+	}
+
+	return services, leases
+}

--- a/testing/e2e/e2e_rt_ds_test.go
+++ b/testing/e2e/e2e_rt_ds_test.go
@@ -1,0 +1,201 @@
+//go:build e2e
+// +build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"os"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	kindconfigv1alpha4 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
+	"sigs.k8s.io/kind/pkg/log"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kube-vip/kube-vip/pkg/utils"
+	"github.com/kube-vip/kube-vip/testing/e2e"
+)
+
+var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ordered, func() {
+	if Mode == ModeRT {
+		var (
+			logger          log.Logger
+			imagePath       string
+			k8sImagePath    string
+			configPath      string
+			tempDirPathRoot string
+		)
+
+		ctx, cancel := context.WithCancel(context.TODO())
+
+		BeforeEach(func() {
+			klog.SetOutput(GinkgoWriter)
+			logger = e2e.TestLogger{}
+
+			imagePath = os.Getenv("E2E_IMAGE_PATH")    // Path to kube-vip image
+			configPath = os.Getenv("CONFIG_PATH")      // path to the api server config
+			k8sImagePath = os.Getenv("K8S_IMAGE_PATH") // path to the kubernetes image (version for kind)
+			if configPath == "" {
+				configPath = "/etc/kubernetes/admin.conf"
+			}
+		})
+
+		BeforeAll(func() {
+			var err error
+			tempDirPathRoot, err = os.MkdirTemp("", "kube-vip-test-arp")
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+
+		AfterAll(func() {
+			if os.Getenv("E2E_KEEP_LOGS") != "true" {
+				Expect(os.RemoveAll(tempDirPathRoot)).To(Succeed())
+			}
+			cancel()
+		})
+
+		Describe("kube-vip RT functionality", Ordered, func() {
+			var (
+				client      kubernetes.Interface
+				clusterName string
+				tempDirPath string
+			)
+
+			BeforeAll(func() {
+				networking := &kindconfigv1alpha4.Networking{
+					IPFamily: kindconfigv1alpha4.IPv4Family,
+				}
+
+				var err error
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				Expect(err).NotTo(HaveOccurred())
+
+				clusterName, client, _ = prepareClusterForDS(ctx, tempDirPath, "rt-ds", imagePath, k8sImagePath,
+					logger, networking, 1, nil, 1)
+			})
+
+			AfterAll(func() {
+				Eventually(func() error {
+					return e2e.GetLogs(ctx, client, tempDirPath)
+				}, "60s", "5s").Should(Succeed())
+				cleanupCluster(clusterName, ConfigMtx, logger)
+			})
+
+			It(clusterName+" exits gracefully on exit when only control plane is enabled", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "true",
+					VipElectionEnable:    "false",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "false",
+					SvcElectionEnable:    "false",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv4Family, clusterName)
+			})
+
+			It(clusterName+" exits gracefully on exit when only services are enabled without leaderelection", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "false",
+					VipElectionEnable:    "false",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "false",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv4Family, clusterName)
+			})
+
+			It(clusterName+" exits gracefully on exit when only services are enabled with leaderelection", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "false",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "false",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv4Family, clusterName)
+			})
+
+			It(clusterName+" exits gracefully on exit when only services are enabled with leaderelection per service", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "false",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "true",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv4Family, clusterName)
+			})
+
+			It(clusterName+" exits gracefully on exit when control-plane and services are enabled without leaderelection", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "true",
+					VipElectionEnable:    "false",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "false",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv4Family, clusterName)
+			})
+
+			It(clusterName+" exits gracefully on exit when control-plane and services are enabled with leaderelection", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "true",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "false",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv4Family, clusterName)
+			})
+
+			It(clusterName+" exits gracefully when control-plane and services are enabled with leaderelection per service", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "true",
+					VipElectionEnable:    "true",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "true",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+				}
+
+				testDsArp(ctx, manifestValues, client, utils.IPv4Family, clusterName)
+			})
+
+		})
+	}
+})

--- a/testing/e2e/template.go
+++ b/testing/e2e/template.go
@@ -14,6 +14,7 @@ type KubevipManifestValues struct {
 	ConfigPath           string
 	SvcEnable            string
 	SvcElectionEnable    string
+	VipElectionEnable    string
 	EnableEndpointslices string
 	EnableNodeLabeling   string
 	ControlPlaneEnable   string
@@ -22,6 +23,7 @@ type KubevipManifestValues struct {
 	MPBGPNexthop         string
 	MPBGPNexthopIPv4     string
 	MPBGPNexthopIPv6     string
+	Mode                 string
 }
 
 type BGPPeerValues struct {


### PR DESCRIPTION
This PR should fix #1413 and #1418 

Previously not all goroutines were synchronized when kube-vip was exiting, which, I believe, resulted in IP addresses not being removed properly. This PR adds `sync.WaitGroup` for every goroutine so we could ensure that all goroutines are finished before kub-vip's process exits.

I have added e2e tests for ARP, BGP and RT modes. However only in ARP mode the test tests for the IP address presence/deletion as it seems we do not clear IP addresses on exit in BGP and RT modes. For those modes the e2e test only checks if kube-vip exits within 10 seconds (which should mean it was not force-removed by k8s).

Discussion:

I'd also like to discuss the IP removal process for each mode. Should IP addresses and routes/bgp announcements be removed on exit in RT and BGP modes as well? Maybe this should be optional and something similar to `preserveVipOnLeadershipLoss` should be  introduced for other modes? Or maybe the addresses should not be deleted as RT and BGP modes can work fine without kube-vip's presence (and ARP cannot as kube-vip has to perform ARP/NDP advertisement). I'd just like to get some more guidance on the expected outcome for each mode.