### PR TITLE
Improve logging in election.go and set defaultBGPPort constant

### DIFF
--- a/pkg/bgp/peers.go
+++ b/pkg/bgp/peers.go
@@ -6,8 +6,6 @@ import (
 	"net"
 	"strconv"
 
-	//nolint
-
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/vip"
 	api "github.com/osrg/gobgp/v3/api"
@@ -17,6 +15,8 @@ import (
 	"github.com/osrg/gobgp/v3/pkg/server"
 	"google.golang.org/protobuf/types/known/anypb"
 )
+
+const defaultBGPPort uint32 = 179
 
 // AddPeer will add peers to the BGP configuration
 func (b *Server) AddPeer(ctx context.Context, peer kubevip.BGPPeer) (err error) {
@@ -45,7 +45,7 @@ func (b *Server) AddPeer(ctx context.Context, peer kubevip.BGPPeer) (err error) 
 		Transport: &api.Transport{
 			MtuDiscovery:  true,
 			RemoteAddress: peer.Address,
-			RemotePort:    uint32(179),
+			RemotePort:    defaultBGPPort,
 		},
 	}
 

--- a/pkg/detector/interfaces.go
+++ b/pkg/detector/interfaces.go
@@ -27,7 +27,7 @@ func FindIPAddress(addrName string) (string, string, error) {
 					// If we're not searching for a specific adapter return the first one
 					if addrName == "" {
 						return iface.Name, address, nil
-					} else
+					}
 					// If this is the correct adapter return the details
 					if iface.Name == addrName {
 						return iface.Name, address, nil

--- a/pkg/election/election.go
+++ b/pkg/election/election.go
@@ -198,7 +198,7 @@ func (em *Manager) NodeWatcher(ctx context.Context, lb *loadbalancer.IPVSLoadBal
 					if checkIfNodeIsReady(node) {
 						err = lb.AddBackend(node.Status.Addresses[x].Address, port)
 						if err != nil {
-							log.Error("failed to add node to load balancer", "node", node.Name, "ip", node.Status.Addresses[x].Address, "err", err)
+							log.Error("adding node to load balancer", "node", node.Name, "ip", node.Status.Addresses[x].Address, "err", err)
 							if errors.Is(err, &utils.PanicError{}) {
 								return fmt.Errorf("add IPVS backend: %w", err)
 							}
@@ -206,7 +206,7 @@ func (em *Manager) NodeWatcher(ctx context.Context, lb *loadbalancer.IPVSLoadBal
 					} else {
 						err = lb.RemoveBackend(node.Status.Addresses[x].Address, port)
 						if err != nil {
-							log.Error("failed to remove node from load balancer", "node", node.Name, "ip", node.Status.Addresses[x].Address, "err", err)
+							log.Error("removing node from load balancer", "node", node.Name, "ip", node.Status.Addresses[x].Address, "err", err)
 						}
 					}
 				}
@@ -222,7 +222,7 @@ func (em *Manager) NodeWatcher(ctx context.Context, lb *loadbalancer.IPVSLoadBal
 				if node.Status.Addresses[x].Type == v1.NodeInternalIP {
 					err = lb.RemoveBackend(node.Status.Addresses[x].Address, port)
 					if err != nil {
-						log.Error("failed to remove node from load balancer", "node", node.Name, "ip", node.Status.Addresses[x].Address, "err", err)
+						log.Error("removing node from load balancer", "node", node.Name, "ip", node.Status.Addresses[x].Address, "err", err)
 					}
 				}
 			}

--- a/pkg/election/election.go
+++ b/pkg/election/election.go
@@ -68,7 +68,7 @@ func RunOrDie(ctx context.Context, run *RunConfig, c *kubevip.Config) error {
 			return err
 		}
 	default:
-		log.Info(fmt.Sprintf("LeaderElectionMode %s not supported, exiting", c.LeaderElectionType))
+		log.Info("LeaderElectionMode not supported, exiting", "mode", c.LeaderElectionType)
 	}
 
 	return nil
@@ -171,7 +171,7 @@ func (em *Manager) NodeWatcher(ctx context.Context, lb *loadbalancer.IPVSLoadBal
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("error creating label watcher: %s", err.Error())
+		return fmt.Errorf("error creating label watcher: %w", err)
 	}
 
 	wg.Go(func() {
@@ -198,7 +198,7 @@ func (em *Manager) NodeWatcher(ctx context.Context, lb *loadbalancer.IPVSLoadBal
 					if checkIfNodeIsReady(node) {
 						err = lb.AddBackend(node.Status.Addresses[x].Address, port)
 						if err != nil {
-							log.Error("add IPVS backend", "err", err)
+							log.Error("failed to add node to load balancer", "node", node.Name, "ip", node.Status.Addresses[x].Address, "err", err)
 							if errors.Is(err, &utils.PanicError{}) {
 								return fmt.Errorf("add IPVS backend: %w", err)
 							}
@@ -206,7 +206,7 @@ func (em *Manager) NodeWatcher(ctx context.Context, lb *loadbalancer.IPVSLoadBal
 					} else {
 						err = lb.RemoveBackend(node.Status.Addresses[x].Address, port)
 						if err != nil {
-							log.Error("remove IPVS backend", "err", err)
+							log.Error("failed to remove node from load balancer", "node", node.Name, "ip", node.Status.Addresses[x].Address, "err", err)
 						}
 					}
 				}
@@ -222,7 +222,7 @@ func (em *Manager) NodeWatcher(ctx context.Context, lb *loadbalancer.IPVSLoadBal
 				if node.Status.Addresses[x].Type == v1.NodeInternalIP {
 					err = lb.RemoveBackend(node.Status.Addresses[x].Address, port)
 					if err != nil {
-						log.Error("Del IPVS backend", "err", err)
+						log.Error("failed to remove node from load balancer", "node", node.Name, "ip", node.Status.Addresses[x].Address, "err", err)
 					}
 				}
 			}


### PR DESCRIPTION
**Changes:**

- Logging: Refactored election.go to use structured logging and error wrapping (%w) for better trace debugging.
- BGP: Introduced a defaultBGPPort constant (179) to replace magic numbers in peer configuration.
- Cleanup: Simplified conditional logic in interfaces.go