### PR TITLE
Tidy - Extract duplicate code to remove VIP

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/networkinterface"
 	"github.com/kube-vip/kube-vip/pkg/node"
 	"github.com/kube-vip/kube-vip/pkg/route"
+	"github.com/kube-vip/kube-vip/pkg/utils"
 	"github.com/kube-vip/kube-vip/pkg/vip"
 )
 
@@ -131,4 +132,40 @@ func newHealthCheckHTTPClient(c *kubevip.Config) (*http.Client, error) {
 		Timeout:   time.Duration(c.ControlPlaneHealthCheck.TimeoutSeconds) * time.Second,
 		Transport: transport,
 	}, nil
+}
+
+// cleanupVIPs handles VIP removal based on the PreserveVIPOnLeadershipLoss configuration.
+// When preservation is enabled, IPv6 VIPs are always removed immediately to prevent DAD
+// failures on the new leader, while IPv4 VIPs are intentionally left in place.
+// When preservation is disabled (legacy behavior), all VIPs are removed.
+func (cluster *Cluster) cleanupVIPs(c *kubevip.Config) {
+	for i := range cluster.Network {
+		if c.EnableARP && cluster.arpMgr.Count(cluster.Network[i].ARPName()) > 1 {
+			continue
+		}
+
+		if c.PreserveVIPOnLeadershipLoss {
+			if utils.IsIPv6(cluster.Network[i].IP()) {
+				log.Info("[VIP] Removing IPv6 VIP immediately (required to prevent DAD failures on new leader)", "ip", cluster.Network[i].IP())
+				deleted, err := cluster.Network[i].DeleteIP()
+				if err != nil {
+					log.Warn(err.Error())
+				}
+				if deleted {
+					log.Info("deleted address", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
+				}
+			} else {
+				log.Info("[VIP] Preserving IPv4 VIP address on interface, only stopped ARP broadcasting", "ip", cluster.Network[i].IP())
+			}
+		} else {
+			log.Info("[VIP] Deleting VIP", "ip", cluster.Network[i].IP())
+			deleted, err := cluster.Network[i].DeleteIP()
+			if err != nil {
+				log.Warn(err.Error())
+			}
+			if deleted {
+				log.Info("deleted address", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
+			}
+		}
+	}
 }

--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -179,38 +179,7 @@ func (cluster *Cluster) OnStoppedLeading(c *kubevip.Config, objLease *lease.Leas
 	// Stop the cluster context if it is running
 	objLease.Cancel()
 
-	// Handle VIP cleanup based on configuration
-	if c.PreserveVIPOnLeadershipLoss {
-		// For IPv6, we must remove VIPs immediately to avoid DAD failures on the new leader
-		// IPv6 Duplicate Address Detection will fail if the new leader tries to add an IP that is still present on this node's interface
-		// We need to check each VIP individually and only remove IPv6 VIPs
-		for i := range cluster.Network {
-			if utils.IsIPv6(cluster.Network[i].IP()) {
-				log.Info("Removing IPv6 VIP immediately (required to prevent DAD failures on new leader)", "ip", cluster.Network[i].IP())
-				deleted, err := cluster.Network[i].DeleteIP()
-				if err != nil {
-					log.Warn("delete VIP", "err", err)
-				}
-				if deleted {
-					log.Info("deleted address", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
-				}
-			} else {
-				log.Info("Preserving IPv4 VIP address on interface, only stopped ARP broadcasting", "ip", cluster.Network[i].IP())
-			}
-		}
-	} else {
-		// Legacy behavior: delete VIP addresses on leadership loss
-		log.Info("Deleting VIP addresses on leadership loss (legacy behavior)")
-		for i := range cluster.Network {
-			deleted, err := cluster.Network[i].DeleteIP()
-			if err != nil {
-				log.Warn("delete VIP", "err", err)
-			}
-			if deleted {
-				log.Info("deleted address", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
-			}
-		}
-	}
+	cluster.cleanupVIPs(c)
 
 	log.Error("lost leadership, restarting kube-vip")
 }

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -460,40 +460,8 @@ func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip
 
 			return
 		}
-		for i := range cluster.Network {
-			if c.EnableARP && cluster.arpMgr.Count(cluster.Network[i].ARPName()) > 1 {
-				continue
-			}
 
-			// Handle VIP cleanup based on configuration
-			if c.PreserveVIPOnLeadershipLoss {
-				// For IPv6, we must remove VIPs immediately to avoid DAD failures on the new leader
-				// IPv6 Duplicate Address Detection will fail if the new leader tries to add an IP
-				// that is still present on this node's interface
-				if utils.IsIPv6(cluster.Network[i].IP()) {
-					log.Info("[VIP] Removing IPv6 VIP immediately (required to prevent DAD failures on new leader)", "ip", cluster.Network[i].IP())
-					deleted, err := cluster.Network[i].DeleteIP()
-					if err != nil {
-						log.Warn(err.Error())
-					}
-					if deleted {
-						log.Info("deleted address", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
-					}
-				} else {
-					log.Info("[VIP] Preserving IPv4 VIP address on interface, only stopped ARP broadcasting", "ip", cluster.Network[i].IP())
-				}
-			} else {
-				// Legacy behavior: delete VIP addresses on leadership loss
-				log.Info("[VIP] Deleting VIP", "ip", cluster.Network[i].IP())
-				deleted, err := cluster.Network[i].DeleteIP()
-				if err != nil {
-					log.Warn(err.Error())
-				}
-				if deleted {
-					log.Info("deleted address", "IP", cluster.Network[i].IP(), "interface", cluster.Network[i].Interface())
-				}
-			}
-		}
+		cluster.cleanupVIPs(c)
 	})
 
 	return nil


### PR DESCRIPTION
There was somewhat duplicated code in `pkg/cluster/clusterLeaderElection.go - OnStoppedLeading()` and `pkg/cluster/service.go - StartLoadBalancerService()`. 

This PR extracts the duplicate code into a separate function that is called by both.