### PR TITLE
fix: skip UPNP refresh logging when no service instances

### DIFF
--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -723,6 +723,11 @@ func (p *Processor) RefreshUPNPForwards(ctx context.Context) {
 	for {
 		time.Sleep(300 * time.Second)
 
+		// Skip logging if no service instances
+		if len(p.ServiceInstances) == 0 {
+			continue
+		}
+
 		log.Info("[UPNP] Refreshing Instances", "number of instances", len(p.ServiceInstances))
 		for i := range p.ServiceInstances {
 			p.upnpMap(ctx, p.ServiceInstances[i])


### PR DESCRIPTION
Prevents log spam in control-plane-only deployments where ServiceInstances is always empty. The UPNP refresh goroutine still runs but no longer logs every 5 minutes when there's nothing to refresh.

Fixes noise in SIEM systems and log aggregators.