### PR TITLE
Added route tracker

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -8,19 +8,21 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/arp"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/networkinterface"
+	"github.com/kube-vip/kube-vip/pkg/route"
 	"github.com/kube-vip/kube-vip/pkg/vip"
 )
 
 // Cluster - The Cluster object manages the state of the cluster for a particular node
 type Cluster struct {
-	stop    chan bool
-	once    sync.Once
-	Network []vip.Network
-	arpMgr  *arp.Manager
+	stop     chan bool
+	once     sync.Once
+	Network  []vip.Network
+	arpMgr   *arp.Manager
+	routeMgr *route.Manager
 }
 
 // InitCluster - Will attempt to initialise all of the required settings for the cluster
-func InitCluster(c *kubevip.Config, disableVIP bool, intfMgr *networkinterface.Manager, arpMgr *arp.Manager) (*Cluster, error) {
+func InitCluster(c *kubevip.Config, disableVIP bool, intfMgr *networkinterface.Manager, arpMgr *arp.Manager, routeMgr *route.Manager) (*Cluster, error) {
 	var networks []vip.Network
 	var err error
 
@@ -33,9 +35,10 @@ func InitCluster(c *kubevip.Config, disableVIP bool, intfMgr *networkinterface.M
 	}
 	// Initialise the Cluster structure
 	newCluster := &Cluster{
-		Network: networks,
-		arpMgr:  arpMgr,
-		stop:    make(chan bool),
+		Network:  networks,
+		arpMgr:   arpMgr,
+		stop:     make(chan bool),
+		routeMgr: routeMgr,
 	}
 
 	log.Debug("service security", "enabled", c.EnableServiceSecurity)

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -21,7 +21,6 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/loadbalancer"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 	"github.com/kube-vip/kube-vip/pkg/vip"
-	"github.com/vishvananda/netlink"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -194,11 +193,11 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 							log.Info("added backend", "ip", network.IP())
 						}
 
-						err = network.AddRoute(true)
+						err = cluster.routeMgr.Add(c.NodeName, network, true, false)
 						if err != nil && !errors.Is(err, fs.ErrExist) && !errors.Is(err, syscall.ESRCH) {
 							log.Warn(err.Error())
 						} else if err == nil && !(*backendMap)[entry] {
-							log.Info("added route", "route", network.PrepareRoute().String())
+							log.Info("added route", "route", network.PrepareRoute())
 						}
 
 						(*backendMap)[entry] = true
@@ -216,11 +215,9 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 				}
 
 				if deleteAddress {
-					err = network.DeleteRoute()
-					if err != nil && !errors.Is(err, fs.ErrNotExist) && !errors.Is(err, syscall.ESRCH) {
+					err = cluster.routeMgr.Delete(c.NodeName, network)
+					if err != nil {
 						log.Warn("deleting route", "err", err)
-					} else if err == nil {
-						log.Info("deleted route", "route", network.PrepareRoute().String())
 					}
 
 					deleted, err := network.DeleteIP()
@@ -267,7 +264,7 @@ func getNodeIPs(ctx context.Context, nodename string, client *kubernetes.Clients
 }
 
 // StartLoadBalancerService will start a VIP instance and leave it for kube-proxy to handle
-func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip.Config, bgp *bgp.Server, name string, CountRouteReferences func(*netlink.Route) int, wg *sync.WaitGroup) error {
+func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip.Config, bgp *bgp.Server, name string, wg *sync.WaitGroup) error {
 	// use a Go context so we can tell the arp loop code when we
 	// want to step down
 	//nolint
@@ -306,7 +303,7 @@ func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip
 		log.Debug("config flags", "enable_routing_table", c.EnableRoutingTable, "enable_leader_election", c.EnableLeaderElection, "enable_services_election", c.EnableServicesElection)
 
 		if c.EnableRoutingTable && (c.EnableLeaderElection || c.EnableServicesElection) {
-			err = network.AddRoute(false)
+			err = cluster.routeMgr.Add(name, network, false, false)
 			if err != nil {
 				log.Warn(err.Error())
 			} else {
@@ -365,13 +362,8 @@ func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip
 
 		if c.EnableRoutingTable {
 			for i := range cluster.Network {
-				// chek if route is not  referenced by another service
-				r := cluster.Network[i].PrepareRoute()
-				if CountRouteReferences(r) < 1 {
-					log.Info("[VIP] Deleting Route for VIP", "IP", cluster.Network[i].IP())
-					if err := cluster.Network[i].DeleteRoute(); err != nil {
-						log.Warn(err.Error())
-					}
+				if err := cluster.routeMgr.Delete(name, cluster.Network[i]); err != nil {
+					log.Warn(err.Error())
 				}
 			}
 

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/instance"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
+	"github.com/kube-vip/kube-vip/pkg/route"
 	"github.com/kube-vip/kube-vip/pkg/servicecontext"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 	"github.com/kube-vip/kube-vip/pkg/wireguard"
@@ -30,13 +31,13 @@ type Processor struct {
 }
 
 func NewEndpointProcessor(config *kubevip.Config, provider providers.Provider, bgpServer *bgp.Server,
-	instances *[]*instance.Instance, leaseMgr *lease.Manager, tunnelMgr *wireguard.TunnelManager) *Processor {
+	instances *[]*instance.Instance, leaseMgr *lease.Manager, tunnelMgr *wireguard.TunnelManager, routeMgr *route.Manager) *Processor {
 	return &Processor{
 		config:    config,
 		provider:  provider,
 		bgpServer: bgpServer,
 		instances: instances,
-		worker:    newEndpointWorker(config, provider, bgpServer, instances, leaseMgr, tunnelMgr),
+		worker:    newEndpointWorker(config, provider, bgpServer, instances, leaseMgr, tunnelMgr, routeMgr),
 	}
 }
 

--- a/pkg/endpoints/endpoints_generic.go
+++ b/pkg/endpoints/endpoints_generic.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/instance"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
+	"github.com/kube-vip/kube-vip/pkg/route"
 	"github.com/kube-vip/kube-vip/pkg/servicecontext"
 	"github.com/kube-vip/kube-vip/pkg/wireguard"
 	v1 "k8s.io/api/core/v1"
@@ -25,14 +26,15 @@ type endpointWorker interface {
 	setInstanceEndpointsStatus(service *v1.Service, endpoints []string) error
 }
 
-func newEndpointWorker(config *kubevip.Config, provider providers.Provider, bgpServer *bgp.Server, instances *[]*instance.Instance, leaseMgr *lease.Manager, tunnelMgr *wireguard.TunnelManager) endpointWorker {
+func newEndpointWorker(config *kubevip.Config, provider providers.Provider, bgpServer *bgp.Server, instances *[]*instance.Instance,
+	leaseMgr *lease.Manager, tunnelMgr *wireguard.TunnelManager, routeMgr *route.Manager) endpointWorker {
 	generic := newGeneric(config, provider, instances, leaseMgr)
 
 	if config.EnableWireguard {
 		return newWireguardWorker(config, provider, bgpServer, instances, leaseMgr, tunnelMgr)
 	}
 	if config.EnableRoutingTable {
-		return newRoutingTable(generic)
+		return newRoutingTable(generic, routeMgr)
 	}
 	if config.EnableBGP {
 		return newBGP(generic, bgpServer)

--- a/pkg/endpoints/endpoints_routing_table.go
+++ b/pkg/endpoints/endpoints_routing_table.go
@@ -2,27 +2,28 @@ package endpoints
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
-	"syscall"
 
 	log "log/slog"
 
 	"github.com/kube-vip/kube-vip/pkg/egress"
 	"github.com/kube-vip/kube-vip/pkg/instance"
+	"github.com/kube-vip/kube-vip/pkg/lease"
+	"github.com/kube-vip/kube-vip/pkg/route"
 	"github.com/kube-vip/kube-vip/pkg/servicecontext"
-	"github.com/vishvananda/netlink"
 	v1 "k8s.io/api/core/v1"
 )
 
 type RoutingTable struct {
 	generic
+	routeMgr *route.Manager
 }
 
-func newRoutingTable(generic generic) endpointWorker {
+func newRoutingTable(generic generic, routeMgr *route.Manager) endpointWorker {
 	return &RoutingTable{
-		generic: generic,
+		generic:  generic,
+		routeMgr: routeMgr,
 	}
 }
 
@@ -32,28 +33,8 @@ func (rt *RoutingTable) processInstance(ctx *servicecontext.Context, service *v1
 		for _, cluster := range instance.Clusters {
 			for i := range cluster.Network {
 				if !ctx.IsNetworkConfigured(cluster.Network[i].IP()) && cluster.Network[i].HasEndpoints() {
-					err := cluster.Network[i].AddRoute(false)
-					if err != nil {
-						if errors.Is(err, syscall.EEXIST) {
-							// If route exists, but protocol is not set (e.g. the route was created by the older version
-							// of kube-vip) try to update it if necessary
-							isUpdated, err := cluster.Network[i].UpdateRoutes()
-							if err != nil {
-								return fmt.Errorf("[%s] error updating existing routes: %w", rt.provider.GetLabel(), err)
-							}
-							if isUpdated {
-								log.Info("updated route", "provider",
-									rt.provider.GetLabel(), "ip", cluster.Network[i].IP(), "service name", service.Name, "namespace",
-									service.Namespace, "interface", cluster.Network[i].Interface(), "tableID", rt.config.RoutingTableID)
-							} else {
-								log.Info("route already present", "provider",
-									rt.provider.GetLabel(), "ip", cluster.Network[i].IP(), "service name", service.Name, "namespace",
-									service.Namespace, "interface", cluster.Network[i].Interface(), "tableID", rt.config.RoutingTableID)
-							}
-						} else {
-							// If other error occurs, return error
-							return fmt.Errorf("[%s] error adding route: %s", rt.provider.GetLabel(), err.Error())
-						}
+					if err := rt.routeMgr.Add(lease.ServiceNamespacedName(service), cluster.Network[i], false, true); err != nil {
+						return fmt.Errorf("[%s] error adding route: %s", rt.provider.GetLabel(), err.Error())
 					} else {
 						log.Info("added route", "provider",
 							rt.provider.GetLabel(), "ip", cluster.Network[i].IP(), "service name", service.Name, "namespace",
@@ -70,7 +51,7 @@ func (rt *RoutingTable) processInstance(ctx *servicecontext.Context, service *v1
 
 func (rt *RoutingTable) clear(svcCtx *servicecontext.Context, lastKnownGoodEndpoint *string, service *v1.Service) {
 	if !rt.config.EnableServicesElection && !rt.config.EnableLeaderElection {
-		if errs := ClearRoutes(service, rt.instances); len(errs) == 0 {
+		if errs := ClearRoutes(service, rt.instances, rt.routeMgr); len(errs) == 0 {
 			svcCtx.ConfiguredNetworks.Clear()
 		} else {
 			for _, err := range errs {
@@ -116,7 +97,7 @@ func (rt *RoutingTable) delete(_ context.Context, service *v1.Service, id string
 }
 
 func (rt *RoutingTable) deleteAction(service *v1.Service) {
-	ClearRoutes(service, rt.instances)
+	ClearRoutes(service, rt.instances, rt.routeMgr)
 }
 
 func (rt *RoutingTable) setInstanceEndpointsStatus(service *v1.Service, endpoints []string) error {
@@ -145,52 +126,32 @@ func (rt *RoutingTable) setInstanceEndpointsStatus(service *v1.Service, endpoint
 	return nil
 }
 
-func ClearRoutes(service *v1.Service, instances *[]*instance.Instance) []error {
+func ClearRoutes(service *v1.Service, instances *[]*instance.Instance, routeMgr *route.Manager) []error {
 	errs := []error{}
 	if svcInst := instance.FindServiceInstance(service, *instances); svcInst != nil {
-		clearErrs := ClearRoutesByInstance(service, svcInst, instances)
+		clearErrs := ClearRoutesByInstance(service, svcInst, instances, routeMgr)
 		errs = append(errs, clearErrs...)
 	}
 	return errs
 }
 
-func ClearRoutesByInstance(service *v1.Service, svcInst *instance.Instance, instances *[]*instance.Instance) []error {
+func ClearRoutesByInstance(service *v1.Service, svcInst *instance.Instance, instances *[]*instance.Instance, routeMgr *route.Manager) []error {
 	if svcInst == nil {
 		return []error{fmt.Errorf("failed to remove routes for nil instance of service %s/%s, uid: %s", service.Namespace, service.Name, service.UID)}
 	}
 	errs := []error{}
 	for _, cluster := range svcInst.Clusters {
 		for i := range cluster.Network {
-			route := cluster.Network[i].PrepareRoute()
-			// check if route we are about to delete is not referenced by more than one service
-			if CountRouteReferences(route, instances) <= 1 {
-				err := cluster.Network[i].DeleteRoute()
-				if err != nil && !errors.Is(err, syscall.ESRCH) {
-					log.Error("failed to delete route", "ip", cluster.Network[i].IP(), "err", err)
-					errs = append(errs, err)
-				}
-				log.Debug("deleted route", "ip",
-					cluster.Network[i].IP(), "service name", service.Name, "namespace", service.Namespace, "interface", cluster.Network[i].Interface())
+			err := routeMgr.Delete(lease.ServiceNamespacedName(service), cluster.Network[i])
+			if err != nil {
+				log.Error("failed to delete route", "ip", cluster.Network[i].IP(), "err", err)
+				errs = append(errs, err)
 			}
+			log.Debug("deleted route", "ip",
+				cluster.Network[i].IP(), "service name", service.Name, "namespace", service.Namespace, "interface", cluster.Network[i].Interface())
+
 		}
 	}
 
 	return errs
-}
-
-func CountRouteReferences(route *netlink.Route, instances *[]*instance.Instance) int {
-	cnt := 0
-	for _, instance := range *instances {
-		for _, cluster := range instance.Clusters {
-			for n := range cluster.Network {
-				if cluster.Network[n].HasEndpoints() {
-					r := cluster.Network[n].PrepareRoute()
-					if r.Dst.String() == route.Dst.String() {
-						cnt++
-					}
-				}
-			}
-		}
-	}
-	return cnt
 }

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/cluster"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/networkinterface"
+	"github.com/kube-vip/kube-vip/pkg/route"
 	"github.com/kube-vip/kube-vip/pkg/sysctl"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 	"github.com/kube-vip/kube-vip/pkg/vip"
@@ -60,7 +61,9 @@ type Port struct {
 	Type string
 }
 
-func NewInstance(ctx context.Context, svc *v1.Service, config *kubevip.Config, intfMgr *networkinterface.Manager, arpMgr *arp.Manager, wg *sync.WaitGroup) (*Instance, error) {
+func NewInstance(ctx context.Context, svc *v1.Service, config *kubevip.Config,
+	intfMgr *networkinterface.Manager, arpMgr *arp.Manager, routeMgr *route.Manager,
+	wg *sync.WaitGroup) (*Instance, error) {
 	instanceAddresses, instanceHostnames := FetchServiceAddresses(svc)
 	log.Info("new instance", "namespace", svc.Namespace, "service", svc.Name, "addresses", instanceAddresses, "hostnames", instanceHostnames)
 
@@ -355,7 +358,7 @@ func NewInstance(ctx context.Context, svc *v1.Service, config *kubevip.Config, i
 			}
 		}
 
-		c, err := cluster.InitCluster(instance.VIPConfigs[i], false, intfMgr, arpMgr)
+		c, err := cluster.InitCluster(instance.VIPConfigs[i], false, intfMgr, arpMgr, routeMgr)
 		if err != nil {
 			log.Error("failed to add service", "err", err)
 			return nil, err

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/networkinterface"
 	"github.com/kube-vip/kube-vip/pkg/nftables"
 	"github.com/kube-vip/kube-vip/pkg/node"
+	"github.com/kube-vip/kube-vip/pkg/route"
 	"github.com/kube-vip/kube-vip/pkg/services"
 	"github.com/kube-vip/kube-vip/pkg/upnp"
 	"github.com/kube-vip/kube-vip/pkg/utils"
@@ -87,6 +88,9 @@ type Manager struct {
 
 	// Will handle leases
 	leaseMgr *lease.Manager
+
+	// Will handle routes
+	routeMgr *route.Manager
 }
 
 // New will create a new managing object
@@ -240,9 +244,10 @@ func New(ctx context.Context, configMap string, config *kubevip.Config) (*Manage
 	}
 
 	leaseMgr := lease.NewManager()
+	routeMgr := route.NewManager()
 
 	svcProcessor := services.NewServicesProcessor(config, bgpServer, clientset, rwClientSet,
-		intfMgr, arpMgr, nodeLabelManager, electionMgr, leaseMgr)
+		intfMgr, arpMgr, nodeLabelManager, electionMgr, leaseMgr, routeMgr)
 
 	return &Manager{
 		clientSet:   clientset,
@@ -269,6 +274,7 @@ func New(ctx context.Context, configMap string, config *kubevip.Config) (*Manage
 		nodeLabelManager: nodeLabelManager,
 		electionMgr:      electionMgr,
 		leaseMgr:         leaseMgr,
+		routeMgr:         routeMgr,
 	}, nil
 }
 
@@ -337,7 +343,7 @@ func (sm *Manager) startMode(ctx context.Context) error {
 
 	w := worker.New(sm.arpMgr, sm.intfMgr, sm.config, &sm.closing, sm.Kill,
 		sm.svcProcessor, &sm.mutex, sm.clientSet, sm.bgpServer, sm.bgpSessionInfoGauge,
-		sm.electionMgr, sm.leaseMgr)
+		sm.electionMgr, sm.leaseMgr, sm.routeMgr)
 
 	// use a Go context so we can tell the leaderelection code when we
 	// want to step down

--- a/pkg/manager/worker/arp.go
+++ b/pkg/manager/worker/arp.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/networkinterface"
+	"github.com/kube-vip/kube-vip/pkg/route"
 	"github.com/kube-vip/kube-vip/pkg/services"
 	"k8s.io/client-go/kubernetes"
 )
@@ -22,10 +23,10 @@ type ARP struct {
 func NewARP(arpMgr *arp.Manager, intfMgr *networkinterface.Manager,
 	config *kubevip.Config, closing *atomic.Bool, killFunc func(),
 	svcProcessor *services.Processor, mutex *sync.Mutex, clientSet *kubernetes.Clientset,
-	electionMgr *election.Manager, leaseMgr *lease.Manager) *ARP {
+	electionMgr *election.Manager, leaseMgr *lease.Manager, routeMgr *route.Manager) *ARP {
 	return &ARP{
 		Common: *newCommon(arpMgr, intfMgr, config, closing, killFunc,
-			svcProcessor, mutex, clientSet, electionMgr, leaseMgr),
+			svcProcessor, mutex, clientSet, electionMgr, leaseMgr, routeMgr),
 	}
 }
 

--- a/pkg/manager/worker/bgp.go
+++ b/pkg/manager/worker/bgp.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/networkinterface"
+	"github.com/kube-vip/kube-vip/pkg/route"
 	"github.com/kube-vip/kube-vip/pkg/services"
 	api "github.com/osrg/gobgp/v3/api"
 
@@ -30,10 +31,10 @@ func NewBGP(arpMgr *arp.Manager, intfMgr *networkinterface.Manager,
 	config *kubevip.Config, closing *atomic.Bool, killFunc func(),
 	svcProcessor *services.Processor, mutex *sync.Mutex, clientSet *kubernetes.Clientset,
 	bgpServer *bgp.Server, bgpSessionInfoGauge *prometheus.GaugeVec,
-	electionMgr *election.Manager, leaseMgr *lease.Manager) *BGP {
+	electionMgr *election.Manager, leaseMgr *lease.Manager, routeMgr *route.Manager) *BGP {
 	return &BGP{
 		Common: *newCommon(arpMgr, intfMgr, config, closing, killFunc,
-			svcProcessor, mutex, clientSet, electionMgr, leaseMgr),
+			svcProcessor, mutex, clientSet, electionMgr, leaseMgr, routeMgr),
 		bgpServer:           bgpServer,
 		bgpSessionInfoGauge: bgpSessionInfoGauge,
 	}

--- a/pkg/manager/worker/common.go
+++ b/pkg/manager/worker/common.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/networkinterface"
+	"github.com/kube-vip/kube-vip/pkg/route"
 	"github.com/kube-vip/kube-vip/pkg/services"
 	"k8s.io/client-go/kubernetes"
 )
@@ -30,12 +31,13 @@ type Common struct {
 	clientSet    *kubernetes.Clientset
 	electionMgr  *election.Manager
 	leaseMgr     *lease.Manager
+	routeMgr     *route.Manager
 }
 
 func newCommon(arpMgr *arp.Manager, intfMgr *networkinterface.Manager,
 	config *kubevip.Config, closing *atomic.Bool, killFunc func(),
 	svcProcessor *services.Processor, mutex *sync.Mutex, clientSet *kubernetes.Clientset,
-	electionMgr *election.Manager, leaseMgr *lease.Manager) *Common {
+	electionMgr *election.Manager, leaseMgr *lease.Manager, routeMgr *route.Manager) *Common {
 	return &Common{
 		arpMgr:       arpMgr,
 		intfMgr:      intfMgr,
@@ -47,12 +49,13 @@ func newCommon(arpMgr *arp.Manager, intfMgr *networkinterface.Manager,
 		clientSet:    clientSet,
 		electionMgr:  electionMgr,
 		leaseMgr:     leaseMgr,
+		routeMgr:     routeMgr,
 	}
 }
 
 func (c *Common) InitControlPlane() error {
 	var err error
-	c.cpCluster, err = cluster.InitCluster(c.config, false, c.intfMgr, c.arpMgr)
+	c.cpCluster, err = cluster.InitCluster(c.config, false, c.intfMgr, c.arpMgr, c.routeMgr)
 	if err != nil {
 		return fmt.Errorf("cluster initialization error: %w", err)
 	}

--- a/pkg/manager/worker/table.go
+++ b/pkg/manager/worker/table.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/kube-vip/kube-vip/pkg/arp"
 	"github.com/kube-vip/kube-vip/pkg/election"
-	"github.com/kube-vip/kube-vip/pkg/endpoints"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/networkinterface"
+	"github.com/kube-vip/kube-vip/pkg/route"
 	"github.com/kube-vip/kube-vip/pkg/services"
 	"github.com/kube-vip/kube-vip/pkg/vip"
 	"github.com/vishvananda/netlink"
@@ -27,10 +27,10 @@ type Table struct {
 func NewTable(arpMgr *arp.Manager, intfMgr *networkinterface.Manager,
 	config *kubevip.Config, closing *atomic.Bool, killFUnc func(),
 	svcProcessor *services.Processor, mutex *sync.Mutex, clientSet *kubernetes.Clientset,
-	electionMgr *election.Manager, leaseMgr *lease.Manager) *Table {
+	electionMgr *election.Manager, leaseMgr *lease.Manager, routeMgr *route.Manager) *Table {
 	return &Table{
 		Common: *newCommon(arpMgr, intfMgr, config, closing, killFUnc,
-			svcProcessor, mutex, clientSet, electionMgr, leaseMgr),
+			svcProcessor, mutex, clientSet, electionMgr, leaseMgr, routeMgr),
 	}
 }
 
@@ -97,7 +97,7 @@ func (t *Table) cleanRoutes() error {
 		if t.config.EnableControlPlane {
 			found = (routes[i].Dst.IP.String() == t.config.Address)
 		} else {
-			found = endpoints.CountRouteReferences(&routes[i], &t.svcProcessor.ServiceInstances) > 0
+			found = t.routeMgr.Check(routes[i].String())
 		}
 
 		if !found {

--- a/pkg/manager/worker/wireguard.go
+++ b/pkg/manager/worker/wireguard.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/networkinterface"
 	"github.com/kube-vip/kube-vip/pkg/nftables"
+	"github.com/kube-vip/kube-vip/pkg/route"
 	"github.com/kube-vip/kube-vip/pkg/services"
 	"github.com/kube-vip/kube-vip/pkg/sysctl"
 	"github.com/kube-vip/kube-vip/pkg/utils"
@@ -38,10 +39,10 @@ type WireGuard struct {
 func NewWireGuard(arpMgr *arp.Manager, intfMgr *networkinterface.Manager,
 	config *kubevip.Config, closing *atomic.Bool, killFUnc func(),
 	svcProcessor *services.Processor, mutex *sync.Mutex, clientSet *kubernetes.Clientset,
-	electionMgr *election.Manager, leaseMgr *lease.Manager) *WireGuard {
+	electionMgr *election.Manager, leaseMgr *lease.Manager, routeMgr *route.Manager) *WireGuard {
 	return &WireGuard{
 		Common: *newCommon(arpMgr, intfMgr, config, closing, killFUnc,
-			svcProcessor, mutex, clientSet, electionMgr, leaseMgr),
+			svcProcessor, mutex, clientSet, electionMgr, leaseMgr, routeMgr),
 	}
 }
 

--- a/pkg/manager/worker/worker.go
+++ b/pkg/manager/worker/worker.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/networkinterface"
+	"github.com/kube-vip/kube-vip/pkg/route"
 	"github.com/kube-vip/kube-vip/pkg/services"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/kubernetes"
@@ -30,26 +31,26 @@ func New(arpMgr *arp.Manager, intfMgr *networkinterface.Manager,
 	config *kubevip.Config, closing *atomic.Bool, killFunc func(),
 	svcProcessor *services.Processor, mutex *sync.Mutex, clientSet *kubernetes.Clientset,
 	bgpServer *bgp.Server, bgpSessionInfoGauge *prometheus.GaugeVec,
-	electionMgr *election.Manager, leaseMgr *lease.Manager) Worker {
+	electionMgr *election.Manager, leaseMgr *lease.Manager, routeMgr *route.Manager) Worker {
 	if config.EnableARP {
 		return NewARP(arpMgr, intfMgr, config, closing, killFunc,
-			svcProcessor, mutex, clientSet, electionMgr, leaseMgr)
+			svcProcessor, mutex, clientSet, electionMgr, leaseMgr, routeMgr)
 	}
 
 	if config.EnableBGP {
 		return NewBGP(arpMgr, intfMgr, config, closing, killFunc,
 			svcProcessor, mutex, clientSet, bgpServer, bgpSessionInfoGauge,
-			electionMgr, leaseMgr)
+			electionMgr, leaseMgr, routeMgr)
 	}
 
 	if config.EnableRoutingTable {
 		return NewTable(arpMgr, intfMgr, config, closing, killFunc,
-			svcProcessor, mutex, clientSet, electionMgr, leaseMgr)
+			svcProcessor, mutex, clientSet, electionMgr, leaseMgr, routeMgr)
 	}
 
 	if config.EnableWireguard {
 		return NewWireGuard(arpMgr, intfMgr, config, closing, killFunc,
-			svcProcessor, mutex, clientSet, electionMgr, leaseMgr)
+			svcProcessor, mutex, clientSet, electionMgr, leaseMgr, routeMgr)
 	}
 
 	return nil

--- a/pkg/route/manager.go
+++ b/pkg/route/manager.go
@@ -1,0 +1,126 @@
+package route
+
+import (
+	"errors"
+	"fmt"
+	log "log/slog"
+	"sync"
+	"syscall"
+)
+
+type Manager struct {
+	tracker map[string]*item
+	mtx     sync.Mutex
+}
+
+func NewManager() *Manager {
+	return &Manager{
+		tracker: make(map[string]*item),
+	}
+}
+
+type item struct {
+	objects map[string]bool
+	route   route
+}
+
+func newItem(r route) *item {
+	return &item{
+		objects: make(map[string]bool),
+		route:   r,
+	}
+}
+
+type route interface {
+	AddRoute(bool) (bool, error)
+	UpdateRoutes() (bool, error)
+	DeleteRoute() error
+	RouteHash() string
+	Interface() string
+}
+
+// Add will add route
+func (m *Manager) Add(object string, r route, precheck, update bool) error {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	key := r.RouteHash()
+
+	itm, exists := m.tracker[key]
+
+	if !exists {
+		m.tracker[key] = newItem(r)
+		itm = m.tracker[key]
+
+		added, err := r.AddRoute(precheck)
+		if err != nil {
+			if update && errors.Is(err, syscall.EEXIST) && update {
+				// If route exists, but protocol is not set (e.g. the route was created by the older version
+				// of kube-vip) try to update it if necessary
+				isUpdated, err := r.UpdateRoutes()
+				if err != nil {
+					return fmt.Errorf("error updating existing route: %w", err)
+				}
+				if isUpdated {
+					log.Debug("[RT] updated route", "path", key, "object", object, "interface", r.Interface())
+				}
+			} else {
+				// If other error occurs, return error
+				return fmt.Errorf("error adding route %q: %w", key, err)
+			}
+		}
+
+		if added {
+			log.Debug("[RT] added route", "path", key, "object", object)
+		}
+	}
+
+	itm.objects[object] = true
+
+	log.Debug("[RT] incremented route", "path", key, "object", object, "cnt", len(itm.objects))
+
+	return nil
+}
+
+// Delete will delete route
+func (m *Manager) Delete(object string, r route) error {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	key := r.RouteHash()
+
+	itm, exists := m.tracker[key]
+	if !exists {
+		log.Debug("[RT] deleting route - nothing to delete", "path", key, "object", object)
+		return nil
+	}
+
+	delete(itm.objects, object)
+
+	log.Debug("[RT] decremented route", "path", key, "object", object, "cnt", len(itm.objects))
+
+	if len(itm.objects) == 0 {
+		if err := r.DeleteRoute(); err != nil {
+			itm.objects[object] = true
+			return fmt.Errorf("failed to delete route: %w", err)
+		}
+		delete(m.tracker, key)
+		log.Debug("[RT] deleted route", "path", key, "object", object)
+	}
+
+	return nil
+}
+
+func (m *Manager) Clear() {
+	for _, itm := range m.tracker {
+		if err := itm.route.DeleteRoute(); err != nil {
+			log.Warn("[RT] failed to delete route", "err", err.Error())
+		}
+	}
+	m.tracker = make(map[string]*item)
+}
+
+func (m *Manager) Check(key string) bool {
+	_, exists := m.tracker[key]
+	return exists
+}

--- a/pkg/route/manager_test.go
+++ b/pkg/route/manager_test.go
@@ -1,0 +1,215 @@
+package route
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_SingleAddDel(t *testing.T) {
+	t.Run("Add and delete single route", func(_ *testing.T) {
+		m := NewManager()
+		if m == nil { // nolint
+			t.Error("failed to create manager")
+		}
+
+		r := &mockRoute{hash: "123456"}
+
+		name := "test-service"
+
+		if err := m.Add(name, r, false, false); err != nil {
+			t.Errorf("add failed for route %q, object %q", r.RouteHash(), name)
+		}
+
+		expected := 1
+		if len(m.tracker) != expected { //nolint
+			t.Errorf("number of items in tracker should be %d, but is %d", expected, len(m.tracker))
+		}
+
+		item, exists := m.tracker[r.RouteHash()]
+		if !exists {
+			t.Errorf("object %q was not added to tracker for service %q", r.RouteHash(), name)
+		}
+
+		if len(item.objects) != 1 {
+			t.Errorf("number of objects for %q was %d instead of 1", name, len(item.objects))
+		}
+
+		if err := m.Delete(name, r); err != nil {
+			t.Errorf("deletion of object %q failed for service %q", r.RouteHash(), name)
+		}
+
+		expected = 0
+		if len(m.tracker) != expected {
+			t.Errorf("number of items in tracker should be %d, but is %d", expected, len(m.tracker))
+		}
+	})
+}
+
+func Test_MultipleAddDel(t *testing.T) {
+	t.Run("Add and delete same route multiple times", func(_ *testing.T) {
+		m := NewManager()
+		if m == nil {
+			t.Error("failed to create manager")
+		}
+
+		r := &mockRoute{hash: "123456"}
+
+		numOfServices := 50
+		expectedRoutes := 1
+
+		for i := range numOfServices {
+			name := fmt.Sprintf("test-service-%d", i)
+
+			if err := m.Add(name, r, false, false); err != nil {
+				t.Errorf("add failed for route %q, object %q", r.RouteHash(), name)
+			}
+
+			if len(m.tracker) != expectedRoutes {
+				t.Errorf("number of routes in tracker should be %d, but is %d", expectedRoutes, len(m.tracker))
+			}
+
+			item, exists := m.tracker[r.RouteHash()]
+			if !exists {
+				t.Errorf("route %q was not added to the tracker", r.RouteHash())
+			}
+
+			expected := i + 1
+			if len(item.objects) != expected {
+				t.Errorf("number of objects for %q was %d instead of 1", name, len(item.objects))
+			}
+		}
+
+		for i := range numOfServices {
+			name := fmt.Sprintf("test-service-%d", i)
+
+			if err := m.Delete(name, r); err != nil {
+				t.Errorf("delete failed for route %q, object %q", r.RouteHash(), name)
+			}
+
+			if i == numOfServices-1 {
+				expectedRoutes = 0
+			}
+
+			if len(m.tracker) != expectedRoutes {
+				t.Errorf("number of routes in tracker should be %d, but is %d", expectedRoutes, len(m.tracker))
+			}
+
+			exists := m.Check(r.RouteHash())
+			if i < numOfServices-1 {
+				if !exists {
+					t.Errorf("route %q was not added to the tracker", r.RouteHash())
+				}
+			} else {
+				if exists {
+					t.Errorf("route %q was not deleted from the tracker", r.RouteHash())
+				}
+			}
+		}
+	})
+}
+
+func Test_MultipleRoutesAddDel(t *testing.T) {
+	t.Run("Add and delete multiple routes multiple times", func(_ *testing.T) {
+		m := NewManager()
+		if m == nil {
+			t.Error("failed to create manager")
+		}
+
+		routes := []*mockRoute{}
+
+		numOfRoutes := 20
+		hashBase := 123456
+
+		for i := range numOfRoutes {
+			routes = append(routes, &mockRoute{hash: fmt.Sprintf("%d%d", hashBase, i)})
+		}
+
+		numOfServices := 50
+
+		for rtCnt, r := range routes {
+			for i := range numOfServices {
+
+				expectedRoutes := rtCnt + 1
+				name := fmt.Sprintf("test-service-%d", i)
+
+				if err := m.Add(name, r, false, false); err != nil {
+					t.Errorf("add failed for route %q, object %q", r.RouteHash(), name)
+				}
+
+				if len(m.tracker) != expectedRoutes {
+					t.Errorf("number of routes in tracker should be %d, but is %d", expectedRoutes, len(m.tracker))
+				}
+
+				item, exists := m.tracker[r.RouteHash()]
+				if !exists {
+					t.Errorf("route %q was not added to the tracker", r.RouteHash())
+				}
+
+				expected := i + 1
+				if len(item.objects) != expected {
+					t.Errorf("number of objects for %q was %d instead of 1", name, len(item.objects))
+				}
+			}
+		}
+
+		for rtCnt, r := range routes {
+			for i := range numOfServices {
+				name := fmt.Sprintf("test-service-%d", i)
+
+				if err := m.Delete(name, r); err != nil {
+					t.Errorf("delete failed for route %q, object %q", r.RouteHash(), name)
+				}
+
+				expectedRoutes := numOfRoutes - rtCnt
+				if i == numOfServices-1 {
+					expectedRoutes -= 1
+				}
+
+				if len(m.tracker) != expectedRoutes {
+					t.Errorf("number of routes in tracker should be %d, but is %d", expectedRoutes, len(m.tracker))
+				}
+
+				exists := m.Check(r.RouteHash())
+				if i < numOfServices-1 {
+					if !exists {
+						t.Errorf("route %q should not be deleted", r.RouteHash())
+					}
+				} else {
+					if exists {
+						t.Errorf("route %q was not deleted from the tracker", r.RouteHash())
+					}
+				}
+			}
+		}
+	})
+}
+
+type mockRoute struct {
+	added     bool
+	addErr    error
+	updated   bool
+	updateErr error
+	delErr    error
+	hash      string
+	intf      string
+}
+
+func (mr *mockRoute) AddRoute(_ bool) (bool, error) {
+	return mr.added, mr.addErr
+}
+
+func (mr *mockRoute) UpdateRoutes() (bool, error) {
+	return mr.updated, mr.updateErr
+}
+
+func (mr *mockRoute) DeleteRoute() error {
+	return mr.delErr
+}
+
+func (mr *mockRoute) RouteHash() string {
+	return mr.hash
+}
+
+func (mr *mockRoute) Interface() string {
+	return mr.intf
+}

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -21,13 +21,7 @@ func (p *Processor) StartServicesWatchForLeaderElection(ctx context.Context) err
 	}
 
 	if p.config.EnableRoutingTable {
-		for _, instance := range p.ServiceInstances {
-			for _, cluster := range instance.Clusters {
-				for i := range cluster.Network {
-					_ = cluster.Network[i].DeleteRoute()
-				}
-			}
-		}
+		p.routeMgr.Clear()
 	}
 
 	log.Info("Shutting down kube-Vip")

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -17,12 +17,12 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/networkinterface"
+	"github.com/kube-vip/kube-vip/pkg/route"
 	"github.com/kube-vip/kube-vip/pkg/servicecontext"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 	"github.com/kube-vip/kube-vip/pkg/vip"
 	"github.com/kube-vip/kube-vip/pkg/wireguard"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/vishvananda/netlink"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
@@ -59,6 +59,8 @@ type Processor struct {
 
 	// TunnelMgr manages multiple WireGuard tunnels (one per service VIP)
 	TunnelMgr *wireguard.TunnelManager
+
+	routeMgr *route.Manager
 }
 
 // labelManager is the interface for the node label manager to add/remove labels
@@ -70,7 +72,7 @@ type labelManager interface {
 func NewServicesProcessor(config *kubevip.Config, bgpServer *bgp.Server,
 	clientSet *kubernetes.Clientset, rwClientSet *kubernetes.Clientset,
 	intfMgr *networkinterface.Manager, arpMgr *arp.Manager, nodeLabelManager labelManager,
-	electionMgr *election.Manager, leaseMgr *lease.Manager) *Processor {
+	electionMgr *election.Manager, leaseMgr *lease.Manager, routeMgr *route.Manager) *Processor {
 	lbClassFilterFunc := lbClassFilter
 	if config.LoadBalancerClassLegacyHandling {
 		lbClassFilterFunc = lbClassFilterLegacy
@@ -96,6 +98,7 @@ func NewServicesProcessor(config *kubevip.Config, bgpServer *bgp.Server,
 		nodeLabelManager: nodeLabelManager,
 		electionMgr:      electionMgr,
 		TunnelMgr:        wireguard.NewTunnelManager(),
+		routeMgr:         routeMgr,
 	}
 }
 
@@ -131,7 +134,7 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 	svcInstance := instance.FindServiceInstance(svc, p.ServiceInstances)
 	var err error
 	if svcInstance == nil {
-		svcInstance, err = instance.NewInstance(ctx, svc, p.config, p.intfMgr, p.arpMgr, wg)
+		svcInstance, err = instance.NewInstance(ctx, svc, p.config, p.intfMgr, p.arpMgr, p.routeMgr, wg)
 		if err != nil {
 			return fmt.Errorf("unalbe to create instance for service %s/%s", svc.Namespace, svc.Name)
 		}
@@ -395,7 +398,7 @@ func (p *Processor) Delete(event watch.Event) error {
 		// If no leader election is enabled, delete routes here
 		if !p.config.EnableLeaderElection && !p.config.EnableServicesElection &&
 			p.config.EnableRoutingTable && svcCtx.HasConfiguredNetworks() {
-			if errs := endpoints.ClearRoutes(svc, &p.ServiceInstances); len(errs) == 0 {
+			if errs := endpoints.ClearRoutes(svc, &p.ServiceInstances, p.routeMgr); len(errs) == 0 {
 				svcCtx.ConfiguredNetworks.Clear()
 			}
 		}
@@ -440,8 +443,4 @@ func (p *Processor) getServiceContext(uid types.UID) (*servicecontext.Context, e
 		return nil, fmt.Errorf("failed to cast service context pointer - UID: %s", uid)
 	}
 	return ctx, nil
-}
-
-func (p *Processor) CountRouteReferences(route *netlink.Route) int {
-	return endpoints.CountRouteReferences(route, &p.ServiceInstances)
 }

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -164,7 +164,7 @@ func (p *Processor) addService(ctx context.Context, newService *instance.Instanc
 
 	var err error
 	if newService == nil {
-		newService, err = instance.NewInstance(ctx, svc, p.config, p.intfMgr, p.arpMgr, wg)
+		newService, err = instance.NewInstance(ctx, svc, p.config, p.intfMgr, p.arpMgr, p.routeMgr, wg)
 		if err != nil {
 			return err
 		}
@@ -174,7 +174,7 @@ func (p *Processor) addService(ctx context.Context, newService *instance.Instanc
 
 	for x := range newService.VIPConfigs {
 		log.Debug("starting loadbalancer for service", "name", svc.Name, "namespace", svc.Namespace, "uid", svc.UID)
-		if err := newService.Clusters[x].StartLoadBalancerService(ctx, newService.VIPConfigs[x], p.bgpServer, lease.ServiceNamespacedName(svc), p.CountRouteReferences, wg); err != nil {
+		if err := newService.Clusters[x].StartLoadBalancerService(ctx, newService.VIPConfigs[x], p.bgpServer, lease.ServiceNamespacedName(svc), wg); err != nil {
 			return fmt.Errorf("failed to start lb: %w", err)
 		}
 	}
@@ -395,6 +395,14 @@ func (p *Processor) deleteService(ctx context.Context, uid types.UID) error {
 		endpoints.ClearBGPHostsByInstance(ctx, serviceInstance, p.bgpServer)
 	}
 
+	if p.config.EnableRoutingTable && (p.config.EnableLeaderElection || p.config.EnableServicesElection) {
+		if errs := endpoints.ClearRoutesByInstance(serviceInstance.ServiceSnapshot, serviceInstance, &p.ServiceInstances, p.routeMgr); len(errs) > 0 {
+			for _, err := range errs {
+				log.Error("unable to clear routes", "err", err)
+			}
+		}
+	}
+
 	if !shared {
 		for x := range serviceInstance.Clusters {
 			serviceInstance.Clusters[x].Stop()
@@ -416,14 +424,6 @@ func (p *Processor) deleteService(ctx context.Context, uid types.UID) error {
 			err = netlink.LinkDel(macvlan)
 			if err != nil {
 				return fmt.Errorf("[service] error deleting DHCP Link : %v", err)
-			}
-		}
-
-		if p.config.EnableRoutingTable && (p.config.EnableLeaderElection || p.config.EnableServicesElection) {
-			if errs := endpoints.ClearRoutesByInstance(serviceInstance.ServiceSnapshot, serviceInstance, &p.ServiceInstances); len(errs) > 0 {
-				for _, err := range errs {
-					log.Error("unable to clear routes", "err", err)
-				}
 			}
 		}
 

--- a/pkg/services/watch_endpoints.go
+++ b/pkg/services/watch_endpoints.go
@@ -37,7 +37,7 @@ func (p *Processor) watchEndpoint(svcCtx *servicecontext.Context, id string, ser
 
 	ch := rw.ResultChan()
 
-	epProcessor := endpoints.NewEndpointProcessor(p.config, provider, p.bgpServer, &p.ServiceInstances, p.leaseMgr, p.TunnelMgr)
+	epProcessor := endpoints.NewEndpointProcessor(p.config, provider, p.bgpServer, &p.ServiceInstances, p.leaseMgr, p.TunnelMgr, p.routeMgr)
 
 	var lastKnownGoodEndpoint string
 	for event := range ch {

--- a/pkg/vip/address.go
+++ b/pkg/vip/address.go
@@ -2,6 +2,7 @@ package vip
 
 import (
 	"fmt"
+	"hash/fnv"
 	"math"
 	"net"
 	"slices"
@@ -38,7 +39,7 @@ const (
 // Network is an interface that enable managing operations for a given IP
 type Network interface {
 	AddIP(precheck bool, skipDAD bool, minLifetime ...int) (bool, error)
-	AddRoute(precheck bool) error
+	AddRoute(precheck bool) (bool, error)
 	DeleteIP() (bool, error)
 	DeleteRoute() error
 	UpdateRoutes() (bool, error)
@@ -47,6 +48,7 @@ type Network interface {
 	CIDR() string
 	IPisLinkLocal() bool
 	PrepareRoute() *netlink.Route
+	RouteHash() string
 	SetIP(ip string) error
 	SetServicePorts(service *v1.Service)
 	Interface() string
@@ -284,8 +286,16 @@ func (configurator *network) PrepareRoute() *netlink.Route {
 	return route
 }
 
+func (configurator *network) RouteHash() string {
+	r := configurator.PrepareRoute()
+	h := fnv.New32a()
+	h.Write([]byte(r.String()))
+
+	return strconv.FormatUint(uint64(h.Sum32()), 16)
+}
+
 // AddRoute - Add an IP address to a route table
-func (configurator *network) AddRoute(precheck bool) error {
+func (configurator *network) AddRoute(precheck bool) (bool, error) {
 	configurator.link.Lock.Lock()
 	defer configurator.link.Lock.Unlock()
 	route := configurator.PrepareRoute()
@@ -295,17 +305,18 @@ func (configurator *network) AddRoute(precheck bool) error {
 	if precheck {
 		exists, err = configurator.routeExists(route)
 		if err != nil {
-			return errors.Wrap(err, "failed to check route")
+			return false, errors.Wrap(err, "failed to check route")
 		}
 	}
 
 	if !exists {
 		if err := netlink.RouteAdd(route); err != nil {
-			return errors.Wrap(err, "failed to add route")
+			return false, errors.Wrap(err, "failed to add route")
 		}
+		return true, nil
 	}
 
-	return nil
+	return false, nil
 }
 
 func (configurator *network) routeExists(route *netlink.Route) (bool, error) {


### PR DESCRIPTION
This is a continuation of #1518 

It adds similar tracking object as it was implemented for BGP and ARP. This way routes can be deleted without tracking separately if they are shared (all the logic is contained within the `route.Manager`).