### PR TITLE
This fixes the rules for egress allowed-networks

### DIFF
--- a/pkg/nftables/nftables.go
+++ b/pkg/nftables/nftables.go
@@ -88,21 +88,40 @@ func ApplySNAT(podIP, vipIP, service, destinationPorts string, ignoreCIDR []stri
 	if len(portExpressions) != 0 {
 		for x := range portExpressions {
 			// Create our nftables rule
-			rule, err = CreateRule(podIP, vipIP, service, ignoreCIDR, allowCIDR, conn, IPv6, portExpressions[x])
+			if len(allowCIDR) == 0 {
+				// No allowed CIDRs
+				rule, err = CreateRule(podIP, vipIP, service, ignoreCIDR, "", conn, IPv6, portExpressions[x])
+				slog.Debug("[egress]", "table", rule.Table.Name, "chain", rule.Chain.Name, "expr", rule.Exprs)
+				conn.AddRule(rule) // Add the rule
+			} else {
+				// Create a rule for each allowed CIDR
+				for x := range allowCIDR {
+					rule, err = CreateRule(podIP, vipIP, service, ignoreCIDR, allowCIDR[x], conn, IPv6, portExpressions[x])
+					slog.Debug("[egress]", "table", rule.Table.Name, "chain", rule.Chain.Name, "expr", rule.Exprs)
+					conn.AddRule(rule) // Add the rule
+				}
+			}
 			if err != nil {
 				return err
 			}
-			slog.Debug("[egress]", "table", rule.Table.Name, "chain", rule.Chain.Name, "expr", rule.Exprs)
-			conn.AddRule(rule) // Add the rule
+
 		}
 	} else {
 		// Create our nftables rule
-		rule, err = CreateRule(podIP, vipIP, service, ignoreCIDR, allowCIDR, conn, IPv6, nil)
-		if err != nil {
-			return err
+		if len(allowCIDR) == 0 {
+			// No allowed CIDRs
+			rule, err = CreateRule(podIP, vipIP, service, ignoreCIDR, "", conn, IPv6, nil)
+			slog.Debug("[egress]", "table", rule.Table.Name, "chain", rule.Chain.Name, "expr", rule.Exprs)
+			conn.AddRule(rule) // Add the rule
+		} else {
+			// Create a rule for each allowed CIDR
+			for x := range allowCIDR {
+				rule, err = CreateRule(podIP, vipIP, service, ignoreCIDR, allowCIDR[x], conn, IPv6, nil)
+				slog.Debug("[egress]", "table", rule.Table.Name, "chain", rule.Chain.Name, "expr", rule.Exprs)
+				conn.AddRule(rule) // Add the rule
+			}
 		}
-		slog.Debug("[egress]", "table", rule.Table.Name, "chain", rule.Chain.Name, "expr", rule.Exprs)
-		conn.AddRule(rule) // Add the rule
+
 	}
 
 	err = conn.Flush() // Commit the rule to nftables
@@ -366,7 +385,7 @@ func ClearTables() error {
 }
 
 // Create our nftables rule
-func CreateRule(podIP, vipIP, service string, ignoreCIDR []string, allowCIDR []string, conn *nftables.Conn, IPv6 bool, portExpression []expr.Any) (*nftables.Rule, error) {
+func CreateRule(podIP, vipIP, service string, ignoreCIDR []string, allowCIDR string, conn *nftables.Conn, IPv6 bool, portExpression []expr.Any) (*nftables.Rule, error) {
 
 	// Validate pod IP
 	if net.ParseIP(podIP) == nil {
@@ -489,8 +508,8 @@ func CreateRule(podIP, vipIP, service string, ignoreCIDR []string, allowCIDR []s
 	}
 
 	// Parse which CIDRs we will only SNAT for
-	for _, cidr := range allowCIDR {
-		start, end, err := nftables.NetFirstAndLastIP(cidr)
+	if allowCIDR != "" {
+		start, end, err := nftables.NetFirstAndLastIP(allowCIDR)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/nftables/nftables.go
+++ b/pkg/nftables/nftables.go
@@ -91,18 +91,21 @@ func ApplySNAT(podIP, vipIP, service, destinationPorts string, ignoreCIDR []stri
 			if len(allowCIDR) == 0 {
 				// No allowed CIDRs
 				rule, err = CreateRule(podIP, vipIP, service, ignoreCIDR, "", conn, IPv6, portExpressions[x])
+				if err != nil {
+					return err
+				}
 				slog.Debug("[egress]", "table", rule.Table.Name, "chain", rule.Chain.Name, "expr", rule.Exprs)
 				conn.AddRule(rule) // Add the rule
 			} else {
 				// Create a rule for each allowed CIDR
 				for x := range allowCIDR {
 					rule, err = CreateRule(podIP, vipIP, service, ignoreCIDR, allowCIDR[x], conn, IPv6, portExpressions[x])
+					if err != nil {
+						return err
+					}
 					slog.Debug("[egress]", "table", rule.Table.Name, "chain", rule.Chain.Name, "expr", rule.Exprs)
 					conn.AddRule(rule) // Add the rule
 				}
-			}
-			if err != nil {
-				return err
 			}
 
 		}
@@ -111,17 +114,22 @@ func ApplySNAT(podIP, vipIP, service, destinationPorts string, ignoreCIDR []stri
 		if len(allowCIDR) == 0 {
 			// No allowed CIDRs
 			rule, err = CreateRule(podIP, vipIP, service, ignoreCIDR, "", conn, IPv6, nil)
+			if err != nil {
+				return err
+			}
 			slog.Debug("[egress]", "table", rule.Table.Name, "chain", rule.Chain.Name, "expr", rule.Exprs)
 			conn.AddRule(rule) // Add the rule
 		} else {
 			// Create a rule for each allowed CIDR
 			for x := range allowCIDR {
 				rule, err = CreateRule(podIP, vipIP, service, ignoreCIDR, allowCIDR[x], conn, IPv6, nil)
+				if err != nil {
+					return err
+				}
 				slog.Debug("[egress]", "table", rule.Table.Name, "chain", rule.Chain.Name, "expr", rule.Exprs)
 				conn.AddRule(rule) // Add the rule
 			}
 		}
-
 	}
 
 	err = conn.Flush() // Commit the rule to nftables

--- a/pkg/nftables/nftables.go
+++ b/pkg/nftables/nftables.go
@@ -98,8 +98,8 @@ func ApplySNAT(podIP, vipIP, service, destinationPorts string, ignoreCIDR []stri
 				conn.AddRule(rule) // Add the rule
 			} else {
 				// Create a rule for each allowed CIDR
-				for x := range allowCIDR {
-					rule, err = CreateRule(podIP, vipIP, service, ignoreCIDR, allowCIDR[x], conn, IPv6, portExpressions[x])
+				for y := range allowCIDR {
+					rule, err = CreateRule(podIP, vipIP, service, ignoreCIDR, allowCIDR[y], conn, IPv6, portExpressions[x])
 					if err != nil {
 						return err
 					}
@@ -121,8 +121,8 @@ func ApplySNAT(podIP, vipIP, service, destinationPorts string, ignoreCIDR []stri
 			conn.AddRule(rule) // Add the rule
 		} else {
 			// Create a rule for each allowed CIDR
-			for x := range allowCIDR {
-				rule, err = CreateRule(podIP, vipIP, service, ignoreCIDR, allowCIDR[x], conn, IPv6, nil)
+			for y := range allowCIDR {
+				rule, err = CreateRule(podIP, vipIP, service, ignoreCIDR, allowCIDR[y], conn, IPv6, nil)
 				if err != nil {
 					return err
 				}

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -430,7 +430,7 @@ func (p *Processor) deleteService(ctx context.Context, uid types.UID) error {
 				log.Info("[service] egress re-write enabled", "service", serviceInstance.ServiceSnapshot.Name)
 				err := egress.Teardown(serviceInstance.ServiceSnapshot.Annotations[kubevip.ActiveEndpoint], serviceInstance.ServiceSnapshot.Spec.LoadBalancerIP, serviceInstance.ServiceSnapshot.Namespace, string(serviceInstance.ServiceSnapshot.UID), serviceInstance.ServiceSnapshot.Annotations, p.config.EgressWithNftables)
 				if err != nil {
-					log.Error("[service] egress teardown", "err", err)
+					log.Warn("[service] egress teardown", "err", err)
 				}
 			}
 		}

--- a/testing/kind/egress_internal.yaml
+++ b/testing/kind/egress_internal.yaml
@@ -52,7 +52,7 @@ metadata:
   annotations:
     kube-vip.io/egress: "true"
     kube-vip.io/egress-internal: "true"
-    kube-vip.io/egress-allowed-networks: 172.18.0.0/24
+    kube-vip.io/egress-allowed-networks: 172.18.0.0/24,192.168.0.0/24
 spec:
   type: LoadBalancer
   # "Local" preserves the client source IP and avoids a second hop for


### PR DESCRIPTION
Originally kube-vip woud create a single rule for SNAT, however if the destination wasn't the first network then the connection wouldn't be egressed as nftables acted on the first match. To fix this, we now create multiple rules for allowed-networks. This means if the first rule doesn't match it will then move on to the next rule. The ignored-networks can remain as-is as the logic works for that mechanism.


`    kube-vip.io/egress-allowed-networks: 172.18.0.0/24,192.168.0.0/24`

Will now result in multiple rules for allowed networks..

```
        chain kube_vip_snat_e9981533-04eb-43d6-a52b-e710bd7cbb31 {
                type nat hook postrouting priority srcnat; policy accept;
                ip saddr { 10.244.2.5 } ip daddr != 10.244.0.0-10.244.255.255 ip daddr != 10.96.0.0-10.96.255.255 ip daddr 172.18.0.0-172.18.0.255 snat to 172.18.100.11
                ip saddr { 10.244.2.5 } ip daddr != 10.244.0.0-10.244.255.255 ip daddr != 10.96.0.0-10.96.255.255 ip daddr 192.168.0.0-192.168.0.255 snat to 172.18.100.11
        }
```