### PR TITLE
feat: add support for BGP unnumbered peers

### DIFF
--- a/pkg/bgp/peers.go
+++ b/pkg/bgp/peers.go
@@ -13,6 +13,7 @@ import (
 	api "github.com/osrg/gobgp/v3/api"
 
 	"github.com/kube-vip/kube-vip/pkg/utils"
+	"github.com/osrg/gobgp/v3/pkg/config/oc"
 	"github.com/osrg/gobgp/v3/pkg/server"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -21,9 +22,10 @@ import (
 func (b *Server) AddPeer(ctx context.Context, peer kubevip.BGPPeer) (err error) {
 	p := &api.Peer{
 		Conf: &api.PeerConf{
-			NeighborAddress: peer.Address,
-			PeerAsn:         peer.AS,
-			AuthPassword:    peer.Password,
+			NeighborAddress:   peer.Address,
+			PeerAsn:           peer.AS,
+			NeighborInterface: peer.Interface,
+			AuthPassword:      peer.Password,
 		},
 
 		Timers: &api.Timers{
@@ -45,6 +47,17 @@ func (b *Server) AddPeer(ctx context.Context, peer kubevip.BGPPeer) (err error) 
 			RemoteAddress: peer.Address,
 			RemotePort:    uint32(179),
 		},
+	}
+
+	if peer.Interface != "" {
+		neighborAddress, err := oc.GetIPv6LinkLocalNeighborAddress(peer.Interface)
+		if err != nil {
+			return fmt.Errorf("failed to get link-local address of interface %s: %w", peer.Interface, err)
+		}
+
+		p.State = &api.PeerState{
+			NeighborAddress: neighborAddress,
+		}
 	}
 
 	if b.c.MpbgpNexthop != "" {

--- a/pkg/kubevip/config_bgp.go
+++ b/pkg/kubevip/config_bgp.go
@@ -16,6 +16,7 @@ import (
 type BGPPeer struct {
 	Address      string
 	Port         uint16
+	Interface    string
 	AS           uint32
 	Password     string
 	MultiHop     bool
@@ -65,6 +66,7 @@ func ParseBGPPeerConfig(config string) (bgpPeers []BGPPeer, err error) {
 			continue
 		}
 		isV6Peer := peerStr[0] == '['
+		isUnnumberedPeer := strings.HasPrefix(peerStr, "unnumbered:")
 
 		address := ""
 		if isV6Peer {
@@ -74,20 +76,29 @@ func ParseBGPPeerConfig(config string) (bgpPeers []BGPPeer, err error) {
 			}
 			address = peerStr[1:addressEndPos]
 			peerStr = peerStr[addressEndPos+1:]
+		} else if isUnnumberedPeer {
+			unnumberedEndPos := strings.IndexByte(peerStr, ':')
+			peerStr = peerStr[unnumberedEndPos+1:]
 		}
 
 		peer := strings.Split(peerStr, ":")
-		if len(peer) < 2 {
+		if len(peer) < 2 && !isUnnumberedPeer {
 			return nil, fmt.Errorf("mandatory peering params <host>:<AS> incomplete")
 		}
 
-		if !isV6Peer {
+		iface := ""
+		if isUnnumberedPeer {
+			iface = peer[0]
+		} else if !isV6Peer {
 			address = peer[0]
 		}
 
-		ASNumber, err := strconv.ParseUint(peer[1], 10, 32)
-		if err != nil {
-			return nil, fmt.Errorf("BGP Peer AS format error [%s]", peer[1])
+		var ASNumber uint64
+		if len(peer) >= 2 {
+			ASNumber, err = strconv.ParseUint(peer[1], 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("BGP Peer AS format error [%s]", peer[1])
+			}
 		}
 
 		password := ""
@@ -107,9 +118,9 @@ func ParseBGPPeerConfig(config string) (bgpPeers []BGPPeer, err error) {
 		if len(peer) >= 5 {
 			port, err = strconv.ParseUint(peer[4], 10, 16)
 			if err != nil {
-				return nil, fmt.Errorf("BGP Peer AS format error [%s]", peer[1])
+				return nil, fmt.Errorf("BGP Peer Port format error [%s]", peer[4])
 			}
-		} else {
+		} else if !isUnnumberedPeer {
 			port = 179
 		}
 
@@ -133,9 +144,11 @@ func ParseBGPPeerConfig(config string) (bgpPeers []BGPPeer, err error) {
 		}
 
 		peerConfig := BGPPeer{
-			Address:      address,
+			Address: address,
+			//nolint:gosec // previously parsed into uint32
 			AS:           uint32(ASNumber),
 			Port:         uint16(port),
+			Interface:    iface,
 			Password:     password,
 			MultiHop:     multiHop,
 			MpbgpNexthop: mpbgpNexthop,

--- a/pkg/kubevip/config_bgp_test.go
+++ b/pkg/kubevip/config_bgp_test.go
@@ -1,10 +1,8 @@
-package bgp
+package kubevip
 
 import (
 	"reflect"
 	"testing"
-
-	"github.com/kube-vip/kube-vip/pkg/kubevip"
 )
 
 func TestParseBGPPeerConfig(t *testing.T) {
@@ -14,13 +12,13 @@ func TestParseBGPPeerConfig(t *testing.T) {
 	tests := []struct {
 		name         string
 		args         args
-		wantBgpPeers []kubevip.BGPPeer
+		wantBgpPeers []BGPPeer
 		wantErr      bool
 	}{
 		{
 			name: "IPv4, default port",
 			args: args{config: "192.168.0.10:65000::false,192.168.0.11:65000::false"},
-			wantBgpPeers: []kubevip.BGPPeer{
+			wantBgpPeers: []BGPPeer{
 				{Address: "192.168.0.10", Port: 179, AS: 65000, MultiHop: false},
 				{Address: "192.168.0.11", Port: 179, AS: 65000, MultiHop: false},
 			},
@@ -28,7 +26,7 @@ func TestParseBGPPeerConfig(t *testing.T) {
 		{
 			name: "IPv4, different port",
 			args: args{config: "192.168.0.10:65000::false:180,192.168.0.11:65000::false:190"},
-			wantBgpPeers: []kubevip.BGPPeer{
+			wantBgpPeers: []BGPPeer{
 				{Address: "192.168.0.10", Port: 180, AS: 65000, MultiHop: false},
 				{Address: "192.168.0.11", Port: 190, AS: 65000, MultiHop: false},
 			},
@@ -36,14 +34,22 @@ func TestParseBGPPeerConfig(t *testing.T) {
 		{
 			name: "IPv6, multi-protocol",
 			args: args{config: "[fd00:1111:2222:3333:c7d9:7235:6bf7:5d52]:65501::false/mpbgp_nexthop=auto_sourceif"},
-			wantBgpPeers: []kubevip.BGPPeer{
+			wantBgpPeers: []BGPPeer{
 				{Address: "fd00:1111:2222:3333:c7d9:7235:6bf7:5d52", Port: 179, AS: 65501, MultiHop: false, MpbgpNexthop: "auto_sourceif"},
+			},
+		},
+		{
+			name: "Unnumbered",
+			args: args{config: "unnumbered:eth0,unnumbered:eth1:65000::true/mpbgp_nexthop=auto_sourceif"},
+			wantBgpPeers: []BGPPeer{
+				{Interface: "eth0", MultiHop: false},
+				{Interface: "eth1", AS: 65000, MultiHop: true, MpbgpNexthop: "auto_sourceif"},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotBgpPeers, err := kubevip.ParseBGPPeerConfig(tt.args.config)
+			gotBgpPeers, err := ParseBGPPeerConfig(tt.args.config)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseBGPPeerConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/testing/e2e/e2e_bgp_ds_test.go
+++ b/testing/e2e/e2e_bgp_ds_test.go
@@ -265,6 +265,13 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 				Expect(err).ToNot(HaveOccurred())
 			})
 
+			AfterEach(func() {
+				tempDirPathLocal, err := os.MkdirTemp(tempDirPath, "kube-vip-test")
+				By(fmt.Sprintf("saving logs to %q", tempDirPathLocal))
+				err = e2e.GetLogs(ctx, client, tempDirPathLocal, clusterName)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
 			It(clusterName+" exits gracefully when unnumbered BGP peers are configured", func() {
 				manifestValues := &e2e.KubevipManifestValues{
 					Mode:                 Mode,

--- a/testing/e2e/e2e_bgp_ds_test.go
+++ b/testing/e2e/e2e_bgp_ds_test.go
@@ -265,13 +265,6 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			AfterEach(func() {
-				tempDirPathLocal, err := os.MkdirTemp(tempDirPath, "kube-vip-test")
-				By(fmt.Sprintf("saving logs to %q", tempDirPathLocal))
-				err = e2e.GetLogs(ctx, client, tempDirPathLocal, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-			})
-
 			It(clusterName+" exits gracefully when unnumbered BGP peers are configured", func() {
 				manifestValues := &e2e.KubevipManifestValues{
 					Mode:                 Mode,

--- a/testing/e2e/e2e_bgp_ds_test.go
+++ b/testing/e2e/e2e_bgp_ds_test.go
@@ -234,7 +234,7 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 		})
 
-		/*Describe("kube-vip IPv6 BGP unnumbered functionality", Ordered, func() {
+		Describe("kube-vip IPv6 BGP unnumbered functionality", Ordered, func() {
 			var (
 				client      kubernetes.Interface
 				clusterName string
@@ -282,6 +282,6 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 				testDS(ctx, manifestValues, client, utils.IPv6Family, clusterName)
 			})
-		})*/
+		})
 	}
 })

--- a/testing/e2e/e2e_bgp_ds_test.go
+++ b/testing/e2e/e2e_bgp_ds_test.go
@@ -234,5 +234,51 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 			})
 
 		})
+
+		Describe("kube-vip IPv6 BGP unnumbered functionality", Ordered, func() {
+			var (
+				client      kubernetes.Interface
+				clusterName string
+				tempDirPath string
+			)
+
+			BeforeAll(func() {
+				networking := &kindconfigv1alpha4.Networking{
+					IPFamily: kindconfigv1alpha4.IPv6Family, 
+				}
+
+				var err error
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test-bgp-v6")
+				Expect(err).NotTo(HaveOccurred())
+
+				clusterName, client, _ = prepareClusterForDS(tempDirPath, "bgp-ds-v6", imagePath, k8sImagePath,
+					logger, networking, 1, nil)
+			})
+
+			AfterAll(func() {
+				Eventually(func() error {
+					return e2e.GetLogs(ctx, client, tempDirPath)
+				}, "60s", "5s").Should(Succeed())
+				cleanupCluster(clusterName, ConfigMtx, logger)
+			})
+
+			It(clusterName+" exits gracefully when unnumbered BGP peers are configured", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "true",
+					VipElectionEnable:    "false",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "false",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+					BGPPeers:             "unnumbered:eth0",
+					BGPAS:                2,
+				}
+
+				testDS(ctx, manifestValues, client, utils.IPv6Family, clusterName)
+			})
+		})
 	}
 })

--- a/testing/e2e/e2e_bgp_ds_test.go
+++ b/testing/e2e/e2e_bgp_ds_test.go
@@ -244,7 +244,7 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			BeforeAll(func() {
 				networking := &kindconfigv1alpha4.Networking{
-					IPFamily: kindconfigv1alpha4.IPv6Family, 
+					IPFamily: kindconfigv1alpha4.IPv6Family,
 				}
 
 				var err error
@@ -256,10 +256,14 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 			})
 
 			AfterAll(func() {
-				Eventually(func() error {
-					return e2e.GetLogs(ctx, client, tempDirPath)
-				}, "60s", "5s").Should(Succeed())
 				cleanupCluster(clusterName, ConfigMtx, logger)
+			})
+
+			AfterEach(func() {
+				tempDirPathLocal, err := os.MkdirTemp(tempDirPath, "kube-vip-test")
+				By(fmt.Sprintf("saving logs to %q", tempDirPathLocal))
+				err = e2e.GetLogs(ctx, client, tempDirPathLocal, clusterName)
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It(clusterName+" exits gracefully when unnumbered BGP peers are configured", func() {


### PR DESCRIPTION
### Title: 
feat: Add BGP Unnumbered peering support (Supersedes #1208)

### Related Issues
* **Fixes:** #1207 
* **Supersedes:** #1208 

Note: This PR revives and continues the fantastic foundational work started by @excepshenal in #1208, bringing it up to date with the current `main` branch.

### Validation & Testing
* Added unit tests to explicitly verify that `ParseBGPPeerConfig` correctly parses the `unnumbered:` prefix while maintaining strict backwards compatibility for standard IPv4 and IPv6 BGP configurations.
