### PR TITLE
Refactored service handling

### DIFF
--- a/pkg/bgp/peers.go
+++ b/pkg/bgp/peers.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"time"
 
+	"github.com/jpillora/backoff"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/vip"
 	api "github.com/osrg/gobgp/v3/api"
@@ -50,7 +52,7 @@ func (b *Server) AddPeer(ctx context.Context, peer kubevip.BGPPeer) (err error) 
 	}
 
 	if peer.Interface != "" {
-		neighborAddress, err := oc.GetIPv6LinkLocalNeighborAddress(peer.Interface)
+		neighborAddress, err := getIPv6LinkLocalNeighborAddress(ctx, peer.Interface)
 		if err != nil {
 			return fmt.Errorf("failed to get link-local address of interface %s: %w", peer.Interface, err)
 		}
@@ -256,4 +258,45 @@ func insertPolicy(ctx context.Context, s *server.BgpServer, address string, p *a
 	}
 
 	return nil
+}
+
+func getIPv6LinkLocalNeighborAddress(ctx context.Context, peerInterface string) (string, error) {
+	neighCtx, neighCancel := context.WithTimeout(ctx, time.Minute)
+	defer neighCancel()
+
+	bo := backoff.Backoff{
+		Factor: 2,
+		Jitter: true,
+		Min:    1 * time.Second,
+		Max:    5 * time.Second,
+	}
+
+	maxAttempts := 20.0
+
+	var err error
+	for {
+		select {
+		case <-neighCtx.Done():
+			if err != nil {
+				return "", fmt.Errorf("failed to get link-local address of interface %s: %w", peerInterface, err)
+			}
+			return "", fmt.Errorf("failed to get link-local address of interface %s: %w", peerInterface, neighCtx.Err())
+		default:
+			dur := bo.Duration()
+			neighborAddress, err := oc.GetIPv6LinkLocalNeighborAddress(peerInterface)
+			if err != nil && bo.Attempt() >= maxAttempts {
+				return "", fmt.Errorf("failed to get link-local address of interface %s: %w", peerInterface, err)
+			}
+			if neighborAddress != "" {
+				return neighborAddress, nil
+			}
+			t := time.NewTimer(dur)
+			select {
+			case <-neighCtx.Done():
+				t.Stop()
+			case <-t.C:
+			}
+		}
+
+	}
 }

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	log "log/slog"
 
@@ -28,6 +29,7 @@ type Processor struct {
 	bgpServer *bgp.Server
 	worker    endpointWorker
 	instances *[]*instance.Instance
+	leaseMgr  *lease.Manager
 }
 
 func NewEndpointProcessor(config *kubevip.Config, provider providers.Provider, bgpServer *bgp.Server,
@@ -37,13 +39,14 @@ func NewEndpointProcessor(config *kubevip.Config, provider providers.Provider, b
 		provider:  provider,
 		bgpServer: bgpServer,
 		instances: instances,
+		leaseMgr:  leaseMgr,
 		worker:    newEndpointWorker(config, provider, bgpServer, instances, leaseMgr, tunnelMgr, routeMgr),
 	}
 }
 
 func (p *Processor) AddOrModify(svcCtx *servicecontext.Context, event watch.Event,
 	lastKnownGoodEndpoint *string, service *v1.Service, id string,
-	serviceFunc func(*servicecontext.Context, *v1.Service, *sync.WaitGroup) error, wg *sync.WaitGroup,
+	serviceFunc func(*servicecontext.Context, *v1.Service, *sync.WaitGroup, bool) error, wg *sync.WaitGroup,
 	clientSet *kubernetes.Clientset,
 	egressUpdateFunc func(context.Context, *v1.Service) error) (bool, error) {
 
@@ -57,7 +60,7 @@ func (p *Processor) AddOrModify(svcCtx *servicecontext.Context, event watch.Even
 		return false, err
 	}
 
-	if err := p.worker.setInstanceEndpointsStatus(service, endpoints); err != nil {
+	if err := p.worker.setInstanceEndpointsStatus(svcCtx.Ctx, service, endpoints); err != nil {
 		log.Error("updating instance", "err", err)
 	}
 
@@ -74,12 +77,12 @@ func (p *Processor) AddOrModify(svcCtx *servicecontext.Context, event watch.Even
 			return true, nil
 		}
 
-		p.updateLastKnownGoodEndpoint(svcCtx, lastKnownGoodEndpoint, endpoints, service)
-		svcCtx.HasEndpoints.Store(true)
-		// start leader election if it's enabled and not already started
-		if !svcCtx.IsActive && p.config.EnableServicesElection {
+		p.updateLastKnownGoodEndpoint(lastKnownGoodEndpoint, endpoints, service)
+		svcCtx.SignalReadiness()
+
+		if p.config.EnableServicesElection {
 			wg.Go(func() {
-				startLeaderElection(svcCtx, service, serviceFunc, wg)
+				p.startLeaderElection(svcCtx, service, serviceFunc, wg)
 			})
 		}
 
@@ -93,8 +96,8 @@ func (p *Processor) AddOrModify(svcCtx *servicecontext.Context, event watch.Even
 			}
 		}
 	} else {
-		svcCtx.HasEndpoints.Store(false)
 		// There are no local endpoints
+		svcCtx.ResetReadiness()
 		p.worker.clear(svcCtx, lastKnownGoodEndpoint, service)
 	}
 
@@ -102,7 +105,7 @@ func (p *Processor) AddOrModify(svcCtx *servicecontext.Context, event watch.Even
 	p.updateAnnotations(service, lastKnownGoodEndpoint, clientSet, egressUpdateFunc)
 
 	log.Debug("watcher", "provider",
-		p.provider.GetLabel(), "service name", service.Name, "namespace", service.Namespace, "endpoints", len(endpoints), "last endpoint", *lastKnownGoodEndpoint, "active leader election", svcCtx.IsActive)
+		p.provider.GetLabel(), "service name", service.Name, "namespace", service.Namespace, "endpoints", len(endpoints), "last endpoint", *lastKnownGoodEndpoint)
 
 	return false, nil
 }
@@ -114,7 +117,7 @@ func (p *Processor) Delete(ctx context.Context, service *v1.Service, id string) 
 	return nil
 }
 
-func (p *Processor) updateLastKnownGoodEndpoint(svcCtx *servicecontext.Context, lastKnownGoodEndpoint *string, endpoints []string, service *v1.Service) {
+func (p *Processor) updateLastKnownGoodEndpoint(lastKnownGoodEndpoint *string, endpoints []string, service *v1.Service) {
 	// if we haven't populated one, then do so
 	family := utils.IPv4Family
 	if service.Annotations[kubevip.EgressIPv6] == "true" {
@@ -138,13 +141,10 @@ func (p *Processor) updateLastKnownGoodEndpoint(svcCtx *servicecontext.Context, 
 	}
 	// If the last endpoint no longer exists, we cancel our leader Election, and set another endpoint as last known good
 	if !stillExists {
-		p.worker.removeEgress(service, lastKnownGoodEndpoint)
-		if svcCtx.IsActive && (p.config.EnableServicesElection || p.config.EnableLeaderElection) {
-			log.Warn("existing endpoint has been removed, restarting leaderElection", "provider", p.provider.GetLabel(), "endpoint", *lastKnownGoodEndpoint)
-			// Stop the existing leaderElection
-			if svcCtx.Lease != nil {
-				svcCtx.Lease.Cancel()
-			}
+		ip := net.ParseIP(*lastKnownGoodEndpoint)
+		if (ip.To4() != nil && service.Annotations[kubevip.Egress] == "true") ||
+			(ip.To4() == nil && service.Annotations[kubevip.EgressIPv6] == "true") {
+			p.worker.removeEgress(service, lastKnownGoodEndpoint)
 		}
 		// Set our active endpoint to an existing one
 		*lastKnownGoodEndpoint = ep
@@ -219,16 +219,27 @@ func (p *Processor) updateAnnotations(service *v1.Service, lastKnownGoodEndpoint
 	}
 }
 
-func startLeaderElection(svcCtx *servicecontext.Context, service *v1.Service, serviceFunc func(*servicecontext.Context, *v1.Service, *sync.WaitGroup) error, wg *sync.WaitGroup) {
+func (p *Processor) startLeaderElection(svcCtx *servicecontext.Context, service *v1.Service, serviceFunc func(*servicecontext.Context, *v1.Service, *sync.WaitGroup, bool) error, wg *sync.WaitGroup) {
 	// This is a blocking function, that will restart (in the event of failure)
 	for {
 		select {
 		case <-svcCtx.Ctx.Done():
 			return
 		default:
-			err := serviceFunc(svcCtx, service, wg)
-			if err != nil {
-				log.Error(err.Error())
+			leaseNamespace, serviceLease := lease.ServiceName(service)
+			id := lease.NewID(p.config.LeaderElectionType, leaseNamespace, serviceLease)
+			l := p.leaseMgr.Get(id)
+			l.Lock()
+
+			if !l.Elected.Load() {
+				l.Unlock()
+				err := serviceFunc(svcCtx, service, wg, true)
+				if err != nil {
+					log.Error(err.Error())
+				}
+			} else {
+				l.Unlock()
+				time.Sleep(time.Millisecond * 200)
 			}
 		}
 	}

--- a/pkg/endpoints/endpoints_bgp.go
+++ b/pkg/endpoints/endpoints_bgp.go
@@ -102,7 +102,7 @@ func (b *BGP) clearBGPHosts(ctx context.Context, service *v1.Service) {
 	ClearBGPHosts(ctx, service, b.instances, b.bgpServer)
 }
 
-func (b *BGP) setInstanceEndpointsStatus(_ *v1.Service, _ []string) error {
+func (b *BGP) setInstanceEndpointsStatus(_ context.Context, _ *v1.Service, _ []string) error {
 	return nil
 }
 

--- a/pkg/endpoints/endpoints_generic.go
+++ b/pkg/endpoints/endpoints_generic.go
@@ -23,7 +23,7 @@ type endpointWorker interface {
 	getEndpoints(service *v1.Service, id string) ([]string, error)
 	removeEgress(service *v1.Service, lastKnownGoodEndpoint *string)
 	delete(ctx context.Context, service *v1.Service, id string) error
-	setInstanceEndpointsStatus(service *v1.Service, endpoints []string) error
+	setInstanceEndpointsStatus(ctx context.Context, service *v1.Service, endpoints []string) error
 }
 
 func newEndpointWorker(config *kubevip.Config, provider providers.Provider, bgpServer *bgp.Server, instances *[]*instance.Instance,
@@ -121,6 +121,6 @@ func (g *generic) delete(_ context.Context, _ *v1.Service, _ string) error {
 	return nil
 }
 
-func (g *generic) setInstanceEndpointsStatus(_ *v1.Service, _ []string) error {
+func (g *generic) setInstanceEndpointsStatus(_ context.Context, _ *v1.Service, _ []string) error {
 	return nil
 }

--- a/pkg/endpoints/endpoints_routing_table.go
+++ b/pkg/endpoints/endpoints_routing_table.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 
 	log "log/slog"
 
@@ -17,6 +18,7 @@ import (
 
 type RoutingTable struct {
 	generic
+	mtx      sync.Mutex
 	routeMgr *route.Manager
 }
 
@@ -27,19 +29,19 @@ func newRoutingTable(generic generic, routeMgr *route.Manager) endpointWorker {
 	}
 }
 
-func (rt *RoutingTable) processInstance(ctx *servicecontext.Context, service *v1.Service) error {
-	instance := instance.FindServiceInstance(service, *rt.instances)
-	if instance != nil {
-		for _, cluster := range instance.Clusters {
+func (rt *RoutingTable) processInstance(svcCtx *servicecontext.Context, service *v1.Service) error {
+	inst := instance.FindServiceInstance(service, *rt.instances)
+	if inst != nil {
+		for _, cluster := range inst.Clusters {
 			for i := range cluster.Network {
-				if !ctx.IsNetworkConfigured(cluster.Network[i].IP()) && cluster.Network[i].HasEndpoints() {
+				if !svcCtx.IsNetworkConfigured(cluster.Network[i].IP()) && cluster.Network[i].HasEndpoints() {
 					if err := rt.routeMgr.Add(lease.ServiceNamespacedName(service), cluster.Network[i], false, true); err != nil {
 						return fmt.Errorf("[%s] error adding route: %s", rt.provider.GetLabel(), err.Error())
 					} else {
 						log.Info("added route", "provider",
 							rt.provider.GetLabel(), "ip", cluster.Network[i].IP(), "service name", service.Name, "namespace",
 							service.Namespace, "interface", cluster.Network[i].Interface(), "tableID", rt.config.RoutingTableID)
-						ctx.ConfiguredNetworks.Store(cluster.Network[i].IP(), true)
+						svcCtx.ConfiguredNetworks.Store(cluster.Network[i].IP(), true)
 					}
 				}
 			}
@@ -50,6 +52,8 @@ func (rt *RoutingTable) processInstance(ctx *servicecontext.Context, service *v1
 }
 
 func (rt *RoutingTable) clear(svcCtx *servicecontext.Context, lastKnownGoodEndpoint *string, service *v1.Service) {
+	rt.mtx.Lock()
+	defer rt.mtx.Unlock()
 	if !rt.config.EnableServicesElection && !rt.config.EnableLeaderElection {
 		if errs := ClearRoutes(service, rt.instances, rt.routeMgr); len(errs) == 0 {
 			svcCtx.ConfiguredNetworks.Clear()
@@ -100,12 +104,12 @@ func (rt *RoutingTable) deleteAction(service *v1.Service) {
 	ClearRoutes(service, rt.instances, rt.routeMgr)
 }
 
-func (rt *RoutingTable) setInstanceEndpointsStatus(service *v1.Service, endpoints []string) error {
-	instance := instance.FindServiceInstance(service, *rt.instances)
-	if instance == nil {
+func (rt *RoutingTable) setInstanceEndpointsStatus(ctx context.Context, service *v1.Service, endpoints []string) error {
+	inst := instance.FindServiceInstance(service, *rt.instances)
+	if inst == nil {
 		log.Error("failed to find the instance", "namespace", service.Namespace, "name", service.Name, "uid", service.UID, "provider", rt.provider.GetLabel())
 	} else {
-		for _, c := range instance.Clusters {
+		for _, c := range inst.Clusters {
 			for n := range c.Network {
 				// if there are no endpoints set HasEndpoints false just in case
 				if len(endpoints) < 1 {

--- a/pkg/endpoints/endpoints_wireguard.go
+++ b/pkg/endpoints/endpoints_wireguard.go
@@ -251,7 +251,7 @@ func (w *wireguardWorker) delete(ctx context.Context, service *v1.Service, id st
 }
 
 // setInstanceEndpointsStatus updates the endpoint status on the service instance
-func (w *wireguardWorker) setInstanceEndpointsStatus(service *v1.Service, endpoints []string) error {
+func (w *wireguardWorker) setInstanceEndpointsStatus(_ context.Context, service *v1.Service, endpoints []string) error {
 	hasEndpoints := len(endpoints) > 0
 
 	log.Debug("[wireguard] setting instance endpoint status",

--- a/pkg/manager/worker/bgp.go
+++ b/pkg/manager/worker/bgp.go
@@ -115,15 +115,6 @@ func (b *BGP) ServicesGlobalLeader(ctx context.Context, id string) {
 	// NOT IMPLEMENTED
 }
 
-func (b *BGP) ServicesNoLeader(ctx context.Context) error {
-	log.Info("beginning watching services without leader election")
-	err := b.svcProcessor.ServicesWatcher(ctx, b.svcProcessor.SyncServices)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 func (b *BGP) Name() string {
 	return "BGP"
 }

--- a/pkg/manager/worker/common.go
+++ b/pkg/manager/worker/common.go
@@ -77,7 +77,7 @@ func (c *Common) GlobalLeader(ctx context.Context, leaseName string) {
 
 func (c *Common) ServicesNoLeader(ctx context.Context) error {
 	log.Info("beginning watching services without leader election")
-	err := c.svcProcessor.ServicesWatcher(ctx, c.svcProcessor.SyncServices)
+	err := c.svcProcessor.ServicesWatcher(ctx, services.NewCallback(c.svcProcessor.SyncServices, false))
 	if err != nil {
 		return fmt.Errorf("error while watching services: %w", err)
 	}
@@ -89,7 +89,7 @@ func (c *Common) Cleanup() {
 }
 
 func (c *Common) OnStartedLeading(ctx context.Context) {
-	err := c.svcProcessor.ServicesWatcher(ctx, c.svcProcessor.SyncServices)
+	err := c.svcProcessor.ServicesWatcher(ctx, services.NewCallback(c.svcProcessor.SyncServices, false))
 	if err != nil {
 		log.Error("service watcher", "err", err)
 		c.killFunc()

--- a/pkg/manager/worker/wireguard.go
+++ b/pkg/manager/worker/wireguard.go
@@ -146,7 +146,7 @@ func (w *WireGuard) OnStartedLeading(ctx context.Context) {
 	})
 
 	if w.config.EnableServices && !w.config.EnableServicesElection {
-		if err := w.svcProcessor.ServicesWatcher(ctx, w.svcProcessor.SyncServices); err != nil {
+		if err := w.svcProcessor.ServicesWatcher(ctx, services.NewCallback(w.svcProcessor.SyncServices, false)); err != nil {
 			log.Error("failed to start services watcher", "err", err)
 		}
 	}

--- a/pkg/servicecontext/servicecontext.go
+++ b/pkg/servicecontext/servicecontext.go
@@ -3,19 +3,16 @@ package servicecontext
 import (
 	"context"
 	"sync"
-	"sync/atomic"
-
-	"github.com/kube-vip/kube-vip/pkg/lease"
 )
 
 type Context struct {
 	Ctx                context.Context
 	Cancel             context.CancelFunc
-	IsActive           bool
 	IsWatched          bool
 	ConfiguredNetworks sync.Map
-	Lease              *lease.Lease
-	HasEndpoints       atomic.Bool
+	EndpointsReady     chan any
+	epReady            sync.Once
+	signalled          bool
 	LeaderCancel       context.CancelFunc
 }
 
@@ -23,8 +20,9 @@ func New(ctx context.Context) *Context {
 	// context and cancel stored for a future use, gosec linter disabled
 	svcCtx, svcCancel := context.WithCancel(ctx) //nolint:gosec
 	return &Context{
-		Ctx:    svcCtx,
-		Cancel: svcCancel,
+		Ctx:            svcCtx,
+		Cancel:         svcCancel,
+		EndpointsReady: make(chan any),
 	}
 }
 
@@ -40,4 +38,19 @@ func (ctx *Context) HasConfiguredNetworks() bool {
 func (ctx *Context) IsNetworkConfigured(ip string) bool {
 	_, exists := ctx.ConfiguredNetworks.Load(ip)
 	return exists
+}
+
+func (ctx *Context) SignalReadiness() {
+	ctx.epReady.Do(func() {
+		close(ctx.EndpointsReady)
+		ctx.signalled = true
+	})
+}
+
+func (ctx *Context) ResetReadiness() {
+	if ctx.signalled {
+		ctx.EndpointsReady = make(chan any)
+		ctx.epReady = sync.Once{}
+		ctx.signalled = false
+	}
 }

--- a/pkg/services/callback.go
+++ b/pkg/services/callback.go
@@ -1,0 +1,24 @@
+package services
+
+import (
+	"sync"
+
+	"github.com/kube-vip/kube-vip/pkg/servicecontext"
+	v1 "k8s.io/api/core/v1"
+)
+
+type Callback struct {
+	Function           func(*servicecontext.Context, *v1.Service, *sync.WaitGroup, bool) error
+	UsesLeaderElection bool
+}
+
+func NewCallback(f func(*servicecontext.Context, *v1.Service, *sync.WaitGroup, bool) error, leaderElection bool) *Callback {
+	return &Callback{
+		Function:           f,
+		UsesLeaderElection: leaderElection,
+	}
+}
+
+func (c *Callback) Run(svcCtx *servicecontext.Context, svc *v1.Service, wg *sync.WaitGroup) error {
+	return c.Function(svcCtx, svc, wg, c.UsesLeaderElection)
+}

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -15,7 +15,7 @@ import (
 
 // The StartServicesWatchForLeaderElection function will start a services watcher, the
 func (p *Processor) StartServicesWatchForLeaderElection(ctx context.Context) error {
-	err := p.ServicesWatcher(ctx, p.StartServicesLeaderElection)
+	err := p.ServicesWatcher(ctx, NewCallback(p.StartServicesLeaderElection, true))
 	if err != nil {
 		return err
 	}
@@ -30,7 +30,7 @@ func (p *Processor) StartServicesWatchForLeaderElection(ctx context.Context) err
 }
 
 // The startServicesWatchForLeaderElection function will start a services watcher, the
-func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, service *v1.Service, _ *sync.WaitGroup) error {
+func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, service *v1.Service, _ *sync.WaitGroup, _ bool) error {
 	if svcCtx == nil {
 		return fmt.Errorf("no context context for service %q with UID %q: nil context", service.Name, service.UID)
 	}
@@ -46,8 +46,15 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 
 	isNew := svcLease.Add(objectName)
 
+	svcLease.Lock()
+
+	defer func() {
+		svcLease.Unlock()
+	}()
+
 	// this service was already processed so we do not need to do anything
 	if !isNew && svcLease.Elected.Load() {
+		svcLease.Unlock()
 		log.Debug("this service was already handled, waiting for it to finish", "service", service.Name, "uid", service.UID)
 		// Wait for either the service context or lease context to be done
 		select {
@@ -56,12 +63,6 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 		}
 		return nil
 	}
-
-	svcLease.Lock()
-
-	defer func() {
-		svcLease.Unlock()
-	}()
 
 	wg := sync.WaitGroup{}
 	defer wg.Wait()
@@ -75,6 +76,14 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 		p.leaseMgr.Delete(id, objectName)
 	})
 
+	select {
+	case <-svcCtx.Ctx.Done():
+		return fmt.Errorf("service context cancelled before election start: %w", svcCtx.Ctx.Err())
+	case <-svcLease.Ctx.Done():
+		return fmt.Errorf("lease context cancelled before election start: %w", svcLease.Ctx.Err())
+	case <-svcCtx.EndpointsReady:
+	}
+
 	// this service is sharing lease with another service
 	if svcLease.Elected.Load() {
 		svcLease.Unlock()
@@ -85,31 +94,19 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 			// Lease was cancelled (e.g., leader election ended), return immediately
 			// This allows the restart loop to create a fresh lease
 			log.Debug("lease context cancelled before leader election started", "service", service.Name, "uid", service.UID)
-			svcCtx.IsActive = false
 			return nil
 		}
 
-		// Common lease handling: sync the service and wait for context cancellation
-		if !svcCtx.IsActive {
-			if err := p.SyncServices(svcCtx, service, &wg); err != nil {
-				log.Error("service sync", "err", err, "uid", service.UID)
-				svcLease.Cancel()
-			}
-			svcCtx.IsActive = true
+		if err := p.onStartedLeading(svcCtx, service, &wg); err != nil {
+			log.Error("error on started leading", "error", err)
 		}
 
 		// Block until service context is cancelled
 		<-svcCtx.Ctx.Done()
 
-		if svcCtx.IsActive {
-			// we have no context left here so we use a new one
-			if err := p.deleteService(context.TODO(), service.UID); err != nil {
-				log.Error("service deletion", "uid", service.UID, "err", err)
-			}
+		if err := p.onStoppedLeading(svcLease, service); err != nil {
+			log.Error("error on stopped leading", "error", err)
 		}
-
-		// Mark this service is inactive
-		svcCtx.IsActive = false
 
 		// wait for leaderelection to be finished
 		<-svcLease.Ctx.Done()
@@ -134,9 +131,7 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 			close(svcLease.Started)
 			// Mark this service as active (as we've started leading)
 			// we run this in background as it's blocking
-			svcCtx.IsActive = true
-			if err := p.SyncServices(svcCtx, service, &wg); err != nil {
-				log.Error("service sync", "uid", service.UID, "err", err)
+			if err := p.onStartedLeading(svcCtx, service, &wg); err != nil {
 				leaderCancel()
 			}
 		},
@@ -144,16 +139,10 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 			// we can do cleanup here
 			svcLease.Elected.Store(false)
 			log.Info("leadership lost", "service", service.Name, "uid", service.UID, "leader", p.config.NodeName)
-			if svcCtx.IsActive {
-				log.Debug("deleting service due to lost leadership", "uid", service.UID)
-				if err := p.deleteService(svcLease.Ctx, service.UID); err != nil {
-					log.Error("service deletion", "err", err)
-				}
+			if err := p.onStoppedLeading(svcLease, service); err != nil {
+				leaderCancel()
 			}
-			// Mark this service is inactive
-			svcCtx.IsActive = false
 			svcLease.Started = make(chan any)
-			leaderCancel()
 		},
 		OnNewLeader: func(identity string) {
 			// we're notified when new leader elected
@@ -170,5 +159,26 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 	}
 
 	log.Info("stopping leader election", "service", service.Name, "uid", service.UID)
+	return nil
+}
+
+func (p *Processor) onStartedLeading(svcCtx *servicecontext.Context, service *v1.Service, wg *sync.WaitGroup) error {
+	// Mark this service as active (as we've started leading)
+	// we run this in background as it's blocking
+	err := p.SyncServices(svcCtx, service, wg, true)
+	if err != nil {
+		log.Error("service sync", "uid", service.UID, "err", err)
+		return err
+	}
+	return nil
+}
+
+func (p *Processor) onStoppedLeading(svcLease *lease.Lease, service *v1.Service) error {
+	log.Debug("deleting service due to lost leadership", "uid", service.UID)
+	err := p.deleteService(svcLease.Ctx, service.UID)
+	if err != nil {
+		log.Error("service deletion", "err", err)
+		return err
+	}
 	return nil
 }

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -7,6 +7,7 @@ import (
 	log "log/slog"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/kube-vip/kube-vip/pkg/arp"
 	"github.com/kube-vip/kube-vip/pkg/bgp"
@@ -24,6 +25,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/wireguard"
 	"github.com/prometheus/client_golang/prometheus"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
@@ -102,7 +104,7 @@ func NewServicesProcessor(config *kubevip.Config, bgpServer *bgp.Server,
 	}
 }
 
-func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceFunc func(*servicecontext.Context, *v1.Service, *sync.WaitGroup) error, wg *sync.WaitGroup) error {
+func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceFunc *Callback, wg *sync.WaitGroup) error {
 	svc, ok := event.Object.(*v1.Service)
 	if !ok {
 		return fmt.Errorf("unable to parse Kubernetes services from API watcher")
@@ -128,7 +130,11 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 
 	// We only care about LoadBalancer services that have been allocated an address
 	if len(svcAddresses) <= 0 && len(svcHostnames) <= 0 {
-		return nil
+		s, err := p.waitForAddress(ctx, svc)
+		if err != nil {
+			return fmt.Errorf("failed to get updated LB addresses for service %s/%s: %w", svc.Namespace, svc.Name, err)
+		}
+		svc = s
 	}
 
 	svcInstance := instance.FindServiceInstance(svc, p.ServiceInstances)
@@ -154,23 +160,9 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 
 	// The modified event should only be triggered if the service has been modified (i.e. moved somewhere else)
 	if event.Type == watch.Modified {
-		i := svcInstance
 		shouldGarbageCollect := false
-		if i != nil {
-			originalServiceAddresses, originalServiceHostnames := instance.FetchServiceAddresses(i.ServiceSnapshot)
-			shouldGarbageCollect =
-				// Service addresses changed
-				!reflect.DeepEqual(originalServiceAddresses, svcAddresses) ||
-					// Service hostnames changed
-					!reflect.DeepEqual(originalServiceHostnames, svcHostnames) ||
-					// ExternalTrafficPolicy changed
-					svc.Spec.ExternalTrafficPolicy != i.ServiceSnapshot.Spec.ExternalTrafficPolicy ||
-					// IP stack configuration changed
-					!reflect.DeepEqual(svc.Spec.IPFamilies, i.ServiceSnapshot.Spec.IPFamilies) ||
-					*svc.Spec.IPFamilyPolicy != *i.ServiceSnapshot.Spec.IPFamilyPolicy ||
-					// DDNS was disabled/enabled
-					svc.Annotations[kubevip.ServiceDDNS] != i.ServiceSnapshot.Annotations[kubevip.ServiceDDNS]
-
+		if svcInstance != nil {
+			shouldGarbageCollect = serviceChanged(svcInstance, svc)
 		}
 		if shouldGarbageCollect {
 			for _, addr := range svcAddresses {
@@ -184,13 +176,10 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 				}
 			}
 			// This service has been modified, but it was also active.
-			if svcCtx != nil && svcCtx.IsActive {
+			if svcCtx != nil {
 				log.Warn("(svcs) The load balancer has changed, cancelling original load balancer")
 				//Set it to inactive
-				svcCtx.IsActive = false
 				svcCtx.Cancel()
-				log.Warn("(svcs) waiting for load balancer to finish")
-				<-svcCtx.Ctx.Done()
 
 				if err := p.deleteService(ctx, svc.UID); err != nil {
 					log.Error("(svc) unable to remove", "service", svc.UID)
@@ -204,45 +193,46 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 		}
 	}
 
-	// Architecture walkthrough: (Had to do this as this code path is making my head hurt)
+	ips, hostnames := instance.FetchServiceAddresses(svc)
+	log.Debug("(svcs) has been added/modified with addresses", "service name", svc.Name, "ips", ips, "hostnames", hostnames)
 
-	// Is the service active (bool), if not then process this new service
-	// Does this service use an election per service?
-	//
+	if svcCtx == nil {
+		ns, name := lease.ServiceName(svc)
+		leaseID := lease.NewID(p.config.LeaderElectionType, ns, name)
+		lease := p.leaseMgr.Add(ctx, leaseID)
+		svcCtx = servicecontext.New(lease.Ctx)
+		p.svcMap.Store(svc.UID, svcCtx)
+	}
 
-	if svcCtx == nil || svcCtx != nil && !svcCtx.IsActive {
-		ips, hostnames := instance.FetchServiceAddresses(svc)
-		log.Debug("(svcs) has been added/modified with addresses", "service name", svc.Name, "ips", ips, "hostnames", hostnames)
+	// this goroutine starts service handling function (with or without leaderelection)
+	if !svcCtx.IsWatched {
+		wg.Go(func() {
+			watchWg := sync.WaitGroup{}
+			defer func() {
+				// wait for the sub-goroutines and tag service as not watched
+				watchWg.Wait()
+				svcCtx.IsWatched = false
+			}()
 
-		if svcCtx == nil {
-			log.Debug("new context for service", "namespace", svc.Namespace, "name", svc.Name)
-			ns, name := lease.ServiceName(svc)
-			leaseID := lease.NewID(p.config.LeaderElectionType, ns, name)
-			lease := p.leaseMgr.Add(ctx, leaseID)
-			svcCtx = servicecontext.New(lease.Ctx)
-			p.svcMap.Store(svc.UID, svcCtx)
-		}
-
-		// WireGuard services always need endpoint watching for DNAT rule updates
-		// This is independent of leader election settings (which are for control plane HA)
-		if p.config.EnableWireguard && !svcCtx.IsWatched {
-			// Call serviceFunc first to set up the WireGuard tunnel
-			err = serviceFunc(svcCtx, svc, wg)
-			if err != nil {
-				log.Error(err.Error())
-				if errors.Is(err, &utils.PanicError{}) {
-					return err
-				}
-			}
-
-			wg.Go(func() {
-				defer func() {
-					if svcCtx != nil {
-						svcCtx.IsWatched = false
+			watchWg.Go(func() {
+				// start if service is not already watched/handled
+				// signal endpoints goroutine we are ready to start and run service handling function
+				log.Info("(svcs) service function starting", "uid", svc.UID)
+				err = serviceFunc.Run(svcCtx, svc, wg)
+				if err != nil {
+					log.Error(err.Error())
+					if errors.Is(err, &utils.PanicError{}) {
+						// cancel service context on panic error
+						// TODO:  should we quit kube-vip altogether here?
+						svcCtx.Cancel()
 					}
-				}()
+				}
+				log.Info("(svcs) service function done", "uid", svc.UID)
+			})
 
-				// Start endpoint watcher for WireGuard services (uses EndpointSlices by default)
+			// this goroutine will watch endpoints for the service
+			watchWg.Go(func() {
+				// create provider and start watching the endpoints
 				var provider providers.Provider
 				if p.config.EnableEndpoints {
 					provider = providers.NewEndpoints()
@@ -254,122 +244,39 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 				}
 			})
 
-			svcCtx.IsWatched = true
-		} else if p.config.EnableServicesElection || // Service Election
-			((p.config.EnableRoutingTable || p.config.EnableBGP) && // Routing table mode or BGP
-				(!p.config.EnableLeaderElection && !p.config.EnableServicesElection)) { // No leaderelection or services election
+		})
 
-			// If this load balancer Traffic Policy is "local"
-			if svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal {
+		// tag service as watched
+		svcCtx.IsWatched = true
+	}
 
-				// Start an endpoint watcher if we're not watching it already
-				if !svcCtx.IsWatched {
-					// background the endpoint watcher
-					if (p.config.EnableRoutingTable || p.config.EnableBGP) && (!p.config.EnableLeaderElection && !p.config.EnableServicesElection) {
-						err = serviceFunc(svcCtx, svc, wg)
-						if err != nil {
-							log.Error(err.Error())
-							if errors.Is(err, &utils.PanicError{}) {
-								return err
-							}
-						}
-					}
-
-					wg.Go(func() {
-						defer func() {
-							if svcCtx != nil {
-								svcCtx.IsWatched = false
-							}
-						}()
-
-						if svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal {
-							// Add Endpoint or EndpointSlices watcher
-							var provider providers.Provider
-							if p.config.EnableEndpoints {
-								provider = providers.NewEndpoints()
-							} else {
-								provider = providers.NewEndpointslices()
-							}
-							if err = p.watchEndpoint(svcCtx, p.config.NodeName, svc, provider); err != nil {
-								log.Error(err.Error())
-							}
-						}
-					})
-
-					// We're now watching this service
-					svcCtx.IsWatched = true
-				}
-			} else if (p.config.EnableBGP || p.config.EnableRoutingTable) && (!p.config.EnableLeaderElection && !p.config.EnableServicesElection) {
-				err = serviceFunc(svcCtx, svc, wg)
-				if err != nil {
-					log.Error(err.Error())
-					if errors.Is(err, &utils.PanicError{}) {
-						return err
-					}
-				}
-
-				wg.Go(func() {
-					defer func() {
-						if svcCtx != nil {
-							svcCtx.IsWatched = false
-						}
-					}()
-
-					if svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeCluster {
-						// Add Endpoint watcher
-						var provider providers.Provider
-						if p.config.EnableEndpoints {
-							provider = providers.NewEndpoints()
-						} else {
-							provider = providers.NewEndpointslices()
-						}
-						if err = p.watchEndpoint(svcCtx, p.config.NodeName, svc, provider); err != nil {
-							log.Error(err.Error())
-						}
-					}
-				})
-				// We're now watching this service
-				svcCtx.IsWatched = true
-			} else {
-				wg.Go(func() {
-					for {
-						select {
-						case <-svcCtx.Ctx.Done():
-							log.Warn("(svcs) restartable service watcher ending", "uid", svc.UID)
-							return
-						default:
-							if !svcCtx.IsActive {
-								log.Info("(svcs) restartable service watcher starting", "uid", svc.UID)
-								err = serviceFunc(svcCtx, svc, wg)
-								if err != nil {
-									log.Error(err.Error())
-									if errors.Is(err, &utils.PanicError{}) {
-										svcCtx.Cancel()
-									}
-								}
-								log.Info("(svcs) restartable service watcher done", "uid", svc.UID)
-							}
-						}
-					}
-				})
-			}
-		} else {
-			// Increment the waitGroup before the service Func is called (Done is completed in there)
-			err = serviceFunc(svcCtx, svc, wg)
-			if err != nil {
-				log.Error(err.Error())
-				if errors.Is(err, &utils.PanicError{}) {
-					return err
-				}
-			}
-		}
-		if !p.config.EnableServicesElection {
-			log.Debug("Service now active", "name", svc.Name, "uid", svc.UID)
-			svcCtx.IsActive = true
-		}
+	if !p.config.EnableServicesElection {
+		log.Debug("Service now active", "name", svc.Name, "uid", svc.UID)
 	}
 
 	return nil
+}
+
+func (p *Processor) waitForAddress(ctx context.Context, svc *v1.Service) (*v1.Service, error) {
+	addressCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	ticker := time.NewTicker(time.Second)
+
+	for {
+		select {
+		case <-addressCtx.Done():
+			return nil, fmt.Errorf("failed to wait for the service LB address: %w", ctx.Err())
+		case <-ticker.C:
+			s, err := p.clientSet.CoreV1().Services(svc.Namespace).Get(addressCtx, svc.Name, metav1.GetOptions{})
+			if err != nil {
+				return nil, fmt.Errorf("failed to get updated service data: %w", err)
+			}
+			addrs, hostnames := instance.FetchServiceAddresses(s)
+			if len(addrs) > 0 || len(hostnames) > 0 {
+				return s, nil
+			}
+		}
+	}
 }
 
 func (p *Processor) Delete(event watch.Event) error {
@@ -403,20 +310,17 @@ func (p *Processor) Delete(event watch.Event) error {
 			}
 		}
 
-		if svcCtx.IsActive && !p.config.EnableServicesElection {
+		if !p.config.EnableServicesElection {
 			// If this is an active service then and additional leaderElection will handle stopping
 			err = p.deleteService(svcCtx.Ctx, svc.UID)
 			if err != nil {
 				log.Error(err.Error())
 			}
-			svcCtx.IsActive = false
 		}
 
 		// Calls the cancel function of the context
 		log.Warn("(svcs) The load balancer was deleted, cancelling context", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
 		svcCtx.Cancel()
-		log.Warn("(svcs) waiting for load balancer to finish", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
-		<-svcCtx.Ctx.Done()
 		p.svcMap.Delete(svc.UID)
 	}
 
@@ -443,4 +347,21 @@ func (p *Processor) getServiceContext(uid types.UID) (*servicecontext.Context, e
 		return nil, fmt.Errorf("failed to cast service context pointer - UID: %s", uid)
 	}
 	return ctx, nil
+}
+
+func serviceChanged(i *instance.Instance, svc *v1.Service) bool {
+	svcAddresses, svcHostnames := instance.FetchServiceAddresses(svc)
+	originalServiceAddresses, originalServiceHostnames := instance.FetchServiceAddresses(i.ServiceSnapshot)
+
+	// Service addresses changed
+	return !reflect.DeepEqual(originalServiceAddresses, svcAddresses) ||
+		// Service hostnames changed
+		!reflect.DeepEqual(originalServiceHostnames, svcHostnames) ||
+		// ExternalTrafficPolicy changed
+		svc.Spec.ExternalTrafficPolicy != i.ServiceSnapshot.Spec.ExternalTrafficPolicy ||
+		// IP stack configuration changed
+		!reflect.DeepEqual(svc.Spec.IPFamilies, i.ServiceSnapshot.Spec.IPFamilies) ||
+		*svc.Spec.IPFamilyPolicy != *i.ServiceSnapshot.Spec.IPFamilyPolicy ||
+		// DDNS was disabled/enabled
+		svc.Annotations[kubevip.ServiceDDNS] != i.ServiceSnapshot.Annotations[kubevip.ServiceDDNS]
 }

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -44,7 +44,7 @@ const (
 	defaultUPNPLeaseDuration = 1 * time.Hour
 )
 
-func (p *Processor) SyncServices(ctx *servicecontext.Context, svc *v1.Service, wg *sync.WaitGroup) error {
+func (p *Processor) SyncServices(ctx *servicecontext.Context, svc *v1.Service, wg *sync.WaitGroup, usesLeaderElection bool) error {
 	log.Debug("[STARTING] Service Sync", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
 
 	// Iterate through the synchronising services
@@ -63,6 +63,18 @@ func (p *Processor) SyncServices(ctx *servicecontext.Context, svc *v1.Service, w
 		}
 	case ActionAdd:
 		log.Debug("[service] add", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
+		if instance != nil {
+			instance.AddCalled = true
+		}
+
+		if !usesLeaderElection {
+			select {
+			case <-ctx.Ctx.Done():
+				return nil
+			case <-ctx.EndpointsReady:
+			}
+		}
+
 		if err := p.addService(ctx.Ctx, instance, svc, wg); err != nil {
 			return fmt.Errorf("error adding service %s/%s: %w", svc.Namespace, svc.Name, err)
 		}
@@ -155,7 +167,7 @@ func comparePortsAndPortStatuses(svc *v1.Service) bool {
 	return true
 }
 
-func (p *Processor) addService(ctx context.Context, newService *instance.Instance, svc *v1.Service, wg *sync.WaitGroup) error {
+func (p *Processor) addService(ctx context.Context, inst *instance.Instance, svc *v1.Service, wg *sync.WaitGroup) error {
 	// protect against addService while reading
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
@@ -163,29 +175,30 @@ func (p *Processor) addService(ctx context.Context, newService *instance.Instanc
 	startTime := time.Now()
 
 	var err error
-	if newService == nil {
-		newService, err = instance.NewInstance(ctx, svc, p.config, p.intfMgr, p.arpMgr, p.routeMgr, wg)
+	if inst == nil {
+		inst, err = instance.NewInstance(ctx, svc, p.config, p.intfMgr, p.arpMgr, p.routeMgr, wg)
 		if err != nil {
 			return err
 		}
+		inst.AddCalled = true
 
-		p.ServiceInstances = append(p.ServiceInstances, newService)
+		p.ServiceInstances = append(p.ServiceInstances, inst)
 	}
 
-	for x := range newService.VIPConfigs {
+	for x := range inst.VIPConfigs {
 		log.Debug("starting loadbalancer for service", "name", svc.Name, "namespace", svc.Namespace, "uid", svc.UID)
-		if err := newService.Clusters[x].StartLoadBalancerService(ctx, newService.VIPConfigs[x], p.bgpServer, lease.ServiceNamespacedName(svc), wg); err != nil {
+		if err := inst.Clusters[x].StartLoadBalancerService(ctx, inst.VIPConfigs[x], p.bgpServer, lease.ServiceNamespacedName(svc), wg); err != nil {
 			return fmt.Errorf("failed to start lb: %w", err)
 		}
 	}
 
-	p.upnpMap(ctx, newService)
+	p.upnpMap(ctx, inst)
 
-	if newService.IsDHCPv4 {
+	if inst.IsDHCPv4 {
 		wg.Go(func() {
 			index := -1
-			for i := range newService.VIPConfigs {
-				ip := net.ParseIP(newService.VIPConfigs[i].VIP)
+			for i := range inst.VIPConfigs {
+				ip := net.ParseIP(inst.VIPConfigs[i].VIP)
 				if ip.To4() != nil {
 					index = i
 					break
@@ -194,12 +207,12 @@ func (p *Processor) addService(ctx context.Context, newService *instance.Instanc
 			if index == -1 {
 				log.Error("unable to find proper VIPConfig for the DHCPv4")
 			} else {
-				for ip := range newService.DHCPv4Client.IPChannel() {
+				for ip := range inst.DHCPv4Client.IPChannel() {
 					log.Debug("IP changed", "ip", ip)
-					newService.VIPConfigs[index].VIP = ip
-					newService.DHCPInterfaceIPv4 = ip
+					inst.VIPConfigs[index].VIP = ip
+					inst.DHCPInterfaceIPv4 = ip
 					if !p.config.DisableServiceUpdates {
-						if err := p.updateStatus(ctx, newService); err != nil {
+						if err := p.updateStatus(ctx, inst); err != nil {
 							log.Warn("updating svc", "err", err)
 						}
 					}
@@ -210,11 +223,11 @@ func (p *Processor) addService(ctx context.Context, newService *instance.Instanc
 		})
 	}
 
-	if newService.IsDHCPv6 {
+	if inst.IsDHCPv6 {
 		wg.Go(func() {
 			index := -1
-			for i := range newService.VIPConfigs {
-				ip := net.ParseIP(newService.VIPConfigs[i].VIP)
+			for i := range inst.VIPConfigs {
+				ip := net.ParseIP(inst.VIPConfigs[i].VIP)
 				if ip.To4() == nil {
 					index = i
 					break
@@ -223,12 +236,12 @@ func (p *Processor) addService(ctx context.Context, newService *instance.Instanc
 			if index == -1 {
 				log.Error("unable to find proper VIPConfig for the DHCPv6")
 			} else {
-				for ip := range newService.DHCPv4Client.IPChannel() {
+				for ip := range inst.DHCPv4Client.IPChannel() {
 					log.Debug("IP changed", "ip", ip)
-					newService.VIPConfigs[index].VIP = ip
-					newService.DHCPInterfaceIPv6 = ip
+					inst.VIPConfigs[index].VIP = ip
+					inst.DHCPInterfaceIPv6 = ip
 					if !p.config.DisableServiceUpdates {
-						if err := p.updateStatus(ctx, newService); err != nil {
+						if err := p.updateStatus(ctx, inst); err != nil {
 							log.Warn("updating svc", "err", err)
 						}
 					}
@@ -239,9 +252,9 @@ func (p *Processor) addService(ctx context.Context, newService *instance.Instanc
 	}
 
 	if !p.config.DisableServiceUpdates {
-		log.Debug("[service] update", "namespace", newService.ServiceSnapshot.Namespace, "name", newService.ServiceSnapshot.Name)
-		if err := p.updateStatus(ctx, newService); err != nil {
-			log.Error("[service] updating status", "namespace", newService.ServiceSnapshot.Namespace, "name", newService.ServiceSnapshot.Name, "err", err)
+		log.Debug("[service] update", "namespace", inst.ServiceSnapshot.Namespace, "name", inst.ServiceSnapshot.Name)
+		if err := p.updateStatus(ctx, inst); err != nil {
+			log.Error("[service] updating status", "namespace", inst.ServiceSnapshot.Namespace, "name", inst.ServiceSnapshot.Name, "err", err)
 		}
 	}
 
@@ -433,7 +446,7 @@ func (p *Processor) deleteService(ctx context.Context, uid types.UID) error {
 				log.Info("[service] egress re-write enabled", "service", serviceInstance.ServiceSnapshot.Name)
 				err := egress.Teardown(serviceInstance.ServiceSnapshot.Annotations[kubevip.ActiveEndpoint], serviceInstance.ServiceSnapshot.Spec.LoadBalancerIP, serviceInstance.ServiceSnapshot.Namespace, string(serviceInstance.ServiceSnapshot.UID), serviceInstance.ServiceSnapshot.Annotations, p.config.EgressWithNftables)
 				if err != nil {
-					log.Warn("[service] egress teardown", "err", err)
+					log.Error("[service] egress teardown", "err", err)
 				}
 			}
 		}

--- a/pkg/services/watch_endpoints.go
+++ b/pkg/services/watch_endpoints.go
@@ -25,14 +25,23 @@ func (p *Processor) watchEndpoint(svcCtx *servicecontext.Context, id string, ser
 
 	wg := sync.WaitGroup{}
 
+	stopChan := make(chan any)
+
 	defer func() {
+		close(stopChan)
 		rw.Stop()
 		wg.Wait()
 	}()
 
 	wg.Go(func() {
-		<-svcCtx.Ctx.Done()
-		log.Debug("[endpoint watcher] service context cancelled", "provider", provider.GetLabel())
+		select {
+		case <-svcCtx.Ctx.Done():
+			log.Debug("[endpoint watcher] context cancelled", "provider", provider.GetLabel())
+			rw.Stop()
+		case <-stopChan:
+			svcCtx.Cancel()
+			log.Debug("[endpoint watcher] exiting endpoint watcher", "namespace", service.Namespace, "service", service.Name, "provider", provider.GetLabel())
+		}
 	})
 
 	ch := rw.ResultChan()
@@ -45,7 +54,8 @@ func (p *Processor) watchEndpoint(svcCtx *servicecontext.Context, id string, ser
 		switch event.Type {
 
 		case watch.Added, watch.Modified:
-			restart, err := epProcessor.AddOrModify(svcCtx, event, &lastKnownGoodEndpoint, service, id, p.StartServicesLeaderElection, &wg, p.clientSet, p.updateEgressConfiguration)
+			restart, err := epProcessor.AddOrModify(svcCtx, event, &lastKnownGoodEndpoint, service, id,
+				p.StartServicesLeaderElection, &wg, p.clientSet, p.updateEgressConfiguration)
 			if restart {
 				continue
 			} else if err != nil {

--- a/pkg/services/watch_services.go
+++ b/pkg/services/watch_services.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
-	"github.com/kube-vip/kube-vip/pkg/servicecontext"
 	"github.com/kube-vip/kube-vip/pkg/trafficmirror"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
@@ -23,7 +22,7 @@ import (
 )
 
 // This function handles the watching of a services endpoints and updates a load balancers endpoint configurations accordingly
-func (p *Processor) ServicesWatcher(ctx context.Context, serviceFunc func(*servicecontext.Context, *v1.Service, *sync.WaitGroup) error) error {
+func (p *Processor) ServicesWatcher(ctx context.Context, serviceFunc *Callback) error {
 	// first start port mirroring if enabled
 	if err := p.startTrafficMirroringIfEnabled(); err != nil {
 		return err

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -1240,7 +1240,7 @@ func checkIPAddress(lbAddress, container string, expected bool) bool {
 	By(withTimestamp(fmt.Sprintf("checking LB %q, should exist: %t", lbAddress, expected)))
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
-	to := time.NewTimer(time.Second * 180)
+	to := time.NewTimer(time.Second * 30)
 	defer to.Stop()
 	for {
 		select {


### PR DESCRIPTION

>// Architecture walkthrough: (Had to do this as this code path is making my head hurt)
> \- pkg/services/processor.go, line 195


This PR aims to cleanup the service processor code. The major change is that in old version the `serviceFunc` was executed differently in every mode and also endpoint watcher's execution was dependent on the mode. I believe that service and endpoint handling should be similar in all modes, and only the actual action (e.g. adding BGP host in BGP mode or configuring routes in RT)  should depend on the mode. Therefore i propose to run `serviceFunc` and endpoint watcher always, regardless of the selected mode.

As kube-vip should only reconcile services that have endpoints (either local for local policy or any for cluster policy) synchronization channel was added to `servicecontext.Context` to achieve this.

I have also changed where the `Instance` for the service is being created which made possible to get rid of `FindServiceInstanceWithTimeout` function.

Additionally minor changes like removing `servicecontext.Context.IsActive` and `servicecontext.Context.HasEndpoints` fields were introduced as those seemed to be redundant now.

> **IMPORTANT**: This PR might be very, very risky, as it changes very important part of the service processing.