### PR TITLE
Fixed ARP and RT modes with global leader election for services in 1.2.0-rc.0

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"sync"
 	"time"
 
 	log "log/slog"
@@ -21,7 +20,6 @@ import (
 // Cluster - The Cluster object manages the state of the cluster for a particular node
 type Cluster struct {
 	stop                  chan bool
-	once                  sync.Once
 	Network               []vip.Network
 	arpMgr                *arp.Manager
 	routeMgr              *route.Manager
@@ -90,9 +88,8 @@ func startNetworking(c *kubevip.Config, intfMgr *networkinterface.Manager) ([]vi
 func (cluster *Cluster) Stop() {
 	// Close the stop channel, which will shut down the VIP (if needed)
 	if cluster.stop != nil {
-		cluster.once.Do(func() { // Ensure that the close channel can only ever be called once
-			close(cluster.stop)
-		})
+		close(cluster.stop)
+		cluster.stop = make(chan bool) // recreate channel for future use
 	}
 }
 

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	log "log/slog"
@@ -70,6 +71,8 @@ func (p *Processor) AddOrModify(svcCtx *servicecontext.Context, event watch.Even
 	// If we have a local endpoint then begin the leader Election, unless it's already running
 	//
 
+	les := atomic.Int64{}
+
 	// Check that we have local endpoints
 	if len(endpoints) != 0 {
 		// Ignore IPv4
@@ -78,13 +81,29 @@ func (p *Processor) AddOrModify(svcCtx *servicecontext.Context, event watch.Even
 		}
 
 		p.updateLastKnownGoodEndpoint(lastKnownGoodEndpoint, endpoints, service)
-		svcCtx.SignalReadiness()
 
 		if p.config.EnableServicesElection {
 			wg.Go(func() {
+				les.Add(1)
 				p.startLeaderElection(svcCtx, service, serviceFunc, wg)
 			})
+		} else if p.config.EnableARP || (p.config.EnableRoutingTable && p.config.EnableLeaderElection) {
+			if !svcCtx.Signalled.Load() {
+				inst := instance.FindServiceInstance(service, *p.instances)
+				if inst == nil {
+					return true, fmt.Errorf("[%s] failed to find an instance for service %s/%s", p.provider.GetLabel(), service.Namespace, service.Name)
+				}
+				// global leader election is enabled for services
+				for x := range inst.VIPConfigs {
+					log.Debug("starting loadbalancer for service", "name", service.Name, "namespace", service.Namespace, "uid", service.UID)
+					if err := inst.Clusters[x].StartLoadBalancerService(svcCtx.Ctx, inst.VIPConfigs[x], p.bgpServer, lease.ServiceNamespacedName(service), wg); err != nil {
+						return true, fmt.Errorf("failed to start lb: %w", err)
+					}
+				}
+			}
 		}
+
+		svcCtx.SignalReadiness()
 
 		// There are local endpoints available on the node
 		// Process immediately if:
@@ -97,8 +116,16 @@ func (p *Processor) AddOrModify(svcCtx *servicecontext.Context, event watch.Even
 		}
 	} else {
 		// There are no local endpoints
-		svcCtx.ResetReadiness()
-		p.worker.clear(svcCtx, lastKnownGoodEndpoint, service)
+		if svcCtx.Signalled.Load() {
+			svcCtx.ResetReadiness()
+			p.worker.clear(svcCtx, lastKnownGoodEndpoint, service)
+			if p.config.EnableARP && !p.config.EnableLeaderElection {
+				i := instance.FindServiceInstance(service, *p.instances)
+				for _, c := range i.Clusters {
+					c.Stop()
+				}
+			}
+		}
 	}
 
 	// Set the service accordingly

--- a/pkg/endpoints/endpoints_routing_table.go
+++ b/pkg/endpoints/endpoints_routing_table.go
@@ -54,7 +54,7 @@ func (rt *RoutingTable) processInstance(svcCtx *servicecontext.Context, service 
 func (rt *RoutingTable) clear(svcCtx *servicecontext.Context, lastKnownGoodEndpoint *string, service *v1.Service) {
 	rt.mtx.Lock()
 	defer rt.mtx.Unlock()
-	if !rt.config.EnableServicesElection && !rt.config.EnableLeaderElection {
+	if !rt.config.EnableServicesElection {
 		if errs := ClearRoutes(service, rt.instances, rt.routeMgr); len(errs) == 0 {
 			svcCtx.ConfiguredNetworks.Clear()
 		} else {

--- a/pkg/servicecontext/servicecontext.go
+++ b/pkg/servicecontext/servicecontext.go
@@ -3,6 +3,7 @@ package servicecontext
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 )
 
 type Context struct {
@@ -12,7 +13,7 @@ type Context struct {
 	ConfiguredNetworks sync.Map
 	EndpointsReady     chan any
 	epReady            sync.Once
-	signalled          bool
+	Signalled          atomic.Bool
 	LeaderCancel       context.CancelFunc
 }
 
@@ -43,14 +44,14 @@ func (ctx *Context) IsNetworkConfigured(ip string) bool {
 func (ctx *Context) SignalReadiness() {
 	ctx.epReady.Do(func() {
 		close(ctx.EndpointsReady)
-		ctx.signalled = true
+		ctx.Signalled.Store(true)
 	})
 }
 
 func (ctx *Context) ResetReadiness() {
-	if ctx.signalled {
+	if ctx.Signalled.Load() {
 		ctx.EndpointsReady = make(chan any)
 		ctx.epReady = sync.Once{}
-		ctx.signalled = false
+		ctx.Signalled.Store(false)
 	}
 }

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -185,10 +185,24 @@ func (p *Processor) addService(ctx context.Context, inst *instance.Instance, svc
 		p.ServiceInstances = append(p.ServiceInstances, inst)
 	}
 
-	for x := range inst.VIPConfigs {
-		log.Debug("starting loadbalancer for service", "name", svc.Name, "namespace", svc.Namespace, "uid", svc.UID)
-		if err := inst.Clusters[x].StartLoadBalancerService(ctx, inst.VIPConfigs[x], p.bgpServer, lease.ServiceNamespacedName(svc), wg); err != nil {
-			return fmt.Errorf("failed to start lb: %w", err)
+	if err := p.configureService(ctx, inst, svc, wg); err != nil {
+		return fmt.Errorf("failed to configure service: %w", err)
+	}
+
+	finishTime := time.Since(startTime)
+	log.Info("[service]", "service", svc.Name, "namespace", svc.Namespace, "synchronised in", fmt.Sprintf("%dms", finishTime.Milliseconds()))
+
+	return nil
+}
+
+func (p *Processor) configureService(ctx context.Context, inst *instance.Instance, svc *v1.Service, wg *sync.WaitGroup) error {
+	// is not a global leader election mode
+	if p.config.EnableServicesElection || (!p.config.EnableARP && !p.config.EnableLeaderElection) || (!p.config.EnableARP && !p.config.EnableRoutingTable) {
+		for x := range inst.VIPConfigs {
+			log.Debug("starting loadbalancer for service", "name", svc.Name, "namespace", svc.Namespace, "uid", svc.UID)
+			if err := inst.Clusters[x].StartLoadBalancerService(ctx, inst.VIPConfigs[x], p.bgpServer, lease.ServiceNamespacedName(svc), wg); err != nil {
+				return fmt.Errorf("failed to start lb: %w", err)
+			}
 		}
 	}
 
@@ -264,7 +278,7 @@ func (p *Processor) addService(ctx context.Context, inst *instance.Instance, svc
 
 		log.Debug("[service] Flushing conntrack rules", "service", svc.Name, "namespace", svc.Namespace)
 		for _, serviceIP := range serviceIPs {
-			err = vip.DeleteExistingSessions(serviceIP, false, svc.Annotations[kubevip.EgressDestinationPorts], svc.Annotations[kubevip.EgressSourcePorts])
+			err := vip.DeleteExistingSessions(serviceIP, false, svc.Annotations[kubevip.EgressDestinationPorts], svc.Annotations[kubevip.EgressSourcePorts])
 			if err != nil {
 				log.Error("[service] flushing any remaining egress connections", "service", svc.Name, "namespace", svc.Namespace, "err", err)
 			}
@@ -281,13 +295,13 @@ func (p *Processor) addService(ctx context.Context, inst *instance.Instance, svc
 		// If we'er not using NFtables, then ensure that the correct iptables modules are loaded
 		if p.config.EgressWithNftables {
 			// Ensure that kernel modules are loaded and report back missing modules.
-			err = p.nftablesCheck()
+			err := p.nftablesCheck()
 			if err != nil {
 				log.Warn("[service] configuring nft egress", "service", svc.Name, "namespace", svc.Namespace, "err", err)
 			}
 		} else {
 			// Ensure that kernel modules are loaded and report back missing modules.
-			err = p.iptablesCheck()
+			err := p.iptablesCheck()
 			if err != nil {
 				log.Warn("[service] configuring egress", "service", svc.Name, "namespace", svc.Namespace, "err", err)
 			}
@@ -304,7 +318,7 @@ func (p *Processor) addService(ctx context.Context, inst *instance.Instance, svc
 
 						podIP = svc.Annotations[kubevip.ActiveEndpointIPv6]
 
-						err = p.configureEgress(ctx, serviceIP, podIP, svc.Namespace, string(svc.UID), svc.Annotations)
+						err := p.configureEgress(ctx, serviceIP, podIP, svc.Namespace, string(svc.UID), svc.Annotations)
 						if err != nil {
 							errList = append(errList, err)
 							log.Warn("[service] configuring egress IPv6", "service", svc.Name, "namespace", svc.Namespace, "err", err)
@@ -318,7 +332,7 @@ func (p *Processor) addService(ctx context.Context, inst *instance.Instance, svc
 				if !p.config.EnableEndpoints && utils.IsIPv6(serviceIP) {
 					podIPs = svc.Annotations[kubevip.ActiveEndpointIPv6]
 				}
-				err = p.configureEgress(ctx, serviceIP, podIPs, svc.Namespace, string(svc.UID), svc.Annotations)
+				err := p.configureEgress(ctx, serviceIP, podIPs, svc.Namespace, string(svc.UID), svc.Annotations)
 				if err != nil {
 					errList = append(errList, err)
 					log.Warn("[service] configuring egress IPv4", "service", svc.Name, "namespace", svc.Namespace, "err", err)
@@ -332,7 +346,7 @@ func (p *Processor) addService(ctx context.Context, inst *instance.Instance, svc
 			} else {
 				provider = providers.NewEndpointslices()
 			}
-			err = provider.UpdateServiceAnnotation(ctx, svc.Annotations[kubevip.ActiveEndpoint], svc.Annotations[kubevip.ActiveEndpointIPv6], svc, p.clientSet)
+			err := provider.UpdateServiceAnnotation(ctx, svc.Annotations[kubevip.ActiveEndpoint], svc.Annotations[kubevip.ActiveEndpointIPv6], svc, p.clientSet)
 			if err != nil {
 				log.Warn("[service] configuring egress", "service", svc.Name, "namespace", svc.Namespace, "err", err)
 			}
@@ -347,9 +361,6 @@ func (p *Processor) addService(ctx context.Context, inst *instance.Instance, svc
 			// Don't fail the entire service if WireGuard config fails
 		}
 	}
-
-	finishTime := time.Since(startTime)
-	log.Info("[service]", "service", svc.Name, "namespace", svc.Namespace, "synchronised in", fmt.Sprintf("%dms", finishTime.Milliseconds()))
 
 	return nil
 }


### PR DESCRIPTION
This is a followup to #1553 

This PR fixes the VIP deletion and re-addition error I observed in ARP mode when using global leader election.

E2E tests for such case will be added in a separate PR.

EDIT: I have found similar issue in RT mode (it's the same code path) - this is fixed in this PR as well.