### PR TITLE
fix: don't add VIP to interface in routing table and BGP service modes

### DIFF
--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -347,11 +347,13 @@ func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip
 			}
 		}
 
-		// Normal VIP addition, use skipDAD=false for normal DAD process
-		if _, err = network.AddIP(false, false); err != nil {
-			log.Warn(err.Error())
-		} else {
-			log.Info("successful add IP")
+		if !c.EnableRoutingTable && !c.EnableBGP {
+			// Normal VIP addition, use skipDAD=false for normal DAD process
+			if _, err = network.AddIP(false, false); err != nil {
+				log.Warn(err.Error())
+			} else {
+				log.Info("successful add IP")
+			}
 		}
 
 		if c.EnableARP {


### PR DESCRIPTION
New PR instead of #1441

PR #1252 (fix for #1243) removed the guard that prevented adding the service IP to the interface in routing table mode. This made AddIP() unconditional in StartLoadBalancerService(), causing the LoadBalancer IP to be added to the interface on ALL nodes.

In no-election routing table mode (vip_leaderelection=false, svc_election=false), this leads to traffic blackholing: every node has the VIP bound to its interface, but only the node with local endpoints can actually serve traffic when externalTrafficPolicy is Local. (In our case a `redistribute connected` picked up the address and advertised it)

The original code correctly guarded AddIP() behind `!c.EnableRoutingTable` because in L3 modes (routing table / BGP), traffic is attracted via routing protocols, not by having the IP present on the interface. The endpoint watchers (endpoints_routing_table.go, endpoints_bgp.go) manage routes/advertisements based on local endpoint presence.

Restore the guard and extend it to also cover BGP mode:
- Routing table mode: only routes are managed (by endpoint watcher or leader), no IP on interface
- BGP mode: only BGP advertisements are managed, no IP on interface
- ARP/L2 mode: IP is added to interface (unchanged behavior)

Control plane (cp_enable) is unaffected as vipService() has its own independent AddIP() call.

Existing stale IPs from the buggy version are cleaned up automatically on restart, as StartLoadBalancerService() unconditionally calls DeleteIP() before the now-guarded AddIP().