### PR TITLE
docs: clarify vip_arpRate usage and minimum value

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,20 @@ Additionally it is now relatively easy and quick to develop with [skaffold](http
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=kube-vip/kube-vip&type=Date)](https://star-history.com/#kube-vip/kube-vip&Date)
+
+## Configuration
+
+For detailed configuration options, refer to the official documentation: https://kube-vip.io
+
+### vip_arpRate
+
+The `vip_arpRate` environment variable controls the rate (in milliseconds) of gratuitous ARP (gARP) broadcasts.
+
+- Default: 3000 ms (3 seconds)
+
+⚠️ **Warning**: Values lower than 500ms are not supported and may be ignored.
+
+### Example
+
+```bash
+export vip_arpRate=5000


### PR DESCRIPTION
## Description
Clarifies usage of `vip_arpRate` environment variable in README.

## Changes
- Added explanation of vip_arpRate
- Included default value (3000 ms)
- Added warning about minimum supported value (500ms)
- Added example usage

## Problem
Users were confused about how to control ARP frequency and minimum supported values were not documented (see issue #1392).

## Type
- [x] Documentation update