### PR TITLE
fix(metrics): register correct gauge for BGP session info

### DIFF
--- a/pkg/manager/prom.go
+++ b/pkg/manager/prom.go
@@ -9,7 +9,7 @@ func (sm *Manager) PrometheusCollector() []prometheus.Collector {
 		collectors = append(collectors, sm.svcProcessor.CountServiceWatchEvent)
 	}
 	if sm.bgpServer != nil {
-		collectors = append(collectors, sm.bgpServer.BGPSessionInfoGauge)
+		collectors = append(collectors, sm.bgpSessionInfoGauge)
 	}
 	return collectors
 }


### PR DESCRIPTION
## Bug
`kube_vip_manager_bgp_session_info` was missing from the Prometheus metrics endpoint despite BGP being enabled and the BGP engine starting successfully.

Two separate `*prometheus.GaugeVec` instances represented the same metric:
- `bgp.Server.BGPSessionInfoGauge`, registered with Prometheus via `PrometheusCollector()`
- `Manager.bgpSessionInfoGauge`, passed to the worker and written to on BGP peer state changes

`PrometheusCollector()` registered the `bgpServer`'s gauge, but the worker wrote to the `Manager`'s gauge. The registered metric was always empty because nothing ever wrote to it.

This might to be a regression introduced when `bgpSessionInfoGauge` was moved from `bgp.Server` into `Manager` without updating `prom.go` accordingly.