### PR TITLE
This enables BFD in kube-vip

### DIFF
--- a/pkg/bgp/peers.go
+++ b/pkg/bgp/peers.go
@@ -53,6 +53,16 @@ func (b *Server) AddPeer(ctx context.Context, peer kubevip.BGPPeer) (err error) 
 		},
 	}
 
+	if peer.BFDEnabled {
+		p.Bfd = &api.BfdPeerConfig{
+			Enabled:                  true,
+			DesiredMinimumTxInterval: peer.BFDReceiveInterval,
+			RequiredMinimumReceive:   peer.BFDTransmitInterval,
+			DetectionMultiplier:      peer.BFDDetectMultiplier,
+			Port:                     3784, // Should this be configurable??
+		}
+	}
+
 	if peer.Interface != "" {
 		neighborAddress, err := getIPv6LinkLocalNeighborAddress(ctx, peer.Interface)
 		if err != nil {

--- a/pkg/bgp/peers.go
+++ b/pkg/bgp/peers.go
@@ -3,6 +3,7 @@ package bgp
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/netip"
 	"strconv"
@@ -141,7 +142,7 @@ func (b *Server) AddPeer(ctx context.Context, peer kubevip.BGPPeer) (err error) 
 	if err := b.s.AddPeer(ctx, &api.AddPeerRequest{Peer: p}); err != nil {
 		return fmt.Errorf("failed to add peer: %v", err)
 	}
-
+	slog.Info("[BGP]", "peer", p.Conf.NeighborAddress, "AS", p.Conf.PeerAsn, "BFD", p.Bfd)
 	return nil
 }
 

--- a/pkg/bgp/peers.go
+++ b/pkg/bgp/peers.go
@@ -56,10 +56,10 @@ func (b *Server) AddPeer(ctx context.Context, peer kubevip.BGPPeer) (err error) 
 	if peer.BFDEnabled {
 		p.Bfd = &api.BfdPeerConfig{
 			Enabled:                  true,
-			DesiredMinimumTxInterval: peer.BFDReceiveInterval,
-			RequiredMinimumReceive:   peer.BFDTransmitInterval,
+			DesiredMinimumTxInterval: peer.BFDTransmitInterval,
+			RequiredMinimumReceive:   peer.BFDReceiveInterval,
 			DetectionMultiplier:      peer.BFDDetectMultiplier,
-			Port:                     3784, // Should this be configurable??
+			Port:                     3784, // TODO: Should this be configurable??
 		}
 	}
 

--- a/pkg/bgp/server.go
+++ b/pkg/bgp/server.go
@@ -24,7 +24,7 @@ type Server struct {
 }
 
 // NewBGPServer takes a configuration and returns a running BGP server instance
-func NewBGPServer(c kubevip.BGPConfig) (b *Server, err error) {
+func NewBGPServer(c kubevip.BGPConfig, logLevel log.Level) (b *Server, err error) {
 	if c.AS == 0 {
 		return nil, fmt.Errorf("you need to provide AS")
 	}
@@ -38,7 +38,7 @@ func NewBGPServer(c kubevip.BGPConfig) (b *Server, err error) {
 	}
 	bgpLogger := log.Default()
 	lvl := &log.LevelVar{}
-	lvl.Set(log.LevelInfo)
+	lvl.Set(logLevel)
 
 	b = &Server{
 		s:       gobgp.NewBgpServer(gobgp.LoggerOption(bgpLogger, lvl)),

--- a/pkg/bgp/server.go
+++ b/pkg/bgp/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	api "github.com/osrg/gobgp/v4/api"
 	"github.com/osrg/gobgp/v4/pkg/apiutil"
+	bgp "github.com/osrg/gobgp/v4/pkg/packet/bgp"
 	gobgp "github.com/osrg/gobgp/v4/pkg/server"
 )
 
@@ -99,27 +100,38 @@ func (b *Server) Close() error {
 // ListAdvertisedRoutes retrieves all active routes inside GoBGP's local RIB.
 // It queries the GLOBAL table type to find routes that kube-vip has requested GoBGP to advertise.
 func (b *Server) ListAdvertisedRoutes(ctx context.Context, isIPv6 bool) ([]*api.Destination, error) {
-	family := &api.Family{
-		Afi:  api.Family_AFI_IP,
-		Safi: api.Family_SAFI_UNICAST,
-	}
+	afi := bgp.AFI_IP
+
 	if isIPv6 {
-		family.Afi = api.Family_AFI_IP6
+		afi = bgp.AFI_IP6
 	}
+
+	family := bgp.NewFamily(uint16(afi), bgp.SAFI_UNICAST)
 
 	var destinations []*api.Destination
 
-	req := &api.ListPathRequest{
-		TableType: api.TableType_GLOBAL,
+	req := apiutil.ListPathRequest{
+		TableType: api.TableType_TABLE_TYPE_GLOBAL,
 		Family:    family,
 	}
 
 	// GoBGP's embedded server API uses a callback function to stream results
 	// locally without requiring a gRPC client stream setup.
-	err := b.s.ListPath(ctx, req, func(destination *api.Destination) {
-		if destination != nil {
-			destinations = append(destinations, destination)
+	err := b.s.ListPath(req, func(prefix bgp.NLRI, paths []*apiutil.Path) {
+		var newPaths []*api.Path
+		for _, p := range paths {
+			np, err := apiutil.NewPath(p.Family, p.Nlri, p.Withdrawal, p.Attrs, time.Unix(p.Age, 0))
+			if err != nil {
+				log.Error("failed to create BGP path details", "err", err)
+				continue
+			}
+			newPaths = append(newPaths, np)
 		}
+		d := &api.Destination{
+			Prefix: prefix.String(),
+			Paths:  newPaths,
+		}
+		destinations = append(destinations, d)
 	})
 
 	if err != nil {

--- a/pkg/bgp/server.go
+++ b/pkg/bgp/server.go
@@ -36,9 +36,12 @@ func NewBGPServer(c kubevip.BGPConfig) (b *Server, err error) {
 	if len(c.Peers) == 0 {
 		return nil, fmt.Errorf("you need to provide at least one peer")
 	}
+	bgpLogger := log.Default()
+	lvl := &log.LevelVar{}
+	lvl.Set(log.LevelInfo)
 
 	b = &Server{
-		s:       gobgp.NewBgpServer(),
+		s:       gobgp.NewBgpServer(gobgp.LoggerOption(bgpLogger, lvl)),
 		c:       &c,
 		tracker: make(map[string]map[string]bool),
 	}

--- a/pkg/kubevip/config_bgp.go
+++ b/pkg/kubevip/config_bgp.go
@@ -23,6 +23,12 @@ type BGPPeer struct {
 	MpbgpNexthop string
 	MpbgpIPv4    string
 	MpbgpIPv6    string
+
+	// BFD Configurtion
+	BFDEnabled          bool
+	BFDReceiveInterval  uint32
+	BFDTransmitInterval uint32
+	BFDDetectMultiplier uint32
 }
 
 // Config defines the BGP server configuration
@@ -51,6 +57,17 @@ type ZebraConfig struct {
 	SoftwareName string
 }
 
+// BGP Peer layout is as follows:
+// <address>:<AS>:<password>:<multihop>:<port><optional mpbgp options>:<BFD options>
+
+// <address> - IP address of the peer. For IPv6 addresses, the address should be enclosed in square brackets (e.g. [fd00:100:64::2]). For unnumbered peers, the address should be prefixed with "unnumbered:" followed by the interface name (e.g. unnumbered:eth0).
+// <AS> - Autonomous System number of the peer (e.g. 65000)
+// <password> - Optional password for BGP authentication (e.g. secret)
+// <multihop> - Optional flag to indicate if this is a multihop peer (true/false, default: false)
+// <port> - Optional BGP port number (default: 179)
+// <optional mpbgp options> - Optional MP-BGP parameters in the format of key=value pairs separated by ';' (e.g. mpbgp_nexthop=auto_sourceif;mpbgp_ipv4=)
+// <BFD options> - Optional BFD parameters (if any) in the format of comma-separated values (e.g. bfd_receive_interval=300,bfd_transmit_interval=300,bfd_detect_multiplier=3)
+
 // ParseBGPPeerConfig - take a string and parses it into an array of peers
 func ParseBGPPeerConfig(config string) (bgpPeers []BGPPeer, err error) {
 	peers := strings.Split(config, ",")
@@ -60,11 +77,13 @@ func ParseBGPPeerConfig(config string) (bgpPeers []BGPPeer, err error) {
 
 	for x := range peers {
 		peerStr := peers[x]
-		config := strings.Split(peerStr, "/")
-		peerStr = config[0]
+		//config := strings.Split(peerStr, "/")
+		//peerStr = config[0]
 		if peerStr == "" {
 			continue
 		}
+
+		// Look at address peer
 		isV6Peer := peerStr[0] == '['
 		isUnnumberedPeer := strings.HasPrefix(peerStr, "unnumbered:")
 
@@ -93,6 +112,7 @@ func ParseBGPPeerConfig(config string) (bgpPeers []BGPPeer, err error) {
 			address = peer[0]
 		}
 
+		// Look at peer[1] for AS number
 		var ASNumber uint64
 		if len(peer) >= 2 {
 			ASNumber, err = strconv.ParseUint(peer[1], 10, 32)
@@ -101,11 +121,13 @@ func ParseBGPPeerConfig(config string) (bgpPeers []BGPPeer, err error) {
 			}
 		}
 
+		// Look at peer[2] for password
 		password := ""
 		if len(peer) >= 3 {
 			password = peer[2]
 		}
 
+		// Look at peer[3] for multihop
 		multiHop := false
 		if len(peer) >= 4 && peer[3] != "" {
 			multiHop, err = strconv.ParseBool(peer[3])
@@ -114,20 +136,26 @@ func ParseBGPPeerConfig(config string) (bgpPeers []BGPPeer, err error) {
 			}
 		}
 
+		// Look at peer[4] for BGP port
 		var port uint64
 		if len(peer) >= 5 {
-			port, err = strconv.ParseUint(peer[4], 10, 16)
-			if err != nil {
-				return nil, fmt.Errorf("BGP Peer Port format error [%s]", peer[4])
+			if peer[4] == "" {
+				port = 179
+			} else {
+				port, err = strconv.ParseUint(peer[4], 10, 16)
+				if err != nil {
+					return nil, fmt.Errorf("BGP Peer Port format error [%s]", peer[4])
+				}
 			}
 		} else if !isUnnumberedPeer {
 			port = 179
 		}
 
+		// Look at peer[5] for optional MP-BGP parameters
 		var mpbgpNexthop, mpbgpIPv4, mpbgpIPv6 string
 
-		if len(config) > 1 {
-			configData := strings.Split(config[1], ";")
+		if len(peer) >= 6 {
+			configData := strings.Split(peer[5], ";")
 			for _, cfg := range configData {
 				c := strings.Split(cfg, "=")
 				if len(c) < 2 {
@@ -144,19 +172,61 @@ func ParseBGPPeerConfig(config string) (bgpPeers []BGPPeer, err error) {
 					return nil, fmt.Errorf("peer configuration parameter '%s' is not supported", c[0])
 				}
 			}
+
+		}
+
+		// Look at peer[6] for optional BFD parameters (if any)
+		bpfEnabled := false
+		bpfReceiveInterval := uint64(300)
+		bpfTransmitInterval := uint64(300)
+		bpfDetectMultiplier := uint64(3)
+
+		if len(peer) >= 7 {
+			c := strings.Split(peer[6], ";")
+			if len(c) < 4 {
+				return nil, fmt.Errorf("BFD configuration error: at least 4 parameters are required (enable, receive_interval, transmit_interval, detect_multiplier)[%s]", c[1])
+			}
+			bpfEnabled, err = strconv.ParseBool(c[0])
+			if err != nil {
+				return nil, fmt.Errorf("BFD configuration error: invalid value for bfd_enabled (true/false) [%s]", c[0])
+			}
+
+			if c[1] != "" {
+				bpfReceiveInterval, err = strconv.ParseUint(c[1], 10, 32)
+				if err != nil {
+					return nil, fmt.Errorf("BFD configuration error: invalid value for bfd_receive_interval [%s]", c[1])
+				}
+			}
+
+			if c[2] != "" {
+				bpfTransmitInterval, err = strconv.ParseUint(c[2], 10, 32)
+				if err != nil {
+					return nil, fmt.Errorf("BFD configuration error: invalid value for bfd_transmit_interval [%s]", c[2])
+				}
+			}
+			if c[3] != "" {
+				bpfDetectMultiplier, err = strconv.ParseUint(c[3], 10, 32)
+				if err != nil {
+					return nil, fmt.Errorf("BFD configuration error: invalid value for bfd_detect_multiplier [%s]", c[3])
+				}
+			}
 		}
 
 		peerConfig := BGPPeer{
 			Address: address,
 			//nolint:gosec // previously parsed into uint32
-			AS:           uint32(ASNumber),
-			Port:         uint16(port),
-			Interface:    iface,
-			Password:     password,
-			MultiHop:     multiHop,
-			MpbgpNexthop: mpbgpNexthop,
-			MpbgpIPv4:    mpbgpIPv4,
-			MpbgpIPv6:    mpbgpIPv6,
+			AS:                  uint32(ASNumber),
+			Port:                uint16(port),
+			Interface:           iface,
+			Password:            password,
+			MultiHop:            multiHop,
+			MpbgpNexthop:        mpbgpNexthop,
+			MpbgpIPv4:           mpbgpIPv4,
+			MpbgpIPv6:           mpbgpIPv6,
+			BFDEnabled:          bpfEnabled,
+			BFDReceiveInterval:  uint32(bpfReceiveInterval),
+			BFDTransmitInterval: uint32(bpfTransmitInterval),
+			BFDDetectMultiplier: uint32(bpfDetectMultiplier),
 		}
 
 		bgpPeers = append(bgpPeers, peerConfig)

--- a/pkg/kubevip/config_bgp.go
+++ b/pkg/kubevip/config_bgp.go
@@ -24,7 +24,7 @@ type BGPPeer struct {
 	MpbgpIPv4    string
 	MpbgpIPv6    string
 
-	// BFD Configurtion
+	// BFD Configuration
 	BFDEnabled          bool
 	BFDReceiveInterval  uint32
 	BFDTransmitInterval uint32
@@ -58,7 +58,7 @@ type ZebraConfig struct {
 }
 
 // BGP Peer layout is as follows:
-// <address>:<AS>:<password>:<multihop>:<port><optional mpbgp options>:<BFD options>
+// <address>:<AS>:<password>:<multihop>:<port>:<optional mpbgp options>:<BFD options>
 
 // <address> - IP address of the peer. For IPv6 addresses, the address should be enclosed in square brackets (e.g. [fd00:100:64::2]). For unnumbered peers, the address should be prefixed with "unnumbered:" followed by the interface name (e.g. unnumbered:eth0).
 // <AS> - Autonomous System number of the peer (e.g. 65000)
@@ -66,19 +66,17 @@ type ZebraConfig struct {
 // <multihop> - Optional flag to indicate if this is a multihop peer (true/false, default: false)
 // <port> - Optional BGP port number (default: 179)
 // <optional mpbgp options> - Optional MP-BGP parameters in the format of key=value pairs separated by ';' (e.g. mpbgp_nexthop=auto_sourceif;mpbgp_ipv4=)
-// <BFD options> - Optional BFD parameters (if any) in the format of comma-separated values (e.g. bfd_receive_interval=300,bfd_transmit_interval=300,bfd_detect_multiplier=3)
+// <BFD options> - Optional BFD parameters (if any) in the format of semicolon-separated values (enable, receive_interval, transmit_interval, detect_multiplier) (e.g. true;300;300;3)
 
 // ParseBGPPeerConfig - take a string and parses it into an array of peers
 func ParseBGPPeerConfig(config string) (bgpPeers []BGPPeer, err error) {
 	peers := strings.Split(config, ",")
-	if len(peers) == 0 {
+	if len(peers) == 0 || config == "" {
 		return nil, fmt.Errorf("no BGP Peer configurations found")
 	}
 
 	for x := range peers {
 		peerStr := peers[x]
-		//config := strings.Split(peerStr, "/")
-		//peerStr = config[0]
 		if peerStr == "" {
 			continue
 		}
@@ -154,7 +152,7 @@ func ParseBGPPeerConfig(config string) (bgpPeers []BGPPeer, err error) {
 		// Look at peer[5] for optional MP-BGP parameters
 		var mpbgpNexthop, mpbgpIPv4, mpbgpIPv6 string
 
-		if len(peer) >= 6 {
+		if len(peer) >= 6 && peer[5] != "" {
 			configData := strings.Split(peer[5], ";")
 			for _, cfg := range configData {
 				c := strings.Split(cfg, "=")
@@ -176,36 +174,36 @@ func ParseBGPPeerConfig(config string) (bgpPeers []BGPPeer, err error) {
 		}
 
 		// Look at peer[6] for optional BFD parameters (if any)
-		bpfEnabled := false
-		bpfReceiveInterval := uint64(300)
-		bpfTransmitInterval := uint64(300)
-		bpfDetectMultiplier := uint64(3)
+		bfdEnabled := false
+		bfdReceiveInterval := uint64(300)
+		bfdTransmitInterval := uint64(300)
+		bfdDetectMultiplier := uint64(3)
 
-		if len(peer) >= 7 {
+		if len(peer) >= 7 && peer[6] != "" {
 			c := strings.Split(peer[6], ";")
 			if len(c) < 4 {
-				return nil, fmt.Errorf("BFD configuration error: at least 4 parameters are required (enable, receive_interval, transmit_interval, detect_multiplier)[%s]", c[1])
+				return nil, fmt.Errorf("BFD configuration error: at least 4 parameters are required (enable, receive_interval, transmit_interval, detect_multiplier) [%s]", peer[6])
 			}
-			bpfEnabled, err = strconv.ParseBool(c[0])
+			bfdEnabled, err = strconv.ParseBool(c[0])
 			if err != nil {
 				return nil, fmt.Errorf("BFD configuration error: invalid value for bfd_enabled (true/false) [%s]", c[0])
 			}
 
 			if c[1] != "" {
-				bpfReceiveInterval, err = strconv.ParseUint(c[1], 10, 32)
+				bfdReceiveInterval, err = strconv.ParseUint(c[1], 10, 32)
 				if err != nil {
 					return nil, fmt.Errorf("BFD configuration error: invalid value for bfd_receive_interval [%s]", c[1])
 				}
 			}
 
 			if c[2] != "" {
-				bpfTransmitInterval, err = strconv.ParseUint(c[2], 10, 32)
+				bfdTransmitInterval, err = strconv.ParseUint(c[2], 10, 32)
 				if err != nil {
 					return nil, fmt.Errorf("BFD configuration error: invalid value for bfd_transmit_interval [%s]", c[2])
 				}
 			}
 			if c[3] != "" {
-				bpfDetectMultiplier, err = strconv.ParseUint(c[3], 10, 32)
+				bfdDetectMultiplier, err = strconv.ParseUint(c[3], 10, 32)
 				if err != nil {
 					return nil, fmt.Errorf("BFD configuration error: invalid value for bfd_detect_multiplier [%s]", c[3])
 				}
@@ -223,10 +221,10 @@ func ParseBGPPeerConfig(config string) (bgpPeers []BGPPeer, err error) {
 			MpbgpNexthop:        mpbgpNexthop,
 			MpbgpIPv4:           mpbgpIPv4,
 			MpbgpIPv6:           mpbgpIPv6,
-			BFDEnabled:          bpfEnabled,
-			BFDReceiveInterval:  uint32(bpfReceiveInterval),
-			BFDTransmitInterval: uint32(bpfTransmitInterval),
-			BFDDetectMultiplier: uint32(bpfDetectMultiplier),
+			BFDEnabled:          bfdEnabled,
+			BFDReceiveInterval:  uint32(bfdReceiveInterval),
+			BFDTransmitInterval: uint32(bfdTransmitInterval),
+			BFDDetectMultiplier: uint32(bfdDetectMultiplier),
 		}
 
 		bgpPeers = append(bgpPeers, peerConfig)

--- a/pkg/kubevip/config_bgp_test.go
+++ b/pkg/kubevip/config_bgp_test.go
@@ -19,45 +19,52 @@ func TestParseBGPPeerConfig(t *testing.T) {
 			name: "IPv4, default port",
 			args: args{config: "192.168.0.10:65000::false,192.168.0.11:65000::false"},
 			wantBgpPeers: []BGPPeer{
-				{Address: "192.168.0.10", Port: 179, AS: 65000, MultiHop: false},
-				{Address: "192.168.0.11", Port: 179, AS: 65000, MultiHop: false},
+				{Address: "192.168.0.10", Port: 179, AS: 65000, MultiHop: false, BFDEnabled: false, BFDReceiveInterval: 300, BFDTransmitInterval: 300, BFDDetectMultiplier: 3},
+				{Address: "192.168.0.11", Port: 179, AS: 65000, MultiHop: false, BFDEnabled: false, BFDReceiveInterval: 300, BFDTransmitInterval: 300, BFDDetectMultiplier: 3},
 			},
 		},
 		{
 			name: "IPv4, different port",
 			args: args{config: "192.168.0.10:65000::false:180,192.168.0.11:65000::false:190"},
 			wantBgpPeers: []BGPPeer{
-				{Address: "192.168.0.10", Port: 180, AS: 65000, MultiHop: false},
-				{Address: "192.168.0.11", Port: 190, AS: 65000, MultiHop: false},
+				{Address: "192.168.0.10", Port: 180, AS: 65000, MultiHop: false, BFDEnabled: false, BFDReceiveInterval: 300, BFDTransmitInterval: 300, BFDDetectMultiplier: 3},
+				{Address: "192.168.0.11", Port: 190, AS: 65000, MultiHop: false, BFDEnabled: false, BFDReceiveInterval: 300, BFDTransmitInterval: 300, BFDDetectMultiplier: 3},
 			},
 		},
 		{
 			name: "IPv6, multi-protocol",
-			args: args{config: "[fd00:1111:2222:3333:c7d9:7235:6bf7:5d52]:65501::false/mpbgp_nexthop=auto_sourceif"},
+			args: args{config: "[fd00:1111:2222:3333:c7d9:7235:6bf7:5d52]:65501::false::mpbgp_nexthop=auto_sourceif"},
 			wantBgpPeers: []BGPPeer{
-				{Address: "fd00:1111:2222:3333:c7d9:7235:6bf7:5d52", Port: 179, AS: 65501, MultiHop: false, MpbgpNexthop: "auto_sourceif"},
+				{Address: "fd00:1111:2222:3333:c7d9:7235:6bf7:5d52", Port: 179, AS: 65501, MultiHop: false, MpbgpNexthop: "auto_sourceif", BFDEnabled: false, BFDReceiveInterval: 300, BFDTransmitInterval: 300, BFDDetectMultiplier: 3},
+			},
+		},
+		{
+			name: "IPv6, multi-protocol, BFD",
+			args: args{config: "[fd00:1111:2222:3333:c7d9:7235:6bf7:5d52]:65501::false::mpbgp_nexthop=auto_sourceif:true;300;300;3"},
+			wantBgpPeers: []BGPPeer{
+				{Address: "fd00:1111:2222:3333:c7d9:7235:6bf7:5d52", Port: 179, AS: 65501, MultiHop: false, MpbgpNexthop: "auto_sourceif", BFDEnabled: true, BFDReceiveInterval: 300, BFDTransmitInterval: 300, BFDDetectMultiplier: 3},
 			},
 		},
 		{
 			name: "IPv6 bracketed, with password and multihop",
 			args: args{config: "[fd00:100:64::2]:65000:secret:true"},
 			wantBgpPeers: []BGPPeer{
-				{Address: "fd00:100:64::2", Port: 179, AS: 65000, Password: "secret", MultiHop: true},
+				{Address: "fd00:100:64::2", Port: 179, AS: 65000, Password: "secret", MultiHop: true, BFDEnabled: false, BFDReceiveInterval: 300, BFDTransmitInterval: 300, BFDDetectMultiplier: 3},
 			},
 		},
 		{
 			name: "IPv6 bracketed, empty fields",
 			args: args{config: "[fd00:100:64::2]:65000::false"},
 			wantBgpPeers: []BGPPeer{
-				{Address: "fd00:100:64::2", Port: 179, AS: 65000, MultiHop: false},
+				{Address: "fd00:100:64::2", Port: 179, AS: 65000, MultiHop: false, BFDEnabled: false, BFDReceiveInterval: 300, BFDTransmitInterval: 300, BFDDetectMultiplier: 3},
 			},
 		},
 		{
 			name: "Unnumbered",
-			args: args{config: "unnumbered:eth0,unnumbered:eth1:65000::true/mpbgp_nexthop=auto_sourceif"},
+			args: args{config: "unnumbered:eth0,unnumbered:eth1:65000::true::mpbgp_nexthop=auto_sourceif"},
 			wantBgpPeers: []BGPPeer{
-				{Interface: "eth0", MultiHop: false},
-				{Interface: "eth1", AS: 65000, MultiHop: true, MpbgpNexthop: "auto_sourceif"},
+				{Interface: "eth0", MultiHop: false, BFDEnabled: false, BFDReceiveInterval: 300, BFDTransmitInterval: 300, BFDDetectMultiplier: 3},
+				{Interface: "eth1", Port: 179, AS: 65000, MultiHop: true, MpbgpNexthop: "auto_sourceif", BFDEnabled: false, BFDReceiveInterval: 300, BFDTransmitInterval: 300, BFDDetectMultiplier: 3},
 			},
 		},
 		{
@@ -80,11 +87,11 @@ func TestParseBGPPeerConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gotBgpPeers, err := ParseBGPPeerConfig(tt.args.config)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseBGPPeerConfig() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ParseBGPPeerConfig() error = \n%v, wantErr \n%v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(gotBgpPeers, tt.wantBgpPeers) {
-				t.Errorf("ParseBGPPeerConfig() = %v, want %v", gotBgpPeers, tt.wantBgpPeers)
+				t.Errorf("ParseBGPPeerConfig() = \n%v, want \n%v", gotBgpPeers, tt.wantBgpPeers)
 			}
 		})
 	}

--- a/pkg/kubevip/config_bgp_test.go
+++ b/pkg/kubevip/config_bgp_test.go
@@ -15,6 +15,7 @@ func TestParseBGPPeerConfig(t *testing.T) {
 		wantBgpPeers []BGPPeer
 		wantErr      bool
 	}{
+
 		{
 			name: "IPv4, default port",
 			args: args{config: "192.168.0.10:65000::false,192.168.0.11:65000::false"},
@@ -36,6 +37,13 @@ func TestParseBGPPeerConfig(t *testing.T) {
 			args: args{config: "[fd00:1111:2222:3333:c7d9:7235:6bf7:5d52]:65501::false::mpbgp_nexthop=auto_sourceif"},
 			wantBgpPeers: []BGPPeer{
 				{Address: "fd00:1111:2222:3333:c7d9:7235:6bf7:5d52", Port: 179, AS: 65501, MultiHop: false, MpbgpNexthop: "auto_sourceif", BFDEnabled: false, BFDReceiveInterval: 300, BFDTransmitInterval: 300, BFDDetectMultiplier: 3},
+			},
+		},
+		{
+			name: "IPv6, multi-protocol, BFD, no multi-protocol options",
+			args: args{config: "[fd00:1111:2222:3333:c7d9:7235:6bf7:5d52]:65501::false:::true;300;300;3"},
+			wantBgpPeers: []BGPPeer{
+				{Address: "fd00:1111:2222:3333:c7d9:7235:6bf7:5d52", Port: 179, AS: 65501, MultiHop: false, BFDEnabled: true, BFDReceiveInterval: 300, BFDTransmitInterval: 300, BFDDetectMultiplier: 3},
 			},
 		},
 		{
@@ -68,13 +76,23 @@ func TestParseBGPPeerConfig(t *testing.T) {
 			},
 		},
 		{
+			name:    "Completely empty config",
+			args:    args{config: ""},
+			wantErr: true,
+		},
+		{
+			name:    "Completely empty config (but with the seperators)",
+			args:    args{config: ":::::::"},
+			wantErr: true,
+		},
+		{
 			name:    "Malformed parameter (no value)",
 			args:    args{config: "1.2.3.4:65000/mpbgp_nexthop"},
 			wantErr: true,
 		},
 		{
 			name:    "Unsupported parameter",
-			args:    args{config: "1.2.3.4:65000/unknown=value"},
+			args:    args{config: "1.2.3.4:65000;unknown=value"},
 			wantErr: true,
 		},
 		{
@@ -87,7 +105,7 @@ func TestParseBGPPeerConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gotBgpPeers, err := ParseBGPPeerConfig(tt.args.config)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseBGPPeerConfig() error = \n%v, wantErr \n%v", err, tt.wantErr)
+				t.Errorf("ParseBGPPeerConfig() error = \n%v, wantErr \n%v %v", err, tt.wantErr, gotBgpPeers)
 				return
 			}
 			if !reflect.DeepEqual(gotBgpPeers, tt.wantBgpPeers) {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -227,8 +227,7 @@ func New(ctx context.Context, configMap string, config *kubevip.Config) (*Manage
 		if err != nil {
 			return nil, err
 		}
-
-		bgpServer, err = bgp.NewBGPServer(config.BGPConfig)
+		bgpServer, err = bgp.NewBGPServer(config.BGPConfig, log.Level(config.Logging))
 		if err != nil {
 			return nil, fmt.Errorf("creating BGP server: %w", err)
 		}

--- a/pkg/manager/worker/bgp.go
+++ b/pkg/manager/worker/bgp.go
@@ -45,7 +45,7 @@ func NewBGP(arpMgr *arp.Manager, intfMgr *networkinterface.Manager,
 func (b *BGP) Configure(ctx context.Context, _ *sync.WaitGroup) error {
 	var err error
 	if b.bgpServer == nil {
-		b.bgpServer, err = bgp.NewBGPServer(b.config.BGPConfig)
+		b.bgpServer, err = bgp.NewBGPServer(b.config.BGPConfig, log.Level(b.config.Logging))
 		if err != nil {
 			return fmt.Errorf("creating BGP server: %w", err)
 		}

--- a/testing/kind/kube-vip-skaffold-bgp.yaml
+++ b/testing/kind/kube-vip-skaffold-bgp.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-vip-ds
+  name: kube-vip-ds
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-vip-ds
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-vip-ds
+    spec:
+      containers:
+        - args:
+            - manager
+          env:
+            - name: vip_arp
+              value: "false"
+            - name: port
+              value: "6443"
+            - name: vip_nodename
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: bgp_routerinterface
+              value: eth0
+            - name: bgp_enable
+              value: "true"
+            - name: bgp_as
+              value: "65001"
+            - name: bgp_peers
+              value: "192.168.0.10:65001::false:::true;300000;300000;3"
+            - name: bgp_routerid
+              value: "10.0.255.254"
+            - name: vip_interface
+              value: eth0
+            - name: dns_mode
+              value: first
+            - name: svc_enable
+              value: "true"
+            - name: svc_leasename
+              value: plndr-svcs-lock
+            - name: svc_election
+              value: "true"
+            - name: vip_address
+            - name: prometheus_server
+              value: :2112
+            - name: enable_endpoints
+              value: "false"
+            - name: EGRESS_CLEAN
+              value: "true"
+            - name: egress_withnftables
+              value: "true"
+          image: ghcr.io/kube-vip/kube-vip
+          imagePullPolicy: IfNotPresent
+          name: kube-vip
+          resources: {}
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+                - NET_RAW
+      hostNetwork: true
+      serviceAccountName: kube-vip
+  updateStrategy: {}


### PR DESCRIPTION
This adds the capability to enable BFD for faster failover in kube-vip 

Fixes #582 (amongst other requests)

Special care needs to be applied to the configuration:

The new format:
```
// BGP Peer layout is as follows:
// <address>:<AS>:<password>:<multihop>:<port><optional mpbgp options>:<BFD options>
```
Below enables timers and bfd:
`"[fd00:1111:2222:3333:c7d9:7235:6bf7:5d52]:65501::false::mpbgp_nexthop=auto_sourceif:true;300;300;3"`

I'd appreciate your thoughts @p-strusiewiczsurmacki-mobica 
