### PR TITLE
Fixed restart on node watcher error

### DIFF
--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -83,17 +83,25 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 
 		if c.EnableLoadBalancer {
 			lb, err := loadbalancer.NewIPVSLB(ctx, network.IP(), c.LoadBalancerPort, c.LoadBalancerForwardingMethod,
-				c.BackendHealthCheckInterval, c.Interface, killFunc, &wg)
+				c.BackendHealthCheckInterval, killFunc, &wg)
 			if err != nil {
 				return fmt.Errorf("creating IPVS LoadBalance: %w", err)
 			}
 
 			wg.Go(func() {
-				err = em.NodeWatcher(ctx, lb, c.Port)
-				if err != nil {
-					log.Error("Error watching node labels", "err", err)
-					if errors.Is(err, &utils.PanicError{}) {
-						killFunc()
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					default:
+						err = em.NodeWatcher(ctx, lb, c.Port)
+						if err != nil {
+							log.Error("Error watching node labels", "err", err)
+							if errors.Is(err, &utils.PanicError{}) {
+								killFunc()
+								return
+							}
+						}
 					}
 				}
 			})

--- a/pkg/election/election.go
+++ b/pkg/election/election.go
@@ -157,28 +157,33 @@ func (em *Manager) NodeWatcher(ctx context.Context, lb *loadbalancer.IPVSLoadBal
 		LabelSelector: "node-role.kubernetes.io/control-plane",
 	}
 
-	rw, err := watchtools.NewRetryWatcherWithContext(ctx, "1", &cache.ListWatch{
+	wg := sync.WaitGroup{}
+	defer wg.Wait()
+
+	watchCtx, watchCancel := context.WithCancel(ctx)
+	defer watchCancel()
+
+	rw, err := watchtools.NewRetryWatcherWithContext(watchCtx, "1", &cache.ListWatch{
 		WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) {
-			return em.RetryWatcherClient.CoreV1().Nodes().Watch(ctx, listOptions)
+			return utils.WatchWithAuthRetry(ctx, func(ctx context.Context) (watch.Interface, error) {
+				return em.RetryWatcherClient.CoreV1().Nodes().Watch(watchCtx, listOptions)
+			})
 		},
 	})
 	if err != nil {
 		return fmt.Errorf("error creating label watcher: %s", err.Error())
 	}
 
-	wg := sync.WaitGroup{}
-	defer wg.Wait()
-
 	wg.Go(func() {
-		<-ctx.Done()
-		log.Info("Received termination, signaling shutdown")
-		// Cancel the context
+		<-watchCtx.Done()
+		log.Info("Node watcher context cancelled, stopping")
+		// Stop the retrywatcher
 		rw.Stop()
 	})
 
 	ch := rw.ResultChan()
-	// defer rw.Stop()
 
+	var watchErr error
 	for event := range ch {
 		// We need to inspect the event and get ResourceVersion out of it
 		switch event.Type {
@@ -238,12 +243,13 @@ func (em *Manager) NodeWatcher(ctx context.Context, lb *loadbalancer.IPVSLoadBal
 
 			status := statusErr.ErrStatus
 			log.Error("watcher", "status", status)
+			watchErr = fmt.Errorf("node watcher error, status: %s", status.String())
 		default:
 		}
 	}
 
 	log.Info("Exiting Node watcher")
-	return nil
+	return watchErr
 }
 
 func checkIfNodeIsReady(node *v1.Node) bool {

--- a/pkg/loadbalancer/ipvs.go
+++ b/pkg/loadbalancer/ipvs.go
@@ -51,15 +51,13 @@ type IPVSLoadBalancer struct {
 	backendMap          backend.Map
 	interval            int
 	lock                sync.Mutex
-	stop                chan struct{}
-	networkInterface    string
 	killFunc            func()
 	address             string
 	family              ipvs.AddressFamily
 }
 
 func NewIPVSLB(ctx context.Context, address string, port uint16, forwardingMethod string, backendHealthCheckInterval int,
-	networkInterface string, killFunc func(), wg *sync.WaitGroup) (*IPVSLoadBalancer, error) {
+	killFunc func(), wg *sync.WaitGroup) (*IPVSLoadBalancer, error) {
 	log.Info("Starting IPVS LoadBalancer", "address", address)
 
 	// Create IPVS client
@@ -140,7 +138,6 @@ func NewIPVSLB(ctx context.Context, address string, port uint16, forwardingMetho
 		forwardingMethod:    m,
 		interval:            backendHealthCheckInterval,
 		backendMap:          make(backend.Map),
-		networkInterface:    networkInterface,
 		killFunc:            killFunc,
 		address:             address,
 		family:              family,
@@ -167,7 +164,6 @@ func enableProcSys(path, name string) error {
 
 func (lb *IPVSLoadBalancer) RemoveIPVSLB() error {
 	log.Info("Stopping IPVS LoadBalancer", "address", lb.address)
-	close(lb.stop)
 	err := lb.client.RemoveService(lb.loadBalancerService)
 	if err != nil {
 		return fmt.Errorf("error removing existing IPVS service: %v", err)
@@ -190,6 +186,7 @@ func (lb *IPVSLoadBalancer) AddBackend(address string, port uint16) error {
 		if err != nil {
 			log.Error("checking if backend is local", "err", err)
 		}
+		log.Info("checked if backend is local", "addr", address, "local", isLocal)
 	}
 
 	backend := backend.Entry{Addr: address, Port: port, IsLocal: isLocal}
@@ -346,6 +343,7 @@ func (lb *IPVSLoadBalancer) healthCheck(ctx context.Context) {
 				}
 				if lb.forwardingMethod == ipvs.Local && !lb.localBackendExists() {
 					if lb.killFunc != nil {
+						log.Error("no local backends available, restarting kube-vip")
 						lb.killFunc()
 					}
 				}
@@ -355,29 +353,39 @@ func (lb *IPVSLoadBalancer) healthCheck(ctx context.Context) {
 }
 
 func (lb *IPVSLoadBalancer) isLocal(address string) (bool, error) {
-	link, err := netlink.LinkByName(lb.networkInterface)
-	if err != nil {
-		return false, fmt.Errorf("getting link '%s': %w", lb.networkInterface, err)
-	}
-
-	family := netlink.FAMILY_V6
-	if utils.IsIPv4(address) {
-		family = netlink.FAMILY_V4
-	}
-
 	target := net.ParseIP(address)
 	if target == nil {
-		return false, fmt.Errorf("address '%s' is not a valid IP address", address)
+		return false, fmt.Errorf("unable to parse IP address %s", address)
 	}
 
-	addrs, err := netlink.AddrList(link, family)
+	links, err := netlink.LinkList()
 	if err != nil {
-		return false, fmt.Errorf("listing addresses for link '%s': %w", lb.networkInterface, err)
+		return false, fmt.Errorf("listing links: %w", err)
 	}
 
-	for _, addr := range addrs {
-		if addr.IP.Equal(target) {
-			return true, nil
+	family := netlink.FAMILY_V4
+	if utils.IsIPv6(address) {
+		family = netlink.FAMILY_V6
+	}
+
+	for _, link := range links {
+		if link.Type() == "veth" {
+			continue
+		}
+
+		addrs, err := netlink.AddrList(link, family)
+		if err != nil {
+			log.Error("listing addresses", "link", link.Attrs().Name, "error", err.Error())
+			continue
+		}
+
+		for _, addr := range addrs {
+			if addr.Scope != int(netlink.SCOPE_UNIVERSE) {
+				continue
+			}
+			if addr.IP.Equal(target) {
+				return true, nil
+			}
 		}
 	}
 

--- a/pkg/services/watch_services.go
+++ b/pkg/services/watch_services.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	log "log/slog"
 
@@ -18,44 +17,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 	watchtools "k8s.io/client-go/tools/watch"
 )
-
-// watchWithAuthRetry retries watchFn with exponential backoff on transient 403 Forbidden
-// and 401 Unauthorized errors. On joining control plane nodes with K8s 1.34+, the local
-// etcd may still be a learner when kube-vip starts, causing RBAC data to be unavailable.
-// These auth errors resolve once etcd is promoted to a full member (typically within seconds).
-// Non-auth errors are returned immediately. Context cancellation stops the retry loop.
-func watchWithAuthRetry(ctx context.Context, watchFn func(context.Context) (watch.Interface, error)) (watch.Interface, error) {
-	var w watch.Interface
-	var lastErr error
-	err := wait.ExponentialBackoffWithContext(ctx, wait.Backoff{
-		Duration: 2 * time.Second,
-		Factor:   2.0,
-		Jitter:   0.1,
-		Steps:    10,
-		Cap:      30 * time.Second,
-	}, func(ctx context.Context) (bool, error) {
-		var watchErr error
-		w, watchErr = watchFn(ctx)
-		if watchErr == nil {
-			return true, nil
-		}
-		if !apierrors.IsForbidden(watchErr) && !apierrors.IsUnauthorized(watchErr) {
-			return false, watchErr
-		}
-		lastErr = watchErr
-		log.Warn("(svcs) services watch auth error, retrying", "err", watchErr)
-		return false, nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("(svcs) services watch failed after retries: %w (last: %v)", err, lastErr)
-	}
-	return w, nil
-}
 
 // This function handles the watching of a services endpoints and updates a load balancers endpoint configurations accordingly
 func (p *Processor) ServicesWatcher(ctx context.Context, serviceFunc func(*servicecontext.Context, *v1.Service, *sync.WaitGroup) error) error {
@@ -82,7 +47,7 @@ func (p *Processor) ServicesWatcher(ctx context.Context, serviceFunc func(*servi
 	// Use a restartable watcher, as this should help in the event of etcd or timeout issues
 	rw, err := watchtools.NewRetryWatcherWithContext(ctx, "1", &cache.ListWatch{
 		WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) {
-			return watchWithAuthRetry(ctx, func(ctx context.Context) (watch.Interface, error) {
+			return utils.WatchWithAuthRetry(ctx, func(ctx context.Context) (watch.Interface, error) {
 				return p.rwClientSet.CoreV1().Services(p.config.ServiceNamespace).Watch(ctx, metav1.ListOptions{})
 			})
 		},

--- a/pkg/services/watch_services_test.go
+++ b/pkg/services/watch_services_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kube-vip/kube-vip/pkg/utils"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
@@ -76,7 +77,7 @@ func TestWatchWithAuthRetry(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 
-			w, err := watchWithAuthRetry(ctx, func(_ context.Context) (watch.Interface, error) {
+			w, err := utils.WatchWithAuthRetry(ctx, func(_ context.Context) (watch.Interface, error) {
 				attempts++
 				return tc.watchFn(attempts)
 			})

--- a/pkg/utils/watcher.go
+++ b/pkg/utils/watcher.go
@@ -1,0 +1,45 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	log "log/slog"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// watchWithAuthRetry retries watchFn with exponential backoff on transient 403 Forbidden
+// and 401 Unauthorized errors. On joining control plane nodes with K8s 1.34+, the local
+// etcd may still be a learner when kube-vip starts, causing RBAC data to be unavailable.
+// These auth errors resolve once etcd is promoted to a full member (typically within seconds).
+// Non-auth errors are returned immediately. Context cancellation stops the retry loop.
+func WatchWithAuthRetry(ctx context.Context, watchFn func(context.Context) (watch.Interface, error)) (watch.Interface, error) {
+	var w watch.Interface
+	var lastErr error
+	err := wait.ExponentialBackoffWithContext(ctx, wait.Backoff{
+		Duration: 2 * time.Second,
+		Factor:   2.0,
+		Jitter:   0.1,
+		Steps:    10,
+		Cap:      30 * time.Second,
+	}, func(ctx context.Context) (bool, error) {
+		var watchErr error
+		w, watchErr = watchFn(ctx)
+		if watchErr == nil {
+			return true, nil
+		}
+		if !apierrors.IsForbidden(watchErr) && !apierrors.IsUnauthorized(watchErr) {
+			return false, watchErr
+		}
+		lastErr = watchErr
+		log.Warn("watch auth error, retrying", "err", watchErr)
+		return false, nil
+	})
+	if err != nil {
+		return nil, NewPanicError(fmt.Sprintf("watch failed after retries: %q (last: %v)", err.Error(), lastErr))
+	}
+	return w, nil
+}


### PR DESCRIPTION
This should fix #1510 I think

On Node watcher error kube-vip does not either restart the watch itself nor restarts the kube-vip's pod. This PR levereges `watchWithAuthRetry` function added in #1465 to add watch restart on `403 forbidden` error. Addtionally, if watch will not be properly restarted after 30s, kube-vip pod will be killed and recreated.