### PR TITLE
Configuration of the deprecated endpoints in the tests fixed

### DIFF
--- a/testing/e2e/cluster.go
+++ b/testing/e2e/cluster.go
@@ -76,8 +76,8 @@ func CreateCluster(ctx context.Context, spec *ClusterSpec) *Cluster {
 	if spec.KubeVip.EnableNodeLabeling == "" {
 		spec.KubeVip.EnableNodeLabeling = "false"
 	}
-	if spec.KubeVip.EnableEndpointslices == "" {
-		spec.KubeVip.EnableEndpointslices = "false"
+	if spec.KubeVip.EnableEndpoints == "" {
+		spec.KubeVip.EnableEndpoints = "true"
 	}
 
 	// Render kube-vip manifest
@@ -115,7 +115,7 @@ func CreateCluster(ctx context.Context, spec *ClusterSpec) *Cluster {
 	// Build Kind cluster config
 	k8sImage := os.Getenv("K8S_IMAGE_PATH")
 	clusterConfig := kindconfigv1alpha4.Cluster{
-		Networking:                    spec.Networking,
+		Networking:                   spec.Networking,
 		KubeadmConfigPatchesJSON6902: spec.KubeadmPatches,
 	}
 	for i := range spec.Nodes {

--- a/testing/e2e/e2e_bgp_ds_test.go
+++ b/testing/e2e/e2e_bgp_ds_test.go
@@ -90,17 +90,17 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when only control plane is enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "true",
-					VipElectionEnable:    "false",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "false",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
-					BGPPeers:             "127.0.0.1:1::false",
-					BGPAS:                2,
+					Mode:               Mode,
+					ControlPlaneEnable: "true",
+					VipElectionEnable:  "false",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "false",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
+					BGPPeers:           "127.0.0.1:1::false",
+					BGPAS:              2,
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -108,17 +108,17 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when only control plane is enabled with leader election", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "true",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "false",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
-					BGPPeers:             "127.0.0.1:1::false",
-					BGPAS:                2,
+					Mode:               Mode,
+					ControlPlaneEnable: "true",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "false",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
+					BGPPeers:           "127.0.0.1:1::false",
+					BGPAS:              2,
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -126,17 +126,17 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when only services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "false",
-					VipElectionEnable:    "false",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
-					BGPPeers:             "127.0.0.1:1::false",
-					BGPAS:                2,
+					Mode:               Mode,
+					ControlPlaneEnable: "false",
+					VipElectionEnable:  "false",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
+					BGPPeers:           "127.0.0.1:1::false",
+					BGPAS:              2,
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -144,17 +144,17 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when only services are enabled with leader election", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "false",
-					VipElectionEnable:    "false",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
-					BGPPeers:             "127.0.0.1:1::false",
-					BGPAS:                2,
+					Mode:               Mode,
+					ControlPlaneEnable: "false",
+					VipElectionEnable:  "false",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
+					BGPPeers:           "127.0.0.1:1::false",
+					BGPAS:              2,
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -162,17 +162,17 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when control plane services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "true",
-					VipElectionEnable:    "false",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
-					BGPPeers:             "127.0.0.1:1::false",
-					BGPAS:                2,
+					Mode:               Mode,
+					ControlPlaneEnable: "true",
+					VipElectionEnable:  "false",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
+					BGPPeers:           "127.0.0.1:1::false",
+					BGPAS:              2,
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -180,17 +180,17 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when control plane w/ leader election and services w/o leader election are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "true",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
-					BGPPeers:             "127.0.0.1:1::false",
-					BGPAS:                2,
+					Mode:               Mode,
+					ControlPlaneEnable: "true",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
+					BGPPeers:           "127.0.0.1:1::false",
+					BGPAS:              2,
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -198,17 +198,17 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when control plane w/o leader election and services w/ leader election are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "true",
-					VipElectionEnable:    "false",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
-					BGPPeers:             "127.0.0.1:1::false",
-					BGPAS:                2,
+					Mode:               Mode,
+					ControlPlaneEnable: "true",
+					VipElectionEnable:  "false",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
+					BGPPeers:           "127.0.0.1:1::false",
+					BGPAS:              2,
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -216,17 +216,17 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when control plane and services w/ leader election are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "true",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
-					BGPPeers:             "127.0.0.1:1::false",
-					BGPAS:                2,
+					Mode:               Mode,
+					ControlPlaneEnable: "true",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
+					BGPPeers:           "127.0.0.1:1::false",
+					BGPAS:              2,
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -267,17 +267,17 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when unnumbered BGP peers are configured", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "true",
-					VipElectionEnable:    "false",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
-					BGPPeers:             "unnumbered:eth0",
-					BGPAS:                2,
+					Mode:               Mode,
+					ControlPlaneEnable: "true",
+					VipElectionEnable:  "false",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
+					BGPPeers:           "unnumbered:eth0",
+					BGPAS:              2,
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv6Family, clusterName)

--- a/testing/e2e/e2e_ds_test.go
+++ b/testing/e2e/e2e_ds_test.go
@@ -98,15 +98,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv4 addresses on exit when only control plane is enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "true",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "false",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "true",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "false",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -114,15 +114,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv4 addresses on exit when only services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "false",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "false",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -130,15 +130,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv4 addresses on exit when only services with per-service leaderelection are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "false",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "false",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -146,15 +146,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv4 addresses on exit when control-plane and services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "true",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "true",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -162,15 +162,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv4 addresses on exit when control plane and services with per-service leaderelection are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "true",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "true",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -178,15 +178,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" is able to pick up leaderelection when all endpoints for the service were deleted", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "false",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "false",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testEndpoints(ctx, manifestValues, client, utils.IPv4Family, clusterName, corev1.ServiceExternalTrafficPolicyLocal)
@@ -226,15 +226,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv6 addresses on exit when only control plane is enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "true",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "false",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "true",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "false",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv6Family, clusterName)
@@ -242,15 +242,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv6 addresses on exit when only services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "false",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "false",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv6Family, clusterName)
@@ -258,15 +258,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv6 addresses on exit when only services with per-service leaderelection are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "false",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "false",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv6Family, clusterName)
@@ -274,15 +274,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv6 addresses on exit when control-plane and services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "true",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "true",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv6Family, clusterName)
@@ -290,15 +290,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv6 addresses on exit when control plane and services with per-service leaderelection are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "true",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "true",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv6Family, clusterName)
@@ -306,15 +306,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" is able to pick up leaderelection when all endpoints for the service were deleted", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "false",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "false",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testEndpoints(ctx, manifestValues, client, utils.IPv6Family, clusterName, corev1.ServiceExternalTrafficPolicyLocal)
@@ -354,15 +354,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all addresses on exit when only control plane is enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "true",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "false",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "true",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "false",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.DualFamily, clusterName)
@@ -370,15 +370,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all addresses on exit when only services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "false",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "false",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.DualFamily, clusterName)
@@ -386,15 +386,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all addresses on exit when only services with per-service leaderelection are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "false",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "false",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.DualFamily, clusterName)
@@ -402,15 +402,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all addresses on exit when control-plane and services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "true",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "true",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.DualFamily, clusterName)
@@ -418,15 +418,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all addresses on exit when control plane and services with per-service leaderelection are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "true",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "true",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.DualFamily, clusterName)
@@ -434,15 +434,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" is able to pick up leaderelection when all endpoints for the service were deleted", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "false",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "false",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testEndpoints(ctx, manifestValues, client, utils.DualFamily, clusterName, corev1.ServiceExternalTrafficPolicyLocal)
@@ -793,8 +793,8 @@ func createKubeVipDS(ctx context.Context, name, namespace string, manifestValues
 									Value: manifestValues.EnableNodeLabeling,
 								},
 								{
-									Name:  "enable_endpointslices",
-									Value: manifestValues.EnableEndpointslices,
+									Name:  "enable_endpoints",
+									Value: manifestValues.EnableEndpoints,
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{

--- a/testing/e2e/e2e_rt_ds_test.go
+++ b/testing/e2e/e2e_rt_ds_test.go
@@ -91,15 +91,15 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 
 			It(clusterName+" exits gracefully on exit when only control plane is enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "true",
-					VipElectionEnable:    "false",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "false",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "true",
+					VipElectionEnable:  "false",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "false",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -107,15 +107,15 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 
 			It(clusterName+" exits gracefully on exit when only services are enabled without leaderelection", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "false",
-					VipElectionEnable:    "false",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "false",
+					VipElectionEnable:  "false",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -123,15 +123,15 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 
 			It(clusterName+" exits gracefully on exit when only services are enabled with leaderelection", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "false",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "false",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -139,15 +139,15 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 
 			It(clusterName+" exits gracefully on exit when only services are enabled with leaderelection per service", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "false",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "false",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -155,15 +155,15 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 
 			It(clusterName+" exits gracefully on exit when control-plane and services are enabled without leaderelection", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "true",
-					VipElectionEnable:    "false",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "true",
+					VipElectionEnable:  "false",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -171,15 +171,15 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 
 			It(clusterName+" exits gracefully on exit when control-plane and services are enabled with leaderelection", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "true",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "true",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -187,15 +187,15 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 
 			It(clusterName+" exits gracefully when control-plane and services are enabled with leaderelection per service", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                 Mode,
-					ControlPlaneEnable:   "true",
-					VipElectionEnable:    "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					Mode:               Mode,
+					ControlPlaneEnable: "true",
+					VipElectionEnable:  "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)

--- a/testing/e2e/e2e_rt_test.go
+++ b/testing/e2e/e2e_rt_test.go
@@ -509,13 +509,13 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				manifestValues = &e2e.KubevipManifestValues{
-					ControlPlaneVIP:      cpVIP,
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					ControlPlaneEnable:   "false",
-					SvcEnable:            "true",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
+					ControlPlaneVIP:    cpVIP,
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					ControlPlaneEnable: "false",
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
 				}
 
 				var err error
@@ -582,13 +582,13 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				manifestValues = &e2e.KubevipManifestValues{
-					ControlPlaneVIP:      cpVIP,
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					ControlPlaneEnable:   "false",
-					SvcEnable:            "true",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
+					ControlPlaneVIP:    cpVIP,
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					ControlPlaneEnable: "false",
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
 				}
 
 				var err error
@@ -811,13 +811,13 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				manifestValues = &e2e.KubevipManifestValues{
-					ControlPlaneVIP:      cpVIP,
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					ControlPlaneEnable:   "false",
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "true",
+					ControlPlaneVIP:    cpVIP,
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					ControlPlaneEnable: "false",
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "false",
 				}
 
 				var err error
@@ -893,13 +893,13 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				manifestValues = &e2e.KubevipManifestValues{
-					ControlPlaneVIP:      cpVIP,
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					ControlPlaneEnable:   "false",
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "true",
+					ControlPlaneVIP:    cpVIP,
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					ControlPlaneEnable: "false",
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "false",
 				}
 
 				var err error

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -129,14 +129,14 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:      cpVIP,
-					ControlPlaneEnable:   "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "false",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "false",
-					EnableNodeLabeling:   "false",
+					ControlPlaneVIP:    cpVIP,
+					ControlPlaneEnable: "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "false",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "true",
+					EnableNodeLabeling: "false",
 				}
 
 				var err error
@@ -176,14 +176,14 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:      cpVIP,
-					ControlPlaneEnable:   "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "false",
-					EnableNodeLabeling:   "false",
+					ControlPlaneVIP:    cpVIP,
+					ControlPlaneEnable: "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "true",
+					EnableNodeLabeling: "false",
 				}
 
 				var err error
@@ -237,14 +237,14 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:      cpVIP,
-					ControlPlaneEnable:   "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "false",
-					EnableNodeLabeling:   "false",
+					ControlPlaneVIP:    cpVIP,
+					ControlPlaneEnable: "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "true",
+					EnableNodeLabeling: "false",
 				}
 
 				var err error
@@ -290,14 +290,14 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:      cpVIP,
-					ControlPlaneEnable:   "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "false",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "false",
-					EnableNodeLabeling:   "false",
+					ControlPlaneVIP:    cpVIP,
+					ControlPlaneEnable: "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "false",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "true",
+					EnableNodeLabeling: "false",
 				}
 
 				var err error
@@ -339,14 +339,14 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:      cpVIP,
-					ControlPlaneEnable:   "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "false",
-					EnableNodeLabeling:   "false",
+					ControlPlaneVIP:    cpVIP,
+					ControlPlaneEnable: "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "true",
+					EnableNodeLabeling: "false",
 				}
 
 				var err error
@@ -400,14 +400,14 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:      cpVIP,
-					ControlPlaneEnable:   "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "false",
-					EnableNodeLabeling:   "false",
+					ControlPlaneVIP:    cpVIP,
+					ControlPlaneEnable: "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "true",
+					EnableNodeLabeling: "false",
 				}
 
 				var err error
@@ -452,14 +452,14 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:      cpVIP,
-					ControlPlaneEnable:   "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "false",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					ControlPlaneVIP:    cpVIP,
+					ControlPlaneEnable: "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "false",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				var err error
@@ -499,14 +499,14 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:      cpVIP,
-					ControlPlaneEnable:   "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					ControlPlaneVIP:    cpVIP,
+					ControlPlaneEnable: "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				var err error
@@ -560,14 +560,14 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:      cpVIP,
-					ControlPlaneEnable:   "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					ControlPlaneVIP:    cpVIP,
+					ControlPlaneEnable: "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				var err error
@@ -614,14 +614,14 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:      cpVIP,
-					ControlPlaneEnable:   "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					ControlPlaneVIP:    cpVIP,
+					ControlPlaneEnable: "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				var err error
@@ -663,14 +663,14 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:      cpVIP,
-					ControlPlaneEnable:   "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					ControlPlaneVIP:    cpVIP,
+					ControlPlaneEnable: "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				var err error
@@ -726,14 +726,14 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:      cpVIP,
-					ControlPlaneEnable:   "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "true",
-					EnableNodeLabeling:   "false",
+					ControlPlaneVIP:    cpVIP,
+					ControlPlaneEnable: "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "false",
+					EnableNodeLabeling: "false",
 				}
 
 				var err error
@@ -778,14 +778,14 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:      cpVIP,
-					ControlPlaneEnable:   "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "false",
-					SvcElectionEnable:    "false",
-					EnableEndpointslices: "false",
-					EnableNodeLabeling:   "false",
+					ControlPlaneVIP:    cpVIP,
+					ControlPlaneEnable: "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "false",
+					SvcElectionEnable:  "false",
+					EnableEndpoints:    "true",
+					EnableNodeLabeling: "false",
 				}
 
 				var err error
@@ -825,14 +825,14 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:      cpVIP,
-					ControlPlaneEnable:   "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "false",
-					EnableNodeLabeling:   "false",
+					ControlPlaneVIP:    cpVIP,
+					ControlPlaneEnable: "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "true",
+					EnableNodeLabeling: "false",
 				}
 
 				var err error
@@ -880,14 +880,14 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:      cpVIP,
-					ControlPlaneEnable:   "true",
-					ImagePath:            imagePath,
-					ConfigPath:           configPath,
-					SvcEnable:            "true",
-					SvcElectionEnable:    "true",
-					EnableEndpointslices: "false",
-					EnableNodeLabeling:   "false",
+					ControlPlaneVIP:    cpVIP,
+					ControlPlaneEnable: "true",
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					SvcEnable:          "true",
+					SvcElectionEnable:  "true",
+					EnableEndpoints:    "true",
+					EnableNodeLabeling: "false",
 				}
 
 				var err error

--- a/testing/e2e/kube-vip-routing-table.yaml.tmpl
+++ b/testing/e2e/kube-vip-routing-table.yaml.tmpl
@@ -48,8 +48,8 @@ spec:
       value: "{{ .SvcElectionEnable }}"
     - name: enable_node_labeling
       value: "{{ .EnableNodeLabeling }}"
-    - name: enable_endpointslices
-      value: "{{ .EnableEndpointslices }}"
+    - name: enable_endpoints
+      value: "{{ .EnableEndpoints }}"
     image: "{{ .ImagePath }}"
     imagePullPolicy: Never
     securityContext:

--- a/testing/e2e/kube-vip.yaml.tmpl
+++ b/testing/e2e/kube-vip.yaml.tmpl
@@ -84,8 +84,8 @@ spec:
       value: "{{ .SvcElectionEnable }}"
     - name: enable_node_labeling
       value: "{{ .EnableNodeLabeling }}"
-    - name: enable_endpointslices
-      value: "{{ .EnableEndpointslices }}"
+    - name: enable_endpoints
+      value: "{{ .EnableEndpoints }}"
 {{- if .ControlPlaneHealthCheckAddress }}
     - name: control_plane_health_check_address
       value: "{{ .ControlPlaneHealthCheckAddress }}"

--- a/testing/e2e/template.go
+++ b/testing/e2e/template.go
@@ -15,7 +15,7 @@ type KubevipManifestValues struct {
 	SvcEnable                               string
 	SvcElectionEnable                       string
 	VipElectionEnable                       string
-	EnableEndpointslices                    string
+	EnableEndpoints                         string
 	EnableNodeLabeling                      string
 	ControlPlaneEnable                      string
 	BGPAS                                   uint32

--- a/testing/kind/kube-vip-egress.yaml
+++ b/testing/kind/kube-vip-egress.yaml
@@ -43,8 +43,8 @@ spec:
             - name: vip_address
             - name: prometheus_server
               value: :2112
-            - name: enable_endpointslices
-              value: "true"
+            - name: enable_endpoints
+              value: "false"
             - name: EGRESS_CLEAN
               value: "true"
             - name: egress_withnftables

--- a/testing/kind/kube-vip-skaffold.yaml
+++ b/testing/kind/kube-vip-skaffold.yaml
@@ -39,8 +39,8 @@ spec:
             - name: vip_address
             - name: prometheus_server
               value: :2112
-            - name: enable_endpointslices
-              value: "true"
+            - name: enable_endpoints
+              value: "false"
             - name: EGRESS_CLEAN
               value: "true"
             - name: egress_withnftables

--- a/testing/services/pkg/deployment/kubernetes.go
+++ b/testing/services/pkg/deployment/kubernetes.go
@@ -84,8 +84,8 @@ func (d *Deployment) CreateKVDs(ctx context.Context, clientset *kubernetes.Clien
 									Value: "true",
 								},
 								{
-									Name:  "enable_endpointslices",
-									Value: "true",
+									Name:  "enable_endpoints",
+									Value: "false",
 								},
 								{
 									Name:  "svc_election",


### PR DESCRIPTION
PR #1215 set `EndpointSlices` as a default instead of the deprecated `Endpoints`. However this change was not reflected in the tests, and therefore all the tests, even those configured explicitly to use `Endpoints`, used `EndpointSlices` despite the settings. As the support for the deprecated `Endpoints` was not yet removed, I think this should be fixed.