### PR TITLE
Fix - Backend Watch Ticker

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -66,7 +66,7 @@ func (e *Entry) Check() bool {
 	return true
 }
 
-func Watch(ctx context.Context, tickAction func(), interval int) {
+func Watch(ctx context.Context, interval int, tickAction func()) {
 	if interval <= 0 {
 		interval = 5
 	}
@@ -77,7 +77,6 @@ func Watch(ctx context.Context, tickAction func(), interval int) {
 	for {
 		select {
 		case <-ctx.Done():
-			ticker.Stop()
 			return
 		case <-ticker.C:
 			tickAction()

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -80,9 +80,7 @@ func Watch(ctx context.Context, tickAction func(), interval int) {
 			ticker.Stop()
 			return
 		case <-ticker.C:
-			ticker.Stop()
 			tickAction()
-			ticker.Reset(time.Second * time.Duration(interval))
 		}
 	}
 }

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -179,7 +179,7 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 			}
 		}
 
-		backend.Watch(ctx, func() {
+		backend.Watch(ctx, c.BackendHealthCheckInterval, func() {
 			for i := range cluster.Network {
 				network := cluster.Network[i]
 				networkIP := network.IP()
@@ -246,7 +246,7 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 					}
 				}
 			}
-		}, c.BackendHealthCheckInterval)
+		})
 	}
 
 	if c.EnableBGP {

--- a/pkg/loadbalancer/ipvs.go
+++ b/pkg/loadbalancer/ipvs.go
@@ -317,7 +317,7 @@ func ipAndFamily(address string) (netip.Addr, ipvs.AddressFamily) {
 }
 
 func (lb *IPVSLoadBalancer) healthCheck(ctx context.Context) {
-	backend.Watch(ctx, func() {
+	backend.Watch(ctx, lb.interval, func() {
 		lb.lock.Lock()
 		defer lb.lock.Unlock()
 		for backend, oldStatus := range lb.backendMap {
@@ -349,7 +349,7 @@ func (lb *IPVSLoadBalancer) healthCheck(ctx context.Context) {
 				}
 			}
 		}
-	}, lb.interval)
+	})
 }
 
 func (lb *IPVSLoadBalancer) isLocal(address string) (bool, error) {


### PR DESCRIPTION
In `pkg/backend/backend.go` the `Watch` function was unnecessarily calling `ticker.Stop()` and `ticker.Reset()`. 

This PR removes those unnecessary calls and additionally refactors the function signature of `Watch` to be more idiomatic.