### PR TITLE
Added macvlan annotation for DHCP

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -44,6 +44,7 @@ type Instance struct {
 	DHCPHostname        string
 	DHCPv4Client        vip.DHCPClient
 	DHCPv6Client        vip.DHCPClient
+	macvlanName         string
 
 	// Service use Vlan
 	IsVLAN        bool
@@ -301,6 +302,7 @@ func NewInstance(ctx context.Context, svc *v1.Service, config *kubevip.Config,
 			}
 		}
 		instance.DHCPHostname = svc.Annotations[kubevip.LoadbalancerHostname]
+		instance.macvlanName = svc.Annotations[kubevip.MacvlanName]
 	}
 
 	configPorts := make([]kubevip.Port, 0)
@@ -530,8 +532,12 @@ func (i *Instance) startDHCP(ctx context.Context, index int, backoffAttempts uin
 		return fmt.Errorf("error finding VIP Interface, for building DHCP Link : %v", err)
 	}
 
-	// Generate name from UID
-	interfaceName := fmt.Sprintf("vip-%s", i.ServiceSnapshot.UID[0:8])
+	interfaceName := i.macvlanName
+
+	if interfaceName == "" {
+		// Generate name from UID
+		interfaceName = fmt.Sprintf("vip-%s", i.ServiceSnapshot.UID[0:8])
+	}
 
 	// Check if the interface doesn't exist first
 	iface, err := net.InterfaceByName(interfaceName)

--- a/pkg/kubevip/annotations.go
+++ b/pkg/kubevip/annotations.go
@@ -70,4 +70,7 @@ const (
 
 	// Enable DDNS for the service
 	ServiceDDNS = "kube-vip.io/ddns"
+
+	// Forces kube-vip to use the specified veth interface when DHCP is being used for a service
+	MacvlanName = "kube-vip.io/macvlanName"
 )


### PR DESCRIPTION
This PR introduces changes that could potentially satisfy request in #1078 

It introduces new service annotation `kube-vip.io/macvlanName` which can be used to force multiple services to use the same macvlan interface. In such case, those services will use the same DHCP IP address.

Example configuration:

```
kube-vip.io/loadbalancerIPs: "0.0.0.0"  # this enables DHCP for the service
kube-vip.io/macvlanName: "test-macvlan" # this ties service to specified macvlan interface
```

When using `extarnalClusterPolicy: Cluster` this can be used alongside `kube-vip.io/leaseName` annotation to tie multiple services with DHCP to single node with single IP address.

The annotation `kube-vip.io/hwaddr` can be used to assign MAC address to the macvlan interface, and therefore preserve the DHCP IP addresses between e.g. kube-vip's restarts.