### PR TITLE
Added missing mutex lock in ARP manager

### DIFF
--- a/pkg/arp/arp.go
+++ b/pkg/arp/arp.go
@@ -84,9 +84,8 @@ func (m *Manager) RemoveWithIPDelete(instance *Instance, deleteIP bool) {
 	if i != nil {
 		i.mu.Lock()
 		defer i.mu.Unlock()
-		if i.counter > 1 {
-			i.counter--
-		} else {
+		i.counter--
+		if i.counter == 0 {
 			log.Info("[ARP manager] removing ARP/NDP instance", "name", instance.Name())
 			if deleteIP {
 				if _, err := instance.network.DeleteIP(); err != nil {
@@ -127,6 +126,8 @@ func (m *Manager) StartAdvertisement(ctx context.Context) {
 		case <-ticker.C: // send gratuitous ARP/NDP on each tick
 			m.instances.Range(func(_ any, instance any) bool {
 				if i, ok := instance.(*Instance); ok {
+					i.mu.Lock()
+					defer i.mu.Unlock()
 					if i.counter > 0 {
 						ensureIPAndSendGratuitous(i)
 					} else {


### PR DESCRIPTION
While doing other work I have encountered an error in ARP code. When leadership for service is lost, the VIP should be deleted, but with a bit of bad timing it is deleted, but re-applied by the ARP manager.

```
// leadership lost

2026/04/29 13:07:40 INFO leadership lost service=test-svc-0 uid=d68427d9-ab1a-4c3c-8f0d-24a18897de56 leader=kube-vip-test2989490769-ipdual-ds-control-plane
2026/04/29 13:07:40 DEBUG deleting service due to lost leadership uid=d68427d9-ab1a-4c3c-8f0d-24a18897de56
2026/04/29 13:07:40 DEBUG [service] lookup "target UID"=d68427d9-ab1a-4c3c-8f0d-24a18897de56 "found UID"=d68427d9-ab1a-4c3c-8f0d-24a18897de56 name=test-svc-0 namespace=default
2026/04/29 13:07:40 DEBUG setting HasEndpoints ip=172.19.255.201 value=false
2026/04/29 13:07:40 DEBUG setting HasEndpoints ip=fc00:6ed4:1c72:ef4b:ffff:ffff:ffff:ffc9 value=false
2026/04/29 13:07:40 INFO Removed instance from manager uid=d68427d9-ab1a-4c3c-8f0d-24a18897de56 name=test-svc-0 "remaining advertised services"=0
2026/04/29 13:07:40 INFO stopping leader election service=test-svc-0 uid=d68427d9-ab1a-4c3c-8f0d-24a18897de56
2026/04/29 13:07:40 DEBUG ending layer 2 update ip=fc00:6ed4:1c72:ef4b:ffff:ffff:ffff:ffc9 interface=eth0 ms=3000

// instance should be removed from the manager and VIP should be deleted

2026/04/29 13:07:40 INFO [ARP manager] removing ARP/NDP instance name=fc00:6ed4:1c72:ef4b:ffff:ffff:ffff:ffc9/128-eth0
2026/04/29 13:07:40 DEBUG ending layer 2 update ip=172.19.255.201 interface=eth0 ms=3000
2026/04/29 13:07:40 INFO [ARP manager] removing ARP/NDP instance name=172.19.255.201/32-eth0
2026/04/29 13:07:40 INFO [LOADBALANCER] Stopping load balancers name=default/test-svc-0
2026/04/29 13:07:40 INFO [VIP] Deleting VIP ip=fc00:6ed4:1c72:ef4b:ffff:ffff:ffff:ffc9
2026/04/29 13:07:40 INFO [LOADBALANCER] Stopping load balancers name=default/test-svc-0
2026/04/29 13:07:40 INFO [VIP] Deleting VIP ip=172.19.255.201

//  due to bad timing the VIP is re-applied here and NDP is  still being broadcasted

2026/04/29 13:07:40 DEBUG replacing IP address=fc00:6ed4:1c72:ef4b:ffff:ffff:ffff:ffc9/128
2026/04/29 13:07:40 WARN Re-applied the VIP configuration ip=fc00:6ed4:1c72:ef4b:ffff:ffff:ffff:ffc9 interface=eth0
2026/04/29 13:07:40 INFO Broadcasting NDP update ip=fc00:6ed4:1c72:ef4b:ffff:ffff:ffff:ffc9 hwaddr="\xe2\xbd\x0f\xaf7h" interface=eth0
```

I think that a mutex lock call is missed for the instance counter, so the VIP is being deleted, but the ARP loop reads the counter's pre-deletion value, and still executes `ensureIPAndSendGratuitous` for the instance.