### PR TITLE
fix: Assign VIP to interface in BGP mode

### DIFF
--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -312,9 +312,7 @@ func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip
 			} else {
 				log.Info("successful add Route")
 			}
-		}
-
-		if !c.EnableRoutingTable && !c.EnableBGP {
+		} else if !c.EnableRoutingTable {
 			// Normal VIP addition, use skipDAD=false for normal DAD process
 			if _, err = network.AddIP(false, false); err != nil {
 				log.Warn(err.Error())


### PR DESCRIPTION
PR https://github.com/kube-vip/kube-vip/pull/1442 re-introduced a guard for assigning the service IP to an interface - this time including a check for BGP being disabled.

There is a use-case where it's important that in BGP mode the IP is actually assigned to an interface: when using https://github.com/angeloxx/cilium-haegress-operator in BGP mode. 

Cilium docs say [here](https://docs.cilium.io/en/stable/network/egress-gateway/egress-gateway/):
> When Cilium is unable to select the Egress IP for an Egress Gateway policy (for example because the specified egressIP is not configured for any network interface on the gateway node), then the gateway node will drop traffic that matches the policy with the reason No Egress IP configured.

We need the ip to be assigned on an interface for the cilium egress gateway to work. 

Seeing as the original problem the contributor in https://github.com/kube-vip/kube-vip/pull/1442  was trying to solve was adding a guard for the routing table, I think this change should not affect their use case.