### PR TITLE
Changed logs gathering path in the CI

### DIFF
--- a/.github/workflows/ci-pull-request.yaml
+++ b/.github/workflows/ci-pull-request.yaml
@@ -38,13 +38,13 @@ jobs:
         run: sudo -E PATH=$PATH DOCKER_API_VERSION=1.48 E2E_KEEP_LOGS=true make e2e-tests-bgp
         if: matrix.mode== 'bgp'
       - name: Change log directory permissions
-        run: sudo chmod -R 755 /tmp/kube-vip-test-${{ matrix.mode }}*
+        run: sudo chmod -R 755 /tmp/kube-vip-test*
         if: matrix.mode== 'bgp' && always()
       - name: Save logs
         uses: actions/upload-artifact@v7
         with:
           name: e2e-test-logs-${{ matrix.mode }}-${{ steps.date.outputs.date }}
-          path: /tmp/kube-vip-test-${{ matrix.mode }}*
+          path: /tmp/kube-vip-test*
         if: always()
   service-e2e-tests:
     runs-on: ubuntu-latest

--- a/testing/e2e/e2e_bgp_ds_test.go
+++ b/testing/e2e/e2e_bgp_ds_test.go
@@ -46,7 +46,7 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 		BeforeAll(func() {
 			var err error
-			tempDirPathRoot, err = os.MkdirTemp("", "kube-vip-test-bgp-ds")
+			tempDirPathRoot, err = os.MkdirTemp("", fmt.Sprintf("%s-bgp-ds", testDirPrefix))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -70,7 +70,7 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test-ds")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, fmt.Sprintf("%s-ds", testDirPrefix))
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareClusterForDS(tempDirPath, "bgp-ds", imagePath, k8sImagePath,
@@ -82,7 +82,7 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 			})
 
 			AfterEach(func() {
-				tempDirPathLocal, err := os.MkdirTemp(tempDirPath, "kube-vip-test")
+				tempDirPathLocal, err := os.MkdirTemp(tempDirPath, testDirPrefix)
 				By(fmt.Sprintf("saving logs to %q", tempDirPathLocal))
 				err = e2e.GetLogs(ctx, client, tempDirPathLocal, clusterName)
 				Expect(err).ToNot(HaveOccurred())
@@ -247,7 +247,7 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test-bgp-v6")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, fmt.Sprintf("%s-bgp-v6", testDirPrefix))
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareClusterForDS(tempDirPath, "bgp-ds-v6", imagePath, k8sImagePath,
@@ -259,7 +259,7 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 			})
 
 			AfterEach(func() {
-				tempDirPathLocal, err := os.MkdirTemp(tempDirPath, "kube-vip-test")
+				tempDirPathLocal, err := os.MkdirTemp(tempDirPath, testDirPrefix)
 				By(fmt.Sprintf("saving logs to %q", tempDirPathLocal))
 				err = e2e.GetLogs(ctx, client, tempDirPathLocal, clusterName)
 				Expect(err).ToNot(HaveOccurred())

--- a/testing/e2e/e2e_bgp_healthcheck_test.go
+++ b/testing/e2e/e2e_bgp_healthcheck_test.go
@@ -43,7 +43,7 @@ var _ = Describe("kube-vip BGP ControlPlane health-check", Ordered, func() {
 		Expect(server).ToNot(BeNil(), "SharedBGPServer not initialized")
 
 		var err error
-		tempDirRoot, err = os.MkdirTemp("", "kube-vip-test-bgp-hc")
+		tempDirRoot, err = os.MkdirTemp("", fmt.Sprintf("%s-bgp-hc", testDirPrefix))
 		Expect(err).NotTo(HaveOccurred())
 
 		cpVIP = e2e.GenerateVIP(utils.IPv4Family, SOffset.Get(), defaultNetwork)

--- a/testing/e2e/e2e_bgp_test.go
+++ b/testing/e2e/e2e_bgp_test.go
@@ -71,7 +71,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 
 			BeforeAll(func() {
 				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, utils.IPv4Family, utils.IPv4Family,
@@ -106,7 +106,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 
 			BeforeAll(func() {
 				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, utils.IPv6Family, utils.IPv6Family,
@@ -141,7 +141,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 
 			BeforeAll(func() {
 				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamily, utils.IPv4Family,
@@ -176,7 +176,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 
 			BeforeAll(func() {
 				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamilyIPv6, utils.IPv6Family,
@@ -210,7 +210,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 
 			BeforeAll(func() {
 				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, utils.IPv4Family, utils.IPv4Family,
@@ -257,7 +257,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 
 			BeforeAll(func() {
 				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, utils.IPv6Family, utils.IPv6Family,
@@ -304,7 +304,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 
 			BeforeAll(func() {
 				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamily, utils.IPv4Family,
@@ -351,7 +351,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 
 			BeforeAll(func() {
 				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamilyIPv6, utils.IPv6Family,
@@ -399,7 +399,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 
 			BeforeAll(func() {
 				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 				kindCluster, _, containerIP = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamily, utils.IPv4Family,
@@ -447,7 +447,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 
 			BeforeAll(func() {
 				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 				kindCluster, containerIP, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamilyIPv6, utils.IPv6Family,
@@ -494,7 +494,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 
 			BeforeAll(func() {
 				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, utils.IPv4Family, utils.IPv4Family,
@@ -549,7 +549,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 
 			BeforeAll(func() {
 				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, utils.IPv6Family, utils.IPv6Family,
@@ -604,7 +604,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 
 			BeforeAll(func() {
 				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamily, utils.IPv4Family,
@@ -659,7 +659,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 
 			BeforeAll(func() {
 				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamilyIPv6, utils.IPv6Family,
@@ -715,7 +715,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 
 			BeforeAll(func() {
 				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 				kindCluster, _, containerIP = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamily, utils.IPv4Family,
@@ -771,7 +771,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 
 			BeforeAll(func() {
 				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 				kindCluster, containerIP, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamilyIPv6, utils.IPv6Family,
@@ -824,7 +824,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 
 			BeforeAll(func() {
 				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				kindCluster = e2e.CreateCluster(ctx, &e2e.ClusterSpec{

--- a/testing/e2e/e2e_ds_test.go
+++ b/testing/e2e/e2e_ds_test.go
@@ -54,7 +54,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 		BeforeAll(func() {
 			var err error
-			tempDirPathRoot, err = os.MkdirTemp("", "kube-vip-test-arp-ds")
+			tempDirPathRoot, err = os.MkdirTemp("", fmt.Sprintf("%s-arp-ds", testDirPrefix))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -78,7 +78,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareClusterForDS(tempDirPath, "ipv4-ds", imagePath, k8sImagePath,
@@ -90,7 +90,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 			})
 
 			AfterEach(func() {
-				tempDirPathLocal, err := os.MkdirTemp(tempDirPath, "kube-vip-test")
+				tempDirPathLocal, err := os.MkdirTemp(tempDirPath, testDirPrefix)
 				By(fmt.Sprintf("saving logs to %q", tempDirPathLocal))
 				err = e2e.GetLogs(ctx, client, tempDirPathLocal, clusterName)
 				Expect(err).ToNot(HaveOccurred())
@@ -206,7 +206,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareClusterForDS(tempDirPath, "ipv6-ds", imagePath, k8sImagePath,
@@ -218,7 +218,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 			})
 
 			AfterEach(func() {
-				tempDirPathLocal, err := os.MkdirTemp(tempDirPath, "kube-vip-test")
+				tempDirPathLocal, err := os.MkdirTemp(tempDirPath, testDirPrefix)
 				By(fmt.Sprintf("saving logs to %q", tempDirPathLocal))
 				err = e2e.GetLogs(ctx, client, tempDirPathLocal, clusterName)
 				Expect(err).ToNot(HaveOccurred())
@@ -334,7 +334,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareClusterForDS(tempDirPath, "ipdual-ds", imagePath, k8sImagePath,
@@ -346,7 +346,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 			})
 
 			AfterEach(func() {
-				tempDirPathLocal, err := os.MkdirTemp(tempDirPath, "kube-vip-test")
+				tempDirPathLocal, err := os.MkdirTemp(tempDirPath, testDirPrefix)
 				By(fmt.Sprintf("saving logs to %q", tempDirPathLocal))
 				err = e2e.GetLogs(ctx, client, tempDirPathLocal, clusterName)
 				Expect(err).ToNot(HaveOccurred())

--- a/testing/e2e/e2e_rt_ds_test.go
+++ b/testing/e2e/e2e_rt_ds_test.go
@@ -46,7 +46,7 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 
 		BeforeAll(func() {
 			var err error
-			tempDirPathRoot, err = os.MkdirTemp("", "kube-vip-test-rt-ds")
+			tempDirPathRoot, err = os.MkdirTemp("", fmt.Sprintf("%s-rt-ds", testDirPrefix))
 			Expect(err).NotTo(HaveOccurred())
 
 		})
@@ -71,7 +71,7 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareClusterForDS(tempDirPath, "rt-ds", imagePath, k8sImagePath,
@@ -83,7 +83,7 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 			})
 
 			AfterEach(func() {
-				tempDirPathLocal, err := os.MkdirTemp(tempDirPath, "kube-vip-test")
+				tempDirPathLocal, err := os.MkdirTemp(tempDirPath, testDirPrefix)
 				By(fmt.Sprintf("saving logs to %q", tempDirPathLocal))
 				err = e2e.GetLogs(ctx, client, tempDirPathLocal, clusterName)
 				Expect(err).ToNot(HaveOccurred())

--- a/testing/e2e/e2e_rt_test.go
+++ b/testing/e2e/e2e_rt_test.go
@@ -45,7 +45,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 		BeforeAll(func() {
 			var err error
-			tempDirPathRoot, err = os.MkdirTemp("", "kube-vip-test-rt")
+			tempDirPathRoot, err = os.MkdirTemp("", fmt.Sprintf("%s-rt", testDirPrefix))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -103,7 +103,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ipv4", k8sImagePath, v129,
@@ -164,7 +164,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ipv6", k8sImagePath, v129,
@@ -235,7 +235,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					ipnet: localIPv6Net,
 				}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-ipv4", k8sImagePath, v129,
@@ -312,7 +312,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					ipnet: localIPv4Net,
 				}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-ipv6", k8sImagePath, v129,
@@ -383,7 +383,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 				ipFamily = []corev1.IPFamily{corev1.IPv4Protocol}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-svc-ipv4", k8sImagePath, v129,
@@ -453,7 +453,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 				ipFamily = []corev1.IPFamily{corev1.IPv6Protocol}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-svc-ipv6", k8sImagePath, v129,
@@ -524,7 +524,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 				ipFamily = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-svc-ipv4", k8sImagePath, v129,
@@ -597,7 +597,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 				ipFamily = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-svc-ipv6", k8sImagePath, v129,
@@ -667,7 +667,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 				ipFamily = []corev1.IPFamily{corev1.IPv4Protocol}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-svc-ipv4", k8sImagePath, v129,
@@ -746,7 +746,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 				ipFamily = []corev1.IPFamily{corev1.IPv6Protocol}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-svc-ipv6", k8sImagePath, v129,
@@ -826,7 +826,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 				ipFamily = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-svc-ipv4", k8sImagePath, v129,
@@ -908,7 +908,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 				ipFamily = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-svc-ipv6", k8sImagePath, v129,

--- a/testing/e2e/e2e_suite_test.go
+++ b/testing/e2e/e2e_suite_test.go
@@ -5,6 +5,7 @@ package e2e_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
 	"sync"
@@ -70,7 +71,7 @@ var _ = SynchronizedBeforeSuite(
 			return nil
 		}
 
-		tmpDir, err := os.MkdirTemp("", "kube-vip-bgp-shared")
+		tmpDir, err := os.MkdirTemp("", fmt.Sprintf("%s-bgp-shared", testDirPrefix))
 		Expect(err).NotTo(HaveOccurred())
 
 		srv := bgp.NewServer(tmpDir)

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -48,6 +48,7 @@ const (
 	dsNamespace    = "default"
 	defaultNetwork = "kind"
 	kindNetworkEnv = "KIND_EXPERIMENTAL_DOCKER_NETWORK"
+	testDirPrefix  = "kube-vip-test"
 )
 
 const testJSON = `
@@ -102,7 +103,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 
 		BeforeAll(func() {
 			var err error
-			tempDirPathRoot, err = os.MkdirTemp("", "kube-vip-test-arp")
+			tempDirPathRoot, err = os.MkdirTemp("", fmt.Sprintf("%s-arp", testDirPrefix))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -140,7 +141,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "ipv4", k8sImagePath, v129,
@@ -187,7 +188,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "svc-ipv4", k8sImagePath, v129,
@@ -248,7 +249,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "svc-el-ipv4", k8sImagePath, v129,
@@ -301,7 +302,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, clusterCfg = prepareCluster(ctx, tempDirPath, "ipv6", k8sImagePath, v129,
@@ -350,7 +351,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "svc-ipv6", k8sImagePath, v129,
@@ -411,7 +412,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "svc-el-ipv6", k8sImagePath, v129,
@@ -463,7 +464,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "ds-ipv4", k8sImagePath, v129,
@@ -510,7 +511,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "ds-svc-ipv4", k8sImagePath, v129,
@@ -571,7 +572,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "ds-svc-el-ipv4", k8sImagePath, v129,
@@ -625,7 +626,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "ds-ipv6", k8sImagePath, v129,
@@ -674,7 +675,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "ds-svc-ipv6", k8sImagePath, v129,
@@ -737,7 +738,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "ds-svc-el-ipv6", k8sImagePath, v129,
@@ -789,7 +790,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "ipv4-hostname", k8sImagePath, v129,
@@ -836,7 +837,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "svc-el-m-ipv6", k8sImagePath, v129,
@@ -891,7 +892,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, "kube-vip-test")
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "svc-el-m-ds", k8sImagePath, v129,


### PR DESCRIPTION
While trying to figure out another CI error I have discovered that not all logs are gathered as not all paths follow the same convention with `kube-vip-test` directory name prefix. This should be fixed with this PR.