### PR TITLE
Bump Go to 1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM golang:1.26.3-alpine3.23 as dev
+FROM golang:1.26.4-alpine3.23 as dev
 RUN apk add --no-cache git ca-certificates make
 RUN adduser -D appuser
 COPY . /src/

--- a/Dockerfile_iptables
+++ b/Dockerfile_iptables
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM golang:1.26.3-alpine3.23 as dev
+FROM golang:1.26.4-alpine3.23 as dev
 RUN apk add --no-cache git make
 RUN adduser -D appuser
 COPY . /src/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kube-vip/kube-vip
 
-go 1.26.0
+go 1.26.4
 
 require (
 	github.com/cloudflare/ipvs v0.12.0


### PR DESCRIPTION
This PR changes Go version to 1.26.4 to fix the current vulnerability scan issue.