### PR TITLE
Feat: Dump BGP Routes

### DIFF
--- a/pkg/bgp/server.go
+++ b/pkg/bgp/server.go
@@ -95,3 +95,36 @@ func (b *Server) Close() error {
 	defer cancel()
 	return b.s.StopBgp(ctx, &api.StopBgpRequest{})
 }
+
+// ListAdvertisedRoutes retrieves all active routes inside GoBGP's local RIB.
+// It queries the GLOBAL table type to find routes that kube-vip has requested GoBGP to advertise.
+func (b *Server) ListAdvertisedRoutes(ctx context.Context, isIPv6 bool) ([]*api.Destination, error) {
+	family := &api.Family{
+		Afi:  api.Family_AFI_IP,
+		Safi: api.Family_SAFI_UNICAST,
+	}
+	if isIPv6 {
+		family.Afi = api.Family_AFI_IP6
+	}
+
+	var destinations []*api.Destination
+
+	req := &api.ListPathRequest{
+		TableType: api.TableType_GLOBAL,
+		Family:    family,
+	}
+
+	// GoBGP's embedded server API uses a callback function to stream results
+	// locally without requiring a gRPC client stream setup.
+	err := b.s.ListPath(ctx, req, func(destination *api.Destination) {
+		if destination != nil {
+			destinations = append(destinations, destination)
+		}
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract local RIB: %w", err)
+	}
+
+	return destinations, nil
+}

--- a/pkg/manager/manager_dump.go
+++ b/pkg/manager/manager_dump.go
@@ -27,7 +27,7 @@ func (sm *Manager) dumpConfiguration(ctx context.Context) {
 	fmt.Printf("\n")
 
 	sm.dumpConfigSection()
-	sm.dumpBGPSection()
+	sm.dumpBGPSection(ctx)
 	sm.dumpARPSection()
 	sm.dumpServicesSection(ctx)
 	sm.dumpNetworkInterfacesSection()
@@ -54,7 +54,7 @@ func (sm *Manager) dumpConfigSection() {
 	fmt.Printf("\n")
 }
 
-func (sm *Manager) dumpBGPSection() {
+func (sm *Manager) dumpBGPSection(ctx context.Context) {
 	fmt.Printf("--- BGP CONFIGURATION ---\n")
 	fmt.Printf("BGP Enabled: %t\n", sm.config.EnableBGP)
 	if sm.config.EnableBGP {
@@ -69,6 +69,8 @@ func (sm *Manager) dumpBGPSection() {
 			fmt.Printf("  Peer %d: %s:%d (AS: %d, MultiHop: %t)\n",
 				i+1, peer.Address, peer.Port, peer.AS, peer.MultiHop)
 		}
+		fmt.Printf("\n--- ACTIVE BGP RIB STATE ---\n")
+		sm.dumpBGPRoutes(ctx)
 	}
 	fmt.Printf("\n")
 }
@@ -232,4 +234,55 @@ func (sm *Manager) dumpNFTablesSection() {
 		fmt.Printf("Chain: %s\n", chains[x])
 	}
 	fmt.Println()
+}
+
+func (sm *Manager) dumpBGPRoutes(ctx context.Context) {
+	if sm.bgpServer == nil {
+		fmt.Printf("  BGP Server instance is inactive or uninitialized\n")
+		return
+	}
+
+	// Create a short-lived execution window so a stuck BGP loop won't hang the entire SIGUSR1 routine
+	queryCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	for _, isIPv6 := range []bool{false, true} {
+		label := "IPv4"
+		if isIPv6 {
+			label = "IPv6"
+		}
+
+		routes, err := sm.bgpServer.ListAdvertisedRoutes(queryCtx, isIPv6)
+		if err != nil {
+			fmt.Printf("  Error fetching %s routes: %v\n", label, err)
+			continue
+		}
+
+		if len(routes) == 0 {
+			fmt.Printf("  No %s routes found in global RIB\n", label)
+			continue
+		}
+
+		fmt.Printf("  %-18s | %-15s | %s\n", "Prefix", "Next Hop", "Discovered/Updated")
+		fmt.Printf("  ------------------------------------------------------------\n")
+
+		for _, dest := range routes {
+			for _, path := range dest.Paths {
+				nextHop := "N/A"
+				if path.NeighborIp != "" {
+					nextHop = path.NeighborIp
+				}
+
+				var timeStr string
+				if path.Age != nil {
+					timeStr = path.Age.AsTime().Format("15:04:05")
+				} else {
+					timeStr = "Unknown"
+				}
+
+				fmt.Printf("  %-18s | %-15s | %s\n", dest.Prefix, nextHop, timeStr)
+			}
+		}
+		fmt.Println()
+	}
 }

--- a/pkg/manager/manager_dump_test.go
+++ b/pkg/manager/manager_dump_test.go
@@ -111,7 +111,7 @@ func TestDumpBGPSection(t *testing.T) {
 		r, w, _ := os.Pipe()
 		os.Stdout = w
 
-		mgr.dumpBGPSection()
+		mgr.dumpBGPSection(t.Context())
 
 		w.Close()
 		os.Stdout = old
@@ -142,7 +142,7 @@ func TestDumpBGPSection(t *testing.T) {
 		r, w, _ := os.Pipe()
 		os.Stdout = w
 
-		mgr.dumpBGPSection()
+		mgr.dumpBGPSection(t.Context())
 
 		w.Close()
 		os.Stdout = old
@@ -156,6 +156,9 @@ func TestDumpBGPSection(t *testing.T) {
 		assert.Contains(t, output, "BGP Router ID: 192.168.1.1")
 		assert.Contains(t, output, "BGP AS: 65000")
 		assert.Contains(t, output, "BGP Peers: 2")
+
+		assert.Contains(t, output, "--- ACTIVE BGP RIB STATE ---")
+		assert.Contains(t, output, "BGP Server instance is inactive or uninitialized")
 	})
 }
 

--- a/testing/e2e/e2e_sigusr1_test.go
+++ b/testing/e2e/e2e_sigusr1_test.go
@@ -48,6 +48,7 @@ var _ = Describe("SIGUSR1 Signal Handler", func() {
 				"--address", "192.168.1.100",
 				"--interface", "lo",
 				"--port", "6443",
+				"--bgp", 
 			)
 
 			var err error
@@ -61,6 +62,7 @@ var _ = Describe("SIGUSR1 Signal Handler", func() {
 
 			Eventually(session.Out, "5s").Should(gbytes.Say("KUBE-VIP CONFIGURATION DUMP"))
 			Eventually(session.Out).Should(gbytes.Say("VIP: 192.168.1.100"))
+			Eventually(session.Out).Should(gbytes.Say("ACTIVE BGP RIB STATE"))
 
 			Consistently(session, "2s").ShouldNot(gexec.Exit())
 		})


### PR DESCRIPTION
This PR adds functionality to `pkg/manager/manager_dump.go` to dump BGP routes. 

Closes: #1311 