### PR TITLE
Fix and E2E tests for endpoints deletion - ARP and RT

### DIFF
--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -119,7 +119,7 @@ func (p *Processor) AddOrModify(svcCtx *servicecontext.Context, event watch.Even
 		if svcCtx.Signalled.Load() {
 			svcCtx.ResetReadiness()
 			p.worker.clear(svcCtx, lastKnownGoodEndpoint, service)
-			if p.config.EnableARP && !p.config.EnableLeaderElection {
+			if p.config.EnableARP && !p.config.EnableServicesElection {
 				i := instance.FindServiceInstance(service, *p.instances)
 				for _, c := range i.Clusters {
 					c.Stop()

--- a/testing/e2e/e2e_ds_test.go
+++ b/testing/e2e/e2e_ds_test.go
@@ -997,7 +997,7 @@ func createTestDS(ctx context.Context, client kubernetes.Interface, namespace, n
 }
 
 func removeTestDS(ctx context.Context, client kubernetes.Interface, namespace, name string, dsNumber int) {
-	By(withTimestamp("creating test daemonsets"))
+	By(withTimestamp("removing test daemonsets"))
 	for i := range dsNumber {
 		tmpName := name
 		if i > 0 {

--- a/testing/e2e/e2e_rt_test.go
+++ b/testing/e2e/e2e_rt_test.go
@@ -41,6 +41,8 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 			v129                                bool
 		)
 
+		dsNumber := 1
+
 		ctx, cancel := context.WithCancel(context.TODO())
 
 		BeforeAll(func() {
@@ -107,7 +109,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ipv4", k8sImagePath, v129,
-					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, 1)
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -168,7 +170,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ipv6", k8sImagePath, v129,
-					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, 1)
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -239,7 +241,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-ipv4", k8sImagePath, v129,
-					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, addSAN, 1)
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, addSAN, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -316,7 +318,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-ipv6", k8sImagePath, v129,
-					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, addSAN, 1)
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, addSAN, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -387,7 +389,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-svc-ipv4", k8sImagePath, v129,
-					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, 1)
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -401,7 +403,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", clusterName,
-						trafficPolicy, client, svcElection, ipFamily, 1, false)
+						trafficPolicy, client, svcElection, ipFamily, 1, false, dsNumber, false)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -411,7 +413,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", clusterName,
-						trafficPolicy, client, svcElection, ipFamily, 2, false)
+						trafficPolicy, client, svcElection, ipFamily, 2, false, dsNumber, false)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -457,7 +459,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-svc-ipv6", k8sImagePath, v129,
-					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, 1)
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -471,7 +473,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", clusterName,
-						trafficPolicy, client, svcElection, ipFamily, 1, false)
+						trafficPolicy, client, svcElection, ipFamily, 1, false, dsNumber, false)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -481,7 +483,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", clusterName,
-						trafficPolicy, client, svcElection, ipFamily, 2, false)
+						trafficPolicy, client, svcElection, ipFamily, 2, false, dsNumber, false)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -528,7 +530,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-svc-ipv4", k8sImagePath, v129,
-					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, 1)
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -542,7 +544,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", clusterName,
-						trafficPolicy, client, svcElection, ipFamily, 1, false)
+						trafficPolicy, client, svcElection, ipFamily, 1, false, dsNumber, false)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -552,7 +554,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", clusterName,
-						trafficPolicy, client, svcElection, ipFamily, 2, false)
+						trafficPolicy, client, svcElection, ipFamily, 2, false, dsNumber, false)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -601,7 +603,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-svc-ipv6", k8sImagePath, v129,
-					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, 1)
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -615,7 +617,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", clusterName,
-						trafficPolicy, client, svcElection, ipFamily, 1, false)
+						trafficPolicy, client, svcElection, ipFamily, 1, false, dsNumber, false)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -625,7 +627,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", clusterName,
-						trafficPolicy, client, svcElection, ipFamily, 2, false)
+						trafficPolicy, client, svcElection, ipFamily, 2, false, dsNumber, false)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -671,7 +673,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-svc-ipv4", k8sImagePath, v129,
-					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, 1)
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -685,7 +687,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
-						trafficPolicy, client, svcElection, ipFamily, 1, false)
+						trafficPolicy, client, svcElection, ipFamily, 1, false, dsNumber, false)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -695,7 +697,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
-						trafficPolicy, client, svcElection, ipFamily, 2, false)
+						trafficPolicy, client, svcElection, ipFamily, 2, false, dsNumber, false)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -705,7 +707,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
-						trafficPolicy, client, svcElection, ipFamily, 2, true)
+						trafficPolicy, client, svcElection, ipFamily, 2, true, dsNumber, false)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 			)
@@ -750,7 +752,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-svc-ipv6", k8sImagePath, v129,
-					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, 1)
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -764,7 +766,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
-						trafficPolicy, client, svcElection, ipFamily, 1, false)
+						trafficPolicy, client, svcElection, ipFamily, 1, false, dsNumber, false)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -774,7 +776,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
-						trafficPolicy, client, svcElection, ipFamily, 2, false)
+						trafficPolicy, client, svcElection, ipFamily, 2, false, dsNumber, false)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -784,7 +786,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
-						trafficPolicy, client, svcElection, ipFamily, 2, true)
+						trafficPolicy, client, svcElection, ipFamily, 2, true, dsNumber, false)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 			)
@@ -830,7 +832,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-svc-ipv4", k8sImagePath, v129,
-					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, 1)
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -844,7 +846,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
-						trafficPolicy, client, svcElection, ipFamily, 1, false)
+						trafficPolicy, client, svcElection, ipFamily, 1, false, dsNumber, false)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -854,7 +856,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
-						trafficPolicy, client, svcElection, ipFamily, 2, false)
+						trafficPolicy, client, svcElection, ipFamily, 2, false, dsNumber, false)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -864,7 +866,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
-						trafficPolicy, client, svcElection, ipFamily, 2, true)
+						trafficPolicy, client, svcElection, ipFamily, 2, true, dsNumber, false)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 			)
@@ -912,7 +914,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-svc-ipv6", k8sImagePath, v129,
-					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, 1)
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -926,7 +928,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
-						trafficPolicy, client, svcElection, ipFamily, 1, false)
+						trafficPolicy, client, svcElection, ipFamily, 1, false, dsNumber, false)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -936,7 +938,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
-						trafficPolicy, client, svcElection, ipFamily, 2, false)
+						trafficPolicy, client, svcElection, ipFamily, 2, false, dsNumber, false)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -946,16 +948,342 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, clusterName,
-						trafficPolicy, client, svcElection, ipFamily, 2, true)
+						trafficPolicy, client, svcElection, ipFamily, 2, true, dsNumber, false)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+			)
+		})
+
+		Describe("kube-vip IPv4 services routing table mode functionality with global election", Ordered, func() {
+			var (
+				cpVIP          string
+				clusterName    string
+				client         kubernetes.Interface
+				manifestValues *e2e.KubevipManifestValues
+				svcElection    bool
+				ipFamily       []corev1.IPFamily
+				tempDirPath    string
+
+				nodesNumber = 1
+			)
+
+			BeforeAll(func() {
+				cpVIP = e2e.GenerateVIP(utils.IPv4Family, SOffset.Get(), defaultNetwork)
+
+				networking := &kindconfigv1alpha4.Networking{
+					IPFamily: kindconfigv1alpha4.IPv4Family,
+				}
+
+				manifestValues = &e2e.KubevipManifestValues{
+					ControlPlaneVIP:    cpVIP,
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					ControlPlaneEnable: "false",
+					SvcEnable:          "true",
+					VipElectionEnable:  "true",
+					SvcElectionEnable:  "false",
+				}
+
+				var err error
+				svcElection, err = strconv.ParseBool(manifestValues.SvcElectionEnable)
+				Expect(err).ToNot(HaveOccurred())
+
+				ipFamily = []corev1.IPFamily{corev1.IPv4Protocol}
+
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
+				Expect(err).NotTo(HaveOccurred())
+
+				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-svc-ipv4-global", k8sImagePath, v129,
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
+			})
+
+			AfterAll(func() {
+				By(fmt.Sprintf("saving logs to %q", tempDirPath))
+				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
+				Expect(err).ToNot(HaveOccurred())
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+			})
+
+			DescribeTable("configures an IPv4 routes for services",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
+					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", dsNamespace, clusterName,
+						trafficPolicy, client, svcElection, ipFamily, 1, false, dsNumber, false)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+
+			DescribeTable("only removes route if it was referenced by multiple services and all of them were deleted",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
+					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", dsNamespace, clusterName,
+						trafficPolicy, client, svcElection, ipFamily, 2, false, dsNumber, false)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+
+			DescribeTable("removes route if all endpoint were deleted, and re-adds when endpoints are created",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
+					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", dsNamespace, clusterName,
+						trafficPolicy, client, svcElection, ipFamily, 1, false, dsNumber, true)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+		})
+
+		Describe("kube-vip IPv6 services routing table mode functionality with global election", Ordered, func() {
+			var (
+				cpVIP          string
+				clusterName    string
+				client         kubernetes.Interface
+				manifestValues *e2e.KubevipManifestValues
+				svcElection    bool
+				ipFamily       []corev1.IPFamily
+				tempDirPath    string
+
+				nodesNumber = 1
+			)
+
+			BeforeAll(func() {
+				cpVIP = e2e.GenerateVIP(utils.IPv6Family, SOffset.Get(), defaultNetwork)
+
+				networking := &kindconfigv1alpha4.Networking{
+					IPFamily: kindconfigv1alpha4.IPv6Family,
+				}
+
+				manifestValues = &e2e.KubevipManifestValues{
+					ControlPlaneVIP:    cpVIP,
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					ControlPlaneEnable: "false",
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					VipElectionEnable:  "true",
+				}
+
+				var err error
+				svcElection, err = strconv.ParseBool(manifestValues.SvcElectionEnable)
+				Expect(err).ToNot(HaveOccurred())
+
+				ipFamily = []corev1.IPFamily{corev1.IPv6Protocol}
+
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
+				Expect(err).NotTo(HaveOccurred())
+
+				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-svc-ipv6-global", k8sImagePath, v129,
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
+			})
+
+			AfterAll(func() {
+				By(fmt.Sprintf("saving logs to %q", tempDirPath))
+				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
+				Expect(err).ToNot(HaveOccurred())
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+			})
+
+			DescribeTable("configures an IPv6 routes for services",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
+					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", dsNamespace, clusterName,
+						trafficPolicy, client, svcElection, ipFamily, 1, false, dsNumber, false)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+
+			DescribeTable("only removes route if it was referenced by multiple services and all of them were deleted",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
+					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", dsNamespace, clusterName,
+						trafficPolicy, client, svcElection, ipFamily, 2, false, dsNumber, false)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+
+			DescribeTable("removes route if all endpoint were deleted, and re-adds when endpoints are created",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
+					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", dsNamespace, clusterName,
+						trafficPolicy, client, svcElection, ipFamily, 1, false, dsNumber, true)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+		})
+
+		Describe("kube-vip DualStack services routing table mode functionality - IPv4 primary with global election", Ordered, func() {
+			var (
+				cpVIP          string
+				clusterName    string
+				client         kubernetes.Interface
+				manifestValues *e2e.KubevipManifestValues
+				svcElection    bool
+				ipFamily       []corev1.IPFamily
+				tempDirPath    string
+
+				nodesNumber = 1
+			)
+
+			BeforeAll(func() {
+				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get(), defaultNetwork)
+
+				networking := &kindconfigv1alpha4.Networking{
+					IPFamily: kindconfigv1alpha4.DualStackFamily,
+				}
+
+				manifestValues = &e2e.KubevipManifestValues{
+					ControlPlaneVIP:    cpVIP,
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					ControlPlaneEnable: "false",
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					VipElectionEnable:  "true",
+					EnableEndpoints:    "false",
+				}
+
+				var err error
+				svcElection, err = strconv.ParseBool(manifestValues.SvcElectionEnable)
+				Expect(err).ToNot(HaveOccurred())
+
+				ipFamily = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
+
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
+				Expect(err).NotTo(HaveOccurred())
+
+				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-svc-ipv4-global", k8sImagePath, v129,
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
+			})
+
+			AfterAll(func() {
+				By(fmt.Sprintf("saving logs to %q", tempDirPath))
+				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
+				Expect(err).ToNot(HaveOccurred())
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+			})
+
+			DescribeTable("configures an IPv4 and IPv6 routes for services",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
+					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", dsNamespace, clusterName,
+						trafficPolicy, client, svcElection, ipFamily, 1, false, dsNumber, false)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+
+			DescribeTable("only removes route if it was referenced by multiple services and all of them were deleted",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
+					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", dsNamespace, clusterName,
+						trafficPolicy, client, svcElection, ipFamily, 2, false, dsNumber, false)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+
+			DescribeTable("removes route if all endpoint were deleted, and re-adds when endpoints are created",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
+					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", dsNamespace, clusterName,
+						trafficPolicy, client, svcElection, ipFamily, 1, false, dsNumber, true)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+		})
+
+		Describe("kube-vip DualStack services routing table mode functionality - IPv6 primary with global election", Ordered, func() {
+			var (
+				cpVIP          string
+				clusterName    string
+				client         kubernetes.Interface
+				manifestValues *e2e.KubevipManifestValues
+				svcElection    bool
+				ipFamily       []corev1.IPFamily
+				tempDirPath    string
+
+				nodesNumber = 1
+			)
+
+			BeforeAll(func() {
+				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get(), defaultNetwork)
+
+				networking := &kindconfigv1alpha4.Networking{
+					IPFamily: kindconfigv1alpha4.DualStackFamily,
+				}
+
+				manifestValues = &e2e.KubevipManifestValues{
+					ControlPlaneVIP:    cpVIP,
+					ImagePath:          imagePath,
+					ConfigPath:         configPath,
+					ControlPlaneEnable: "false",
+					SvcEnable:          "true",
+					SvcElectionEnable:  "false",
+					VipElectionEnable:  "true",
+					EnableEndpoints:    "false",
+				}
+
+				var err error
+				svcElection, err = strconv.ParseBool(manifestValues.SvcElectionEnable)
+				Expect(err).ToNot(HaveOccurred())
+
+				ipFamily = []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}
+
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
+				Expect(err).NotTo(HaveOccurred())
+
+				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-svc-ipv6-global", k8sImagePath, v129,
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
+			})
+
+			AfterAll(func() {
+				By(fmt.Sprintf("saving logs to %q", tempDirPath))
+				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
+				Expect(err).ToNot(HaveOccurred())
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+			})
+
+			DescribeTable("configures an IPv4 and IPv6 routes for services",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
+					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", dsNamespace, clusterName,
+						trafficPolicy, client, svcElection, ipFamily, 1, false, dsNumber, false)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+
+			DescribeTable("only removes route if it was referenced by multiple services and all of them were deleted",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
+					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", dsNamespace, clusterName,
+						trafficPolicy, client, svcElection, ipFamily, 2, false, dsNumber, false)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+
+			DescribeTable("removes route if all endpoint were deleted, and re-adds when endpoints are created",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
+					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", dsNamespace, clusterName,
+						trafficPolicy, client, svcElection, ipFamily, 1, false, dsNumber, true)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
 			)
 		})
 	}
 })
 
 func testServiceRT(ctx context.Context, svcName, lbAddress, leaseName, leaseNamespace, clusterName string, trafficPolicy corev1.ServiceExternalTrafficPolicy,
-	client kubernetes.Interface, serviceElection bool, ipFamily []corev1.IPFamily, numberOfServices int, commonLease bool) {
+	client kubernetes.Interface, serviceElection bool, ipFamily []corev1.IPFamily, numberOfServices int, commonLease bool, dsNumber int, deleteDS bool) {
 	lbAddresses := vip.Split(lbAddress)
 
 	services := []string{}
@@ -969,7 +1297,7 @@ func testServiceRT(ctx context.Context, svcName, lbAddress, leaseName, leaseName
 			svcLease = leaseName
 		}
 		createTestService(ctx, svc, dsNamespace, dsName, lbAddress,
-			client, corev1.IPFamilyPolicyPreferDualStack, ipFamily, trafficPolicy, svcLease, 1)
+			client, corev1.IPFamilyPolicyPreferDualStack, ipFamily, trafficPolicy, svcLease, dsNumber)
 		time.Sleep(time.Second)
 	}
 
@@ -989,6 +1317,25 @@ func testServiceRT(ctx context.Context, svcName, lbAddress, leaseName, leaseName
 		}
 	} else {
 		container = fmt.Sprintf("%s-control-plane", clusterName)
+		for _, addr := range lbAddresses {
+			By(withTimestamp(fmt.Sprintf("checking route presence for address %q on container %q", addr, container)))
+			e2e.CheckRoutePresence(addr, container, true)
+		}
+	}
+
+	if deleteDS {
+		removeTestDS(ctx, client, dsNamespace, dsName, dsNumber)
+		time.Sleep(time.Second)
+
+		container = fmt.Sprintf("%s-control-plane", clusterName)
+		for _, addr := range lbAddresses {
+			By(withTimestamp(fmt.Sprintf("checking route presence for address %q on container %q", addr, container)))
+			e2e.CheckRoutePresence(addr, container, false)
+		}
+
+		createTestDS(ctx, client, dsNamespace, dsName, dsNumber)
+		time.Sleep(time.Second)
+
 		for _, addr := range lbAddresses {
 			By(withTimestamp(fmt.Sprintf("checking route presence for address %q on container %q", addr, container)))
 			e2e.CheckRoutePresence(addr, container, true)

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -167,6 +167,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				client      kubernetes.Interface
 				clusterName string
 				tempDirPath string
+				dsNumber    int
 			)
 
 			BeforeAll(func() {
@@ -191,8 +192,10 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
+				dsNumber = 1
+
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "svc-ipv4", k8sImagePath, v129,
-					kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil, 1)
+					kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -206,7 +209,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			DescribeTable("configures an IPv4 VIP address for service",
 				func(svcName string, currentOffset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv4Family, currentOffset, defaultNetwork)
-					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol}, 1)
+					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol}, 1, false, dsNumber)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -215,7 +218,16 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			DescribeTable("only removes VIP address if it was referenced by multiple services and all of them were deleted",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
-					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol}, 2)
+					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol}, 2, false, dsNumber)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+
+			DescribeTable("removes VIP if all endpoints were deleted and re-adds VIP on endpoint creation",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
+					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol}, 1, true, dsNumber)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -228,6 +240,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				client      kubernetes.Interface
 				clusterName string
 				tempDirPath string
+				dsNumber    int
 			)
 
 			BeforeAll(func() {
@@ -252,8 +265,10 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
+				dsNumber = 1
+
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "svc-el-ipv4", k8sImagePath, v129,
-					kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil, 1)
+					kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -267,7 +282,8 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			DescribeTable("configures an IPv4 VIP address for service",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
-					testService(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, trafficPolicy, client, true, []corev1.IPFamily{corev1.IPv4Protocol}, 1)
+					testService(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, trafficPolicy, client, true,
+						[]corev1.IPFamily{corev1.IPv4Protocol}, 1, false, dsNumber)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -281,6 +297,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				clusterName string
 				clusterCfg  *rest.Config
 				tempDirPath string
+				dsNumber    int
 			)
 
 			BeforeAll(func() {
@@ -305,8 +322,10 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
+				dsNumber = 1
+
 				clusterName, client, clusterCfg = prepareCluster(ctx, tempDirPath, "ipv6", k8sImagePath, v129,
-					kubeVIPManifestTemplate, logger, manifestValues, networking, 3, nil, 1)
+					kubeVIPManifestTemplate, logger, manifestValues, networking, 3, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -330,6 +349,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				client      kubernetes.Interface
 				clusterName string
 				tempDirPath string
+				dsNumber    int
 			)
 
 			BeforeAll(func() {
@@ -354,8 +374,10 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
+				dsNumber = 1
+
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "svc-ipv6", k8sImagePath, v129,
-					kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil, 1)
+					kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -369,7 +391,8 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			DescribeTable("configures an IPv6 VIP address for service",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
-					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv6Protocol}, 1)
+					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false,
+						[]corev1.IPFamily{corev1.IPv6Protocol}, 1, false, dsNumber)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -378,7 +401,17 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			DescribeTable("only removes VIP address if it was referenced by multiple services and all of them were deleted",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
-					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv6Protocol}, 2)
+					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false,
+						[]corev1.IPFamily{corev1.IPv6Protocol}, 2, false, dsNumber)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+
+			DescribeTable("removes VIP if all endpoints were deleted and re-adds VIP on endpoint creation",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
+					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv6Protocol}, 1, true, dsNumber)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -391,6 +424,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				client      kubernetes.Interface
 				clusterName string
 				tempDirPath string
+				dsNumber    int
 			)
 
 			BeforeAll(func() {
@@ -415,8 +449,10 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
+				dsNumber = 1
+
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "svc-el-ipv6", k8sImagePath, v129,
-					kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil, 1)
+					kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -430,7 +466,8 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			DescribeTable("configures an IPv6 VIP address for service",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
-					testService(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, trafficPolicy, client, true, []corev1.IPFamily{corev1.IPv6Protocol}, 1)
+					testService(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, trafficPolicy, client, true,
+						[]corev1.IPFamily{corev1.IPv6Protocol}, 1, false, dsNumber)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -443,10 +480,11 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				client      kubernetes.Interface
 				clusterName string
 				tempDirPath string
+				dsNumber    int
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateDualStackVIP(23, defaultNetwork)
+				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.DualStackFamily,
@@ -467,8 +505,10 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
+				dsNumber = 1
+
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "ds-ipv4", k8sImagePath, v129,
-					kubeVIPManifestTemplate, logger, manifestValues, networking, 3, nil, 1)
+					kubeVIPManifestTemplate, logger, manifestValues, networking, 3, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -490,10 +530,11 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				client      kubernetes.Interface
 				clusterName string
 				tempDirPath string
+				dsNumber    int
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateDualStackVIP(24, defaultNetwork)
+				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.DualStackFamily,
@@ -514,8 +555,10 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
+				dsNumber = 1
+
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "ds-svc-ipv4", k8sImagePath, v129,
-					kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil, 1)
+					kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -529,7 +572,8 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			DescribeTable("configures an IPv4 and IPv6 VIP addresses for service",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
-					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}, 1)
+					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false,
+						[]corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}, 1, false, dsNumber)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -538,7 +582,18 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			DescribeTable("only removes VIP address if it was referenced by multiple services and all of them were deleted",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
-					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}, 2)
+					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false,
+						[]corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}, 2, false, dsNumber)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+
+			DescribeTable("removes VIP if all endpoints were deleted and re-adds VIP on endpoint creation",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
+					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false,
+						[]corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}, 1, true, dsNumber)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -551,10 +606,11 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				client      kubernetes.Interface
 				clusterName string
 				tempDirPath string
+				dsNumber    int
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateDualStackVIP(29, defaultNetwork)
+				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.DualStackFamily,
@@ -575,8 +631,10 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
+				dsNumber = 1
+
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "ds-svc-el-ipv4", k8sImagePath, v129,
-					kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil, 1)
+					kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -590,7 +648,8 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			DescribeTable("configures an IPv4 and IPv6 VIP addresses for service",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
-					testService(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, trafficPolicy, client, true, []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}, 1)
+					testService(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, trafficPolicy, client, true,
+						[]corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}, 1, false, dsNumber)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -603,10 +662,11 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				client      kubernetes.Interface
 				clusterName string
 				tempDirPath string
+				dsNumber    int
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateDualStackVIP(32, defaultNetwork)
+				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily:      kindconfigv1alpha4.DualStackFamily,
@@ -629,8 +689,10 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
+				dsNumber = 1
+
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "ds-ipv6", k8sImagePath, v129,
-					kubeVIPManifestTemplate, logger, manifestValues, networking, 3, nil, 1)
+					kubeVIPManifestTemplate, logger, manifestValues, networking, 3, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -652,10 +714,11 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				client      kubernetes.Interface
 				clusterName string
 				tempDirPath string
+				dsNumber    int
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateDualStackVIP(33, defaultNetwork)
+				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily:      kindconfigv1alpha4.DualStackFamily,
@@ -678,8 +741,10 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
+				dsNumber = 1
+
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "ds-svc-ipv6", k8sImagePath, v129,
-					kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil, 1)
+					kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -693,7 +758,8 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			DescribeTable("configures an IPv4 and IPv6 VIP addresses for service",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
-					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}, 1)
+					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false,
+						[]corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}, 1, false, dsNumber)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -702,7 +768,18 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			DescribeTable("only removes VIP address if it was referenced by multiple services and all of them were deleted",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
-					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}, 2)
+					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false,
+						[]corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}, 2, false, dsNumber)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+
+			DescribeTable("removes VIP if all endpoints were deleted and re-adds VIP on endpoint creation",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
+					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false,
+						[]corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}, 1, true, dsNumber)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -715,10 +792,11 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				client      kubernetes.Interface
 				clusterName string
 				tempDirPath string
+				dsNumber    int
 			)
 
 			BeforeAll(func() {
-				cpVIP = e2e.GenerateDualStackVIP(38, defaultNetwork)
+				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get(), defaultNetwork)
 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily:      kindconfigv1alpha4.DualStackFamily,
@@ -741,8 +819,10 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
+				dsNumber = 1
+
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "ds-svc-el-ipv6", k8sImagePath, v129,
-					kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil, 1)
+					kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -756,7 +836,8 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			DescribeTable("configures an IPv6 VIP address for service",
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
-					testService(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, trafficPolicy, client, true, []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}, 1)
+					testService(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, trafficPolicy, client, true,
+						[]corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}, 1, false, dsNumber)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -769,6 +850,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				client      kubernetes.Interface
 				clusterName string
 				tempDirPath string
+				dsNumber    int
 			)
 
 			BeforeAll(func() {
@@ -793,8 +875,10 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
+				dsNumber = 1
+
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "ipv4-hostname", k8sImagePath, v129,
-					kubeVIPHostnameManifestTemplate, logger, manifestValues, networking, 3, nil, 1)
+					kubeVIPHostnameManifestTemplate, logger, manifestValues, networking, 3, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -816,6 +900,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				client      kubernetes.Interface
 				clusterName string
 				tempDirPath string
+				dsNumber    int
 			)
 
 			BeforeAll(func() {
@@ -840,8 +925,10 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
 				Expect(err).NotTo(HaveOccurred())
 
+				dsNumber = 3
+
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "svc-el-m-ipv6", k8sImagePath, v129,
-					kubeVIPManifestTemplate, logger, manifestValues, networking, 2, nil, 3)
+					kubeVIPManifestTemplate, logger, manifestValues, networking, 2, nil, dsNumber)
 			})
 
 			AfterAll(func() {
@@ -1431,7 +1518,7 @@ func testControlPlaneVIPs(ctx context.Context, cpVIPs []string, clusterName stri
 }
 
 func testService(ctx context.Context, svcName, lbAddress, leaseName, leaseNamespace string, trafficPolicy corev1.ServiceExternalTrafficPolicy,
-	client kubernetes.Interface, serviceElection bool, ipFamily []corev1.IPFamily, numberOfServices int,
+	client kubernetes.Interface, serviceElection bool, ipFamily []corev1.IPFamily, numberOfServices int, deleteDS bool, dsNumber int,
 ) {
 	lbAddresses := vip.Split(lbAddress)
 
@@ -1460,6 +1547,28 @@ func testService(ctx context.Context, svcName, lbAddress, leaseName, leaseNamesp
 
 	container := e2e.GetLeaseHolder(ctx, leases[0], leaseNamespace, client)
 
+	if deleteDS {
+		removeTestDS(ctx, client, dsNamespace, dsName, dsNumber)
+		time.Sleep(time.Second)
+
+		for _, addr := range lbAddresses {
+			if serviceElection {
+				Expect(checkIPAddress(addr, container, false)).To(BeTrue())
+			} else {
+				Expect(checkIPAddressByLease(ctx, leases[0], leaseNamespace, addr, false, client)).To(BeTrue())
+			}
+			assertConnectionError("http", addr, "80", "", 3*time.Second, 30*time.Second)
+		}
+
+		createTestDS(ctx, client, dsNamespace, dsName, dsNumber)
+		time.Sleep(time.Second)
+
+		for _, addr := range lbAddresses {
+			Expect(checkIPAddressByLease(ctx, leases[0], leaseNamespace, addr, true, client)).To(BeTrue())
+			assertConnection("http", addr, "80", "", 3*time.Second, 60*time.Second)
+		}
+	}
+
 	for i := range numberOfServices {
 		expected := i < numberOfServices-1
 
@@ -1481,6 +1590,7 @@ func testService(ctx context.Context, svcName, lbAddress, leaseName, leaseNamesp
 			}
 		}
 	}
+
 }
 
 func testServiceCommonLease(ctx context.Context, svcName, lbAddress, leaseNamespace string, trafficPolicy corev1.ServiceExternalTrafficPolicy,

--- a/testing/e2e/kube-vip-routing-table.yaml.tmpl
+++ b/testing/e2e/kube-vip-routing-table.yaml.tmpl
@@ -21,7 +21,7 @@ spec:
     - name: vip_interface
       value: eth0
     - name: vip_leaderelection
-      value: "false"
+      value: "{{ .VipElectionEnable }}"
     - name: address
       value: "{{ .ControlPlaneVIP }}"
     - name: vip_leaseduration


### PR DESCRIPTION
This PR is a followup for #1561 

It fixes an error in an if statement and adds E2E tests for deletion and re-creation of addresses/routes in ARP and RT modes when global leader election for services is being used in case of deleted endpoints.