### PR TITLE
fix: #1466 print bgp config + change order of AddPeer and GetPeer

### DIFF
--- a/pkg/bgp/server.go
+++ b/pkg/bgp/server.go
@@ -65,6 +65,12 @@ func (b *Server) Start(ctx context.Context, peerStateChangeCallback func(*api.Wa
 		return
 	}
 
+	for _, p := range b.c.Peers {
+		if err = b.AddPeer(ctx, p); err != nil {
+			return
+		}
+	}
+
 	if err = b.s.WatchEvent(ctx, &api.WatchEventRequest{Peer: &api.WatchEventRequest_Peer{}}, func(r *api.WatchEventResponse) {
 		if p := r.GetPeer(); p != nil && p.Type == api.WatchEventResponse_PeerEvent_STATE {
 			log.Info("[BGP]", "peer", p.String())
@@ -74,12 +80,6 @@ func (b *Server) Start(ctx context.Context, peerStateChangeCallback func(*api.Wa
 		}
 	}); err != nil {
 		return
-	}
-
-	for _, p := range b.c.Peers {
-		if err = b.AddPeer(ctx, p); err != nil {
-			return
-		}
 	}
 
 	if b.c.Zebra.Enabled {

--- a/pkg/manager/worker/bgp.go
+++ b/pkg/manager/worker/bgp.go
@@ -47,8 +47,7 @@ func (b *BGP) Configure(ctx context.Context, _ *sync.WaitGroup) error {
 			return fmt.Errorf("creating BGP server: %w", err)
 		}
 	}
-
-	log.Info("Starting the BGP server to advertise VIP routes to BGP peers")
+	log.Info("Starting the BGP server to advertise VIP routes to BGP peers", "config", b.config.BGPConfig)
 	if err := b.bgpServer.Start(ctx, func(p *api.WatchEventResponse_PeerEvent) {
 		ipaddr := p.GetPeer().GetState().GetNeighborAddress()
 		port := uint64(179)


### PR DESCRIPTION
* This tries to fix a race condition in the `Start` function of the BGP mode.