### PR TITLE
Use golangci/golangci-lint-action in the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,10 @@ jobs:
       - name: Init
         run: sudo apt-get update && sudo apt-get install -y build-essential &&  sudo sysctl fs.inotify.max_user_instances=8192 &&  sudo sysctl fs.inotify.max_user_watches=524288
       - name: Install golangci-lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.7.2
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12
+          install-only: true
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Install Go

--- a/pkg/manager/watcher_test.go
+++ b/pkg/manager/watcher_test.go
@@ -44,12 +44,12 @@ func TestParseBgpAnnotations(t *testing.T) {
 	assert.EqualValues(t, 15, bgpConfig.HoldTime, "base bgpConfig.HoldTime should not be overwritten")
 	assert.EqualValues(t, 5, bgpConfig.KeepaliveInterval, "base bgpConfig.KeepaliveInterval should not be overwritten")
 
-	node.Annotations = map[string]string{
+	node.Annotations = map[string]string{ //nolint:gosec
 		"bgp/node-asn":       "65000",
 		"bgp/peer-asn":       "64000",
 		"bgp/src-ip":         "10.0.0.254",
 		"bgp/peer-ip":        "10.0.0.1,10.0.0.2,10.0.0.3",
-		"bgp/bgp-pass":       "cGFzc3dvcmQ=", // password
+		"bgp/bgp-pass":       "cGFzc3dvcmQ=", // dummy password for the test, gosec linter disabled
 		"bgp/peer-multi-hop": "true",
 	}
 
@@ -90,12 +90,12 @@ func TestParseNewBgpAnnotations(t *testing.T) {
 		t.Fatal("Parsing BGP annotations should return an error when no annotations exist")
 	}
 
-	node.Annotations = map[string]string{
+	node.Annotations = map[string]string{ //nolint:gosec
 		"bgp/bgp-peers-0-node-asn": "65000",
 		"bgp/bgp-peers-0-peer-asn": "64000",
 		"bgp/bgp-peers-0-peer-ip":  "10.0.0.1,10.0.0.2,10.0.0.3",
 		"bgp/bgp-peers-0-src-ip":   "10.0.0.254",
-		"bgp/bgp-peers-0-bgp-pass": "cGFzc3dvcmQ=", // password
+		"bgp/bgp-peers-0-bgp-pass": "cGFzc3dvcmQ=", // dummy password for the test, gosec linter disabled
 	}
 
 	bgpConfig, bgpPeer, err := parseBgpAnnotations(bgpConfigBase, node, "bgp")

--- a/pkg/servicecontext/servicecontext.go
+++ b/pkg/servicecontext/servicecontext.go
@@ -20,7 +20,8 @@ type Context struct {
 }
 
 func New(ctx context.Context) *Context {
-	svcCtx, svcCancel := context.WithCancel(ctx)
+	// context and cancel stored for a future use, gosec linter disabled
+	svcCtx, svcCancel := context.WithCancel(ctx) //nolint:gosec
 	return &Context{
 		Ctx:    svcCtx,
 		Cancel: svcCancel,

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -828,19 +828,26 @@ func isUPNPEnabled(s *v1.Service) bool {
 // Refresh UPNP Port Forwards for all Service Instances registered in the processor
 func (p *Processor) RefreshUPNPForwards(ctx context.Context) {
 	log.Info("Starting UPNP Port Refresher")
+
+	ticker := time.NewTicker(300 * time.Second)
+	defer ticker.Stop()
+
 	for {
-		time.Sleep(300 * time.Second)
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// Skip logging if no service instances
+			if len(p.ServiceInstances) == 0 {
+				continue
+			}
 
-		// Skip logging if no service instances
-		if len(p.ServiceInstances) == 0 {
-			continue
-		}
-
-		log.Info("[UPNP] Refreshing Instances", "number of instances", len(p.ServiceInstances))
-		for i := range p.ServiceInstances {
-			p.upnpMap(ctx, p.ServiceInstances[i])
-			if err := p.updateStatus(ctx, p.ServiceInstances[i]); err != nil {
-				log.Warn("[UPNP] Error updating service", "ip", p.ServiceInstances[i].ServiceSnapshot.Name, "err", err)
+			log.Info("[UPNP] Refreshing Instances", "number of instances", len(p.ServiceInstances))
+			for i := range p.ServiceInstances {
+				p.upnpMap(ctx, p.ServiceInstances[i])
+				if err := p.updateStatus(ctx, p.ServiceInstances[i]); err != nil {
+					log.Warn("[UPNP] Error updating service", "ip", p.ServiceInstances[i].ServiceSnapshot.Name, "err", err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR updates golangci-lint version in the CI to `v2.12`, and changes the way it is being installed from the script to the official golangci-lint's github action - https://github.com/golangci/golangci-lint-action

Additionally fixed linter issues reported by a new version of the tool.

This should fix issues with dependabot's PRs #1530 and #1531 

