### PR TITLE
Add endpointless reconciliation after service refactor 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Non-disruptive: Process continues running after configuration dump
   - Added comprehensive unit tests for all dump methods
   - Added E2E tests for signal handling
+- Opt-in support for endpointless `LoadBalancer` services with `externalTrafficPolicy: Cluster`
+  - Annotation: `kube-vip.io/allow-reconcile-without-endpoints: "true"`
+  - Starts service handling path for opted-in endpointless Cluster services while preserving default endpoint-gated behavior for non-opt-in services and `Local` policy
+  - Added endpoint behavior tests and README usage documentation
 
 ### Changed
 - Updated signal handlers in manager_arp.go, manager_bgp.go, manager_wireguard.go, and manager_table.go to use switch statement pattern for handling multiple signals (SIGUSR1, SIGINT, SIGTERM)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,8 +113,8 @@ and *merged* sorts of commits.
 To make it easier for reviewers to review your PR, consider the following:
 
 1. Follow the golang [coding conventions](https://github.com/golang/go/wiki/CodeReviewComments).
-2. Format your code with `make golangci-fix`; if the [linters](ci/README.md) flag an issue that
-   cannot be fixed automatically, an error message will be displayed so you can address the issue.
+2. Format your code with `make simplify` to automatically fix formatting issues.
+2. Lint your code with `make check`; if the linters flag an issue that cannot be fixed automatically, an error message will be displayed so you can address the issue.
 3. Follow [git commit](https://chris.beams.io/posts/git-commit/) guidelines.
 4. Follow [logging](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md) guidelines.
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,26 @@ ip_vs_rr
 Preloading only the required modules is preferred to enabling the SELinux
 `domain_kernel_load_modules` boolean for containers.
 
+### Gateway API `LoadBalancer` services with no endpoints
+
+Some Gateway API controllers create `LoadBalancer` services that intentionally have no Endpoints/EndpointSlices backends.
+
+If you want kube-vip to reconcile such a service, opt in with:
+
+```yaml
+metadata:
+  annotations:
+    kube-vip.io/allow-reconcile-without-endpoints: "true"
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Cluster
+```
+
+Scope:
+- Works only with `externalTrafficPolicy: Cluster`
+- No effect for `Local`
+- Default endpoint-gated behavior remains unchanged for services without this annotation
+
 Please raise issues on the GitHub repository and as mentioned check the documentation at [https://kube-vip.io](https://kube-vip.io/).
 
 ## Community Tools

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -65,6 +66,8 @@ func (p *Processor) AddOrModify(svcCtx *servicecontext.Context, event watch.Even
 		log.Error("updating instance", "err", err)
 	}
 
+	allowReconcileWithoutEndpoints := shouldAllowReconcileWithoutEndpoints(service)
+
 	// Find out if we have any local endpoints
 	// if out endpoint is empty then populate it
 	// if not, go through the endpoints and see if ours still exists
@@ -115,8 +118,11 @@ func (p *Processor) AddOrModify(svcCtx *servicecontext.Context, event watch.Even
 			}
 		}
 	} else {
-		// There are no local endpoints
-		if svcCtx.Signalled.Load() {
+		if allowReconcileWithoutEndpoints {
+			// Explicit opt-in for controllers that create LoadBalancer services without endpoints
+			svcCtx.SignalReadiness()
+		} else if svcCtx.Signalled.Load() {
+			// There are no local endpoints
 			svcCtx.ResetReadiness()
 			p.worker.clear(svcCtx, lastKnownGoodEndpoint, service)
 			if p.config.EnableARP && !p.config.EnableServicesElection {
@@ -270,6 +276,14 @@ func (p *Processor) startLeaderElection(svcCtx *servicecontext.Context, service 
 			}
 		}
 	}
+}
+
+func shouldAllowReconcileWithoutEndpoints(service *v1.Service) bool {
+	if service == nil || service.Spec.ExternalTrafficPolicy != v1.ServiceExternalTrafficPolicyTypeCluster {
+		return false
+	}
+
+	return strings.EqualFold(service.Annotations[kubevip.AllowReconcileWithoutEndpoints], "true")
 }
 
 func hasV6(endpoints []string) bool {

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -85,25 +85,8 @@ func (p *Processor) AddOrModify(svcCtx *servicecontext.Context, event watch.Even
 
 		p.updateLastKnownGoodEndpoint(lastKnownGoodEndpoint, endpoints, service)
 
-		if p.config.EnableServicesElection {
-			wg.Go(func() {
-				les.Add(1)
-				p.startLeaderElection(svcCtx, service, serviceFunc, wg)
-			})
-		} else if p.config.EnableARP || (p.config.EnableRoutingTable && p.config.EnableLeaderElection) {
-			if !svcCtx.Signalled.Load() {
-				inst := instance.FindServiceInstance(service, *p.instances)
-				if inst == nil {
-					return true, fmt.Errorf("[%s] failed to find an instance for service %s/%s", p.provider.GetLabel(), service.Namespace, service.Name)
-				}
-				// global leader election is enabled for services
-				for x := range inst.VIPConfigs {
-					log.Debug("starting loadbalancer for service", "name", service.Name, "namespace", service.Namespace, "uid", service.UID)
-					if err := inst.Clusters[x].StartLoadBalancerService(svcCtx.Ctx, inst.VIPConfigs[x], p.bgpServer, lease.ServiceNamespacedName(service), wg); err != nil {
-						return true, fmt.Errorf("failed to start lb: %w", err)
-					}
-				}
-			}
+		if err := p.startServiceHandlingIfNeeded(svcCtx, service, serviceFunc, wg, &les); err != nil {
+			return true, err
 		}
 
 		svcCtx.SignalReadiness()
@@ -120,7 +103,16 @@ func (p *Processor) AddOrModify(svcCtx *servicecontext.Context, event watch.Even
 	} else {
 		if allowReconcileWithoutEndpoints {
 			// Explicit opt-in for controllers that create LoadBalancer services without endpoints
+			if err := p.startServiceHandlingIfNeeded(svcCtx, service, serviceFunc, wg, &les); err != nil {
+				return true, err
+			}
 			svcCtx.SignalReadiness()
+
+			if (!p.config.EnableServicesElection && !p.config.EnableLeaderElection) || p.config.EnableWireguard {
+				if err := p.worker.processInstance(svcCtx, service); err != nil {
+					return false, fmt.Errorf("failed to process endpointless instance: %w", err)
+				}
+			}
 		} else if svcCtx.Signalled.Load() {
 			// There are no local endpoints
 			svcCtx.ResetReadiness()
@@ -250,6 +242,34 @@ func (p *Processor) updateAnnotations(service *v1.Service, lastKnownGoodEndpoint
 			}
 		}
 	}
+}
+
+func (p *Processor) startServiceHandlingIfNeeded(svcCtx *servicecontext.Context, service *v1.Service,
+	serviceFunc func(*servicecontext.Context, *v1.Service, *sync.WaitGroup, bool) error, wg *sync.WaitGroup, les *atomic.Int64) error {
+	if p.config.EnableServicesElection {
+		wg.Go(func() {
+			les.Add(1)
+			p.startLeaderElection(svcCtx, service, serviceFunc, wg)
+		})
+		return nil
+	}
+
+	if p.config.EnableARP || (p.config.EnableRoutingTable && p.config.EnableLeaderElection) {
+		if !svcCtx.Signalled.Load() {
+			inst := instance.FindServiceInstance(service, *p.instances)
+			if inst == nil {
+				return fmt.Errorf("[%s] failed to find an instance for service %s/%s", p.provider.GetLabel(), service.Namespace, service.Name)
+			}
+			for x := range inst.VIPConfigs {
+				log.Debug("starting loadbalancer for service", "name", service.Name, "namespace", service.Namespace, "uid", service.UID)
+				if err := inst.Clusters[x].StartLoadBalancerService(svcCtx.Ctx, inst.VIPConfigs[x], p.bgpServer, lease.ServiceNamespacedName(service), wg); err != nil {
+					return fmt.Errorf("failed to start lb: %w", err)
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 func (p *Processor) startLeaderElection(svcCtx *servicecontext.Context, service *v1.Service, serviceFunc func(*servicecontext.Context, *v1.Service, *sync.WaitGroup, bool) error, wg *sync.WaitGroup) {

--- a/pkg/endpoints/endpoints_test.go
+++ b/pkg/endpoints/endpoints_test.go
@@ -1,0 +1,63 @@
+package endpoints
+
+import (
+	"testing"
+
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestShouldAllowReconcileWithoutEndpoints(t *testing.T) {
+	tests := []struct {
+		name     string
+		service  *v1.Service
+		expected bool
+	}{
+		{
+			name:     "nil service",
+			expected: false,
+		},
+		{
+			name: "cluster policy with opt-in annotation",
+			service: &v1.Service{
+				Spec:       v1.ServiceSpec{ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster},
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{kubevip.AllowReconcileWithoutEndpoints: "true"}},
+			},
+			expected: true,
+		},
+		{
+			name: "cluster policy with case-insensitive opt-in",
+			service: &v1.Service{
+				Spec:       v1.ServiceSpec{ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster},
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{kubevip.AllowReconcileWithoutEndpoints: "TRUE"}},
+			},
+			expected: true,
+		},
+		{
+			name: "cluster policy without opt-in",
+			service: &v1.Service{
+				Spec:       v1.ServiceSpec{ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster},
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+			},
+			expected: false,
+		},
+		{
+			name: "local policy with opt-in",
+			service: &v1.Service{
+				Spec:       v1.ServiceSpec{ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal},
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{kubevip.AllowReconcileWithoutEndpoints: "true"}},
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := shouldAllowReconcileWithoutEndpoints(test.service)
+			if actual != test.expected {
+				t.Fatalf("expected %v, got %v", test.expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/endpoints/endpoints_test.go
+++ b/pkg/endpoints/endpoints_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/servicecontext"
 	v1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 )
@@ -35,9 +36,8 @@ func TestShouldAllowReconcileWithoutEndpoints(t *testing.T) {
 	}
 }
 
-
 type fakeWorker struct {
-	endpoints      []string
+	endpoints     []string
 	clearCalled   bool
 	processCalled bool
 }
@@ -69,7 +69,7 @@ func TestAddOrModify_ZeroEndpointsBehavior(t *testing.T) {
 		worker := &fakeWorker{endpoints: []string{}}
 		p := &Processor{
 			config:   &kubevip.Config{},
-			provider: providers.NewEndpoints(),
+			provider: providers.NewEndpointslices(),
 			worker:   worker,
 		}
 
@@ -80,7 +80,7 @@ func TestAddOrModify_ZeroEndpointsBehavior(t *testing.T) {
 
 		restart, err := p.AddOrModify(
 			svcCtx,
-			watch.Event{Type: watch.Modified, Object: &v1.Endpoints{}},
+			watch.Event{Type: watch.Modified, Object: &discoveryv1.EndpointSlice{}},
 			new(string),
 			service,
 			"node-1",

--- a/pkg/endpoints/endpoints_test.go
+++ b/pkg/endpoints/endpoints_test.go
@@ -1,63 +1,133 @@
 package endpoints
 
 import (
+	"context"
+	"sync"
 	"testing"
 
+	"github.com/kube-vip/kube-vip/pkg/endpoints/providers"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/servicecontext"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
 )
 
 func TestShouldAllowReconcileWithoutEndpoints(t *testing.T) {
-	tests := []struct {
-		name     string
-		service  *v1.Service
-		expected bool
-	}{
-		{
-			name:     "nil service",
-			expected: false,
-		},
-		{
-			name: "cluster policy with opt-in annotation",
-			service: &v1.Service{
-				Spec:       v1.ServiceSpec{ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster},
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{kubevip.AllowReconcileWithoutEndpoints: "true"}},
-			},
-			expected: true,
-		},
-		{
-			name: "cluster policy with case-insensitive opt-in",
-			service: &v1.Service{
-				Spec:       v1.ServiceSpec{ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster},
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{kubevip.AllowReconcileWithoutEndpoints: "TRUE"}},
-			},
-			expected: true,
-		},
-		{
-			name: "cluster policy without opt-in",
-			service: &v1.Service{
-				Spec:       v1.ServiceSpec{ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster},
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
-			},
-			expected: false,
-		},
-		{
-			name: "local policy with opt-in",
-			service: &v1.Service{
-				Spec:       v1.ServiceSpec{ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal},
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{kubevip.AllowReconcileWithoutEndpoints: "true"}},
-			},
-			expected: false,
-		},
+	if shouldAllowReconcileWithoutEndpoints(nil) {
+		t.Fatal("nil service should not be allowed")
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			actual := shouldAllowReconcileWithoutEndpoints(test.service)
-			if actual != test.expected {
-				t.Fatalf("expected %v, got %v", test.expected, actual)
-			}
-		})
+	clusterOptIn := &v1.Service{
+		Spec:       v1.ServiceSpec{ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster},
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{kubevip.AllowReconcileWithoutEndpoints: "true"}},
 	}
+	if !shouldAllowReconcileWithoutEndpoints(clusterOptIn) {
+		t.Fatal("cluster service with opt-in annotation should be allowed")
+	}
+
+	localOptIn := &v1.Service{
+		Spec:       v1.ServiceSpec{ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal},
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{kubevip.AllowReconcileWithoutEndpoints: "true"}},
+	}
+	if shouldAllowReconcileWithoutEndpoints(localOptIn) {
+		t.Fatal("local service should not be allowed")
+	}
+}
+
+
+type fakeWorker struct {
+	endpoints      []string
+	clearCalled   bool
+	processCalled bool
+}
+
+func (f *fakeWorker) processInstance(_ *servicecontext.Context, _ *v1.Service) error {
+	f.processCalled = true
+	return nil
+}
+
+func (f *fakeWorker) clear(_ *servicecontext.Context, _ *string, _ *v1.Service) {
+	f.clearCalled = true
+}
+
+func (f *fakeWorker) getEndpoints(_ *v1.Service, _ string) ([]string, error) { return f.endpoints, nil }
+func (f *fakeWorker) removeEgress(_ *v1.Service, _ *string)                  {}
+func (f *fakeWorker) delete(_ context.Context, _ *v1.Service, _ string) error {
+	return nil
+}
+func (f *fakeWorker) setInstanceEndpointsStatus(_ context.Context, _ *v1.Service, _ []string) error {
+	return nil
+}
+
+func TestAddOrModify_ZeroEndpointsBehavior(t *testing.T) {
+	t.Parallel()
+
+	run := func(t *testing.T, service *v1.Service, presetSignalled bool, expectReady bool, expectClear bool, expectProcess bool) {
+		t.Helper()
+
+		worker := &fakeWorker{endpoints: []string{}}
+		p := &Processor{
+			config:   &kubevip.Config{},
+			provider: providers.NewEndpoints(),
+			worker:   worker,
+		}
+
+		svcCtx := servicecontext.New(context.Background())
+		if presetSignalled {
+			svcCtx.SignalReadiness()
+		}
+
+		restart, err := p.AddOrModify(
+			svcCtx,
+			watch.Event{Type: watch.Modified, Object: &v1.Endpoints{}},
+			new(string),
+			service,
+			"node-1",
+			func(*servicecontext.Context, *v1.Service, *sync.WaitGroup, bool) error { return nil },
+			&sync.WaitGroup{},
+			nil,
+			nil,
+		)
+		if err != nil {
+			t.Fatalf("AddOrModify returned error: %v", err)
+		}
+		if restart {
+			t.Fatal("AddOrModify unexpectedly requested restart")
+		}
+
+		if ready := svcCtx.Signalled.Load(); ready != expectReady {
+			t.Fatalf("readiness mismatch: expected %v, got %v", expectReady, ready)
+		}
+		if worker.clearCalled != expectClear {
+			t.Fatalf("clearCalled mismatch: expected %v, got %v", expectClear, worker.clearCalled)
+		}
+		if worker.processCalled != expectProcess {
+			t.Fatalf("processCalled mismatch: expected %v, got %v", expectProcess, worker.processCalled)
+		}
+	}
+
+	t.Run("cluster opt-in keeps readiness and skips clear", func(t *testing.T) {
+		service := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{kubevip.AllowReconcileWithoutEndpoints: "true"}},
+			Spec:       v1.ServiceSpec{ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster},
+		}
+		run(t, service, false, true, false, true)
+	})
+
+	t.Run("cluster without opt-in resets and clears when pre-signalled", func(t *testing.T) {
+		service := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+			Spec:       v1.ServiceSpec{ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster},
+		}
+		run(t, service, true, false, true, false)
+	})
+
+	t.Run("local opt-in still resets and clears when pre-signalled", func(t *testing.T) {
+		service := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{kubevip.AllowReconcileWithoutEndpoints: "true"}},
+			Spec:       v1.ServiceSpec{ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal},
+		}
+		run(t, service, true, false, true, false)
+	})
 }

--- a/pkg/kubevip/annotations.go
+++ b/pkg/kubevip/annotations.go
@@ -68,6 +68,9 @@ const (
 	// Name of the service lease object
 	ServiceLease = "kube-vip.io/leaseName"
 
+	// Allow service reconciliation even when no endpoints are present (Cluster policy only)
+	AllowReconcileWithoutEndpoints = "kube-vip.io/allow-reconcile-without-endpoints"
+
 	// Enable DDNS for the service
 	ServiceDDNS = "kube-vip.io/ddns"
 


### PR DESCRIPTION
 ## Summary

 This PR adds an explicit opt-in for reconciling LoadBalancer Services that intentionally have no endpoints (common with some Gateway API controllers like Cilium), while preserving existing default behavior.

We had an "incident" after updating to v1.2.0, since the Gateway services where not being reconciled anymore. Removing the gateway showed it being in pending state and not getting an IP assigned. Reverting to 1.1.X worked. 

 ## What changed

 - Added new Service annotation:
     - kube-vip.io/allow-reconcile-without-endpoints: "true"
 - Narrow scope:
     - applies only to externalTrafficPolicy: Cluster
     - has no effect for externalTrafficPolicy: Local
     - default behavior remains unchanged for services without this annotation
 - Updated endpoint handling flow so opted-in, endpointless Cluster Services still start service handling paths where required.
 - Added/updated unit tests for:
     - annotation gating behavior
     - zero-endpoint AddOrModify behavior (opt-in Cluster vs non-opt-in/Local)
 - Updated CONTRIBUTING.md to reflect actual make targets 
 
 ## Motivation

 After service handling refactors in #1463, kube-vip waits for endpoint readiness before reconciling.
 That is correct by default, but it blocks valid endpointless LoadBalancer patterns used by some Gateway API implementations.