### PR TITLE
Fixed leader election restart issue

### DIFF
--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -75,7 +75,14 @@ func (p *Processor) AddOrModify(svcCtx *servicecontext.Context, event watch.Even
 		// start leader election if it's enabled and not already started
 		if !svcCtx.IsActive && p.config.EnableServicesElection {
 			wg.Go(func() {
-				startLeaderElection(svcCtx, service, serviceFunc, wg)
+				for {
+					select {
+					case <-svcCtx.Ctx.Done():
+						return
+					default:
+						startLeaderElection(svcCtx, service, serviceFunc, wg)
+					}
+				}
 			})
 		}
 

--- a/pkg/endpoints/endpoints_bgp.go
+++ b/pkg/endpoints/endpoints_bgp.go
@@ -65,6 +65,10 @@ func (b *BGP) clear(svcCtx *servicecontext.Context, lastKnownGoodEndpoint *strin
 	}
 
 	b.clearEgress(lastKnownGoodEndpoint, service)
+
+	if svcCtx.LeaderCancel != nil {
+		svcCtx.LeaderCancel()
+	}
 }
 
 func (b *BGP) getEndpoints(service *v1.Service, id string) ([]string, error) {

--- a/pkg/endpoints/endpoints_generic.go
+++ b/pkg/endpoints/endpoints_generic.go
@@ -63,6 +63,9 @@ func (g *generic) processInstance(_ *servicecontext.Context, _ *v1.Service) erro
 
 func (g *generic) clear(svcCtx *servicecontext.Context, lastKnownGoodEndpoint *string, service *v1.Service) {
 	g.clearEgress(lastKnownGoodEndpoint, service)
+	if svcCtx.LeaderCancel != nil {
+		svcCtx.LeaderCancel()
+	}
 }
 
 func (g *generic) clearEgress(lastKnownGoodEndpoint *string, service *v1.Service) {
@@ -73,12 +76,6 @@ func (g *generic) clearEgress(lastKnownGoodEndpoint *string, service *v1.Service
 		}
 
 		*lastKnownGoodEndpoint = "" // reset endpoint
-		if g.config.EnableServicesElection || g.config.EnableLeaderElection {
-			leaseNamespace, leaseName := lease.ServiceName(service)
-			id := lease.NewID(g.config.LeaderElectionType, leaseNamespace, leaseName)
-			objectName := lease.ServiceNamespacedName(service)
-			g.leaseMgr.Delete(id, objectName)
-		}
 	}
 }
 

--- a/pkg/endpoints/endpoints_routing_table.go
+++ b/pkg/endpoints/endpoints_routing_table.go
@@ -80,6 +80,10 @@ func (rt *RoutingTable) clear(svcCtx *servicecontext.Context, lastKnownGoodEndpo
 	}
 
 	rt.clearEgress(lastKnownGoodEndpoint, service)
+
+	if svcCtx.LeaderCancel != nil {
+		svcCtx.LeaderCancel()
+	}
 }
 
 func (rt *RoutingTable) getEndpoints(service *v1.Service, id string) ([]string, error) {

--- a/pkg/endpoints/endpoints_wireguard.go
+++ b/pkg/endpoints/endpoints_wireguard.go
@@ -218,6 +218,10 @@ func (w *wireguardWorker) clear(svcCtx *servicecontext.Context, lastKnownGoodEnd
 			}
 		}
 	}
+
+	if svcCtx.LeaderCancel != nil {
+		svcCtx.LeaderCancel()
+	}
 }
 
 // getEndpoints retrieves the list of endpoints for a service

--- a/pkg/servicecontext/servicecontext.go
+++ b/pkg/servicecontext/servicecontext.go
@@ -16,6 +16,7 @@ type Context struct {
 	ConfiguredNetworks sync.Map
 	Lease              *lease.Lease
 	HasEndpoints       atomic.Bool
+	LeaderCancel       context.CancelFunc
 }
 
 func New(ctx context.Context) *Context {

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -53,15 +53,12 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 	isNew := svcLease.Add(objectName)
 
 	// this service was already processed so we do not need to do anything
-	if !isNew {
+	if !isNew && svcLease.Elected.Load() {
 		log.Debug("this service was already handled, waiting for it to finish", "service", service.Name, "uid", service.UID)
 		// Wait for either the service context or lease context to be done
 		select {
 		case <-svcCtx.Ctx.Done():
-			// Service was deleted
-			p.leaseMgr.Delete(id, objectName)
 		case <-svcLease.Ctx.Done():
-			// Leader election ended (leadership lost or context cancelled)
 		}
 		return nil
 	}
@@ -126,19 +123,10 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 		return nil
 	}
 
-	// For new leases (not shared), ensure cleanup when the leader election ends
-	// This is critical for the restartable service watcher to be able to restart
-	// the leader election after leadership loss
-	defer func() {
-		// Delete the lease from the manager so subsequent calls can create a fresh lease
-		// This handles the case where leader election ends due to:
-		// 1. Leadership loss (e.g., network timeout)
-		// 2. Context cancellation
-		// 3. Any other reason RunOrDie returns
-		p.leaseMgr.Delete(id, objectName)
-	}()
-
 	log.Info("new leader election", "service", service.Name, "namespace", service.Namespace, "lock_name", serviceLease, "host_id", p.config.NodeName)
+
+	leaderCtx, leaderCancel := context.WithCancel(svcLease.Ctx)
+	svcCtx.LeaderCancel = leaderCancel
 
 	run := election.RunConfig{
 		Config:           p.config,
@@ -155,7 +143,7 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 			svcCtx.IsActive = true
 			if err := p.SyncServices(svcCtx, service, &wg); err != nil {
 				log.Error("service sync", "uid", service.UID, "err", err)
-				svcLease.Cancel()
+				leaderCancel()
 			}
 		},
 		OnStoppedLeading: func() {
@@ -170,7 +158,8 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 			}
 			// Mark this service is inactive
 			svcCtx.IsActive = false
-			svcLease.Cancel()
+			svcLease.Started = make(chan any)
+			leaderCancel()
 		},
 		OnNewLeader: func(identity string) {
 			// we're notified when new leader elected
@@ -182,7 +171,7 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 		},
 	}
 
-	if err := election.RunOrDie(svcLease.Ctx, &run, p.config); err != nil {
+	if err := election.RunOrDie(leaderCtx, &run, p.config); err != nil {
 		return fmt.Errorf("services election failed: %w", err)
 	}
 

--- a/pkg/services/watch_endpoints.go
+++ b/pkg/services/watch_endpoints.go
@@ -32,7 +32,7 @@ func (p *Processor) watchEndpoint(svcCtx *servicecontext.Context, id string, ser
 
 	wg.Go(func() {
 		<-svcCtx.Ctx.Done()
-		log.Debug("context cancelled", "provider", provider.GetLabel())
+		log.Debug("[endpoint watcher] service context cancelled", "provider", provider.GetLabel())
 	})
 
 	ch := rw.ResultChan()
@@ -57,7 +57,7 @@ func (p *Processor) watchEndpoint(svcCtx *servicecontext.Context, id string, ser
 				return fmt.Errorf("[%s] error while processing delete event: %w", provider.GetLabel(), err)
 			}
 
-			log.Info("stopping watching", "provider", provider.GetLabel(), "service name", service.Name, "namespace", service.Namespace)
+			log.Info("[endpoint watcher] stopping watching - endpoint object deleted", "provider", provider.GetLabel(), "service name", service.Name, "namespace", service.Namespace)
 			return nil
 		case watch.Error:
 			errObject := apierrors.FromObject(event.Object)
@@ -65,6 +65,6 @@ func (p *Processor) watchEndpoint(svcCtx *servicecontext.Context, id string, ser
 			log.Error("watch error", "provider", provider.GetLabel(), "err", statusErr)
 		}
 	}
-	log.Info("stopping watching", "provider", provider.GetLabel(), "service name", service.Name, "namespace", service.Namespace)
+	log.Info("[endpoint watcher] stopping watching", "provider", provider.GetLabel(), "service name", service.Name, "namespace", service.Namespace)
 	return nil //nolint:govet
 }


### PR DESCRIPTION
This should fix #1474 

The issue was, that context for lease and actual leader election was common. When there was no endpoints, service context was cancelled, which lead to lease deletion and leader election cancel and non of those were restarted.