### PR TITLE
Create separate Docker network for each kind cluster in daemonset-bas…

### DIFF
--- a/testing/e2e/e2e_bgp_ds_test.go
+++ b/testing/e2e/e2e_bgp_ds_test.go
@@ -48,7 +48,6 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 			var err error
 			tempDirPathRoot, err = os.MkdirTemp("", "kube-vip-test-bgp-ds")
 			Expect(err).NotTo(HaveOccurred())
-
 		})
 
 		AfterAll(func() {
@@ -79,7 +78,7 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 			})
 
 			AfterAll(func() {
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, clusterName, ConfigMtx, logger)
 			})
 
 			AfterEach(func() {
@@ -234,5 +233,55 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 			})
 
 		})
+
+		/*Describe("kube-vip IPv6 BGP unnumbered functionality", Ordered, func() {
+			var (
+				client      kubernetes.Interface
+				clusterName string
+				tempDirPath string
+			)
+
+			BeforeAll(func() {
+				networking := &kindconfigv1alpha4.Networking{
+					IPFamily: kindconfigv1alpha4.IPv6Family,
+				}
+
+				var err error
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test-bgp-v6")
+				Expect(err).NotTo(HaveOccurred())
+
+				clusterName, client, _ = prepareClusterForDS(tempDirPath, "bgp-ds-v6", imagePath, k8sImagePath,
+					logger, networking, 1, nil)
+			})
+
+			AfterAll(func() {
+				cleanupCluster(clusterName, clusterName, ConfigMtx, logger)
+			})
+
+			AfterEach(func() {
+				tempDirPathLocal, err := os.MkdirTemp(tempDirPath, "kube-vip-test")
+				By(fmt.Sprintf("saving logs to %q", tempDirPathLocal))
+				err = e2e.GetLogs(ctx, client, tempDirPathLocal, clusterName)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It(clusterName+" exits gracefully when unnumbered BGP peers are configured", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                 Mode,
+					ControlPlaneEnable:   "true",
+					VipElectionEnable:    "false",
+					ImagePath:            imagePath,
+					ConfigPath:           configPath,
+					SvcEnable:            "true",
+					SvcElectionEnable:    "false",
+					EnableEndpointslices: "true",
+					EnableNodeLabeling:   "false",
+					BGPPeers:             "unnumbered:eth0",
+					BGPAS:                2,
+				}
+
+				testDS(ctx, manifestValues, client, utils.IPv6Family, clusterName)
+			})
+		})*/
 	}
 })

--- a/testing/e2e/e2e_bgp_test.go
+++ b/testing/e2e/e2e_bgp_test.go
@@ -168,7 +168,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 						return err
 					}, "30s", "200ms").Should(Succeed())
 				}
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			It("should add paths", func() {
@@ -211,7 +211,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 						return err
 					}, "30s", "200ms").Should(Succeed())
 				}
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			It("should add paths", func() {
@@ -254,7 +254,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 						return err
 					}, "30s", "200ms").Should(Succeed())
 				}
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			It("should add paths", func() {
@@ -297,7 +297,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 						return err
 					}, "30s", "200ms").Should(Succeed())
 				}
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			It("should add paths", func() {
@@ -340,7 +340,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 						return err
 					}, "30s", "200ms").Should(Succeed())
 				}
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("advertise IPv4 routes for services",
@@ -394,7 +394,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 					})
 					Expect(err).ToNot(HaveOccurred())
 				}
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("advertise IPv6 routes for services",
@@ -448,7 +448,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 					})
 					Expect(err).ToNot(HaveOccurred())
 				}
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("advertise IPv6 routes over IPv4 session",
@@ -502,7 +502,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 					})
 					Expect(err).ToNot(HaveOccurred())
 				}
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("advertise IPv4 routes over IPv6 session",
@@ -557,7 +557,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 					})
 					Expect(err).ToNot(HaveOccurred())
 				}
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("advertise IPv6 routes over IPv4 session",
@@ -612,7 +612,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 					})
 					Expect(err).ToNot(HaveOccurred())
 				}
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("advertise IPv4 routes over IPv6 session",
@@ -668,7 +668,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 						return err
 					}, "30s", "200ms").Should(Succeed())
 				}
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("advertise IPv4 routes for services",
@@ -730,7 +730,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 					})
 					Expect(err).ToNot(HaveOccurred())
 				}
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("advertise IPv6 routes for services",
@@ -792,7 +792,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 					})
 					Expect(err).ToNot(HaveOccurred())
 				}
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("advertise IPv6 routes over IPv4 session",
@@ -854,7 +854,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 					})
 					Expect(err).ToNot(HaveOccurred())
 				}
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("advertise IPv4 routes over IPv6 session",
@@ -917,7 +917,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 					})
 					Expect(err).ToNot(HaveOccurred())
 				}
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("advertise IPv6 routes over IPv4 session",
@@ -980,7 +980,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 					})
 					Expect(err).ToNot(HaveOccurred())
 				}
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("advertise IPv4 routes over IPv6 session",
@@ -1116,7 +1116,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 						return err
 					}, "30s", "200ms").Should(Succeed())
 				}
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("advertise IPv4 routes for services",
@@ -1134,7 +1134,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 func testBGP(ctx context.Context, offset uint, lbFamily string, afiFamily api.Family_Afi, svcFamily []corev1.IPFamily, svcName string,
 	trafficPolicy corev1.ServiceExternalTrafficPolicy, client kubernetes.Interface, numberOfServices int,
 	gobgpClient api.GobgpApiClient, expectedNexthop string, serviceLease string) {
-	lbAddress := e2e.GenerateVIP(lbFamily, offset)
+	lbAddress := e2e.GenerateVIP(lbFamily, offset, defaultNetwork)
 	routeCheckFamily := &api.Family{
 		Afi:  afiFamily,
 		Safi: api.Family_SAFI_UNICAST,
@@ -1148,7 +1148,7 @@ func setupEnv(ctx context.Context, cpVIP, clusterName *string, tempDirPath strin
 	logger log.Logger, nodesNumber int, mpbgpnexthop, clusterNameSuffix string, serviceElection, cpEnable, svcEnable bool) (string, string) {
 	var err error
 
-	*cpVIP = e2e.GenerateVIP(clusterAddrFamily, SOffset.Get())
+	*cpVIP = e2e.GenerateVIP(clusterAddrFamily, SOffset.Get(), defaultNetwork)
 
 	var clusterIPFamily kindconfigv1alpha4.ClusterIPFamily
 	var podSubnet, serviceSubnet string

--- a/testing/e2e/e2e_ds_test.go
+++ b/testing/e2e/e2e_ds_test.go
@@ -56,7 +56,6 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 			var err error
 			tempDirPathRoot, err = os.MkdirTemp("", "kube-vip-test-arp-ds")
 			Expect(err).NotTo(HaveOccurred())
-
 		})
 
 		AfterAll(func() {
@@ -87,7 +86,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 			})
 
 			AfterAll(func() {
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, clusterName, ConfigMtx, logger)
 			})
 
 			AfterEach(func() {
@@ -215,7 +214,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 			})
 
 			AfterAll(func() {
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, clusterName, ConfigMtx, logger)
 			})
 
 			AfterEach(func() {
@@ -343,7 +342,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 			})
 
 			AfterAll(func() {
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, clusterName, ConfigMtx, logger)
 			})
 
 			AfterEach(func() {
@@ -499,7 +498,7 @@ func testDS(ctx context.Context, manifestValues *e2e.KubevipManifestValues, clie
 	}
 
 	if cpEnable {
-		manifestValues.ControlPlaneVIP = e2e.GenerateVIP(genFam, SOffset.Get())
+		manifestValues.ControlPlaneVIP = e2e.GenerateVIP(genFam, SOffset.Get(), clusterName)
 	}
 
 	createKubeVipDS(ctx, "kube-vip", "kube-system", manifestValues, client)
@@ -536,7 +535,7 @@ func testDS(ctx context.Context, manifestValues *e2e.KubevipManifestValues, clie
 		leaseName := "plndr-svcs-lock"
 		leaseNamespace := "kube-system"
 
-		svcVip = e2e.GenerateVIP(genFam, SOffset.Get())
+		svcVip = e2e.GenerateVIP(genFam, SOffset.Get(), clusterName)
 		var leases []string
 		services, leases = createTestServiceForDS(ctx, "test-svc", svcVip, leaseName,
 			corev1.ServiceExternalTrafficPolicyCluster, client, svcElection, families, 1)
@@ -659,7 +658,7 @@ func testEndpoints(ctx context.Context, manifestValues *e2e.KubevipManifestValue
 		leaseName := "plndr-svcs-lock"
 		leaseNamespace := "kube-system"
 
-		svcVip = e2e.GenerateVIP(genFam, SOffset.Get())
+		svcVip = e2e.GenerateVIP(genFam, SOffset.Get(), clusterName)
 		var leases []string
 		_, leases = createTestServiceForDS(ctx, "test-svc", svcVip, leaseName,
 			trafficPolicy, client, svcElection, families, 1)
@@ -903,6 +902,8 @@ func removeDS(ctx context.Context, client kubernetes.Interface, namespace, name 
 func prepareClusterForDS(tempDirPath, clusterNameSuffix, kvImagePath, k8sImagePath string, logger log.Logger,
 	networking *kindconfigv1alpha4.Networking, nodesNum int,
 	addSAN *san) (string, kubernetes.Interface, *rest.Config) {
+	clusterCreationMtx.Lock()
+	defer clusterCreationMtx.Unlock()
 
 	clusterConfig := kindconfigv1alpha4.Cluster{
 		Networking: *networking,
@@ -939,6 +940,9 @@ func prepareClusterForDS(tempDirPath, clusterNameSuffix, kvImagePath, k8sImagePa
 	}
 
 	clusterName := fmt.Sprintf("%s-%s", filepath.Base(tempDirPath), clusterNameSuffix)
+
+	err := os.Setenv(kindNetworkEnv, clusterName)
+	Expect(err).ToNot(HaveOccurred())
 
 	By(withTimestamp("creating a kind cluster with multiple control plane nodes"))
 	client, cfg, err := createKindCluster(logger, &clusterConfig, clusterName)

--- a/testing/e2e/e2e_rt_ds_test.go
+++ b/testing/e2e/e2e_rt_ds_test.go
@@ -79,7 +79,7 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 			})
 
 			AfterAll(func() {
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, clusterName, ConfigMtx, logger)
 			})
 
 			AfterEach(func() {

--- a/testing/e2e/e2e_rt_test.go
+++ b/testing/e2e/e2e_rt_test.go
@@ -86,7 +86,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateVIP(utils.IPv4Family, SOffset.Get())
+				cpVIP = e2e.GenerateVIP(utils.IPv4Family, SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.IPv4Family,
@@ -114,7 +114,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				By(fmt.Sprintf("saving logs to %q", tempDirPath))
 				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			It("setups IPv4 address and route on control-plane node", func() {
@@ -147,7 +147,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 			BeforeAll(func() {
 
-				cpVIP = e2e.GenerateVIP(utils.IPv6Family, SOffset.Get())
+				cpVIP = e2e.GenerateVIP(utils.IPv6Family, SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.IPv6Family,
@@ -175,7 +175,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				By(fmt.Sprintf("saving logs to %q", tempDirPath))
 				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			It("setups IPv6 address and route on control-plane node", func() {
@@ -207,7 +207,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get())
+				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.DualStackFamily,
@@ -246,7 +246,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				By(fmt.Sprintf("saving logs to %q", tempDirPath))
 				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			It("setups DualStack addresses and routes on control-plane nodes", func() {
@@ -282,7 +282,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get())
+				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily:      kindconfigv1alpha4.DualStackFamily,
@@ -323,7 +323,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				By(fmt.Sprintf("saving logs to %q", tempDirPath))
 				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			It("setups DualStack addresses and routes on control-plane nodes", func() {
@@ -362,7 +362,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateVIP(utils.IPv4Family, SOffset.Get())
+				cpVIP = e2e.GenerateVIP(utils.IPv4Family, SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.IPv4Family,
@@ -394,12 +394,12 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				By(fmt.Sprintf("saving logs to %q", tempDirPath))
 				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("configures an IPv4 routes for services",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset)
+					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 1, false)
 				},
@@ -409,7 +409,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 			DescribeTable("only removes route if it was referenced by multiple services and all of them were deleted",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset)
+					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 2, false)
 				},
@@ -432,7 +432,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateVIP(utils.IPv6Family, SOffset.Get())
+				cpVIP = e2e.GenerateVIP(utils.IPv6Family, SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.IPv6Family,
@@ -464,12 +464,12 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				By(fmt.Sprintf("saving logs to %q", tempDirPath))
 				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("configures an IPv6 routes for services",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset)
+					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 1, false)
 				},
@@ -479,7 +479,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 			DescribeTable("only removes route if it was referenced by multiple services and all of them were deleted",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset)
+					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 2, false)
 				},
@@ -502,7 +502,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get())
+				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.DualStackFamily,
@@ -535,12 +535,12 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				By(fmt.Sprintf("saving logs to %q", tempDirPath))
 				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("configures an IPv4 and IPv6 routes for services",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateDualStackVIP(offset)
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 1, false)
 				},
@@ -550,7 +550,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 			DescribeTable("only removes route if it was referenced by multiple services and all of them were deleted",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateDualStackVIP(offset)
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 2, false)
 				},
@@ -573,7 +573,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get())
+				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily:      kindconfigv1alpha4.DualStackFamily,
@@ -608,12 +608,12 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				By(fmt.Sprintf("saving logs to %q", tempDirPath))
 				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("configures an IPv4 and IPv6 routes for services",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateDualStackVIP(offset)
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 1, false)
 				},
@@ -623,7 +623,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 			DescribeTable("only removes route if it was referenced by multiple services and all of them were deleted",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateDualStackVIP(offset)
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 2, false)
 				},
@@ -646,7 +646,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateVIP(utils.IPv4Family, SOffset.Get())
+				cpVIP = e2e.GenerateVIP(utils.IPv4Family, SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.IPv4Family,
@@ -678,12 +678,12 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				By(fmt.Sprintf("saving logs to %q", tempDirPath))
 				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("configures an IPv4 routes for services",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset)
+					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 1, false)
 				},
@@ -693,7 +693,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 			DescribeTable("only removes route if it was referenced by multiple services and all of them were deleted",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset)
+					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 2, false)
 				},
@@ -703,7 +703,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 			DescribeTable("only removes route if it was referenced by multiple services and all of them were deleted if common lease is used",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset)
+					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 2, true)
 				},
@@ -725,7 +725,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateVIP(utils.IPv6Family, SOffset.Get())
+				cpVIP = e2e.GenerateVIP(utils.IPv6Family, SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.IPv6Family,
@@ -757,12 +757,12 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				By(fmt.Sprintf("saving logs to %q", tempDirPath))
 				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("configures an IPv6 routes for services",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset)
+					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 1, false)
 				},
@@ -772,7 +772,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 			DescribeTable("only removes route if it was referenced by multiple services and all of them were deleted",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset)
+					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 2, false)
 				},
@@ -782,7 +782,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 			DescribeTable("only removes route if it was referenced by multiple services and all of them were deleted when common lease is used",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset)
+					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 2, true)
 				},
@@ -804,7 +804,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get())
+				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.DualStackFamily,
@@ -837,12 +837,12 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				By(fmt.Sprintf("saving logs to %q", tempDirPath))
 				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("configures an IPv4 and IPv6 routes for services",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateDualStackVIP(offset)
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 1, false)
 				},
@@ -852,7 +852,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 			DescribeTable("only removes route if it was referenced by multiple services and all of them were deleted",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateDualStackVIP(offset)
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 2, false)
 				},
@@ -862,7 +862,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 			DescribeTable("only removes route if it was referenced by multiple services and all of them were deleted when common lease is used",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateDualStackVIP(offset)
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 2, true)
 				},
@@ -884,7 +884,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get())
+				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily:      kindconfigv1alpha4.DualStackFamily,
@@ -919,12 +919,12 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				By(fmt.Sprintf("saving logs to %q", tempDirPath))
 				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("configures an IPv4 and IPv6 routes for services",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateDualStackVIP(offset)
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 1, false)
 				},
@@ -934,7 +934,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 			DescribeTable("only removes route if it was referenced by multiple services and all of them were deleted",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateDualStackVIP(offset)
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 2, false)
 				},
@@ -944,7 +944,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 			DescribeTable("only removes route if it was referenced by multiple services and all of them were deleted when common lease is used",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateDualStackVIP(offset)
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 2, true)
 				},

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -44,14 +44,18 @@ import (
 )
 
 const (
-	dsName      = "traefik-whoami"
-	dsNamespace = "default"
+	dsName         = "traefik-whoami"
+	dsNamespace    = "default"
+	defaultNetwork = "kind"
+	kindNetworkEnv = "KIND_EXPERIMENTAL_DOCKER_NETWORK"
 )
 
 const testJSON = `
 - op: add
   path: "/apiServer/certSANs/-"
   value: `
+
+var clusterCreationMtx sync.Mutex
 
 var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 	if Mode == ModeARP {
@@ -119,7 +123,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateVIP(utils.IPv4Family, SOffset.Get())
+				cpVIP = e2e.GenerateVIP(utils.IPv4Family, SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.IPv4Family,
@@ -148,7 +152,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				Eventually(func() error {
 					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			It(clusterName+" provides an IPv4 VIP address for the Kubernetes control plane nodes", func() {
@@ -165,7 +169,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateVIP(utils.IPv4Family, SOffset.Get())
+				cpVIP = e2e.GenerateVIP(utils.IPv4Family, SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.IPv4Family,
@@ -194,12 +198,12 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				Eventually(func() error {
 					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("configures an IPv4 VIP address for service",
 				func(svcName string, currentOffset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateVIP(utils.IPv4Family, currentOffset)
+					lbAddress := e2e.GenerateVIP(utils.IPv4Family, currentOffset, defaultNetwork)
 					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol}, 1)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
@@ -208,7 +212,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 
 			DescribeTable("only removes VIP address if it was referenced by multiple services and all of them were deleted",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset)
+					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
 					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol}, 2)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
@@ -225,7 +229,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateVIP(utils.IPv4Family, SOffset.Get())
+				cpVIP = e2e.GenerateVIP(utils.IPv4Family, SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.IPv4Family,
@@ -254,12 +258,12 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				Eventually(func() error {
 					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("configures an IPv4 VIP address for service",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset)
+					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
 					testService(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, trafficPolicy, client, true, []corev1.IPFamily{corev1.IPv4Protocol}, 1)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
@@ -277,7 +281,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateVIP(utils.IPv6Family, SOffset.Get())
+				cpVIP = e2e.GenerateVIP(utils.IPv6Family, SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.IPv6Family,
@@ -308,7 +312,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				Eventually(func() error {
 					return e2e.GetLogs(ctx, c, tempDirPath, clusterName)
 				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			It(clusterName+"provides an IPv6 VIP address for the Kubernetes control plane nodes", func() {
@@ -325,7 +329,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateVIP(utils.IPv6Family, SOffset.Get())
+				cpVIP = e2e.GenerateVIP(utils.IPv6Family, SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.IPv6Family,
@@ -354,12 +358,12 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				Eventually(func() error {
 					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("configures an IPv6 VIP address for service",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset)
+					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
 					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv6Protocol}, 1)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
@@ -368,7 +372,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 
 			DescribeTable("only removes VIP address if it was referenced by multiple services and all of them were deleted",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset)
+					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
 					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv6Protocol}, 2)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
@@ -385,7 +389,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateVIP(utils.IPv6Family, SOffset.Get())
+				cpVIP = e2e.GenerateVIP(utils.IPv6Family, SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.IPv6Family,
@@ -414,12 +418,12 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				Eventually(func() error {
 					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("configures an IPv6 VIP address for service",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset)
+					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
 					testService(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, trafficPolicy, client, true, []corev1.IPFamily{corev1.IPv6Protocol}, 1)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
@@ -436,7 +440,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateDualStackVIP(23)
+				cpVIP = e2e.GenerateDualStackVIP(23, defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.DualStackFamily,
@@ -465,7 +469,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				Eventually(func() error {
 					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			It(clusterName+" provides a DualStack VIP addresses for the Kubernetes control plane nodes", func() {
@@ -482,7 +486,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateDualStackVIP(24)
+				cpVIP = e2e.GenerateDualStackVIP(24, defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.DualStackFamily,
@@ -511,12 +515,12 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				Eventually(func() error {
 					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("configures an IPv4 and IPv6 VIP addresses for service",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateDualStackVIP(offset)
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}, 1)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
@@ -525,7 +529,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 
 			DescribeTable("only removes VIP address if it was referenced by multiple services and all of them were deleted",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateDualStackVIP(offset)
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}, 2)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
@@ -542,7 +546,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateDualStackVIP(29)
+				cpVIP = e2e.GenerateDualStackVIP(29, defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.DualStackFamily,
@@ -571,12 +575,12 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				Eventually(func() error {
 					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("configures an IPv4 and IPv6 VIP addresses for service",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateDualStackVIP(offset)
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testService(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, trafficPolicy, client, true, []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}, 1)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
@@ -593,7 +597,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateDualStackVIP(32)
+				cpVIP = e2e.GenerateDualStackVIP(32, defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily:      kindconfigv1alpha4.DualStackFamily,
@@ -624,7 +628,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				Eventually(func() error {
 					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			It(clusterName+" provides a DualStack VIP addresses for the Kubernetes control plane nodes", func() {
@@ -641,7 +645,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateDualStackVIP(33)
+				cpVIP = e2e.GenerateDualStackVIP(33, defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily:      kindconfigv1alpha4.DualStackFamily,
@@ -672,12 +676,12 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				Eventually(func() error {
 					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("configures an IPv4 and IPv6 VIP addresses for service",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateDualStackVIP(offset)
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}, 1)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
@@ -686,7 +690,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 
 			DescribeTable("only removes VIP address if it was referenced by multiple services and all of them were deleted",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateDualStackVIP(offset)
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}, 2)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
@@ -703,7 +707,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateDualStackVIP(38)
+				cpVIP = e2e.GenerateDualStackVIP(38, defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily:      kindconfigv1alpha4.DualStackFamily,
@@ -734,12 +738,12 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				Eventually(func() error {
 					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("configures an IPv6 VIP address for service",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateDualStackVIP(offset)
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testService(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, trafficPolicy, client, true, []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}, 1)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
@@ -756,7 +760,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateVIP(utils.IPv4Family, SOffset.Get())
+				cpVIP = e2e.GenerateVIP(utils.IPv4Family, SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.IPv4Family,
@@ -785,7 +789,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				Eventually(func() error {
 					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			It(clusterName+" uses hostname fallback while providing an IPv4 VIP address for the Kubernetes control plane nodes", func() {
@@ -802,7 +806,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateVIP(utils.IPv6Family, SOffset.Get())
+				cpVIP = e2e.GenerateVIP(utils.IPv6Family, SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.IPv6Family,
@@ -831,12 +835,12 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				Eventually(func() error {
 					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("configures an single IPv6 VIP address for multiple services",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset)
+					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
 					testServiceCommonLease(ctx, svcName, lbAddress, dsNamespace,
 						trafficPolicy,
 						client, []corev1.IPFamily{corev1.IPv6Protocol}, 3)
@@ -854,7 +858,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get())
+				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily:      kindconfigv1alpha4.DualStackFamily,
@@ -885,12 +889,12 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				Eventually(func() error {
 					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
 				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, ConfigMtx, logger)
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
 			})
 
 			DescribeTable("configures an single IPv4 and IPv6 VIP address for multiple services",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
-					lbAddress := e2e.GenerateDualStackVIP(offset)
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceCommonLease(ctx, svcName, lbAddress, dsNamespace,
 						trafficPolicy,
 						client, []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}, 3)
@@ -1256,6 +1260,8 @@ func prepareCluster(ctx context.Context, tempDirPath, clusterNameSuffix, k8sImag
 	v129 bool, kubeVIPManifestTemplate *template.Template, logger log.Logger,
 	manifestValues *e2e.KubevipManifestValues, networking *kindconfigv1alpha4.Networking, nodesNum int,
 	addSAN *san, dsNumber int) (string, kubernetes.Interface, *rest.Config) {
+	clusterCreationMtx.Lock()
+	defer clusterCreationMtx.Unlock()
 
 	manifestPath := filepath.Join(tempDirPath, fmt.Sprintf("kube-vip-%s.yaml", clusterNameSuffix))
 
@@ -1325,6 +1331,9 @@ func prepareCluster(ctx context.Context, tempDirPath, clusterNameSuffix, k8sImag
 
 	clusterName := fmt.Sprintf("%s-%s", filepath.Base(tempDirPath), clusterNameSuffix)
 
+	err = os.Unsetenv(kindNetworkEnv)
+	Expect(err).ToNot(HaveOccurred())
+
 	By(withTimestamp("creating a kind cluster with multiple control plane nodes"))
 	client, cfg, err := createKindCluster(logger, &clusterConfig, clusterName)
 	Expect(err).ToNot(HaveOccurred())
@@ -1345,7 +1354,12 @@ func prepareCluster(ctx context.Context, tempDirPath, clusterNameSuffix, k8sImag
 	return clusterName, client, cfg
 }
 
-func cleanupCluster(clusterName string, configMtx *sync.Mutex, logger log.Logger) {
+func cleanupCluster(clusterName, network string, configMtx *sync.Mutex, logger log.Logger) {
+	if network != defaultNetwork {
+		err := os.Unsetenv(kindNetworkEnv)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
 	if os.Getenv("E2E_PRESERVE_CLUSTER") == "true" {
 		return
 	}
@@ -1362,6 +1376,12 @@ func cleanupCluster(clusterName string, configMtx *sync.Mutex, logger log.Logger
 		defer configMtx.Unlock()
 		return provider.Delete(clusterName, "")
 	}, "60s", "200ms").Should(Succeed())
+
+	if network != defaultNetwork {
+		cmd := exec.Command("docker", "network", "rm", network)
+		err := cmd.Run()
+		Expect(err).ToNot(HaveOccurred())
+	}
 }
 
 func testControlPlaneVIPs(ctx context.Context, cpVIPs []string, clusterName string, client kubernetes.Interface) {

--- a/testing/e2e/etcd/election_test.go
+++ b/testing/e2e/etcd/election_test.go
@@ -63,7 +63,7 @@ var _ = Describe("kube-vip with etcd leader election", func() {
 
 			test.kubeVipImage = os.Getenv("E2E_IMAGE_PATH")
 
-			test.vip = e2e.GenerateVIP(utils.IPv4Family, 5)
+			test.vip = e2e.GenerateVIP(utils.IPv4Family, 5, "kind")
 			test.logger.Printf("Selected VIP %s", test.vip)
 
 			test.currentDir, err = os.Getwd()

--- a/testing/e2e/ip.go
+++ b/testing/e2e/ip.go
@@ -68,12 +68,12 @@ func EnsureKindNetwork() {
 	Eventually(session).Should(gexec.Exit(0))
 }
 
-func GenerateVIP(family string, offset uint) string {
+func GenerateVIP(family string, offset uint, network string) string {
 	if family == DualstackFamily || family == DualstackFamilyIPv6 {
-		return fmt.Sprintf("%s,%s", GenerateVIP(utils.IPv4Family, offset), GenerateVIP(utils.IPv6Family, offset))
+		return fmt.Sprintf("%s,%s", GenerateVIP(utils.IPv4Family, offset, network), GenerateVIP(utils.IPv6Family, offset, network))
 	}
 
-	cidrs := getKindNetworkSubnetCIDRs()
+	cidrs := getKindNetworkSubnetCIDRs(network)
 
 	for _, cidr := range cidrs {
 		if cidr != "" {
@@ -107,25 +107,25 @@ func GenerateVIP(family string, offset uint) string {
 	return ""
 }
 
-func GenerateDualStackVIP(offset uint) string {
-	return GenerateVIP(utils.IPv4Family, offset) + "," + GenerateVIP(utils.IPv6Family, offset)
+func GenerateDualStackVIP(offset uint, network string) string {
+	return GenerateVIP(utils.IPv4Family, offset, network) + "," + GenerateVIP(utils.IPv6Family, offset, network)
 }
 
-func getKindNetworkSubnetCIDRs() []string {
+func getKindNetworkSubnetCIDRs(name string) []string {
 	cmd := exec.Command(
-		"docker", "inspect", "kind",
+		"docker", "inspect", name,
 		"--format", `{{ range $i, $a := .IPAM.Config }}{{ println .Subnet }}{{ end }}`,
 	)
 	cmdOut := new(bytes.Buffer)
 	cmd.Stdout = cmdOut
-	Expect(cmd.Run()).To(Succeed(), "The Docker \"kind\" network was not found.")
+	Expect(cmd.Run()).To(Succeed(), fmt.Sprintf("The Docker %q network was not found.", name))
 	reader := bufio.NewReader(cmdOut)
 
 	cidrs := []string{}
 	for {
 		line, readErr := reader.ReadString('\n')
 		if readErr != nil && readErr != io.EOF {
-			Expect(readErr).NotTo(HaveOccurred(), "Error finding subnet CIDRs in the Docker \"kind\" network")
+			Expect(readErr).NotTo(HaveOccurred(), fmt.Sprintf("Error finding subnet CIDRs in the Docker %q network", name))
 		}
 
 		cidrs = append(cidrs, strings.TrimSpace(line))


### PR DESCRIPTION
…ed e2e tests

This should fix issues with the tests in PR #1512 .

This uses env variable `KIND_EXPERIMENTAL_DOCKER_NETWORK` so different docker network can be used for each daemonset-based e2e test cluster instead of the default `kind` network.  The creation of the cluster is guarded by a mutex, so the env will not be overridden by concurrent tests.