### PR TITLE
Fixed deadlock on AddIP() call in StartVipService

### DIFF
--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -58,6 +58,7 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 		}
 
 		if err := network.SetMask(c.VIPSubnet); err != nil {
+			killFunc()
 			return fmt.Errorf("failed to set mask for subnet %q: %w", c.VIPSubnet, err)
 		}
 
@@ -73,7 +74,7 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 		if !c.EnableRoutingTable {
 			// Normal VIP addition, use skipDAD=false for normal DAD process
 			if _, err = network.AddIP(false, false); err != nil {
-				return fmt.Errorf("failed to add IP address %s: %w", network.IP(), err)
+				log.Error("failed to add IP", "address", network.IP(), "error", err)
 			}
 		}
 
@@ -97,6 +98,7 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 			lb, err := loadbalancer.NewIPVSLB(ctx, network.IP(), c.LoadBalancerPort, c.LoadBalancerForwardingMethod,
 				c.BackendHealthCheckInterval, killFunc, &wg)
 			if err != nil {
+				killFunc()
 				return fmt.Errorf("creating IPVS LoadBalance: %w", err)
 			}
 


### PR DESCRIPTION
This PR sgould fix deadlock on AddIP() call in StartVipService as reported in #1590 

I have confirmed that the issue occurs. The error return was changed to log (As it is for other `AddIP()` calls. I have additionally added calls to `killFunc` in case of other errors that can occur in this function, this should result in context being cancelled in case any error would occur. 