### PR TITLE
Added debouncer for watch events

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -19,6 +19,7 @@ import (
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
+	"github.com/kube-vip/kube-vip/pkg/debouncer"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/manager"
 	"github.com/kube-vip/kube-vip/pkg/metrics"
@@ -147,6 +148,8 @@ func init() {
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableEndpoints, "enableEndpoints", false, "If enabled, kube-vip will only advertise services, but will use the (deprecated since v1.33) endpoints for IP addresses")
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.LoInterfaceGlobalScope, "loInterfaceGlobalScope", false, "If true, kube-vip will set global scope when using the lo interface, otherwise a host scope will be used by default")
 	kubeVipCmd.PersistentFlags().IntVar(&initConfig.HealthCheckPort, "healthCheckPort", 0, "If set to non-zero (> 1024), then this is the port that the healthcheck will listen on")
+	kubeVipCmd.PersistentFlags().StringVar(&initConfig.DebounceTime, "debounceTime", debouncer.DefaultTime,
+		"Configures the time that the event debouncer will wait for the events arrival (default 0s - debouncer disabled, enable with min. 200ms)")
 
 	// Prometheus HTTP Server
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.PrometheusHTTPServer, "prometheusHTTPServer", ":2112", "Host and port used to expose Prometheus metrics via an HTTP server")

--- a/pkg/bgp/hosts.go
+++ b/pkg/bgp/hosts.go
@@ -35,7 +35,7 @@ func (b *Server) AddHost(ctx context.Context, addr string, object string) error 
 		}); err != nil {
 			return err
 		}
-		log.Debug("[BGP] added host", "addr", addr, "cnt", len(objects)+1)
+		log.Debug("[BGP] added host", "addr", addr, "cnt", len(objects)+1, "object", object)
 	}
 
 	objects[object] = true
@@ -50,7 +50,7 @@ func (b *Server) DelHost(ctx context.Context, addr string, object string) error 
 
 	objects, exists := b.tracker[addr]
 	if !exists {
-		log.Debug("[BGP] deleting host - nothing to delete", "addr", addr)
+		log.Debug("[BGP] deleting host - nothing to delete", "addr", addr, "object", object)
 		return nil
 	}
 
@@ -73,7 +73,9 @@ func (b *Server) DelHost(ctx context.Context, addr string, object string) error 
 			return err
 		}
 		delete(b.tracker, addr)
-		log.Debug("[BGP] deleted host", "addr", addr, "cnt", len(objects))
+		log.Debug("[BGP] deleted host", "addr", addr, "cnt", len(objects), "object", object)
+	} else {
+		log.Debug("[BGP] deleting from tracker only", "addr", addr, "object", object)
 	}
 
 	return nil

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -422,7 +422,11 @@ func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip
 			}
 		}
 
-		<-cluster.stop
+		select {
+		case <-cluster.stop:
+		case <-ctx.Done():
+		}
+
 		// Stop the loadbalancer context if it is running
 		lbCancel()
 

--- a/pkg/debouncer/debouncer.go
+++ b/pkg/debouncer/debouncer.go
@@ -1,0 +1,252 @@
+package debouncer
+
+import (
+	"context"
+	"fmt"
+	log "log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+const (
+	DefaultTime = "0s"
+	minimalTime = time.Millisecond * 200
+)
+
+type debouncer struct {
+	input    <-chan watch.Event
+	output   chan watch.Event
+	stopChan chan any
+	stopOnce sync.Once
+	// events holds event per namespace
+	namespaces   sync.Map
+	debounceTime time.Duration
+}
+
+type ns struct {
+	sync.Map
+	cnt atomic.Int64
+}
+
+func (n *ns) get(name string) (*object, bool) {
+	value, exists := n.Load(name)
+	if !exists {
+		return nil, false
+	}
+	i, ok := value.(*object)
+	if !ok {
+		return nil, false
+	}
+	return i, true
+}
+
+func (n *ns) add(name string, output chan<- watch.Event) *object {
+	i := newObject(output)
+	n.Store(name, i)
+	n.cnt.Add(1)
+	return i
+}
+
+func (n *ns) del(name string) {
+	if _, exists := n.Load(name); exists {
+		n.Delete(name)
+		n.cnt.Add(-1)
+	}
+}
+
+func New(input <-chan watch.Event, debounceTime string) (*debouncer, error) {
+	dt, err := time.ParseDuration(debounceTime)
+	if err != nil {
+		// debouncer was configured with invalid unparsable value, return error
+		return nil, fmt.Errorf("failed to parse debounce time configuration: %w", err)
+	}
+	if dt < minimalTime {
+		if dt > 0 {
+			log.Warn("configured debounce time is less than the minimal threshold of 200ms, debouncer will remain disabled", "config value", dt.String())
+		}
+		return nil, nil
+	}
+	return &debouncer{
+		input:        input,
+		output:       make(chan watch.Event),
+		stopChan:     make(chan any),
+		debounceTime: dt,
+	}, nil
+}
+
+func (d *debouncer) Start(ctx context.Context) error {
+	wg := sync.WaitGroup{}
+	debouncerCtx, cancel := context.WithCancel(ctx)
+	defer func() {
+		cancel()
+		wg.Wait()
+		close(d.output)
+	}()
+
+	for {
+		select {
+		case <-debouncerCtx.Done():
+			// return if debouncer context was cancelled
+			return nil
+		case <-d.stopChan:
+			// return if Stop() was called
+			return nil
+		case tmp := <-d.input:
+			// event has no type, probably error
+			if tmp.Type == "" {
+				return fmt.Errorf("get undefined object (input channel probably closed)")
+			}
+
+			var namespace, name string
+
+			// type switch event object
+			switch v := tmp.Object.(type) {
+			case *discoveryv1.EndpointSlice:
+				namespace = v.Namespace
+				name = v.Name
+			case *v1.Endpoints: //nolint:staticcheck
+				namespace = v.Namespace
+				name = v.Name
+			case *v1.Service:
+				namespace = v.Namespace
+				name = v.Name
+			default:
+				return fmt.Errorf("objects of type %T are not supported", v)
+			}
+
+			eventNs, exists := d.getNs(namespace)
+			if !exists {
+				// if not, create new map for the namespace
+				eventNs = d.addNs(namespace)
+			}
+
+			// check if the object was previously reconciled
+			eventObject, exists := eventNs.get(name)
+
+			// if not and the event is not of type 'Deleted', create new object
+			if !exists && tmp.Type != watch.Deleted {
+				eventObject = eventNs.add(name, d.output)
+
+				wg.Go(func() {
+					// start deboucing events for this object
+					eventObject.start(debouncerCtx, d.debounceTime)
+					// if debouncer for the object ended - e.g. object was deleted - clean the map of objects
+					eventObject = nil
+					eventNs.del(name)
+					// if namespace is empty, delete the namespace map
+					if eventNs.cnt.Load() == 0 {
+						d.delNs(namespace)
+					}
+				})
+			}
+
+			if eventObject != nil {
+				// pass the watch event to the debouncer object
+				eventObject.input <- tmp
+			}
+		}
+	}
+}
+
+func (d *debouncer) Stop() {
+	d.stopOnce.Do(func() {
+		close(d.stopChan)
+	})
+}
+
+func (d *debouncer) Output() chan watch.Event {
+	return d.output
+}
+
+func (d *debouncer) getNs(namespace string) (*ns, bool) {
+	value, exists := d.namespaces.Load(namespace)
+	if !exists {
+		return nil, false
+	}
+	n, ok := value.(*ns)
+	if !ok {
+		return nil, false
+	}
+	return n, true
+}
+
+func (d *debouncer) addNs(namespace string) *ns {
+	n := ns{}
+	d.namespaces.Store(namespace, &n)
+	return &n
+}
+
+func (d *debouncer) delNs(namespace string) {
+	d.namespaces.Delete(namespace)
+}
+
+type object struct {
+	input    chan watch.Event
+	output   chan<- watch.Event
+	stopChan chan any
+	stopOnce sync.Once
+}
+
+func newObject(output chan<- watch.Event) *object {
+	return &object{
+		input:    make(chan watch.Event),
+		output:   output,
+		stopChan: make(chan any),
+	}
+}
+
+func (o *object) start(ctx context.Context, debounceTime time.Duration) {
+	t := time.NewTicker(debounceTime)
+
+	var last *watch.Event
+
+	defer func() {
+		if last != nil {
+			o.output <- *last
+			last = nil
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			// if context is done, return
+			return
+		case <-o.stopChan:
+			// return if Stop() was called
+			return
+		case tmp := <-o.input:
+			// if last event is known, but an event of another type arrived,
+			// send out the previous event
+			if last != nil && last.Type != tmp.Type {
+				o.output <- *last
+			}
+			// save current event as the last event
+			last = &tmp
+			// reset the ticker to wait for more events
+			t.Reset(debounceTime)
+		case <-t.C:
+			if last != nil {
+				// on tick, if we have an event, send it out
+				o.output <- *last
+				// if the event is of type 'Deleted', stop the debouncer for the object
+				if last.Type == watch.Deleted {
+					o.stop()
+				}
+				// reset last known event, so it won't be send out twice
+				last = nil
+			}
+		}
+	}
+}
+
+func (o *object) stop() {
+	o.stopOnce.Do(func() {
+		close(o.stopChan)
+	})
+}

--- a/pkg/debouncer/debouncer_test.go
+++ b/pkg/debouncer/debouncer_test.go
@@ -1,0 +1,394 @@
+package debouncer
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func TestTimeSetting(t *testing.T) {
+	tcs := []struct {
+		name       string
+		configured string
+		expected   string
+	}{
+		{
+			name:       "configured proper value 10s",
+			configured: "10s",
+			expected:   "10s",
+		},
+		{
+			name:       "configured value less than 200ms",
+			configured: "0s",
+			expected:   "disabled",
+		},
+		{
+			name:       "configured proper value 1s",
+			configured: "1s",
+			expected:   "1s",
+		},
+		{
+			name:       "configured proper value 1500ms",
+			configured: "1500ms",
+			expected:   "1.5s",
+		},
+		{
+			name:       "configured to value greater than 0s but lower than 200ms",
+			configured: "150ms",
+			expected:   "disabled",
+		},
+		{
+			name:       "configured invalid value that cannot be parsed",
+			configured: "invalid",
+			expected:   "error",
+		},
+		{
+			name:       "configured negative value",
+			configured: "-1s",
+			expected:   "disabled",
+		},
+	}
+
+	input := make(chan watch.Event)
+	defer close(input)
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := New(input, tc.configured)
+
+			switch tc.expected {
+			case "disabled":
+				if err != nil {
+					t.Fatalf("failed to create debouncer with debounce time %q", tc.configured)
+				}
+				if d != nil {
+					t.Fatalf("debouncer was created but should be disabled for value %q", tc.configured)
+				}
+			case "error":
+				if err == nil {
+					t.Fatalf("debouncer was created but should error for value %q", tc.configured)
+				}
+			default:
+				if d == nil {
+					t.Fatalf("debouncer was not created for value %q", tc.configured)
+				}
+
+				if d.debounceTime.String() != tc.expected {
+					t.Fatalf("invalid debounce time %q was configured instead of expected %q", d.debounceTime.String(), tc.expected)
+				}
+			}
+
+		})
+	}
+}
+
+func TestStartStop(t *testing.T) {
+	t.Run("Run and stop the debouncer without issues", func(t *testing.T) {
+		input := make(chan watch.Event)
+		defer close(input)
+
+		expected := "200ms"
+
+		d, err := New(input, expected)
+
+		if err != nil {
+			t.Fatalf("failed to create debouncer with debounce time %q", expected)
+		}
+
+		if d.debounceTime.String() != expected {
+			t.Fatalf("invalid debounce time %q was configured instead of expected %q", d.debounceTime.String(), expected)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		wg := sync.WaitGroup{}
+
+		wg.Go(func() {
+			if err := d.Start(ctx); err != nil {
+				t.Fatalf("debouncer error: %s", err.Error())
+			}
+		})
+
+		cancel()
+
+		timedOut := waitTimeout(&wg, time.Second*3)
+
+		if timedOut {
+			t.Fatal("debouncer was not closed before timeout")
+		}
+	})
+}
+
+func TestDebouncing(t *testing.T) {
+	tcs := []string{"endpointslices", "endpoints", "services"}
+
+	for _, tc := range tcs {
+		t.Run(fmt.Sprintf("Get the newest event as the only one when using %s", tc), func(t *testing.T) {
+			expected := "500ms"
+
+			fw := watch.NewFake()
+			defer fw.Stop()
+
+			d, err := New(fw.ResultChan(), expected)
+
+			if err != nil {
+				t.Fatalf("failed to create debouncer with debounce time %q", expected)
+			}
+
+			if d.debounceTime.String() != expected {
+				t.Fatalf("invalid debounce time %q was configured instead of expected %q", d.debounceTime.String(), expected)
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+
+			wg := sync.WaitGroup{}
+
+			wg.Go(func() {
+				if err := d.Start(ctx); err != nil {
+					t.Fatalf("debouncer error: %s", err.Error())
+				}
+			})
+
+			numOfUpdates := 100
+
+			switch tc {
+			case "endpointslices":
+				epslice := &discoveryv1.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Endpoints: make([]discoveryv1.Endpoint, 1),
+				}
+
+				addrEpslices := []string{}
+
+				for i := range numOfUpdates {
+					addrEpslices = append(addrEpslices, strconv.Itoa(i))
+					epslice.Endpoints[0].Addresses = addrEpslices
+					fw.Add(epslice)
+				}
+			case "endpoints":
+				ep := &v1.Endpoints{ //nolint:staticcheck
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Subsets: make([]v1.EndpointSubset, 1), //nolint:staticcheck
+				}
+
+				addrEp := []v1.EndpointAddress{}
+
+				for i := range numOfUpdates {
+					addrEp = append(addrEp, v1.EndpointAddress{IP: strconv.Itoa(i)})
+					ep.Subsets[0].Addresses = addrEp
+					fw.Add(ep)
+				}
+			case "services":
+				svc := &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+				}
+
+				svcPorts := []v1.ServicePort{}
+
+				for i := range numOfUpdates {
+					svcPorts = append(svcPorts, v1.ServicePort{Port: int32(i)})
+					svc.Spec.Ports = svcPorts
+					fw.Add(svc)
+				}
+
+			default:
+				t.Fatal("unknown test", "type", tc)
+			}
+
+			out := <-d.output
+
+			switch tc {
+			case "endpointslices":
+				outEps, ok := out.Object.(*discoveryv1.EndpointSlice)
+				if !ok {
+					t.Fatal("got different type of object than EndpointSlice, failed to cast")
+				}
+
+				if len(outEps.Endpoints[0].Addresses) != numOfUpdates {
+					t.Fatalf("expected to aggregate %d events, but got %d", numOfUpdates, len(outEps.Endpoints[0].Addresses))
+				}
+			case "endpoints":
+				outEps, ok := out.Object.(*v1.Endpoints) //nolint:staticcheck
+				if !ok {
+					t.Fatal("got different type of object than EndpointSlice, failed to cast")
+				}
+
+				if len(outEps.Subsets[0].Addresses) != numOfUpdates {
+					t.Fatalf("expected to aggregate %d events, but got %d", numOfUpdates, len(outEps.Subsets[0].Addresses))
+				}
+			case "services":
+				outSvc, ok := out.Object.(*v1.Service) //nolint:staticcheck
+				if !ok {
+					t.Fatal("got different type of object than EndpointSlice, failed to cast")
+				}
+
+				if len(outSvc.Spec.Ports) != numOfUpdates {
+					t.Fatalf("expected to aggregate %d events, but got %d", numOfUpdates, len(outSvc.Spec.Ports))
+				}
+			default:
+				t.Fatal("unknown test", "type", tc)
+			}
+
+			cancel()
+
+			timedOut := waitTimeout(&wg, time.Second*3)
+
+			if timedOut {
+				t.Fatal("debouncer was not closed before timeout")
+			}
+		})
+	}
+}
+
+func TestTypeChange(t *testing.T) {
+	tcs := []string{"endpointslices", "endpoints", "services"}
+
+	for _, tc := range tcs {
+		t.Run(fmt.Sprintf("Get the newest event as the only one when using %s", tc), func(t *testing.T) {
+			expected := "500ms"
+
+			fw := watch.NewFake()
+			defer fw.Stop()
+
+			d, err := New(fw.ResultChan(), expected)
+
+			if err != nil {
+				t.Fatalf("failed to create debouncer with debounce time %q", expected)
+			}
+
+			if d.debounceTime.String() != expected {
+				t.Fatalf("invalid debounce time %q was configured instead of expected %q", d.debounceTime.String(), expected)
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+
+			wg := sync.WaitGroup{}
+
+			wg.Go(func() {
+				if err := d.Start(ctx); err != nil {
+					t.Fatalf("debouncer error: %s", err.Error())
+				}
+			})
+
+			numOfUpdates := 100
+
+			switch tc {
+			case "endpointslices":
+				epslice := &discoveryv1.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Endpoints: make([]discoveryv1.Endpoint, 1),
+				}
+
+				addrEpslices := []string{}
+
+				for i := range numOfUpdates {
+					addrEpslices = append(addrEpslices, strconv.Itoa(i))
+					epslice.Endpoints[0].Addresses = addrEpslices
+					if i < numOfUpdates-1 {
+						fw.Add(epslice)
+					} else {
+						fw.Delete(epslice)
+					}
+				}
+			case "endpoints":
+				ep := &v1.Endpoints{ //nolint:staticcheck
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Subsets: make([]v1.EndpointSubset, 1), //nolint:staticcheck
+				}
+
+				addrEp := []v1.EndpointAddress{}
+
+				for i := range numOfUpdates {
+					addrEp = append(addrEp, v1.EndpointAddress{IP: strconv.Itoa(i)})
+					ep.Subsets[0].Addresses = addrEp
+					if i < numOfUpdates-1 {
+						fw.Add(ep)
+					} else {
+						fw.Delete(ep)
+					}
+				}
+			case "services":
+				svc := &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+				}
+
+				svcPorts := []v1.ServicePort{}
+
+				for i := range numOfUpdates {
+					svcPorts = append(svcPorts, v1.ServicePort{Port: int32(i)})
+					svc.Spec.Ports = svcPorts
+					if i < numOfUpdates-1 {
+						fw.Add(svc)
+					} else {
+						fw.Delete(svc)
+					}
+				}
+
+			default:
+				t.Fatal("unknown test", "type", tc)
+			}
+
+			out := <-d.output
+
+			if out.Type != watch.Added {
+				t.Fatalf("expected to get add event, but got %s event", out.Type)
+			}
+
+			out = <-d.output
+
+			if out.Type != watch.Deleted {
+				t.Fatalf("expected to get delete event, but got %s event", out.Type)
+			}
+
+			cancel()
+
+			timedOut := waitTimeout(&wg, time.Second*3)
+
+			if timedOut {
+				t.Fatal("debouncer was not closed before timeout")
+			}
+		})
+	}
+}
+
+// waitTimeout waits for the waitgroup for the specified max timeout.
+// Returns true if waiting timed out.
+func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		wg.Wait()
+	}()
+	select {
+	case <-c:
+		return false // completed normally
+	case <-time.After(timeout):
+		return true // timed out
+	}
+}

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/kube-vip/kube-vip/pkg/debouncer"
 	"github.com/kube-vip/kube-vip/pkg/detector"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 	"sigs.k8s.io/yaml"
@@ -988,6 +989,11 @@ func mergeConfigValues(baseConfig, fileConfig *Config) {
 	// Load balancers slice
 	if len(baseConfig.LoadBalancers) == 0 && len(fileConfig.LoadBalancers) > 0 {
 		baseConfig.LoadBalancers = fileConfig.LoadBalancers
+	}
+
+	// Debounce time for watch events
+	if baseConfig.DebounceTime == debouncer.DefaultTime && fileConfig.DebounceTime != debouncer.DefaultTime {
+		baseConfig.DebounceTime = fileConfig.DebounceTime
 	}
 }
 

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -256,4 +256,7 @@ const (
 
 	// configFile defines the path to a JSON/YAML configuration file
 	configFile = "config_file"
+
+	// debounceTime defines what time should the event debouncer wait for events
+	debounceTime = "debounce_time"
 )

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/kube-vip/kube-vip/pkg/debouncer"
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -647,6 +648,15 @@ func generatePodSpec(c *Config, image, imageVersion string, inCluster bool) (*co
 			},
 		}
 		newEnvironment = append(newEnvironment, preserveVIPOnLeadershipLoss...)
+	}
+
+	if c.DebounceTime != debouncer.DefaultTime {
+		debTime := corev1.EnvVar{
+			Name:  debounceTime,
+			Value: c.DebounceTime,
+		}
+
+		newEnvironment = append(newEnvironment, debTime)
 	}
 
 	newManifest := &corev1.Pod{

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -204,8 +204,11 @@ type Config struct {
 	// ConfigFile defines the path to a JSON/YAML configuration file
 	ConfigFile string `yaml:"configFile"`
 
-	// DHCPBackoffAttempts defaines how many times will DHCP client try to obtain address (unlimited when 0)
+	// DHCPBackoffAttempts defines how many times will DHCP client try to obtain address (unlimited when 0)
 	DHCPBackoffAttempts uint `yaml:"dhcpBackoffAttempts"`
+
+	// DebounceTime defines how long will event debouncer wait for the events to arrive
+	DebounceTime string `yaml:"debounceTime"`
 }
 
 // KubernetesLeaderElection defines all of the settings for Kubernetes KubernetesLeaderElection

--- a/pkg/services/watch_endpoints.go
+++ b/pkg/services/watch_endpoints.go
@@ -6,6 +6,7 @@ import (
 
 	log "log/slog"
 
+	"github.com/kube-vip/kube-vip/pkg/debouncer"
 	"github.com/kube-vip/kube-vip/pkg/endpoints"
 	"github.com/kube-vip/kube-vip/pkg/endpoints/providers"
 	"github.com/kube-vip/kube-vip/pkg/servicecontext"
@@ -23,17 +24,31 @@ func (p *Processor) watchEndpoint(svcCtx *servicecontext.Context, id string, ser
 		return fmt.Errorf("[%s] error watching endpoints: %w", provider.GetLabel(), err)
 	}
 
+	d, err := debouncer.New(rw.ResultChan(), p.config.DebounceTime)
+	if err != nil {
+		rw.Stop()
+		return fmt.Errorf("failed to create debouncer for endpoints event: %w", err)
+	}
+
 	wg := sync.WaitGroup{}
 
 	stopChan := make(chan any)
 
 	defer func() {
 		close(stopChan)
-		rw.Stop()
+		if d != nil {
+			d.Stop()
+		}
 		wg.Wait()
 	}()
 
 	wg.Go(func() {
+		if d != nil {
+			if err := d.Start(svcCtx.Ctx); err != nil {
+				log.Error("[endpoint watcher] debouncer, cancelling context", "error", err.Error())
+				svcCtx.Cancel()
+			}
+		}
 		select {
 		case <-svcCtx.Ctx.Done():
 			log.Debug("[endpoint watcher] context cancelled", "provider", provider.GetLabel())
@@ -44,9 +59,12 @@ func (p *Processor) watchEndpoint(svcCtx *servicecontext.Context, id string, ser
 		}
 	})
 
-	ch := rw.ResultChan()
-
 	epProcessor := endpoints.NewEndpointProcessor(p.config, provider, p.bgpServer, &p.ServiceInstances, p.leaseMgr, p.TunnelMgr, p.routeMgr)
+
+	ch := rw.ResultChan()
+	if d != nil {
+		ch = d.Output()
+	}
 
 	var lastKnownGoodEndpoint string
 	for event := range ch {

--- a/pkg/services/watch_services.go
+++ b/pkg/services/watch_services.go
@@ -9,6 +9,7 @@ import (
 	log "log/slog"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/kube-vip/kube-vip/pkg/debouncer"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/trafficmirror"
@@ -56,19 +57,43 @@ func (p *Processor) ServicesWatcher(ctx context.Context, serviceFunc *Callback) 
 		return fmt.Errorf("error creating services watcher: %s", err.Error())
 	}
 
+	d, err := debouncer.New(rw.ResultChan(), p.config.DebounceTime)
+	if err != nil {
+		return fmt.Errorf("failed to create debouncer for endpoints event: %w", err)
+	}
+
 	wg := sync.WaitGroup{}
-	defer wg.Wait()
+	defer func() {
+		if d != nil {
+			d.Stop()
+		}
+		rw.Stop()
+		wg.Wait()
+	}()
 
 	watcherCtx, watcherCancel := context.WithCancel(ctx)
 	defer watcherCancel()
 
 	wg.Go(func() {
+		if d != nil {
+			if err := d.Start(watcherCtx); err != nil {
+				log.Error("(svcs) debouncer, cancelling context", "error", err.Error())
+				watcherCancel()
+			}
+		}
 		<-watcherCtx.Done()
 		log.Debug("(svcs) watcher context cancelled")
+		if d != nil {
+			d.Stop()
+		}
 		rw.Stop()
 		p.Stop()
 	})
+
 	ch := rw.ResultChan()
+	if d != nil {
+		ch = d.Output()
+	}
 
 	// Used for tracking an active endpoint / pod
 	for event := range ch {

--- a/testing/e2e/e2e_ds_test.go
+++ b/testing/e2e/e2e_ds_test.go
@@ -561,9 +561,17 @@ func testDS(ctx context.Context, manifestValues *e2e.KubevipManifestValues, clie
 		}
 	}
 
-	pods, err := client.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{LabelSelector: "app=kube-vip"})
-	Expect(err).ToNot(HaveOccurred())
-	Expect(len(pods.Items)).To(Equal(1))
+	var pods *corev1.PodList
+	Eventually(func() error {
+		pods, err = client.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{LabelSelector: "app=kube-vip"})
+		if err != nil {
+			return err
+		}
+		if len(pods.Items) != 1 {
+			return fmt.Errorf("expected 1 pod, but got %d", len(pods.Items))
+		}
+		return nil
+	}, "40s").Should(Succeed())
 
 	removeKubeVipDS(ctx, client)
 


### PR DESCRIPTION
This PR is a proposal for an event debouncer for Endpoints and services events.

At the moment kube-vip is processing events as those arrive which means in example, that if there is a service that kube-vip is reconciling endpoints for, if, let's say 20 endpoints will be created, and each one will came up within 1 second of another, kube-vip might try to run reconciliation code up to 20 times.

This PR introduces a debouncer that will make kube-vip reconcile only the last request. This should simplify the logs generated by kube-vip and as a result could make maintenance a little bit more approachable.

The debouncer waits for the event for the service/endpoints/endpointslices object to arrive, then waits some `time` from the event. If new event arrives, it overrides the previous event, debouncer waits for the same `time` for another event and so on. If the `time` passes with no new events, the event is sent to the output channel and reconciliation is carried as usual.

The `time` debouncer waits for the event can be configured with a CLI flag `debounceTime`, or with an ENV variable `debounce_time`. Those can be set with a `string` value that can be parsed with [time.ParseDuration()](https://pkg.go.dev/time#ParseDuration) (e.g. "5s", "500ms", etc.). The minimal value is "200ms", and the default one is "2s", however those values were selected arbitrarily and this can be discussed.

Question: If this will be accepted, should it be possible to disable the debouncer, for example with `debounce_time` set to `0s`?

