### PR TITLE
Track BGP paths

### DIFF
--- a/pkg/bgp/hosts.go
+++ b/pkg/bgp/hosts.go
@@ -3,46 +3,80 @@ package bgp
 import (
 	"context"
 	"fmt"
+	log "log/slog"
 	"net"
 
 	api "github.com/osrg/gobgp/v3/api"
 )
 
+const KVNodename = "kube-vip-control-plane"
+
 // AddHost will update peers of a host
-func (b *Server) AddHost(ctx context.Context, addr string) (err error) {
-	ip, _, err := net.ParseCIDR(addr)
-	if err != nil {
-		return err
+func (b *Server) AddHost(ctx context.Context, addr string, object string) error {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+
+	objects, exists := b.tracker[addr]
+
+	if !exists {
+		b.tracker[addr] = make(map[string]bool)
+		objects = b.tracker[addr]
+
+		ip, _, err := net.ParseCIDR(addr)
+		if err != nil {
+			return err
+		}
+
+		p := b.getPath(ip)
+		if p == nil {
+			return fmt.Errorf("failed to get path for %v", ip)
+		}
+
+		if _, err := b.s.AddPath(ctx, &api.AddPathRequest{
+			Path: p,
+		}); err != nil {
+			return err
+		}
+		log.Debug("[BGP] added host", "addr", addr, "cnt", len(objects)+1)
 	}
 
-	p := b.getPath(ip)
-	if p == nil {
-		return fmt.Errorf("failed to get path for %v", ip)
-	}
+	objects[object] = true
 
-	_, err = b.s.AddPath(ctx, &api.AddPathRequest{
-		Path: p,
-	})
-
-	if err != nil {
-		return err
-	}
-
-	return
+	return nil
 }
 
 // DelHost will inform peers to remove a host
-func (b *Server) DelHost(ctx context.Context, addr string) (err error) {
+func (b *Server) DelHost(ctx context.Context, addr string, object string) error {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+
+	objects, exists := b.tracker[addr]
+	if !exists {
+		log.Debug("[BGP] deleting host - nothing to delete", "addr", addr)
+		return nil
+	}
+
 	ip, _, err := net.ParseCIDR(addr)
 	if err != nil {
 		return err
 	}
-	p := b.getPath(ip)
-	if p == nil {
-		return
+
+	delete(objects, object)
+
+	if len(objects) == 0 {
+		p := b.getPath(ip)
+		if p == nil {
+			return nil
+		}
+
+		if err := b.s.DeletePath(ctx, &api.DeletePathRequest{
+			Path: p,
+		}); err != nil {
+			return err
+		}
+		delete(b.tracker, addr)
+		log.Debug("[BGP] deleted host", "addr", addr, "cnt", len(objects))
 	}
 
-	return b.s.DeletePath(ctx, &api.DeletePathRequest{
-		Path: p,
-	})
+	return nil
 }

--- a/pkg/bgp/hosts.go
+++ b/pkg/bgp/hosts.go
@@ -3,46 +3,78 @@ package bgp
 import (
 	"context"
 	"fmt"
+	log "log/slog"
 	"net"
 
 	api "github.com/osrg/gobgp/v3/api"
 )
 
 // AddHost will update peers of a host
-func (b *Server) AddHost(ctx context.Context, addr string) (err error) {
-	ip, _, err := net.ParseCIDR(addr)
-	if err != nil {
-		return err
+func (b *Server) AddHost(ctx context.Context, addr string, object string) error {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+
+	objects, exists := b.tracker[addr]
+
+	if !exists {
+		b.tracker[addr] = make(map[string]bool)
+		objects = b.tracker[addr]
+
+		ip, _, err := net.ParseCIDR(addr)
+		if err != nil {
+			return err
+		}
+
+		p := b.getPath(ip)
+		if p == nil {
+			return fmt.Errorf("failed to get path for %v", ip)
+		}
+
+		if _, err := b.s.AddPath(ctx, &api.AddPathRequest{
+			Path: p,
+		}); err != nil {
+			return err
+		}
+		log.Debug("[BGP] added host", "addr", addr, "cnt", len(objects)+1)
 	}
 
-	p := b.getPath(ip)
-	if p == nil {
-		return fmt.Errorf("failed to get path for %v", ip)
-	}
+	objects[object] = true
 
-	_, err = b.s.AddPath(ctx, &api.AddPathRequest{
-		Path: p,
-	})
-
-	if err != nil {
-		return err
-	}
-
-	return
+	return nil
 }
 
 // DelHost will inform peers to remove a host
-func (b *Server) DelHost(ctx context.Context, addr string) (err error) {
+func (b *Server) DelHost(ctx context.Context, addr string, object string) error {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+
+	objects, exists := b.tracker[addr]
+	if !exists {
+		log.Debug("[BGP] deleting host - nothing to delete", "addr", addr)
+		return nil
+	}
+
 	ip, _, err := net.ParseCIDR(addr)
 	if err != nil {
 		return err
 	}
-	p := b.getPath(ip)
-	if p == nil {
-		return
+
+	delete(objects, object)
+
+	if len(objects) == 0 {
+		p := b.getPath(ip)
+		if p == nil {
+			return nil
+		}
+
+		if err := b.s.DeletePath(ctx, &api.DeletePathRequest{
+			Path: p,
+		}); err != nil {
+			return err
+		}
+		delete(b.tracker, addr)
+		log.Debug("[BGP] deleted host", "addr", addr, "cnt", len(objects))
 	}
 
-	return b.s.DeletePath(ctx, &api.DeletePathRequest{
-		Path: p,
-	})
+	return nil
 }

--- a/pkg/bgp/server.go
+++ b/pkg/bgp/server.go
@@ -3,6 +3,7 @@ package bgp
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	log "log/slog"
@@ -21,6 +22,9 @@ type Server struct {
 	// This is a prometheus gauge indicating the state of the sessions.
 	// 1 means "ESTABLISHED", 0 means "NOT ESTABLISHED"
 	BGPSessionInfoGauge *prometheus.GaugeVec
+
+	mtx     sync.Mutex
+	tracker map[string]map[string]bool
 }
 
 // NewBGPServer takes a configuration and returns a running BGP server instance
@@ -38,8 +42,9 @@ func NewBGPServer(c kubevip.BGPConfig) (b *Server, err error) {
 	}
 
 	b = &Server{
-		s: gobgp.NewBgpServer(),
-		c: &c,
+		s:       gobgp.NewBgpServer(),
+		c:       &c,
+		tracker: make(map[string]map[string]bool),
 
 		BGPSessionInfoGauge: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "kube_vip",

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -41,6 +41,13 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 		killFunc()
 	})
 
+	nodename := ""
+	if c.NodeName != "" {
+		nodename = c.NodeName
+	} else {
+		nodename = os.Getenv("HOSTNAME")
+	}
+
 	loadbalancers := []*loadbalancer.IPVSLoadBalancer{}
 
 	for i := range cluster.Network {
@@ -75,7 +82,10 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 		if c.EnableBGP {
 			// Lets advertise the VIP over BGP, the host needs to be passed using CIDR notation
 			log.Debug("Attempting to advertise over BGP", "address", network.CIDR())
-			err = bgpServer.AddHost(ctx, network.CIDR())
+			if nodename == "" {
+				nodename = bgp.KVNodename
+			}
+			err = bgpServer.AddHost(ctx, network.CIDR(), nodename)
 			if err != nil {
 				log.Error(err.Error())
 			}
@@ -123,13 +133,6 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 		backendMapV4 := backend.Map{}
 		backendMapV6 := backend.Map{}
 		// only check localhost
-
-		nodename := ""
-		if c.NodeName != "" {
-			nodename = c.NodeName
-		} else {
-			nodename = os.Getenv("HOSTNAME")
-		}
 
 		ips := []string{}
 		if nodename != "" {
@@ -334,7 +337,7 @@ func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip
 		if c.EnableBGP && (c.EnableLeaderElection || c.EnableServicesElection) {
 			// Lets advertise the VIP over BGP, the host needs to be passed using CIDR notation
 			log.Debug("(svcs) attempting to advertise over BGP", "address", network.CIDR())
-			err = bgp.AddHost(lbCtx, network.CIDR())
+			err = bgp.AddHost(lbCtx, network.CIDR(), name)
 			if err != nil {
 				log.Error(err.Error())
 			}

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/fs"
 	"net"
-	"os"
 	"strings"
 	"sync"
 	"syscall"
@@ -75,7 +74,7 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 		if c.EnableBGP {
 			// Lets advertise the VIP over BGP, the host needs to be passed using CIDR notation
 			log.Debug("Attempting to advertise over BGP", "address", network.CIDR())
-			err = bgpServer.AddHost(ctx, network.CIDR())
+			err = bgpServer.AddHost(ctx, network.CIDR(), c.NodeName)
 			if err != nil {
 				log.Error(err.Error())
 			}
@@ -132,16 +131,9 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 		backendMapV6 := backend.Map{}
 		// only check localhost
 
-		nodename := ""
-		if c.NodeName != "" {
-			nodename = c.NodeName
-		} else {
-			nodename = os.Getenv("HOSTNAME")
-		}
-
 		ips := []string{}
-		if nodename != "" {
-			if ips, err = getNodeIPs(ctx, nodename, em.KubernetesClient); err != nil && !apierrors.IsNotFound(err) {
+		if c.NodeName != "" {
+			if ips, err = getNodeIPs(ctx, c.NodeName, em.KubernetesClient); err != nil && !apierrors.IsNotFound(err) {
 				log.Error("failed to get IP of control-plane node", "err", err)
 			}
 		}
@@ -342,7 +334,7 @@ func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip
 		if c.EnableBGP && (c.EnableLeaderElection || c.EnableServicesElection) {
 			// Lets advertise the VIP over BGP, the host needs to be passed using CIDR notation
 			log.Debug("(svcs) attempting to advertise over BGP", "address", network.CIDR())
-			err = bgp.AddHost(lbCtx, network.CIDR())
+			err = bgp.AddHost(lbCtx, network.CIDR(), name)
 			if err != nil {
 				log.Error(err.Error())
 			}

--- a/pkg/endpoints/endpoints_bgp.go
+++ b/pkg/endpoints/endpoints_bgp.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kube-vip/kube-vip/pkg/bgp"
 	"github.com/kube-vip/kube-vip/pkg/instance"
+	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/servicecontext"
 	v1 "k8s.io/api/core/v1"
 )
@@ -29,7 +30,7 @@ func (b *BGP) processInstance(svcCtx *servicecontext.Context, service *v1.Servic
 			for i := range cluster.Network {
 				if !svcCtx.IsNetworkConfigured(cluster.Network[i].IP()) {
 					log.Debug("attempting to advertise BGP service", "provider", b.provider.GetLabel(), "ip", cluster.Network[i].IP())
-					err := b.bgpServer.AddHost(svcCtx.Ctx, cluster.Network[i].CIDR())
+					err := b.bgpServer.AddHost(svcCtx.Ctx, cluster.Network[i].CIDR(), lease.ServiceNamespacedName(service))
 					if err != nil {
 						log.Error("error adding BGP host", "provider", b.provider.GetLabel(), "err", err)
 					} else {
@@ -50,7 +51,7 @@ func (b *BGP) clear(svcCtx *servicecontext.Context, lastKnownGoodEndpoint *strin
 		if instance := instance.FindServiceInstance(service, *b.instances); instance != nil {
 			for _, cluster := range instance.Clusters {
 				for i := range cluster.Network {
-					err := b.bgpServer.DelHost(svcCtx.Ctx, cluster.Network[i].CIDR())
+					err := b.bgpServer.DelHost(svcCtx.Ctx, cluster.Network[i].CIDR(), lease.ServiceNamespacedName(service))
 					if err != nil {
 						log.Error("deleting BGP host", "provider", b.provider.GetLabel(), "ip", cluster.Network[i].IP(), "err", err)
 					} else {
@@ -119,7 +120,7 @@ func ClearBGPHostsByInstance(ctx context.Context, instance *instance.Instance, b
 	for _, cluster := range instance.Clusters {
 		for i := range cluster.Network {
 			network := cluster.Network[i]
-			err := bgpServer.DelHost(ctx, network.CIDR())
+			err := bgpServer.DelHost(ctx, network.CIDR(), lease.ServiceNamespacedName(instance.ServiceSnapshot))
 			if err != nil {
 				log.Error("[endpoint] error deleting BGP host", "err", err)
 			} else {

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/endpoints/providers"
 	"github.com/kube-vip/kube-vip/pkg/instance"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/servicecontext"
 	"github.com/kube-vip/kube-vip/pkg/upnp"
 	"github.com/kube-vip/kube-vip/pkg/utils"
@@ -173,7 +174,7 @@ func (p *Processor) addService(ctx context.Context, newService *instance.Instanc
 
 	for x := range newService.VIPConfigs {
 		log.Debug("starting loadbalancer for service", "name", svc.Name, "namespace", svc.Namespace, "uid", svc.UID)
-		if err := newService.Clusters[x].StartLoadBalancerService(ctx, newService.VIPConfigs[x], p.bgpServer, svc.Name, p.CountRouteReferences, wg); err != nil {
+		if err := newService.Clusters[x].StartLoadBalancerService(ctx, newService.VIPConfigs[x], p.bgpServer, lease.ServiceNamespacedName(svc), p.CountRouteReferences, wg); err != nil {
 			return fmt.Errorf("failed to start lb: %w", err)
 		}
 	}
@@ -389,6 +390,11 @@ func (p *Processor) deleteService(ctx context.Context, uid types.UID) error {
 			shared = true
 		}
 	}
+
+	if p.config.EnableBGP {
+		endpoints.ClearBGPHostsByInstance(ctx, serviceInstance, p.bgpServer)
+	}
+
 	if !shared {
 		for x := range serviceInstance.Clusters {
 			serviceInstance.Clusters[x].Stop()
@@ -413,9 +419,6 @@ func (p *Processor) deleteService(ctx context.Context, uid types.UID) error {
 			}
 		}
 
-		if p.config.EnableBGP {
-			endpoints.ClearBGPHostsByInstance(ctx, serviceInstance, p.bgpServer)
-		}
 		if p.config.EnableRoutingTable && (p.config.EnableLeaderElection || p.config.EnableServicesElection) {
 			if errs := endpoints.ClearRoutesByInstance(serviceInstance.ServiceSnapshot, serviceInstance, &p.ServiceInstances); len(errs) > 0 {
 				for _, err := range errs {


### PR DESCRIPTION
This PR introduces a tacker for BGP paths similar to what `ARP manager` does in ARP mode - this should make it much easier to manage BGP paths in case of service/endpoint creation/deletion, as decision whether path should be deleted or created is contained within the BGP server object.

My next step will be to add similar thing for routes in RT mode to get rid of the code that searches for routes common for multiple services, and to get similar workflow for each mode.