### PR TITLE
Added nftables for vip/address.go

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
       - name: Build image with iptables
-        run: make dockerx86ActionIPTables
+        run: make dockerx86Action
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ e2e-tests: e2e-tests-arp e2e-tests-rt e2e-tests-bgp
 
 service-tests:
 	$(MAKE) -C testing/e2e/e2e dockerLocal
-	E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run ./testing/services -Services -simple -deployments -leaderActive -leaderFailover -localDeploy -egress -egressIPv6 -dualStack
+	E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run ./testing/services -Services -simple -deployments -leaderActive -leaderFailover -localDeploy -egress -egressIPv6 -dualStack -egressInternal
 
 trivy: dockerx86ActionIPTables
 	docker run -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:0.47.0 \

--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -163,6 +163,8 @@ func init() {
 	// Configuration file flag
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.ConfigFile, "config-file", "", "Path to a JSON/YAML configuration file to load settings from")
 
+	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EgressWithNftables, "egressWithNftables", true, "Use nftables-based egress implementation")
+
 	kubeVipCmd.AddCommand(kubeKubeadm)
 	kubeVipCmd.AddCommand(kubeManifest)
 	kubeVipCmd.AddCommand(kubeVipManager)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -80,7 +80,8 @@ func startNetworking(c *kubevip.Config, intfMgr *networkinterface.Manager) ([]vi
 	for _, addr := range addresses {
 		network, err := vip.NewConfig(addr, c.Interface, c.LoInterfaceGlobalScope, c.VIPSubnet, c.DDNS, c.DHCPMode,
 			c.RequireDualStack, c.IsDualStack, c.RoutingTableID, c.RoutingTableType, c.RoutingProtocol, c.DNSMode,
-			c.LoadBalancerForwardingMethod, c.IptablesBackend, c.EnableLoadBalancer, c.EnableServiceSecurity, intfMgr)
+			c.LoadBalancerForwardingMethod, c.IptablesBackend, c.EnableLoadBalancer, c.LoadBalancerPort,
+			c.EnableServiceSecurity, intfMgr, c.EgressWithNftables)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -95,11 +95,11 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 		}
 
 		if c.EnableLoadBalancer {
-			lb, err := loadbalancer.NewIPVSLB(ctx, network.IP(), c.LoadBalancerPort, c.LoadBalancerForwardingMethod,
-				c.BackendHealthCheckInterval, killFunc, &wg)
+			lb, err := loadbalancer.NewIPVSLB(ctx, network, c.LoadBalancerPort, c.LoadBalancerForwardingMethod,
+				c.BackendHealthCheckInterval, c.EgressWithNftables, killFunc, &wg)
 			if err != nil {
 				killFunc()
-				return fmt.Errorf("creating IPVS LoadBalance: %w", err)
+				return fmt.Errorf("creating IPVS LoadBalancer: %w", err)
 			}
 
 			wg.Go(func() {

--- a/pkg/cluster/service_test.go
+++ b/pkg/cluster/service_test.go
@@ -367,6 +367,7 @@ func (m *mockNetwork) HasEndpoints() bool              { return false }
 func (m *mockNetwork) ARPName() string                 { return "" }
 func (m *mockNetwork) GetPossibleSubnets() string      { return "" }
 func (m *mockNetwork) DHCPFamily() string              { return "" }
+func (m *mockNetwork) IPVSMark() uint32                { return 0 }
 
 // testHealthServer wraps an HTTPS httptest.Server with an atomic status code.
 // caPath is the path to the server's CA cert for client verification.

--- a/pkg/egress/egress.go
+++ b/pkg/egress/egress.go
@@ -26,7 +26,7 @@ func Teardown(podIP, vipIP, namespace, serviceUUID string, annotations map[strin
 	}
 
 	// Use the internal egress implementation
-	if internalEgress != "" {
+	if internalEgress != "" || useNftables {
 		return nftables.DeleteSNAT(IPv6, serviceUUID)
 	}
 

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -261,7 +261,7 @@ func (p *Processor) startServiceHandlingIfNeeded(svcCtx *servicecontext.Context,
 				return fmt.Errorf("[%s] failed to find an instance for service %s/%s", p.provider.GetLabel(), service.Namespace, service.Name)
 			}
 			for x := range inst.VIPConfigs {
-				log.Debug("starting loadbalancer for service", "name", service.Name, "namespace", service.Namespace, "uid", service.UID)
+				log.Debug("starting loadbalancer for service", "provider", p.provider.GetLabel(), "name", service.Name, "namespace", service.Namespace, "uid", service.UID)
 				if err := inst.Clusters[x].StartLoadBalancerService(svcCtx.Ctx, inst.VIPConfigs[x], p.bgpServer, lease.ServiceNamespacedName(service), wg); err != nil {
 					return fmt.Errorf("failed to start lb: %w", err)
 				}

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -400,6 +400,8 @@ func NewInstance(ctx context.Context, svc *v1.Service, config *kubevip.Config,
 			}
 		}
 
+		instance.VIPConfigs[i].EgressWithNftables = config.EgressWithNftables
+
 		c, err := cluster.InitCluster(instance.VIPConfigs[i], false, intfMgr, arpMgr, routeMgr, nodeLabelMgr)
 		if err != nil {
 			log.Error("failed to add service", "err", err)

--- a/pkg/loadbalancer/ipvs.go
+++ b/pkg/loadbalancer/ipvs.go
@@ -56,9 +56,10 @@ type IPVSLoadBalancer struct {
 	family              ipvs.AddressFamily
 }
 
-func NewIPVSLB(ctx context.Context, address string, port uint16, forwardingMethod string, backendHealthCheckInterval int,
-	killFunc func(), wg *sync.WaitGroup) (*IPVSLoadBalancer, error) {
-	log.Info("Starting IPVS LoadBalancer", "address", address)
+func NewIPVSLB(ctx context.Context, network vip.Network, port uint16, forwardingMethod string, backendHealthCheckInterval int,
+	nftables bool, killFunc func(), wg *sync.WaitGroup) (*IPVSLoadBalancer, error) {
+	address := network.IP()
+	log.Info("Starting IPVS LoadBalancer", "address", network)
 
 	// Create IPVS client
 	c, err := ipvs.New()
@@ -100,6 +101,12 @@ func NewIPVSLB(ctx context.Context, address string, port uint16, forwardingMetho
 		netMask = netmask.MaskFrom(128, vip.DefaultMaskIPv6) // For ipv6
 	}
 
+	var fwmark uint32
+
+	if nftables && forwardingMethod == "masquerade" && family == ipvs.INET {
+		fwmark = network.IPVSMark()
+	}
+
 	// Generate out API Server LoadBalancer instance
 	svc := ipvs.Service{
 		Netmask:   netMask,
@@ -108,6 +115,7 @@ func NewIPVSLB(ctx context.Context, address string, port uint16, forwardingMetho
 		Port:      port,
 		Address:   ip,
 		Scheduler: ROUNDROBIN,
+		FWMark:    fwmark,
 	}
 
 	var m ipvs.ForwardType

--- a/pkg/nftables/client.go
+++ b/pkg/nftables/client.go
@@ -1,0 +1,370 @@
+package nftables
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	log "log/slog"
+	"net"
+	"os"
+	"reflect"
+	"slices"
+
+	"github.com/google/nftables"
+	"github.com/google/nftables/expr"
+	"github.com/google/nftables/userdata"
+)
+
+const (
+	TableFilter = "filter"
+
+	ipv4SrcOffset = 12
+	ipv4DstOffset = 16
+	ipv6SrcOffset = 8
+	ipv6DstOffset = 24
+)
+
+type Client struct {
+	conn   *nftables.Conn
+	family nftables.TableFamily
+}
+
+func NewClient(family nftables.TableFamily) (*Client, error) {
+	conn, err := nftables.New()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create nftables client connection: %w", err)
+	}
+	return &Client{
+		conn:   conn,
+		family: family,
+	}, nil
+}
+
+func (c *Client) Close() error {
+	if err := c.conn.CloseLasting(); err != nil {
+		return fmt.Errorf("failed to close nftables client: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) Flush() {
+	c.conn.Flush()
+}
+
+func (c *Client) GetTable(name string) *nftables.Table {
+	return &nftables.Table{
+		Family: c.family,
+		Name:   name,
+	}
+}
+
+func (c *Client) GetChain(table, chain string) (*nftables.Chain, error) {
+	ch, err := c.conn.ListChain(c.GetTable(table), chain)
+	if err != nil {
+		return nil, err
+	}
+	return ch, nil
+}
+
+func (c *Client) CheckChain(table, chain string) bool {
+	_, err := c.GetChain(table, chain)
+	return err == nil
+}
+
+func (c *Client) AddChain(chain *nftables.Chain) *nftables.Chain {
+	ch, _ := c.GetChain(chain.Table.Name, chain.Name)
+
+	if ch == nil {
+		ch = c.conn.AddChain(chain)
+		c.Flush()
+	}
+	return ch
+}
+
+func (c *Client) DeleteChain(chain *nftables.Chain) {
+	c.conn.DelChain(chain)
+}
+
+func (c *Client) InsertUnique(rule *nftables.Rule) (*nftables.Rule, error) {
+	comment, _ := userdata.GetString(rule.UserData, userdata.TypeComment)
+	log.Debug("inserting rule", "table", rule.Table.Name, "chain", rule.Chain.Name, "comment", comment)
+	return c.add(rule, c.conn.InsertRule)
+}
+
+func (c *Client) AddUnique(rule *nftables.Rule) (*nftables.Rule, error) {
+	comment, _ := userdata.GetString(rule.UserData, userdata.TypeComment)
+	log.Debug("adding rule", "table", rule.Table.Name, "chain", rule.Chain.Name, "comment", comment)
+	return c.add(rule, c.conn.AddRule)
+}
+
+func (c *Client) add(rule *nftables.Rule, f func(r *nftables.Rule) *nftables.Rule) (*nftables.Rule, error) {
+	r, err := c.Exists(rule)
+	if err != nil {
+		return r, err
+	}
+
+	if r == nil {
+		r = f(rule)
+	}
+
+	return r, nil
+}
+
+func (c *Client) FindRuleByComment(table *nftables.Table, chain *nftables.Chain, comment string) (*nftables.Rule, error) {
+	rules, err := c.conn.GetRules(table, chain)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list rules: %w", err)
+	}
+
+	ud := UserDataComment(comment)
+
+	for _, r := range rules {
+		if bytes.Equal(r.UserData, ud) {
+			return r, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (c *Client) DeleteRule(r *nftables.Rule) error {
+	if err := c.conn.DelRule(r); err != nil {
+		return fmt.Errorf("failed to delete rule: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) List(t *nftables.Table, ch *nftables.Chain) ([]*nftables.Rule, error) {
+	rules, err := c.conn.GetRules(t, ch)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list rules in table %q, chain %q: %w", t.Name, ch.Name, err)
+	}
+	return rules, nil
+}
+
+func (c *Client) Exists(rule *nftables.Rule) (*nftables.Rule, error) {
+	rules, err := c.conn.GetRules(rule.Table, rule.Chain)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list rules in table %q, chain %q: %w", rule.Table.Name, rule.Chain.Name, err)
+	}
+
+	var existing *nftables.Rule
+	cnt := 0
+	for _, r := range rules {
+		if ruleEqual(rule, r) {
+			existing = r
+			cnt++
+		}
+	}
+
+	if cnt == 0 {
+		return nil, nil
+	}
+
+	if cnt > 1 {
+		comment, ok := userdata.GetString(rule.UserData, userdata.TypeComment)
+		if !ok {
+			log.Warn("failed to get comment for rule", "handle", rule.Handle, "table", rule.Table.Name, "chain", rule.Chain.Name)
+		} else {
+			log.Warn("too many rules", "present", cnt, "rule", comment, "table", rule.Table.Name, "chain", rule.Chain.Name)
+		}
+	}
+
+	return existing, nil
+}
+
+func (c *Client) GetLen() uint32 {
+	if c.family == nftables.TableFamilyIPv6 {
+		return net.IPv6len
+	}
+	return net.IPv4len
+}
+
+func (c *Client) GetDstOffset() uint32 {
+	if c.family == nftables.TableFamilyIPv6 {
+		return ipv6DstOffset
+	}
+	return ipv4DstOffset
+}
+
+func (c *Client) GetSrcOffset() uint32 {
+	if c.family == nftables.TableFamilyIPv6 {
+		return ipv6SrcOffset
+	}
+	return ipv4SrcOffset
+}
+
+func (c *Client) UpdateSet(set *nftables.Set, elements []nftables.SetElement) error {
+	existingSet, err := c.conn.GetSetByName(set.Table, set.Name)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("failed to get set: %w", err)
+	}
+
+	exists := err == nil && existingSet != nil
+
+	if exists {
+		existingElements, err := c.conn.GetSetElements(existingSet)
+		if err != nil {
+			return fmt.Errorf("failed to get elements for set %q, table %q", existingSet.Name, existingSet.Table.Name)
+		}
+
+		toAdd, toDel := processElements(elements, existingElements)
+
+		if len(toAdd) > 0 || len(toDel) > 0 {
+			log.Debug("updating set", "name", existingSet.Name, "table", existingSet.Table.Name)
+			if len(toDel) > 0 {
+				if err := c.conn.SetDeleteElements(existingSet, toDel); err != nil {
+					return fmt.Errorf("failed to remove elements from set %q: %w", existingSet.Name, err)
+				}
+			}
+
+			if len(toAdd) > 0 {
+				if err := c.conn.SetAddElements(existingSet, toAdd); err != nil {
+					return fmt.Errorf("failed to add elements to set %q: %w", existingSet.Name, err)
+				}
+			}
+		}
+
+		return nil
+	}
+
+	log.Debug("adding set", "name", set.Name, "table", set.Table)
+	if err := c.conn.AddSet(set, elements); err != nil {
+		return fmt.Errorf("failed to add set %q to table %q: %w", set.Name, set.Table.Name, err)
+	}
+
+	return nil
+}
+
+func (c *Client) DeleteSet(table *nftables.Table, name string) error {
+	setName, err := hash(name)
+	if err != nil {
+		return fmt.Errorf("failed to hash name: %w", err)
+	}
+
+	set, err := c.conn.GetSetByName(table, setName)
+	if err != nil {
+		return fmt.Errorf("failed to get set: %w", err)
+	}
+	if set != nil {
+		c.conn.DelSet(set)
+	}
+	return nil
+}
+
+func (c *Client) NewSet(chain *nftables.Chain, name string) (*nftables.Set, error) {
+	setName, err := hash(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to hash name: %w", err)
+	}
+
+	return &nftables.Set{
+		Table:   chain.Table,
+		Name:    setName,
+		Comment: name,
+		KeyType: nftables.TypeInetService,
+	}, nil
+}
+
+func hash(data string) (string, error) {
+	h := fnv.New32a()
+	if _, err := h.Write([]byte(data)); err != nil {
+		return "", fmt.Errorf("failed to generate hash: %w", err)
+	}
+
+	return fmt.Sprintf("%x", h.Sum32()), nil
+}
+
+func processElements(newEls, existingEls []nftables.SetElement) (toAdd, toDel []nftables.SetElement) {
+	toAdd = findNonCommon(newEls, existingEls)
+	toDel = findNonCommon(existingEls, newEls)
+	return
+}
+
+func findNonCommon(a, b []nftables.SetElement) []nftables.SetElement {
+	nonCommon := []nftables.SetElement{}
+	for i := range a {
+		if !isPresent(a[i], b) {
+			nonCommon = append(nonCommon, a[i])
+		}
+	}
+	return nonCommon
+}
+
+func isPresent(toCheck nftables.SetElement, elements []nftables.SetElement) bool {
+	for _, e := range elements {
+		if slices.Compare(toCheck.Key, e.Key) == 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+func ruleEqual(a, b *nftables.Rule) bool {
+	if a.Chain.Name != b.Chain.Name {
+		return false
+	}
+	if a.Table.Name != b.Table.Name {
+		return false
+	}
+
+	if !bytes.Equal(a.UserData, b.UserData) {
+		return false
+	}
+
+	for i := range a.Exprs {
+		switch a.Exprs[i].(type) {
+		case *expr.Meta:
+			if !exprEqual(&expr.Meta{}, a.Exprs[i], b.Exprs[i]) {
+				return false
+			}
+		case *expr.Lookup:
+			if !exprEqual(&expr.Lookup{}, a.Exprs[i], b.Exprs[i]) {
+				return false
+			}
+		case *expr.Verdict:
+			if !exprEqual(&expr.Verdict{}, a.Exprs[i], b.Exprs[i]) {
+				return false
+			}
+		case *expr.Cmp:
+			if !exprEqual(&expr.Cmp{}, a.Exprs[i], b.Exprs[i]) {
+				return false
+			}
+		case *expr.Payload:
+			if !exprEqual(&expr.Payload{}, a.Exprs[i], b.Exprs[i]) {
+				return false
+			}
+		case *expr.Ct:
+			if !exprEqual(&expr.Ct{}, a.Exprs[i], b.Exprs[i]) {
+				return false
+			}
+		case *expr.Bitwise:
+			if !exprEqual(&expr.Bitwise{}, a.Exprs[i], b.Exprs[i]) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+func exprEqual[V *expr.Meta | *expr.Lookup | *expr.Verdict | *expr.Cmp | *expr.Payload | *expr.Ct | *expr.Bitwise](_ V, aExpr, bExpr expr.Any) bool {
+	aExprCast, ok := aExpr.(V)
+	if !ok {
+		return false
+	}
+	bExprCast, ok := bExpr.(V)
+	if !ok {
+		return false
+	}
+	if reflect.DeepEqual(aExprCast, bExprCast) {
+		return true
+	}
+	return false
+}
+
+func UserDataComment(comment string) []byte {
+	return userdata.AppendString([]byte{}, userdata.TypeComment, comment)
+}

--- a/pkg/services/egress.go
+++ b/pkg/services/egress.go
@@ -45,6 +45,10 @@ func (p *Processor) iptablesCheck() error {
 		}
 	}
 
+	if err := scanner.Err(); err != nil {
+		log.Warn("error while reading /proc/modules", "error", err)
+	}
+
 	if !filter || !nat || !mangle {
 		return fmt.Errorf("missing iptables modules -> nat [%t] -> filter [%t] mangle -> [%t]", nat, filter, mangle)
 	}
@@ -68,6 +72,10 @@ func (p *Processor) nftablesCheck() error {
 		case "nft_ct":
 			ct = true
 		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Warn("error while reading /proc/modules", "error", err)
 	}
 
 	if !queue || !ct {
@@ -204,13 +212,8 @@ func (p *Processor) configureEgress(ctx context.Context, vipIP, podIP, namespace
 		return nil
 	}
 
-	protocol := iptables.ProtocolIPv4
-	if utils.IsIPv6(vipIP) {
-		protocol = iptables.ProtocolIPv6
-	}
-
 	// Use the internal egress implementation
-	if internalEgress != "" {
+	if internalEgress != "" || p.config.EgressWithNftables {
 		// Create an array of CIDRs that we wont SNAT to.
 		ignoreCIDRs := []string{
 			podCidr,
@@ -237,6 +240,11 @@ func (p *Processor) configureEgress(ctx context.Context, vipIP, podIP, namespace
 			return fmt.Errorf("error performing netlink nftables [%s]", err)
 		}
 		return nil
+	}
+
+	protocol := iptables.ProtocolIPv4
+	if utils.IsIPv6(vipIP) {
+		protocol = iptables.ProtocolIPv6
 	}
 
 	i, err := vip.CreateIptablesClient(p.config.EgressWithNftables, namespace, protocol)

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -196,7 +196,7 @@ func (p *Processor) configureService(ctx context.Context, inst *instance.Instanc
 	// is not a global leader election mode
 	if p.config.EnableServicesElection || (!p.config.EnableARP && !p.config.EnableLeaderElection) || (!p.config.EnableARP && !p.config.EnableRoutingTable) {
 		for x := range inst.VIPConfigs {
-			log.Debug("starting loadbalancer for service", "name", svc.Name, "namespace", svc.Namespace, "uid", svc.UID)
+			log.Debug("[service] starting loadbalancer for service", "name", svc.Name, "namespace", svc.Namespace, "uid", svc.UID)
 			if err := inst.Clusters[x].StartLoadBalancerService(ctx, inst.VIPConfigs[x], p.bgpServer, lease.ServiceNamespacedName(svc), wg); err != nil {
 				return fmt.Errorf("failed to start lb: %w", err)
 			}

--- a/pkg/vip/address.go
+++ b/pkg/vip/address.go
@@ -1,3 +1,6 @@
+// Some code in this file is copied or based on
+// https://github.com/telekom/multi-networkpolicy-nftables/blob/f037e79605643e5a9f6debef55297a7170800c51/pkg/server/netfilterrules.go
+
 package vip
 
 import (
@@ -12,6 +15,9 @@ import (
 
 	log "log/slog"
 
+	"github.com/google/nftables"
+	"github.com/google/nftables/binaryutil"
+	"github.com/google/nftables/expr"
 	"github.com/pkg/errors"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
@@ -20,20 +26,22 @@ import (
 
 	iptables "github.com/kube-vip/kube-vip/pkg/iptables"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	nfinternal "github.com/kube-vip/kube-vip/pkg/nftables"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 
 	"github.com/kube-vip/kube-vip/pkg/networkinterface"
 )
 
 const (
-	defaultValidLft         = 60
-	iptablesComment         = "%s kube-vip load balancer IP"
-	iptablesCommentMarkRule = "kube-vip load balancer IP set mark for masquerade"
+	defaultValidLft = 60
+	iptablesComment = "%s kube-vip load balancer IP"
 
 	DefaultMaskIPv4 = 32
 	DefaultMaskIPv6 = 128
 
 	NoLifetime = 0
+
+	vipIPVSMark uint32 = 10042
 )
 
 // Network is an interface that enable managing operations for a given IP
@@ -63,6 +71,7 @@ type Network interface {
 	ARPName() string
 	GetPossibleSubnets() string
 	DHCPFamily() string
+	IPVSMark() uint32
 }
 
 // network - This allows network configuration
@@ -79,8 +88,7 @@ type network struct {
 	dnsName string
 	isDDNS  bool
 
-	forwardMethod   string
-	iptablesBackend string
+	forwardMethod string
 
 	routeTable       int
 	routingTableType int
@@ -94,13 +102,21 @@ type network struct {
 
 	// used by DHCP to get address of proper family
 	dhcpFamily string
+
+	// use internal nftables implementation instead of iptables based one
+	nftables bool
+
+	// ipvsMark is used to mark IPVS connections for further processing
+	ipvsMark uint32
+
+	ipvsPort uint16
 }
 
 // NewConfig will attempt to provide an interface to the kernel network configuration
 func NewConfig(address string, iface string, loGlobalScope bool, subnet string, isDDNS bool,
 	dhcpMode string, requireDualStack, isDualStack bool, tableID int, tableType int, routingProtocol int,
-	dnsMode, forwardMethod, iptablesBackend string, ipvsEnabled, enableSecurity bool,
-	intfMgr *networkinterface.Manager) ([]Network, error) {
+	dnsMode, forwardMethod, iptablesBackend string, ipvsEnabled bool, ipvsPort uint16, enableSecurity bool,
+	intfMgr *networkinterface.Manager, nftables bool) ([]Network, error) {
 	networks := []Network{}
 
 	link, err := netlink.LinkByName(iface)
@@ -110,6 +126,8 @@ func NewConfig(address string, iface string, loGlobalScope bool, subnet string, 
 
 	networkLink := intfMgr.Get(link)
 
+	ipvsMark := vipIPVSMark
+
 	if utils.IsIP(address) {
 		result := &network{
 			link:             networkLink,
@@ -117,10 +135,12 @@ func NewConfig(address string, iface string, loGlobalScope bool, subnet string, 
 			routingTableType: tableType,
 			routingProtocol:  routingProtocol,
 			forwardMethod:    forwardMethod,
-			iptablesBackend:  iptablesBackend,
 			ipvsEnabled:      ipvsEnabled,
 			enableSecurity:   enableSecurity,
 			possibleSubnets:  subnet,
+			nftables:         nftables,
+			ipvsMark:         ipvsMark,
+			ipvsPort:         ipvsPort,
 		}
 
 		subnet, err = SelectSubnet(address, subnet)
@@ -166,13 +186,15 @@ func NewConfig(address string, iface string, loGlobalScope bool, subnet string, 
 						routingTableType: tableType,
 						routingProtocol:  routingProtocol,
 						forwardMethod:    forwardMethod,
-						iptablesBackend:  iptablesBackend,
 						isDDNS:           isDDNS,
 						dnsName:          address,
 						ipvsEnabled:      ipvsEnabled,
 						enableSecurity:   enableSecurity,
 						possibleSubnets:  subnet,
 						dhcpFamily:       utils.IPv4Family,
+						nftables:         nftables,
+						ipvsMark:         ipvsMark,
+						ipvsPort:         ipvsPort,
 					}
 
 					networks = append(networks, result)
@@ -185,13 +207,15 @@ func NewConfig(address string, iface string, loGlobalScope bool, subnet string, 
 						routingTableType: tableType,
 						routingProtocol:  routingProtocol,
 						forwardMethod:    forwardMethod,
-						iptablesBackend:  iptablesBackend,
 						isDDNS:           isDDNS,
 						dnsName:          address,
 						ipvsEnabled:      ipvsEnabled,
 						enableSecurity:   enableSecurity,
 						possibleSubnets:  subnet,
 						dhcpFamily:       utils.IPv6Family,
+						nftables:         nftables,
+						ipvsMark:         ipvsMark,
+						ipvsPort:         ipvsPort,
 					}
 
 					networks = append(networks, result)
@@ -209,12 +233,14 @@ func NewConfig(address string, iface string, loGlobalScope bool, subnet string, 
 				routingTableType: tableType,
 				routingProtocol:  routingProtocol,
 				forwardMethod:    forwardMethod,
-				iptablesBackend:  iptablesBackend,
 				isDDNS:           isDDNS,
 				dnsName:          address,
 				ipvsEnabled:      ipvsEnabled,
 				enableSecurity:   enableSecurity,
 				possibleSubnets:  subnet,
+				nftables:         nftables,
+				ipvsMark:         ipvsMark,
+				ipvsPort:         ipvsPort,
 			}
 
 			s, err := SelectSubnet(ip, subnet)
@@ -407,9 +433,17 @@ func (configurator *network) AddIP(precheck bool, skipDAD bool, minLifetime ...i
 		return false, errors.Wrap(err, fmt.Sprintf("could not add ip to device %q", configurator.link.Intf.Attrs().Name))
 	}
 
-	if err := configurator.configureIPTables(); err != nil {
-		return true, errors.Wrap(err, "could not configure IPTables")
+	if configurator.nftables {
+		if err := configurator.configureNFTables(); err != nil {
+			return true, errors.Wrap(err, "could not configure NFTables")
+		}
+	} else {
+		if err := configurator.configureIPTables(); err != nil {
+			return true, errors.Wrap(err, "could not configure IPTables")
+		}
 	}
+
+	log.Debug("IP CONFIGURED", "address", configurator.address)
 
 	return true, nil
 }
@@ -422,10 +456,46 @@ func (configurator *network) configureIPTables() error {
 	}
 
 	// It seems that masquerading is only required with IPv4 for IPVS to work.
-	if configurator.ipvsEnabled && configurator.forwardMethod == "masquerade" && configurator.address.IP.To4() != nil {
+	if configurator.serviceName == "" && configurator.ipvsEnabled && configurator.forwardMethod == "masquerade" && configurator.address.IP.To4() != nil {
 		if err := configurator.addIptablesRulesForMasquerade(); err != nil {
 			return errors.Wrap(err, "could not add iptables rules for masquerade")
 		}
+	}
+
+	return nil
+}
+
+func (configurator *network) configureNFTables() error {
+	log.Debug("configureNFTables", "security enabled", configurator.enableSecurity, "ignore security", configurator.ignoreSecurity,
+		"ports", configurator.ports)
+
+	opt := nftables.TableFamilyIPv4
+	if utils.IsIPv6(configurator.IP()) {
+		opt = nftables.TableFamilyIPv6
+	}
+
+	c, err := nfinternal.NewClient(opt)
+	if err != nil {
+		return fmt.Errorf("unable to create nftables client: %w", err)
+	}
+
+	comment := fmt.Sprintf(iptablesComment, "control-plane")
+
+	if configurator.enableSecurity && !configurator.ignoreSecurity && len(configurator.ports) > 0 {
+		if err := configurator.addNftablesRulesToLimitTrafficPorts(c, comment); err != nil {
+			return errors.Wrap(err, "could not add nftables rules to limit traffic ports")
+		}
+	}
+
+	// It seems that masquerading is only required with IPv4 for IPVS to work.
+	if configurator.serviceName == "" && configurator.ipvsEnabled && configurator.forwardMethod == "masquerade" && configurator.address.IP.To4() != nil {
+		if err := configurator.addNftablesRulesForMasquerade(c, comment); err != nil {
+			return errors.Wrap(err, "could not add nftables rules for masquerade")
+		}
+	}
+
+	if err := c.Close(); err != nil {
+		return fmt.Errorf("failed to close nftables client: %w", err)
 	}
 
 	return nil
@@ -450,6 +520,24 @@ func (configurator *network) addIptablesRulesToLimitTrafficPorts() error {
 	log.Debug("add iptables rules", "vip", vip, "ports", configurator.ports)
 	if err := configurator.insertIPTablesRulesForServicePorts(ipt, vip, comment); err != nil {
 		return fmt.Errorf("could not add iptables rules for service ports: %v", err)
+	}
+
+	return nil
+}
+
+func (configurator *network) addNftablesRulesToLimitTrafficPorts(c *nfinternal.Client, comment string) error {
+
+	firstRule, err := insertCommonNFTablesRules(c, configurator.IP(), comment)
+	if err != nil {
+		return fmt.Errorf("could not add common nftables rules: %w", err)
+	}
+
+	if err := configurator.insertNFTablesRulesForServicePorts(c, configurator.IP(), comment, firstRule.Handle); err != nil {
+		return fmt.Errorf("could not add nftables rules for service ports: %v", err)
+	}
+
+	if err := c.Close(); err != nil {
+		return fmt.Errorf("failed to close client: %w", err)
 	}
 
 	return nil
@@ -512,6 +600,133 @@ func (configurator *network) insertIPTablesRulesForServicePorts(ipt *iptables.IP
 	return nil
 }
 
+func (configurator *network) insertNFTablesRulesForServicePorts(c *nfinternal.Client, vip, comment string, handle uint64) error {
+	chain, err := c.GetChain(nfinternal.TableFilter, iptables.ChainInput)
+	if err != nil {
+		return fmt.Errorf("failed to get chain %q in table %q: %w", iptables.ChainInput, nfinternal.TableFilter, err)
+	}
+
+	portsTCP := []nftables.SetElement{}
+	portsUDP := []nftables.SetElement{}
+	portsSCTP := []nftables.SetElement{}
+	for _, p := range configurator.ports {
+		switch p.Protocol {
+		case v1.ProtocolTCP:
+			portsTCP = append(portsTCP, nftables.SetElement{
+				Key: binaryutil.BigEndian.PutUint16(uint16(p.Port)), //nolint:gosec
+			})
+		case v1.ProtocolUDP:
+			portsUDP = append(portsUDP, nftables.SetElement{
+				Key: binaryutil.BigEndian.PutUint16(uint16(p.Port)), //nolint:gosec
+			})
+		case v1.ProtocolSCTP:
+			portsSCTP = append(portsSCTP, nftables.SetElement{
+				Key: binaryutil.BigEndian.PutUint16(uint16(p.Port)), //nolint:gosec
+			})
+		}
+	}
+
+	if err := addNFTPortRule(c, chain, vip, portsTCP, unix.IPPROTO_TCP, comment, handle); err != nil {
+		return fmt.Errorf("failed to add TCP ports for VIP %q: %w", vip, err)
+	}
+
+	if err := addNFTPortRule(c, chain, vip, portsUDP, unix.IPPROTO_UDP, comment, handle); err != nil {
+		return fmt.Errorf("failed to add UDP ports for VIP %q: %w", vip, err)
+	}
+
+	if err := addNFTPortRule(c, chain, vip, portsSCTP, unix.IPPROTO_SCTP, comment, handle); err != nil {
+		return fmt.Errorf("failed to add SCTP ports for VIP %q: %w", vip, err)
+	}
+
+	return nil
+}
+
+func addNFTPortRule(c *nfinternal.Client, chain *nftables.Chain, vip string,
+	ports []nftables.SetElement, protocol int, comment string, handle uint64) error {
+	if len(ports) == 0 {
+		return nil
+	}
+
+	protocolString := ""
+	switch protocol {
+	case unix.IPPROTO_UDP:
+		protocolString = "UDP"
+	case unix.IPPROTO_SCTP:
+		protocolString = "SCTP"
+	default:
+		protocolString = "TCP"
+	}
+
+	setComment := fmt.Sprintf("%s - %s ports", comment, protocolString)
+
+	set, err := c.NewSet(chain, setComment)
+	if err != nil {
+		return fmt.Errorf("failed to create set: %w", err)
+	}
+
+	if err := c.UpdateSet(set, ports); err != nil {
+		return fmt.Errorf("failed to update set for TCP ports")
+	}
+
+	ip := net.ParseIP(vip)
+
+	if ip.To4() != nil {
+		ip = ip.To4()
+	} else {
+		ip = ip.To16()
+	}
+
+	r := &nftables.Rule{
+		Table:    chain.Table,
+		Chain:    chain,
+		UserData: nfinternal.UserDataComment(setComment),
+		Position: handle,
+		Exprs: []expr.Any{
+			&expr.Payload{
+				DestRegister: 0x1,
+				Base:         expr.PayloadBaseNetworkHeader,
+				Offset:       c.GetDstOffset(),
+				Len:          c.GetLen(),
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 0x1,
+				Data:     []byte(ip),
+			},
+			&expr.Meta{
+				Key:      expr.MetaKeyL4PROTO,
+				Register: 1,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     binaryutil.BigEndian.PutUint32(uint32(protocol)), //nolint:gosec
+			},
+			&expr.Payload{
+				DestRegister: 1,
+				Base:         expr.PayloadBaseTransportHeader,
+				Offset:       2, // l4 offset
+				Len:          2, // l4 offset
+			},
+			&expr.Lookup{
+				SetName:        set.Name,
+				SetID:          set.ID,
+				SourceRegister: 0x1,
+			},
+			&expr.Counter{},
+			&expr.Meta{Key: expr.MetaKeyMARK, SourceRegister: true, Register: 0x1},
+		},
+	}
+
+	if _, err := c.AddUnique(r); err != nil {
+		return fmt.Errorf("failed to create rule for ports: %w", err)
+	}
+
+	c.Flush()
+
+	return nil
+}
+
 func insertCommonIPTablesRules(ipt *iptables.IPTables, vip, comment string) error {
 	if err := ipt.InsertUnique(iptables.TableFilter, iptables.ChainInput, 1, "-d", vip, "-p",
 		string(v1.ProtocolUDP), "--dport", dhcpClientPort, "-m", "comment", "--comment", comment, "-j", "ACCEPT"); err != nil {
@@ -526,6 +741,120 @@ func insertCommonIPTablesRules(ipt *iptables.IPTables, vip, comment string) erro
 	return nil
 }
 
+func insertCommonNFTablesRules(c *nfinternal.Client, vip, comment string) (*nftables.Rule, error) {
+	ch, err := c.GetChain(nfinternal.TableFilter, iptables.ChainInput)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get chain %q in table %q: %w", iptables.ChainInput, nfinternal.TableFilter, err)
+	}
+
+	ip := net.ParseIP(vip)
+
+	port, err := strconv.ParseUint(dhcpClientPort, 10, 16)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert DHCP port to int: %w", err)
+	}
+
+	if ip.To4() != nil {
+		ip = ip.To4()
+	} else {
+		ip = ip.To16()
+	}
+
+	r := &nftables.Rule{
+		Table:    ch.Table,
+		Chain:    ch,
+		UserData: nfinternal.UserDataComment(fmt.Sprintf("%s - DHCP", comment)),
+		Exprs: []expr.Any{
+			&expr.Payload{
+				DestRegister: 0x1,
+				Base:         expr.PayloadBaseNetworkHeader,
+				Offset:       c.GetDstOffset(),
+				Len:          c.GetLen(),
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 0x1,
+				Data:     []byte(ip),
+			},
+			&expr.Meta{
+				Key:      expr.MetaKeyL4PROTO,
+				Register: 1,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     []byte{unix.IPPROTO_UDP},
+			},
+			&expr.Payload{
+				OperationType: expr.PayloadLoad,
+				Len:           2,
+				Base:          expr.PayloadBaseTransportHeader,
+				Offset:        2,
+				DestRegister:  1,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     binaryutil.BigEndian.PutUint16(uint16(port)),
+			},
+			&expr.Counter{},
+			&expr.Verdict{
+				Kind: expr.VerdictAccept,
+			},
+		},
+	}
+
+	firstRule, err := c.InsertUnique(r)
+	if err != nil {
+		return firstRule, fmt.Errorf("failed to insert DHCP rule: %w", err)
+	}
+
+	c.Flush()
+
+	firstRule, err = c.FindRuleByComment(ch.Table, ch, fmt.Sprintf("%s - DHCP", comment))
+	if err != nil {
+		return nil, fmt.Errorf("initial rule not found: %w", err)
+	}
+
+	if firstRule == nil {
+		return nil, fmt.Errorf("ninitial rule not present")
+	}
+
+	r2 := &nftables.Rule{
+		Table:    ch.Table,
+		Chain:    ch,
+		Position: firstRule.Handle,
+		UserData: nfinternal.UserDataComment(fmt.Sprintf("%s - drop", comment)),
+		Exprs: []expr.Any{
+			&expr.Payload{
+				DestRegister: 1,
+				Base:         expr.PayloadBaseNetworkHeader,
+				Offset:       c.GetDstOffset(), // IPv4 destination address
+				Len:          c.GetLen(),
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     []byte(ip),
+			},
+
+			&expr.Counter{},
+
+			&expr.Verdict{
+				Kind: expr.VerdictDrop,
+			},
+		},
+	}
+
+	if _, err := c.AddUnique(r2); err != nil {
+		return firstRule, fmt.Errorf("failed to insert DROP rule: %w", err)
+	}
+
+	c.Flush()
+
+	return firstRule, nil
+}
+
 func deleteCommonIPTablesRules(ipt *iptables.IPTables, vip, comment string) error {
 	if err := ipt.DeleteIfExists(iptables.TableFilter, iptables.ChainInput, "-d", vip, "-p",
 		string(v1.ProtocolUDP), "--dport", dhcpClientPort, "-m", "comment", "--comment", comment, "-j", "ACCEPT"); err != nil {
@@ -537,6 +866,79 @@ func deleteCommonIPTablesRules(ipt *iptables.IPTables, vip, comment string) erro
 		"--comment", comment, "-j", "DROP"); err != nil {
 		return fmt.Errorf("could not delete iptables rule to drop the traffic to VIP %s: %v", vip, err)
 	}
+	return nil
+}
+
+func deleteCommonNFTablesRules(c *nfinternal.Client, comment string) error {
+
+	table := c.GetTable(iptables.TableFilter)
+
+	chain, err := c.GetChain(table.Name, iptables.ChainInput)
+	if err != nil {
+		return fmt.Errorf("failed to find chain: %w", err)
+	}
+
+	ruleDHCP, err := c.FindRuleByComment(table, chain, fmt.Sprintf("%s - DHCP", comment))
+	if err != nil {
+		return fmt.Errorf("failed to find the rule: %w", err)
+	}
+
+	if ruleDHCP == nil {
+		return nil
+	}
+
+	if err := c.DeleteRule(ruleDHCP); err != nil {
+		return fmt.Errorf("failed to delete common rule for DHCP: %w", err)
+	}
+
+	ruleDrop, err := c.FindRuleByComment(table, chain, fmt.Sprintf("%s - drop", comment))
+	if err != nil {
+		return fmt.Errorf("failed to find the rule: %w", err)
+	}
+
+	if ruleDrop == nil {
+		return nil
+	}
+
+	if err := c.DeleteRule(ruleDrop); err != nil {
+		return fmt.Errorf("failed to delete common rule for Drop action: %w", err)
+	}
+
+	c.Flush()
+
+	return nil
+}
+
+func deleteNFTPortRule(c *nfinternal.Client, comment string) error {
+
+	table := c.GetTable(iptables.TableFilter)
+
+	chain, err := c.GetChain(table.Name, iptables.ChainInput)
+	if err != nil {
+		return fmt.Errorf("failed to find chain: %w", err)
+	}
+
+	for _, t := range []string{"TCP", "UDP", "SCTP"} {
+		rule, err := c.FindRuleByComment(table, chain, fmt.Sprintf("%s - %s ports", comment, t))
+		if err != nil {
+			return fmt.Errorf("failed to find the rule: %w", err)
+		}
+
+		if rule == nil {
+			continue
+		}
+
+		if err := c.DeleteRule(rule); err != nil {
+			return fmt.Errorf("failed to delete common rule for Drop action: %w", err)
+		}
+
+		if err := c.DeleteSet(rule.Table, fmt.Sprintf("%s - %s ports", comment, t)); err != nil {
+			return fmt.Errorf("failed to delete ports set: %w", err)
+		}
+	}
+
+	c.Flush()
+
 	return nil
 }
 
@@ -564,6 +966,23 @@ func (configurator *network) removeIptablesRuleToLimitTrafficPorts() error {
 	return nil
 }
 
+func (configurator *network) removeNftablesRuleToLimitTrafficPorts(c *nfinternal.Client) error {
+
+	vip := configurator.address.IP.String()
+	comment := fmt.Sprintf(iptablesComment, configurator.serviceName)
+
+	if err := deleteCommonNFTablesRules(c, comment); err != nil {
+		return fmt.Errorf("could not delete common iptables rules: %w", err)
+	}
+
+	log.Debug("remove nftables rules", "vip", vip, "ports", configurator.ports)
+	if err := deleteNFTPortRule(c, comment); err != nil {
+		return fmt.Errorf("faield to remove port rule: %w", err)
+	}
+
+	return nil
+}
+
 // DeleteIP - Remove an IP address from the interface
 func (configurator *network) DeleteIP() (bool, error) {
 	configurator.link.Lock.Lock()
@@ -583,15 +1002,44 @@ func (configurator *network) DeleteIP() (bool, error) {
 		return false, errors.Wrap(err, "could not delete ip")
 	}
 
-	if configurator.enableSecurity && !configurator.ignoreSecurity {
-		if err := configurator.removeIptablesRuleToLimitTrafficPorts(); err != nil {
-			return true, errors.Wrap(err, "could not remove iptables rules to limit traffic ports")
-		}
-	}
+	if configurator.nftables {
+		vip := configurator.address.IP.String()
 
-	if configurator.ipvsEnabled && configurator.forwardMethod == "masquerade" && configurator.address.IP.To4() != nil {
-		if err := configurator.removeIptablesRulesForMasquerade(); err != nil {
-			return true, errors.Wrap(err, "could not remove iptables masquerade rules ")
+		opt := nftables.TableFamilyIPv4
+		if utils.IsIPv6(vip) {
+			opt = nftables.TableFamilyIPv6
+		}
+		c, err := nfinternal.NewClient(opt)
+		if err != nil {
+			return false, fmt.Errorf("unable to create nftables client: %w", err)
+		}
+
+		if configurator.enableSecurity && !configurator.ignoreSecurity {
+			if err := configurator.removeNftablesRuleToLimitTrafficPorts(c); err != nil {
+				return true, errors.Wrap(err, "could not remove nftables rules to limit traffic ports")
+			}
+		}
+
+		if configurator.serviceName == "" && configurator.ipvsEnabled && configurator.forwardMethod == "masquerade" && configurator.address.IP.To4() != nil {
+			if err := configurator.removeNftablesRulesForMasquerade(c); err != nil {
+				return true, errors.Wrap(err, "could not remove nftables masquerade rules")
+			}
+		}
+
+		if err := c.Close(); err != nil {
+			return true, errors.Wrap(err, "failed to close nftables client")
+		}
+	} else {
+		if configurator.enableSecurity && !configurator.ignoreSecurity {
+			if err := configurator.removeIptablesRuleToLimitTrafficPorts(); err != nil {
+				return true, errors.Wrap(err, "could not remove iptables rules to limit traffic ports")
+			}
+		}
+
+		if configurator.serviceName == "" && configurator.ipvsEnabled && configurator.forwardMethod == "masquerade" && configurator.address.IP.To4() != nil {
+			if err := configurator.removeIptablesRulesForMasquerade(); err != nil {
+				return true, errors.Wrap(err, "could not remove iptables masquerade rules ")
+			}
 		}
 	}
 
@@ -618,6 +1066,111 @@ func (configurator *network) addIptablesRulesForMasquerade() error {
 	return nil
 }
 
+// TO DO: It seems it is not be possible to use google/nftables with IPVS due to lack of IPVS matcher in nft
+func (configurator *network) addNftablesRulesForMasquerade(c *nfinternal.Client, comment string) error {
+	cmt := fmt.Sprintf("%s - IPVS, VIP %s, MARK %d", comment, configurator.IP(), configurator.IPVSMark())
+
+	table := c.GetTable(iptables.TableMangle)
+
+	markChain := &nftables.Chain{
+		Name:     "ipvs_prerouting",
+		Table:    table,
+		Type:     nftables.ChainTypeFilter,
+		Hooknum:  nftables.ChainHookPrerouting,
+		Priority: nftables.ChainPriorityMangle,
+	}
+
+	log.Debug("adding IPVS rule", "table", markChain.Table.Name, "chain", markChain.Name, "comment", cmt)
+
+	markChain = c.AddChain(markChain)
+
+	ip := net.ParseIP(configurator.IP())
+
+	if ip.To4() != nil {
+		ip = ip.To4()
+	} else {
+		ip = ip.To16()
+	}
+
+	port := binaryutil.BigEndian.PutUint16(configurator.ipvsPort)
+
+	mark := binaryutil.NativeEndian.PutUint32(configurator.IPVSMark())
+
+	markRule := &nftables.Rule{
+		Table:    markChain.Table,
+		Chain:    markChain,
+		UserData: nfinternal.UserDataComment(cmt),
+		Exprs: []expr.Any{
+			&expr.Payload{
+				DestRegister: 1,
+				Base:         expr.PayloadBaseNetworkHeader,
+				Offset:       c.GetDstOffset(),
+				Len:          c.GetLen(),
+			},
+			&expr.Cmp{
+				Register: 1,
+				Data:     ip,
+			},
+			&expr.Payload{
+				DestRegister: 1,
+				Base:         expr.PayloadBaseTransportHeader,
+				Offset:       2,
+				Len:          2,
+			},
+			&expr.Cmp{
+				Register: 1,
+				Data:     port,
+			},
+			&expr.Immediate{
+				Register: 1,
+				Data:     mark,
+			},
+			&expr.Meta{
+				Key:            expr.MetaKeyMARK,
+				Register:       1,
+				SourceRegister: true,
+			},
+		},
+	}
+
+	if _, err := c.AddUnique(markRule); err != nil {
+		return fmt.Errorf("failed to add mark rule for IPVS: %w", err)
+	}
+
+	chain, err := c.GetChain(iptables.TableNat, iptables.ChainPOSTROUTING)
+	if err != nil {
+		return fmt.Errorf("failed to get chain %s in table %s: %w", iptables.ChainPOSTROUTING, iptables.TableNat, err)
+	}
+
+	log.Debug("adding IPVS rule", "table", chain.Table.Name, "chain", chain.Name, "comment", cmt)
+
+	rule := &nftables.Rule{
+		Table:    chain.Table,
+		Chain:    chain,
+		UserData: nfinternal.UserDataComment(cmt),
+		Exprs: []expr.Any{
+			&expr.Meta{
+				Key:      expr.MetaKeyMARK,
+				Register: 1,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     mark,
+			},
+			&expr.Masq{},
+		},
+	}
+
+	if _, err := c.InsertUnique(rule); err != nil {
+		return fmt.Errorf("failed to insert nftables rule %q: %w", comment, err)
+	}
+
+	c.Flush()
+
+	return nil
+}
+
 // addIptablesRulesForMasquerade add iptables rules for MASQUERADE
 // insert example
 func (configurator *network) removeIptablesRulesForMasquerade() error {
@@ -636,6 +1189,54 @@ func (configurator *network) removeIptablesRulesForMasquerade() error {
 	if err != nil {
 		return err
 	}
+
+	return nil
+}
+
+func (configurator *network) removeNftablesRulesForMasquerade(c *nfinternal.Client) error {
+	chain, err := c.GetChain(iptables.TableNat, iptables.ChainPOSTROUTING)
+	if err != nil {
+		return fmt.Errorf("failed to get chain %s in table %s: %w", iptables.ChainPOSTROUTING, iptables.TableNat, err)
+	}
+
+	comment := fmt.Sprintf(iptablesComment, "control-plane")
+	cmt := fmt.Sprintf("%s - IPVS, VIP %s, MARK %d", comment, configurator.IP(), configurator.IPVSMark())
+
+	r, err := c.FindRuleByComment(chain.Table, chain, cmt)
+	if err != nil {
+		return fmt.Errorf("failed to find rule %q for deletion: %w", cmt, err)
+	}
+
+	if err := c.DeleteRule(r); err != nil {
+		return fmt.Errorf("failed to delete rule %q: %w", cmt, err)
+	}
+
+	markChain, err := c.GetChain(iptables.TableMangle, "ipvs_prerouting")
+	if err != nil {
+		return fmt.Errorf("failed to get chain %s in table %s: %w", "ipvs_prerouting", iptables.TableMangle, err)
+	}
+
+	markRule, err := c.FindRuleByComment(markChain.Table, markChain, cmt)
+	if err != nil {
+		return fmt.Errorf("failed to find rule %q for deletion: %w", cmt, err)
+	}
+
+	if err := c.DeleteRule(markRule); err != nil {
+		return fmt.Errorf("failed to delete rule %q: %w", cmt, err)
+	}
+
+	c.Flush()
+
+	existing, err := c.List(markChain.Table, markChain)
+	if err != nil {
+		return fmt.Errorf("failed to list rules %s in table %s: %w", "ipvs_prerouting", iptables.TableMangle, err)
+	}
+
+	if len(existing) == 0 {
+		c.DeleteChain(markChain)
+	}
+
+	c.Flush()
 
 	return nil
 }
@@ -940,6 +1541,10 @@ func (configurator *network) GetPossibleSubnets() string {
 
 func (configurator *network) DHCPFamily() string {
 	return configurator.dhcpFamily
+}
+
+func (configurator *network) IPVSMark() uint32 {
+	return configurator.ipvsMark
 }
 
 // SelectSubnet formats an IP address with the appropriate CIDR based on the input.

--- a/testing/e2e/e2e_bgp_ds_test.go
+++ b/testing/e2e/e2e_bgp_ds_test.go
@@ -84,17 +84,18 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when only control plane is enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "true",
-					VipElectionEnable:  "false",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "false",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
-					BGPPeers:           "127.0.0.1:1::false",
-					BGPAS:              2,
+					Mode:                  Mode,
+					ControlPlaneEnable:    "true",
+					VipElectionEnable:     "false",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "false",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					BGPPeers:              "127.0.0.1:1::false",
+					BGPAS:                 2,
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -102,17 +103,18 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when only control plane is enabled with leader election", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "true",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "false",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
-					BGPPeers:           "127.0.0.1:1::false",
-					BGPAS:              2,
+					Mode:                  Mode,
+					ControlPlaneEnable:    "true",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "false",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					BGPPeers:              "127.0.0.1:1::false",
+					BGPAS:                 2,
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -120,17 +122,18 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when only services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "false",
-					VipElectionEnable:  "false",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
-					BGPPeers:           "127.0.0.1:1::false",
-					BGPAS:              2,
+					Mode:                  Mode,
+					ControlPlaneEnable:    "false",
+					VipElectionEnable:     "false",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					BGPPeers:              "127.0.0.1:1::false",
+					BGPAS:                 2,
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -138,17 +141,18 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when only services are enabled with leader election", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "false",
-					VipElectionEnable:  "false",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
-					BGPPeers:           "127.0.0.1:1::false",
-					BGPAS:              2,
+					Mode:                  Mode,
+					ControlPlaneEnable:    "false",
+					VipElectionEnable:     "false",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					BGPPeers:              "127.0.0.1:1::false",
+					BGPAS:                 2,
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -156,17 +160,18 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when control plane services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "true",
-					VipElectionEnable:  "false",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
-					BGPPeers:           "127.0.0.1:1::false",
-					BGPAS:              2,
+					Mode:                  Mode,
+					ControlPlaneEnable:    "true",
+					VipElectionEnable:     "false",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					BGPPeers:              "127.0.0.1:1::false",
+					BGPAS:                 2,
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -174,17 +179,18 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when control plane w/ leader election and services w/o leader election are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "true",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
-					BGPPeers:           "127.0.0.1:1::false",
-					BGPAS:              2,
+					Mode:                  Mode,
+					ControlPlaneEnable:    "true",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					BGPPeers:              "127.0.0.1:1::false",
+					BGPAS:                 2,
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -192,17 +198,18 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when control plane w/o leader election and services w/ leader election are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "true",
-					VipElectionEnable:  "false",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
-					BGPPeers:           "127.0.0.1:1::false",
-					BGPAS:              2,
+					Mode:                  Mode,
+					ControlPlaneEnable:    "true",
+					VipElectionEnable:     "false",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					BGPPeers:              "127.0.0.1:1::false",
+					BGPAS:                 2,
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -210,17 +217,18 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when control plane and services w/ leader election are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "true",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
-					BGPPeers:           "127.0.0.1:1::false",
-					BGPAS:              2,
+					Mode:                  Mode,
+					ControlPlaneEnable:    "true",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					BGPPeers:              "127.0.0.1:1::false",
+					BGPAS:                 2,
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)

--- a/testing/e2e/e2e_bgp_healthcheck_test.go
+++ b/testing/e2e/e2e_bgp_healthcheck_test.go
@@ -66,6 +66,7 @@ var _ = Describe("kube-vip BGP ControlPlane health-check", Ordered, func() {
 				ControlPlaneHealthCheckTimeoutSeconds:   1,
 				ControlPlaneHealthCheckFailureThreshold: 3,
 				ControlPlaneHealthCheckCAPath:           "/etc/kubernetes/pki/ca.crt",
+				EnableServiceSecurity:                   "true",
 			},
 		})
 

--- a/testing/e2e/e2e_bgp_test.go
+++ b/testing/e2e/e2e_bgp_test.go
@@ -868,16 +868,17 @@ func setupEnv(ctx context.Context, cpVIP *string,
 	}
 
 	manifestValues := e2e.KubevipManifestValues{
-		ControlPlaneVIP:    *cpVIP,
-		ControlPlaneEnable: fmt.Sprintf("%t", cpEnable),
-		SvcEnable:          fmt.Sprintf("%t", svcEnable),
-		SvcElectionEnable:  fmt.Sprintf("%t", serviceElection),
-		EnableNodeLabeling: "false",
-		BGPAS:              bgp.KubevipAS,
-		BGPPeers:           bgp.PeerStrings(kvPeers),
-		MPBGPNexthop:       mpbgpnexthop,
-		MPBGPNexthopIPv4:   defaultFixedNexthopv4,
-		MPBGPNexthopIPv6:   defaultFixedNexthopv6,
+		ControlPlaneVIP:       *cpVIP,
+		ControlPlaneEnable:    fmt.Sprintf("%t", cpEnable),
+		SvcEnable:             fmt.Sprintf("%t", svcEnable),
+		SvcElectionEnable:     fmt.Sprintf("%t", serviceElection),
+		EnableNodeLabeling:    "false",
+		BGPAS:                 bgp.KubevipAS,
+		BGPPeers:              bgp.PeerStrings(kvPeers),
+		MPBGPNexthop:          mpbgpnexthop,
+		MPBGPNexthopIPv4:      defaultFixedNexthopv4,
+		MPBGPNexthopIPv6:      defaultFixedNexthopv6,
+		EnableServiceSecurity: "true",
 	}
 
 	By(manifestValues.BGPPeers)

--- a/testing/e2e/e2e_ds_test.go
+++ b/testing/e2e/e2e_ds_test.go
@@ -94,15 +94,16 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv4 addresses on exit when only control plane is enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "true",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "false",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "true",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "false",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -110,15 +111,16 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv4 addresses on exit when only services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "false",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "false",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -126,15 +128,16 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv4 addresses on exit when only services with per-service leaderelection are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "false",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "false",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -142,15 +145,16 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv4 addresses on exit when control-plane and services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "true",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "true",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -158,15 +162,16 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv4 addresses on exit when control plane and services with per-service leaderelection are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "true",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "true",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -174,15 +179,16 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" is able to pick up leaderelection when all endpoints for the service were deleted", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "false",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "false",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testEndpoints(ctx, manifestValues, client, utils.IPv4Family, clusterName, corev1.ServiceExternalTrafficPolicyLocal)
@@ -220,15 +226,16 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv6 addresses on exit when only control plane is enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "true",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "false",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "true",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "false",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv6Family, clusterName)
@@ -236,15 +243,16 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv6 addresses on exit when only services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "false",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "false",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv6Family, clusterName)
@@ -252,15 +260,16 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv6 addresses on exit when only services with per-service leaderelection are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "false",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "false",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv6Family, clusterName)
@@ -268,15 +277,16 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv6 addresses on exit when control-plane and services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "true",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "true",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv6Family, clusterName)
@@ -284,15 +294,16 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv6 addresses on exit when control plane and services with per-service leaderelection are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "true",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "true",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv6Family, clusterName)
@@ -300,15 +311,16 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" is able to pick up leaderelection when all endpoints for the service were deleted", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "false",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "false",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testEndpoints(ctx, manifestValues, client, utils.IPv6Family, clusterName, corev1.ServiceExternalTrafficPolicyLocal)
@@ -346,15 +358,16 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all addresses on exit when only control plane is enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "true",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "false",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "true",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "false",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.DualFamily, clusterName)
@@ -362,15 +375,16 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all addresses on exit when only services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "false",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "false",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.DualFamily, clusterName)
@@ -378,15 +392,16 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all addresses on exit when only services with per-service leaderelection are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "false",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "false",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.DualFamily, clusterName)
@@ -394,15 +409,16 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all addresses on exit when control-plane and services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "true",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "true",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.DualFamily, clusterName)
@@ -410,15 +426,16 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all addresses on exit when control plane and services with per-service leaderelection are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "true",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "true",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.DualFamily, clusterName)
@@ -426,15 +443,16 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" is able to pick up leaderelection when all endpoints for the service were deleted", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "false",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "false",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testEndpoints(ctx, manifestValues, client, utils.DualFamily, clusterName, corev1.ServiceExternalTrafficPolicyLocal)
@@ -787,6 +805,10 @@ func createKubeVipDS(ctx context.Context, name, namespace string, manifestValues
 								{
 									Name:  "enable_endpoints",
 									Value: manifestValues.EnableEndpoints,
+								},
+								{
+									Name:  "enable_service_security",
+									Value: "true",
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{

--- a/testing/e2e/e2e_rt_ds_test.go
+++ b/testing/e2e/e2e_rt_ds_test.go
@@ -86,15 +86,16 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 
 			It(clusterName+" exits gracefully on exit when only control plane is enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "true",
-					VipElectionEnable:  "false",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "false",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "true",
+					VipElectionEnable:     "false",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "false",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -118,15 +119,16 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 
 			It(clusterName+" exits gracefully on exit when only services are enabled with leaderelection", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "false",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "false",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -134,15 +136,16 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 
 			It(clusterName+" exits gracefully on exit when only services are enabled with leaderelection per service", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "false",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "false",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -150,15 +153,16 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 
 			It(clusterName+" exits gracefully on exit when control-plane and services are enabled without leaderelection", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "true",
-					VipElectionEnable:  "false",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "true",
+					VipElectionEnable:     "false",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -166,15 +170,16 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 
 			It(clusterName+" exits gracefully on exit when control-plane and services are enabled with leaderelection", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "true",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "true",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -182,15 +187,16 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 
 			It(clusterName+" exits gracefully when control-plane and services are enabled with leaderelection per service", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "true",
-					VipElectionEnable:  "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					Mode:                  Mode,
+					ControlPlaneEnable:    "true",
+					VipElectionEnable:     "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)

--- a/testing/e2e/e2e_rt_test.go
+++ b/testing/e2e/e2e_rt_test.go
@@ -95,13 +95,14 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					ControlPlaneEnable: "true",
-					SvcEnable:          "false",
-					SvcElectionEnable:  "false",
-					EnableNodeLabeling: "false",
+					ControlPlaneVIP:       cpVIP,
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					ControlPlaneEnable:    "true",
+					SvcEnable:             "false",
+					SvcElectionEnable:     "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -239,13 +240,14 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					ControlPlaneEnable: "true",
-					SvcEnable:          "false",
-					SvcElectionEnable:  "false",
-					EnableNodeLabeling: "false",
+					ControlPlaneVIP:       cpVIP,
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					ControlPlaneEnable:    "true",
+					SvcEnable:             "false",
+					SvcElectionEnable:     "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -382,12 +384,13 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					ControlPlaneEnable: "true",
-					SvcEnable:          "false",
-					SvcElectionEnable:  "false",
+					ControlPlaneVIP:       cpVIP,
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					ControlPlaneEnable:    "true",
+					SvcEnable:             "false",
+					SvcElectionEnable:     "false",
+					EnableServiceSecurity: "true",
 				}
 
 				networkInterface := ""
@@ -457,12 +460,13 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					ControlPlaneEnable: "true",
-					SvcEnable:          "false",
-					SvcElectionEnable:  "false",
+					ControlPlaneVIP:       cpVIP,
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					ControlPlaneEnable:    "true",
+					SvcEnable:             "false",
+					SvcElectionEnable:     "false",
+					EnableServiceSecurity: "true",
 				}
 
 				networkInterface := ""
@@ -532,12 +536,13 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					ControlPlaneEnable: "false",
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
+					ControlPlaneVIP:       cpVIP,
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					ControlPlaneEnable:    "false",
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					EnableServiceSecurity: "true",
 				}
 
 				var err error
@@ -599,12 +604,13 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					ControlPlaneEnable: "false",
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
+					ControlPlaneVIP:       cpVIP,
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					ControlPlaneEnable:    "false",
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					EnableServiceSecurity: "true",
 				}
 
 				var err error
@@ -666,13 +672,14 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					ControlPlaneEnable: "false",
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
+					ControlPlaneVIP:       cpVIP,
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					ControlPlaneEnable:    "false",
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableServiceSecurity: "true",
 				}
 
 				var err error
@@ -736,13 +743,14 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					ControlPlaneEnable: "false",
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
+					ControlPlaneVIP:       cpVIP,
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					ControlPlaneEnable:    "false",
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableServiceSecurity: "true",
 				}
 
 				var err error
@@ -804,12 +812,13 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					ControlPlaneEnable: "false",
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
+					ControlPlaneVIP:       cpVIP,
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					ControlPlaneEnable:    "false",
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableServiceSecurity: "true",
 				}
 
 				var err error
@@ -880,12 +889,13 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					ControlPlaneEnable: "false",
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
+					ControlPlaneVIP:       cpVIP,
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					ControlPlaneEnable:    "false",
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableServiceSecurity: "true",
 				}
 
 				var err error
@@ -956,13 +966,14 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					ControlPlaneEnable: "false",
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "false",
+					ControlPlaneVIP:       cpVIP,
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					ControlPlaneEnable:    "false",
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "false",
+					EnableServiceSecurity: "true",
 				}
 
 				var err error
@@ -1035,13 +1046,14 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					ControlPlaneEnable: "false",
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "false",
+					ControlPlaneVIP:       cpVIP,
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					ControlPlaneEnable:    "false",
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "false",
+					EnableServiceSecurity: "true",
 				}
 
 				var err error
@@ -1112,13 +1124,14 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					ControlPlaneEnable: "false",
-					SvcEnable:          "true",
-					VipElectionEnable:  "true",
-					SvcElectionEnable:  "false",
+					ControlPlaneVIP:       cpVIP,
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					ControlPlaneEnable:    "false",
+					SvcEnable:             "true",
+					VipElectionEnable:     "true",
+					SvcElectionEnable:     "false",
+					EnableServiceSecurity: "true",
 				}
 
 				var err error
@@ -1190,13 +1203,14 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					ControlPlaneEnable: "false",
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					VipElectionEnable:  "true",
+					ControlPlaneVIP:       cpVIP,
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					ControlPlaneEnable:    "false",
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					VipElectionEnable:     "true",
+					EnableServiceSecurity: "true",
 				}
 
 				var err error
@@ -1268,14 +1282,15 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					ControlPlaneEnable: "false",
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					VipElectionEnable:  "true",
-					EnableEndpoints:    "false",
+					ControlPlaneVIP:       cpVIP,
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					ControlPlaneEnable:    "false",
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					VipElectionEnable:     "true",
+					EnableEndpoints:       "false",
+					EnableServiceSecurity: "true",
 				}
 
 				var err error
@@ -1347,14 +1362,15 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					ControlPlaneEnable: "false",
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					VipElectionEnable:  "true",
-					EnableEndpoints:    "false",
+					ControlPlaneVIP:       cpVIP,
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					ControlPlaneEnable:    "false",
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					VipElectionEnable:     "true",
+					EnableEndpoints:       "false",
+					EnableServiceSecurity: "true",
 				}
 
 				var err error

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -128,14 +128,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ControlPlaneEnable: "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "false",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "true",
-					EnableNodeLabeling: "false",
+					ControlPlaneVIP:       cpVIP,
+					ControlPlaneEnable:    "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "false",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "true",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -172,14 +173,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ControlPlaneEnable: "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "true",
-					EnableNodeLabeling: "false",
+					ControlPlaneVIP:       cpVIP,
+					ControlPlaneEnable:    "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "true",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -255,14 +257,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ControlPlaneEnable: "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "true",
-					EnableNodeLabeling: "false",
+					ControlPlaneVIP:       cpVIP,
+					ControlPlaneEnable:    "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "true",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -307,14 +310,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ControlPlaneEnable: "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "false",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "true",
-					EnableNodeLabeling: "false",
+					ControlPlaneVIP:       cpVIP,
+					ControlPlaneEnable:    "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "false",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "true",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -353,14 +357,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ControlPlaneEnable: "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "true",
-					EnableNodeLabeling: "false",
+					ControlPlaneVIP:       cpVIP,
+					ControlPlaneEnable:    "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "true",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -424,14 +429,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ControlPlaneEnable: "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "true",
-					EnableNodeLabeling: "false",
+					ControlPlaneVIP:       cpVIP,
+					ControlPlaneEnable:    "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "true",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -476,14 +482,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ControlPlaneEnable: "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "false",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					ControlPlaneVIP:       cpVIP,
+					ControlPlaneEnable:    "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "false",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -522,14 +529,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ControlPlaneEnable: "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					ControlPlaneVIP:       cpVIP,
+					ControlPlaneEnable:    "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -594,14 +602,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ControlPlaneEnable: "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					ControlPlaneVIP:       cpVIP,
+					ControlPlaneEnable:    "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -648,14 +657,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ControlPlaneEnable: "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					ControlPlaneVIP:       cpVIP,
+					ControlPlaneEnable:    "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -696,14 +706,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ControlPlaneEnable: "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					ControlPlaneVIP:       cpVIP,
+					ControlPlaneEnable:    "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -770,14 +781,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ControlPlaneEnable: "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
+					ControlPlaneVIP:       cpVIP,
+					ControlPlaneEnable:    "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "false",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -822,14 +834,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ControlPlaneEnable: "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "false",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "true",
-					EnableNodeLabeling: "false",
+					ControlPlaneVIP:       cpVIP,
+					ControlPlaneEnable:    "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "false",
+					SvcElectionEnable:     "false",
+					EnableEndpoints:       "true",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -868,14 +881,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ControlPlaneEnable: "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "true",
-					EnableNodeLabeling: "false",
+					ControlPlaneVIP:       cpVIP,
+					ControlPlaneEnable:    "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "true",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -921,14 +935,15 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				}
 
 				manifestValues := &e2e.KubevipManifestValues{
-					ControlPlaneVIP:    cpVIP,
-					ControlPlaneEnable: "true",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "true",
-					EnableEndpoints:    "true",
-					EnableNodeLabeling: "false",
+					ControlPlaneVIP:       cpVIP,
+					ControlPlaneEnable:    "true",
+					ImagePath:             imagePath,
+					ConfigPath:            configPath,
+					SvcEnable:             "true",
+					SvcElectionEnable:     "true",
+					EnableEndpoints:       "true",
+					EnableNodeLabeling:    "false",
+					EnableServiceSecurity: "true",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)

--- a/testing/e2e/kube-vip-hostname.yaml.tmpl
+++ b/testing/e2e/kube-vip-hostname.yaml.tmpl
@@ -32,6 +32,10 @@ spec:
       value: "true"
     - name: enable_node_labeling
       value: "{{ .EnableNodeLabeling }}"
+{{- if .EnableServiceSecurity }}
+    - name: enable_service_security
+      value: "{{ .EnableServiceSecurity }}"
+{{- end }}
     image: "{{ .ImagePath }}"
     imagePullPolicy: Never
     securityContext:

--- a/testing/e2e/kube-vip-routing-table.yaml.tmpl
+++ b/testing/e2e/kube-vip-routing-table.yaml.tmpl
@@ -69,6 +69,10 @@ spec:
     - name: control_plane_health_check_ca_path
       value: "{{ .ControlPlaneHealthCheckCAPath }}"
 {{- end }}
+{{- if .EnableServiceSecurity }}
+    - name: enable_service_security
+      value: "{{ .EnableServiceSecurity }}"
+{{- end }}
 {{- end }}
     image: "{{ .ImagePath }}"
     imagePullPolicy: Never

--- a/testing/e2e/kube-vip.yaml.tmpl
+++ b/testing/e2e/kube-vip.yaml.tmpl
@@ -106,6 +106,10 @@ spec:
       value: "{{ .ControlPlaneHealthCheckCAPath }}"
 {{- end }}
 {{- end }}
+{{- if .EnableServiceSecurity }}
+    - name: enable_service_security
+      value: "{{ .EnableServiceSecurity }}"
+{{- end }}
     image: "{{ .ImagePath }}"
     imagePullPolicy: Never
     securityContext:

--- a/testing/e2e/template.go
+++ b/testing/e2e/template.go
@@ -30,6 +30,7 @@ type KubevipManifestValues struct {
 	ControlPlaneHealthCheckTimeoutSeconds   int
 	ControlPlaneHealthCheckFailureThreshold int
 	ControlPlaneHealthCheckCAPath           string
+	EnableServiceSecurity                   string
 }
 
 type BGPPeerValues struct {


### PR DESCRIPTION
This PR introduces support for `google/nftables` in `vip/address.go` as requested in #1550

**Additional changes and questions**

1. I have decided for now that nftables will be enabled with the already existing `EgressWithNftables` flag (and added that flag as a CLI parameter,). Is this OK, or should we add separate flag that will enable `nftables` use (maybe it could override `EgressWithNftables` when true)? Or maybe `EgressWithNftables` should be completly removed (that might be a breaking change).

~~1. I  am yet unable to figure out how to use `google/nftables` to replace IPVS masquerade rules. The `nft` tool does not support `IPVS` matcher and therefore I can't take a look at the netlink commands that could do that. While investigating this, I've seen some info that this is not really possible, and it might be that we would have to ditch IPVS for internal implementation of loadbalncer with nftables (I believe this is what k8s did), but I am not yet sure. I have omitted this part of code for now, so it still uses `iptables-nft`.~~

~~UPDATE: It seems that instead of using IPVS matcher it should be posible to use IPVS to mark packets with fwmark and then use this mark to match using nftables. Will try that.~~

UPDATE 2: I have implemented the IPVS with `masquerade` forwarding using fwmark and it seems to be OK :)

```
IP Virtual Server version 1.2.1 (size=4096)
Prot LocalAddress:Port               Conns   InPkts  OutPkts  InBytes OutBytes
  -> RemoteAddress:Port
FWM  10001                               7      104       77    11407    21413
  -> kind-control-plane3:6443            3       44       33     4859     9178
  -> kind-control-plane.kind:6443        2       30       22     3274     6117
  -> kind-control-plane2.kind:644        2       30       22     3274     6118
```

