### PR TITLE
Add skipIPOnInterface / vip_skipiponinterface

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -68,6 +68,7 @@ func init() {
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableARP, "arp", false, "Enable Arp for VIP changes")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableWireguard, "wireguard", false, "Enable Wireguard for services VIPs")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableRoutingTable, "table", false, "Enable Routing Table for services VIPs")
+	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.SkipAddingVIP, "skipIPOnInterface", false, "Skip adding the VIP to the network interface (useful in BGP/routing table mode to avoid exposing host services on the VIP)")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.PreserveVIPOnLeadershipLoss, "preserveVipOnLeadershipLoss", false, "Preserve ARP VIP addresses on interface when leadership is lost (default: false for backward compatibility)")
 
 	// LoadBalancer flags

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -82,9 +82,16 @@ func (cluster *Cluster) vipService(ctx context.Context, c *kubevip.Config, sm *e
 		}
 
 		if !c.EnableRoutingTable {
-			// Normal VIP addition, use skipDAD=false for normal DAD process
-			if _, err = network.AddIP(false, false); err != nil {
-				return fmt.Errorf("failed to add IP address %s: %w", network.IP(), err)
+			if c.SkipAddingVIP || c.EnableRoutingTable {
+				// Ensure VIP is not on the interface (cleanup from previous runs)
+				if _, err = network.DeleteIP(); err != nil {
+					log.Warn("attempted to clean existing VIP", "err", err)
+				}
+			} else {
+				// Normal VIP addition, use skipDAD=false for normal DAD process
+				if _, err = network.AddIP(false, false); err != nil {
+					return fmt.Errorf("failed to add IP address %s: %w", network.IP(), err)
+				}
 			}
 		}
 
@@ -207,10 +214,17 @@ func (cluster *Cluster) vipService(ctx context.Context, c *kubevip.Config, sm *e
 					log.Debug("entry.Check() for entry", "entry", entry)
 					if entry.Check() {
 						log.Debug("entry.Check() true")
-						// Normal VIP addition with precheck, use skipDAD=false for normal DAD process
-						_, err = network.AddIP(true, false)
-						if err != nil {
-							log.Error("error adding address", "err", err)
+						if c.SkipAddingVIP {
+							// Ensure VIP is not on the interface (cleanup from previous runs)
+							if _, err = network.DeleteIP(); err != nil {
+								log.Warn("attempted to clean existing VIP", "err", err)
+							}
+						} else {
+							// Normal VIP addition with precheck, use skipDAD=false for normal DAD process
+							_, err = network.AddIP(true, false)
+							if err != nil {
+								log.Error("error adding address", "err", err)
+							}
 						}
 						if !(*backendMap)[entry] {
 							log.Info("added backend", "ip", network.IP())
@@ -347,11 +361,18 @@ func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip
 			}
 		}
 
-		// Normal VIP addition, use skipDAD=false for normal DAD process
-		if _, err = network.AddIP(false, false); err != nil {
-			log.Warn(err.Error())
+		if c.SkipAddingVIP {
+			// Ensure VIP is not on the interface (cleanup from previous runs)
+			if _, err = network.DeleteIP(); err != nil {
+				log.Warn("attempted to clean existing VIP", "err", err)
+			}
 		} else {
-			log.Info("successful add IP")
+			// Normal VIP addition, use skipDAD=false for normal DAD process
+			if _, err = network.AddIP(false, false); err != nil {
+				log.Warn(err.Error())
+			} else {
+				log.Info("successful add IP")
+			}
 		}
 
 		if c.EnableARP {

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -324,6 +324,16 @@ func ParseEnvironment(c *Config) error {
 		c.EnableRoutingTable = b
 	}
 
+	// Skip adding VIP to the interface
+	env = os.Getenv(vipSkipIPOnInterface)
+	if env != "" {
+		b, err := strconv.ParseBool(env)
+		if err != nil {
+			return err
+		}
+		c.SkipAddingVIP = b
+	}
+
 	// Routing Table ID
 	env = os.Getenv(vipRoutingTableID)
 	if env != "" {
@@ -844,6 +854,9 @@ func mergeConfigValues(baseConfig, fileConfig *Config) {
 	}
 	if !baseConfig.PreserveVIPOnLeadershipLoss && fileConfig.PreserveVIPOnLeadershipLoss {
 		baseConfig.PreserveVIPOnLeadershipLoss = fileConfig.PreserveVIPOnLeadershipLoss
+	}
+	if !baseConfig.SkipAddingVIP && fileConfig.SkipAddingVIP {
+		baseConfig.SkipAddingVIP = fileConfig.SkipAddingVIP
 	}
 
 	// Service configuration

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -152,6 +152,9 @@ const (
 	// vipCleanRoutingTable - defines if routing table will be cleaned of redundant routes on kube-vip's start
 	vipCleanRoutingTable = "vip_cleanroutingtable" //nolint
 
+	// vipSkipIPOnInterface - defines if the VIP should not be added to the network interface
+	vipSkipIPOnInterface = "vip_skipiponinterface" //nolint
+
 	// cpNamespace defines the namespace the control plane pods will run in
 	cpNamespace = "cp_namespace"
 

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -433,6 +433,18 @@ func generatePodSpec(c *Config, image, imageVersion string, inCluster bool) (*co
 		}
 		newEnvironment = append(newEnvironment, routingtable...)
 	}
+
+	// Skip adding VIP to network interface
+	if c.SkipAddingVIP {
+		skipVIP := []corev1.EnvVar{
+			{
+				Name:  vipSkipIPOnInterface,
+				Value: strconv.FormatBool(c.SkipAddingVIP),
+			},
+		}
+		newEnvironment = append(newEnvironment, skipVIP...)
+	}
+
 	// If BGP
 	if c.EnableBGP {
 		bgp := []corev1.EnvVar{

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -127,6 +127,9 @@ type Config struct {
 	// Clean routing table of redundant routes on start
 	CleanRoutingTable bool `yaml:"cleanRoutingTable"`
 
+	// SkipAddingVIP, if true, will not add the VIP to the network interface.
+	SkipAddingVIP bool `yaml:"skipAddingVIP"`
+
 	// BGP Configuration
 	BGPConfig     BGPConfig
 	BGPPeerConfig BGPPeer


### PR DESCRIPTION
In some deployments (e.g. RoutingTable mode or BGP) kube-vip works perfectly fine without adding the IP address to an interface.

For example, with node services listening on 0.0.0.0 / ::, adding the VIP would also expose the node services to the VIP, which might not be wanted.

To not break existing deployments, a flag vip-skipiponinterface is introduced, that can be used to disable this behaviour, including cleanup.