### PR TITLE
Add dhcp-broadcast annotation

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -45,6 +45,7 @@ type Instance struct {
 	DHCPv4Client        vip.DHCPClient
 	DHCPv6Client        vip.DHCPClient
 	macvlanName         string
+	dhcpBroadcast       bool
 
 	// Service use Vlan
 	IsVLAN        bool
@@ -303,6 +304,7 @@ func NewInstance(ctx context.Context, svc *v1.Service, config *kubevip.Config,
 		}
 		instance.DHCPHostname = svc.Annotations[kubevip.LoadbalancerHostname]
 		instance.macvlanName = svc.Annotations[kubevip.MacvlanName]
+		instance.dhcpBroadcast = svc.Annotations[kubevip.DHCPBroadcast] == "true"
 	}
 
 	configPorts := make([]kubevip.Port, 0)
@@ -614,7 +616,7 @@ func (i *Instance) startDHCP(ctx context.Context, index int, backoffAttempts uin
 			initRebootFlag = true
 		}
 
-		client = vip.NewDHCPv4Client(iface, initRebootFlag, i.DHCPInterfaceIPv4, backoffAttempts)
+		client = vip.NewDHCPv4Client(iface, initRebootFlag, i.DHCPInterfaceIPv4, backoffAttempts, i.dhcpBroadcast)
 
 		// Add the client so that we can call it to stop function
 		i.DHCPv4Client = client

--- a/pkg/kubevip/annotations.go
+++ b/pkg/kubevip/annotations.go
@@ -73,4 +73,7 @@ const (
 
 	// Forces kube-vip to use the specified veth interface when DHCP is being used for a service
 	MacvlanName = "kube-vip.io/macvlanName"
+
+	// Set the BROADCAST flag in DHCP DISCOVER/REQUEST packets
+	DHCPBroadcast = "kube-vip.io/dhcp-broadcast"
 )

--- a/pkg/vip/dhcp.go
+++ b/pkg/vip/dhcp.go
@@ -32,7 +32,7 @@ func NewDHCPClient(network Network, backoffAttempts uint) (DHCPClient, error) {
 			return nil, fmt.Errorf("failed to create DHCP client: %w", err)
 		}
 	} else {
-		client = NewDHCPv4Client(iface, false, "", backoffAttempts)
+		client = NewDHCPv4Client(iface, false, "", backoffAttempts, false)
 	}
 
 	return client, nil

--- a/pkg/vip/dhcpv4.go
+++ b/pkg/vip/dhcpv4.go
@@ -26,6 +26,7 @@ type DHCPv4Client struct {
 	lease           *nclient4.Lease
 	initRebootFlag  bool
 	requestedIP     net.IP
+	broadcastFlag   bool
 	stopChan        chan struct{} // used as a signal to release the IP and stop the dhcp client daemon
 	releasedChan    chan struct{} // indicate that the IP has been released
 	errorChan       chan error    // indicates there was an error on the IP request
@@ -35,7 +36,7 @@ type DHCPv4Client struct {
 }
 
 // NewDHCPv4Client returns a new DHCP Client.
-func NewDHCPv4Client(iface *net.Interface, initRebootFlag bool, requestedIP string, backoffAttempts uint) *DHCPv4Client {
+func NewDHCPv4Client(iface *net.Interface, initRebootFlag bool, requestedIP string, backoffAttempts uint, broadcastFlag bool) *DHCPv4Client {
 	return &DHCPv4Client{
 		iface:           iface,
 		stopChan:        make(chan struct{}),
@@ -43,6 +44,7 @@ func NewDHCPv4Client(iface *net.Interface, initRebootFlag bool, requestedIP stri
 		errorChan:       make(chan error),
 		initRebootFlag:  initRebootFlag,
 		requestedIP:     net.ParseIP(requestedIP),
+		broadcastFlag:   broadcastFlag,
 		ipChan:          make(chan string),
 		backoffAttempts: backoffAttempts,
 	}
@@ -252,6 +254,10 @@ func (c *DHCPv4Client) request(ctx context.Context, rebind bool) (*nclient4.Leas
 	defer dhclient.Close()
 
 	modifiers := make([]dhcpv4.Modifier, 0)
+
+	if c.broadcastFlag {
+		modifiers = append(modifiers, func(d *dhcpv4.DHCPv4) { d.SetBroadcast() })
+	}
 
 	if c.ddnsHostName != "" {
 		modifiers = append(modifiers,

--- a/testing/e2e/e2e_bgp_test.go
+++ b/testing/e2e/e2e_bgp_test.go
@@ -979,7 +979,7 @@ func testServiceBGP(ctx context.Context, svcName, lbAddress string, trafficPolic
 
 	for _, svc := range services {
 		createTestService(ctx, svc, dsNamespace, dsName, lbAddress,
-			client, corev1.IPFamilyPolicyPreferDualStack, serviceAddrFamily, trafficPolicy, serviceLease, 80)
+			client, corev1.IPFamilyPolicyPreferDualStack, serviceAddrFamily, trafficPolicy, serviceLease, 80, false)
 		time.Sleep(time.Second)
 	}
 

--- a/testing/e2e/e2e_ds_test.go
+++ b/testing/e2e/e2e_ds_test.go
@@ -978,7 +978,7 @@ func createTestServiceForDS(ctx context.Context, svcName, lbAddress, leaseName s
 
 	for _, svc := range services {
 		createTestService(ctx, svc, dsNamespace, dsName, lbAddress,
-			client, corev1.IPFamilyPolicyPreferDualStack, ipFamily, trafficPolicy, "", 80)
+			client, corev1.IPFamilyPolicyPreferDualStack, ipFamily, trafficPolicy, "", 80, false)
 		time.Sleep(time.Second)
 	}
 

--- a/testing/e2e/e2e_rt_test.go
+++ b/testing/e2e/e2e_rt_test.go
@@ -1297,7 +1297,7 @@ func testServiceRT(ctx context.Context, svcName, lbAddress, leaseName, leaseName
 			svcLease = leaseName
 		}
 		createTestService(ctx, svc, dsNamespace, dsName, lbAddress,
-			client, corev1.IPFamilyPolicyPreferDualStack, ipFamily, trafficPolicy, svcLease, dsNumber)
+			client, corev1.IPFamilyPolicyPreferDualStack, ipFamily, trafficPolicy, svcLease, dsNumber, false)
 		time.Sleep(time.Second)
 	}
 

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -232,6 +232,20 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
 			)
+
+			DescribeTable("propagates dhcp-broadcast annotation to service",
+				func(svcName string, offset uint, dhcpBroadcast bool) {
+					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
+					createTestService(ctx, svcName, dsNamespace, dsName, lbAddress,
+						client, corev1.IPFamilyPolicyPreferDualStack, []corev1.IPFamily{corev1.IPv4Protocol},
+						corev1.ServiceExternalTrafficPolicyCluster, "", 80, dhcpBroadcast)
+					checkDHCPBroadcastAnnotation(ctx, svcName, dsNamespace, dhcpBroadcast, client)
+					err := client.CoreV1().Services(dsNamespace).Delete(ctx, svcName, metav1.DeleteOptions{})
+					Expect(err).ToNot(HaveOccurred())
+				},
+				Entry("sets annotation when dhcp-broadcast is true", "test-svc-dhcp-broadcast", SOffset.Get(), true),
+				Entry("does not set annotation when dhcp-broadcast is false", "test-svc-no-broadcast", SOffset.Get(), false),
+			)
 		})
 
 		Describe("kube-vip IPv4 functionality, svc_enable=true, svc_election=true", Ordered, func() {
@@ -1275,12 +1289,15 @@ func removePod(ctx context.Context, name, namespace string, client kubernetes.In
 }
 
 func createTestService(ctx context.Context, name, namespace, target, lbAddress string, client kubernetes.Interface, ipfPolicy corev1.IPFamilyPolicy,
-	ipFamiles []corev1.IPFamily, externalPolicy corev1.ServiceExternalTrafficPolicy, leaseName string, port int,
+	ipFamiles []corev1.IPFamily, externalPolicy corev1.ServiceExternalTrafficPolicy, leaseName string, port int, dhcpBroadcast bool,
 ) {
 	svcAnnotations := make(map[string]string)
 	svcAnnotations[kubevip.LoadbalancerIPAnnotation] = lbAddress
 	if leaseName != "" {
 		svcAnnotations[kubevip.ServiceLease] = leaseName
+	}
+	if dhcpBroadcast {
+		svcAnnotations[kubevip.DHCPBroadcast] = "true"
 	}
 
 	labels := make(map[string]string)
@@ -1339,6 +1356,13 @@ func checkIPAddress(lbAddress, container string, expected bool) bool {
 			}
 		}
 	}
+}
+
+func checkDHCPBroadcastAnnotation(ctx context.Context, name, namespace string, expected bool, client kubernetes.Interface) {
+	svc, err := client.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred())
+	_, annotationSet := svc.Annotations[kubevip.DHCPBroadcast]
+	Expect(annotationSet).To(Equal(expected))
 }
 
 func checkIPAddressByLease(ctx context.Context, name, namespace, lbAddress string, expected bool, client kubernetes.Interface) bool {
@@ -1536,7 +1560,7 @@ func testService(ctx context.Context, svcName, lbAddress, leaseName, leaseNamesp
 
 	for _, svc := range services {
 		createTestService(ctx, svc, dsNamespace, dsName, lbAddress,
-			client, corev1.IPFamilyPolicyPreferDualStack, ipFamily, trafficPolicy, "", 80)
+			client, corev1.IPFamilyPolicyPreferDualStack, ipFamily, trafficPolicy, "", 80, false)
 		time.Sleep(time.Second)
 	}
 
@@ -1611,7 +1635,7 @@ func testServiceCommonLease(ctx context.Context, svcName, lbAddress, leaseNamesp
 			tmpDsName = fmt.Sprintf("%s-%d", tmpDsName, i)
 		}
 		createTestService(ctx, svc, dsNamespace, tmpDsName, lbAddress,
-			client, corev1.IPFamilyPolicyPreferDualStack, ipFamily, trafficPolicy, lease, 80+i)
+			client, corev1.IPFamilyPolicyPreferDualStack, ipFamily, trafficPolicy, lease, 80+i, false)
 		time.Sleep(time.Second)
 	}
 

--- a/testing/services/pkg/deployment/kubernetes.go
+++ b/testing/services/pkg/deployment/kubernetes.go
@@ -26,6 +26,7 @@ type Service struct {
 	policyLocal    bool // set the policy to local pods
 	testHTTP       bool
 	testDualstack  bool // test dualstack loadbalancer services
+	dhcpBroadcast  bool // test dhcp broadcast flag
 	timeout        int  // how long to wait for the service to be created
 }
 
@@ -259,6 +260,13 @@ func (s *Service) CreateService(ctx context.Context, clientset *kubernetes.Clien
 
 	if s.policyLocal {
 		svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
+	}
+
+	if s.dhcpBroadcast {
+		if svc.Annotations == nil {
+			svc.Annotations = make(map[string]string)
+		}
+		svc.Annotations[kubevip.DHCPBroadcast] = "true"
 	}
 
 	if s.testDualstack {


### PR DESCRIPTION
This PR introduces a new service annotation `kube-vip.io/dhcp-broadcast` to address DHCP failures in environments where the relay sends unicasts replies directly to the VIP. In those setups the packet can be intercepted by the Cilium kube-proxy replacement before the macvlan interface receives it.

Setting the BROADCAST flag in DISCOVER/REQUEST packets instructs the DHCP to broadcast the reply instead, bypassing the interception.

Example configuration:

```
kube-vip.io/loadbalancerIPs: "0.0.0.0"    # enables DHCP for the service
kube-vip.io/dhcp-broadcast: "true"        # sets BROADCAST flag in DHCP packets
```

Resolves #1577