### PR TITLE
Added support in ipoib interfaces in ARP mode. Fixes #694

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Annotation: `kube-vip.io/allow-reconcile-without-endpoints: "true"`
   - Starts service handling path for opted-in endpointless Cluster services while preserving default endpoint-gated behavior for non-opt-in services and `Local` policy
   - Added endpoint behavior tests and README usage documentation
+  - Added support in ipoib interfaces in ARP mode. Fixes #694
 
 ### Changed
 - Updated signal handlers in manager_arp.go, manager_bgp.go, manager_wireguard.go, and manager_table.go to use switch statement pattern for handling multiple signals (SIGUSR1, SIGINT, SIGTERM)

--- a/pkg/vip/arp.go
+++ b/pkg/vip/arp.go
@@ -9,27 +9,59 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	log "log/slog"
+	"math"
 	"net"
+	"os"
+	"strconv"
+	"strings"
 	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 const (
 	opARPRequest = 1
 	opARPReply   = 2
-	hwLen        = 6
+	ethHwLen     = 6
+	ipoibHwLen   = 20
 )
 
 var (
 	ethernetBroadcast = net.HardwareAddr{0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
 	// arpRequest is used to flip between garp request or garp reply
-	arpRequest = true
+	arpRequest   = true
+	netClassPath = "/sys/class/net"
 )
 
 func htons(p uint16) uint16 {
 	var b [2]byte
 	binary.BigEndian.PutUint16(b[:], p)
 	return *(*uint16)(unsafe.Pointer(&b))
+}
+
+func getInterfaceBroadcastAddress(ifaceName string) (net.HardwareAddr, error) {
+	data, err := os.ReadFile(netClassPath + "/" + ifaceName + "/broadcast")
+	if err != nil {
+		return nil, err
+	}
+	return net.ParseMAC(strings.TrimSpace(string(data)))
+}
+
+func getHwType(ifaceName string) (uint16, error) {
+	data, err := os.ReadFile(netClassPath + "/" + ifaceName + "/type")
+	if err != nil {
+		return 0, err
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, fmt.Errorf("failed to convert hardware type to integer: %w", err)
+	}
+	if n < 0 || n > math.MaxUint16 {
+		return 0, fmt.Errorf("hardware type %d out of range", n)
+	}
+	return uint16(n), nil
 }
 
 // arpHeader specifies the header for an ARP message.
@@ -50,6 +82,71 @@ type arpMessage struct {
 	targetProtocolAddress []byte
 }
 
+type arpLinkParams struct {
+	hardwareType uint16
+	hwLen        uint8
+	broadcast    net.HardwareAddr
+}
+
+// sockaddrLLExt matches linux sockaddr_ll with room for INFINIBAND_HALEN (20).
+// Standard Go syscall.SockaddrLinklayer only has Addr [8]byte.
+type sockaddrLLExt struct {
+	Family   uint16
+	Protocol uint16
+	Ifindex  int32
+	Hatype   uint16
+	Pkttype  uint8
+	Halen    uint8
+	Addr     [20]byte
+}
+
+func rawSendto(fd int, b []byte, sa *sockaddrLLExt) error {
+	if len(b) == 0 {
+		return syscall.EINVAL
+	}
+
+	_, _, errno := syscall.Syscall6(
+		syscall.SYS_SENDTO,
+		uintptr(fd),
+		uintptr(unsafe.Pointer(&b[0])),
+		uintptr(len(b)),
+		0,
+		uintptr(unsafe.Pointer(sa)),
+		unsafe.Sizeof(*sa),
+	)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+func getARPLinkParams(ifaceName string) (arpLinkParams, error) {
+	hwType, err := getHwType(ifaceName)
+	if err != nil {
+		log.Warn("failed to get hardware type, falling back to ethernet", "iface", ifaceName, "err", err)
+		hwType = unix.ARPHRD_ETHER
+	}
+
+	switch hwType {
+	case unix.ARPHRD_INFINIBAND:
+		log.Info("using ipoib", "iface", ifaceName)
+		bcastAddr, err := getInterfaceBroadcastAddress(ifaceName)
+		if err != nil {
+			return arpLinkParams{}, fmt.Errorf("failed to get broadcast address: %w", err)
+		}
+		if len(bcastAddr) != ipoibHwLen {
+			return arpLinkParams{}, fmt.Errorf("broadcast address length for ipoib is %d, got %d", ipoibHwLen, len(bcastAddr))
+		}
+		return arpLinkParams{hwType, ipoibHwLen, bcastAddr}, nil
+	case unix.ARPHRD_ETHER:
+		log.Info("using ethernet", "iface", ifaceName)
+		return arpLinkParams{hwType, ethHwLen, ethernetBroadcast}, nil
+	default:
+		log.Warn("unexpected hardware type, falling back to ethernet", "iface", ifaceName, "hwType", hwType)
+		return arpLinkParams{unix.ARPHRD_ETHER, ethHwLen, ethernetBroadcast}, nil
+	}
+}
+
 // bytes returns the wire representation of the ARP message.
 func (m *arpMessage) bytes() ([]byte, error) {
 	buf := new(bytes.Buffer)
@@ -67,21 +164,21 @@ func (m *arpMessage) bytes() ([]byte, error) {
 
 // gratuitousARP return a gARP request or gARP reply alternatively
 // because different devices may support either one of them
-func gratuitousARP(ip net.IP, mac net.HardwareAddr) (*arpMessage, error) {
+func gratuitousARP(ip net.IP, mac net.HardwareAddr, linkParams arpLinkParams) (*arpMessage, error) {
 	if ip.To4() == nil {
 		return nil, fmt.Errorf("%q is not an IPv4 address", ip)
 	}
-	if len(mac) != hwLen {
-		return nil, fmt.Errorf("%q is not an Ethernet MAC address", mac)
+	if len(mac) != int(linkParams.hwLen) || len(linkParams.broadcast) != int(linkParams.hwLen) {
+		return nil, fmt.Errorf("hardware address length %d, got %v and %v", linkParams.hwLen, mac, linkParams.broadcast)
 	}
 
 	m := &arpMessage{
 		arpHeader: arpHeader{
-			1,           // Ethernet
-			0x0800,      // IPv4
-			hwLen,       // 48-bit MAC Address
-			net.IPv4len, // 32-bit IPv4 Address
-			opARPReply,  // ARP Reply
+			linkParams.hardwareType,
+			0x0800,           // IPv4
+			linkParams.hwLen, // MAC Address Length
+			net.IPv4len,      // 32-bit IPv4 Address
+			opARPReply,       // ARP Reply
 		},
 	}
 
@@ -109,14 +206,49 @@ func gratuitousARP(ip net.IP, mac net.HardwareAddr) (*arpMessage, error) {
 		m.arpHeader.opcode = opARPRequest
 
 		// this field is not used in an ARP Request packet
-		m.targetHardwareAddress = ethernetBroadcast
+		m.targetHardwareAddress = linkParams.broadcast
 	}
 
 	return m, nil
 }
 
+func sendARPExtended(fd int, iface *net.Interface, m *arpMessage, linkParams arpLinkParams, b []byte) error {
+	if iface.Index < 0 || iface.Index > math.MaxInt32 {
+		return fmt.Errorf("interface index %d out of range", iface.Index)
+	}
+	sa := sockaddrLLExt{
+		Family:   syscall.AF_PACKET,
+		Protocol: htons(syscall.ETH_P_ARP),
+		Ifindex:  int32(iface.Index),
+		Hatype:   m.hardwareType,
+		Halen:    m.hardwareAddressLength,
+	}
+	copy(sa.Addr[:], linkParams.broadcast)
+	if err := rawSendto(fd, b, &sa); err != nil {
+		return fmt.Errorf("failed to send: %v", err)
+	}
+	return nil
+}
+
+func sendARPEthernet(fd int, iface *net.Interface, m *arpMessage, linkParams arpLinkParams, b []byte) error {
+	ll := syscall.SockaddrLinklayer{
+		Protocol: htons(syscall.ETH_P_ARP),
+		Ifindex:  iface.Index,
+		Pkttype:  0, // syscall.PACKET_HOST
+		Hatype:   m.hardwareType,
+		Halen:    m.hardwareAddressLength,
+	}
+	target := linkParams.broadcast
+	copy(ll.Addr[:], target)
+
+	if err := syscall.Sendto(fd, b, 0, &ll); err != nil {
+		return fmt.Errorf("failed to send: %v", err)
+	}
+	return nil
+}
+
 // sendARP sends the given ARP message via the specified interface.
-func sendARP(iface *net.Interface, m *arpMessage) error {
+func sendARP(iface *net.Interface, m *arpMessage, linkParams arpLinkParams) error {
 	fd, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_DGRAM, int(htons(syscall.ETH_P_ARP)))
 	if err != nil {
 		return fmt.Errorf("failed to get raw socket: %v", err)
@@ -127,29 +259,17 @@ func sendARP(iface *net.Interface, m *arpMessage) error {
 		return fmt.Errorf("failed to bind to device: %v", err)
 	}
 
-	ll := syscall.SockaddrLinklayer{
-		Protocol: htons(syscall.ETH_P_ARP),
-		Ifindex:  iface.Index,
-		Pkttype:  0, // syscall.PACKET_HOST
-		Hatype:   m.hardwareType,
-		Halen:    m.hardwareAddressLength,
-	}
-	target := ethernetBroadcast
-	copy(ll.Addr[:], target)
-
 	b, err := m.bytes()
 	if err != nil {
-		return fmt.Errorf("failed to convert ARP message: %v", err)
+		return fmt.Errorf("failed to convert ARP message: %w", err)
 	}
 
-	if err := syscall.Bind(fd, &ll); err != nil {
-		return fmt.Errorf("failed to bind: %v", err)
-	}
-	if err := syscall.Sendto(fd, b, 0, &ll); err != nil {
-		return fmt.Errorf("failed to send: %v", err)
+	// IPoIB (and any HW len > 8): extended sockaddr + raw sendto.
+	if m.hardwareAddressLength > 8 {
+		return sendARPExtended(fd, iface, m, linkParams, b)
 	}
 
-	return nil
+	return sendARPEthernet(fd, iface, m, linkParams, b)
 }
 
 // ARPSendGratuitous sends a gratuitous ARP message via the specified interface.
@@ -161,13 +281,18 @@ func ARPSendGratuitous(address, ifaceName string) error {
 
 	ip := net.ParseIP(address)
 	if ip == nil {
-		return fmt.Errorf("failed to parse address %s", ip)
+		return fmt.Errorf("failed to parse address %s", address)
+	}
+
+	linkParams, err := getARPLinkParams(ifaceName)
+	if err != nil {
+		return fmt.Errorf("failed to get ARP link params: %w", err)
 	}
 
 	// This is a debug message, enable debugging to ensure that the gratuitous arp is repeating
-	m, err := gratuitousARP(ip, iface.HardwareAddr)
+	m, err := gratuitousARP(ip, iface.HardwareAddr, linkParams)
 	if err != nil {
 		return err
 	}
-	return sendARP(iface, m)
+	return sendARP(iface, m, linkParams)
 }

--- a/pkg/vip/arp_linux_test.go
+++ b/pkg/vip/arp_linux_test.go
@@ -1,0 +1,261 @@
+//go:build linux
+// +build linux
+
+package vip
+
+import (
+	"bytes"
+	"net"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func resetARPRequest(t *testing.T, request bool) {
+	t.Helper()
+	arpRequest = request
+}
+
+func ethLinkParams() arpLinkParams {
+	return arpLinkParams{
+		hardwareType: unix.ARPHRD_ETHER,
+		hwLen:        ethHwLen,
+		broadcast:    ethernetBroadcast,
+	}
+}
+
+func ipoibLinkParams(bcast net.HardwareAddr) arpLinkParams {
+	return arpLinkParams{
+		hardwareType: unix.ARPHRD_INFINIBAND,
+		hwLen:        ipoibHwLen,
+		broadcast:    bcast,
+	}
+}
+
+func ipoibBroadcast() net.HardwareAddr {
+	// 20 bytes
+	return net.HardwareAddr{
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	}
+}
+
+func Test_gratuitousARP_ethernet(t *testing.T) {
+	ip := net.ParseIP("10.0.0.1")
+	mac, _ := net.ParseMAC("aa:bb:cc:dd:ee:ff")
+	params := ethLinkParams()
+
+	t.Run("reply when arpRequest starts true", func(t *testing.T) {
+		resetARPRequest(t, true)
+		m, err := gratuitousARP(ip, mac, params)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if m.opcode != opARPReply {
+			t.Fatalf("opcode=%d, want reply (%d)", m.opcode, opARPReply)
+		}
+		if m.hardwareType != unix.ARPHRD_ETHER || m.hardwareAddressLength != ethHwLen {
+			t.Fatalf("header: hwType=%d hwLen=%d", m.hardwareType, m.hardwareAddressLength)
+		}
+		if !bytes.Equal(m.senderProtocolAddress, ip.To4()) ||
+			!bytes.Equal(m.targetProtocolAddress, ip.To4()) {
+			t.Fatal("sender/target IP must both be VIP")
+		}
+		if !bytes.Equal(m.senderHardwareAddress, mac) ||
+			!bytes.Equal(m.targetHardwareAddress, mac) {
+			t.Fatal("reply: target HW should equal sender MAC")
+		}
+	})
+
+	t.Run("request when arpRequest starts false", func(t *testing.T) {
+		resetARPRequest(t, false)
+		m, err := gratuitousARP(ip, mac, params)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if m.opcode != opARPRequest {
+			t.Fatalf("opcode=%d, want request (%d)", m.opcode, opARPRequest)
+		}
+		if !bytes.Equal(m.targetHardwareAddress, ethernetBroadcast) {
+			t.Fatalf("request target HW=%v, want broadcast %v", m.targetHardwareAddress, ethernetBroadcast)
+		}
+	})
+}
+
+func Test_gratuitousARP_ipoib(t *testing.T) {
+	ip := net.ParseIP("192.168.1.50")
+	bcast := ipoibBroadcast()
+	mac := make(net.HardwareAddr, ipoibHwLen)
+	copy(mac, bcast) // any 20-byte addr works for unit test
+	params := ipoibLinkParams(bcast)
+
+	resetARPRequest(t, true)
+	m, err := gratuitousARP(ip, mac, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.hardwareType != unix.ARPHRD_INFINIBAND {
+		t.Fatalf("hwType=%d, want INFINIBAND", m.hardwareType)
+	}
+	if m.hardwareAddressLength != ipoibHwLen {
+		t.Fatalf("hwLen=%d, want %d", m.hardwareAddressLength, ipoibHwLen)
+	}
+	b, err := m.bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 8-byte header + 20 + 4 + 20 + 4
+	if len(b) != 8+ipoibHwLen+4+ipoibHwLen+4 {
+		t.Fatalf("wire len=%d, want %d", len(b), 8+ipoibHwLen+4+ipoibHwLen+4)
+	}
+}
+
+func Test_gratuitousARP_errors(t *testing.T) {
+	params := ethLinkParams()
+	mac, _ := net.ParseMAC("aa:bb:cc:dd:ee:ff")
+
+	tests := []struct {
+		name string
+		ip   net.IP
+		mac  net.HardwareAddr
+		p    arpLinkParams
+	}{
+		{"ipv6", net.ParseIP("2001:db8::1"), mac, params},
+		{"bad mac len", net.ParseIP("10.0.0.1"), net.HardwareAddr{0x01}, params},
+		{"bad broadcast len", net.ParseIP("10.0.0.1"), mac, arpLinkParams{
+			hardwareType: unix.ARPHRD_ETHER,
+			hwLen:        ethHwLen,
+			broadcast:    net.HardwareAddr{0xff},
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetARPRequest(t, true)
+			if _, err := gratuitousARP(tt.ip, tt.mac, tt.p); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func Test_arpMessage_bytes_golden(t *testing.T) {
+	ip := net.ParseIP("10.0.0.1")
+	mac, _ := net.ParseMAC("aa:bb:cc:dd:ee:ff")
+	resetARPRequest(t, true)
+
+	m, err := gratuitousARP(ip, mac, ethLinkParams())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := m.bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ethernet gARP reply: 28 bytes
+	want := []byte{
+		0x00, 0x01, 0x08, 0x00, 0x06, 0x04, 0x00, 0x02, // header
+		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, // sender HW
+		0x0a, 0x00, 0x00, 0x01, // sender IP
+		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, // target HW
+		0x0a, 0x00, 0x00, 0x01, // target IP
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("got % x\nwant % x", got, want)
+	}
+}
+
+func Test_rawSendto_empty(t *testing.T) {
+	err := rawSendto(-1, nil, &sockaddrLLExt{})
+	if err != syscall.EINVAL {
+		t.Fatalf("got %v, want EINVAL", err)
+	}
+}
+
+func Test_sendARPExtended_badIndex(t *testing.T) {
+	iface := &net.Interface{Index: -1, Name: "dummy"}
+	m := &arpMessage{arpHeader: arpHeader{hardwareAddressLength: ipoibHwLen}}
+	err := sendARPExtended(-1, iface, m, ipoibLinkParams(ipoibBroadcast()), []byte{0})
+	if err == nil {
+		t.Fatal("expected error for bad ifindex")
+	}
+}
+
+func Test_getARPLinkParams(t *testing.T) {
+	root := t.TempDir()
+	restore := netClassPath
+	netClassPath = root
+	t.Cleanup(func() { netClassPath = restore })
+
+	writeIface := func(name, typ, bcast string) {
+		dir := filepath.Join(root, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "type"), []byte(typ), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if bcast != "" {
+			if err := os.WriteFile(filepath.Join(dir, "broadcast"), []byte(bcast), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	t.Run("ethernet", func(t *testing.T) {
+		writeIface("eth0", "1\n", "")
+		p, err := getARPLinkParams("eth0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if p.hardwareType != unix.ARPHRD_ETHER || p.hwLen != ethHwLen {
+			t.Fatalf("%+v", p)
+		}
+		if !bytes.Equal(p.broadcast, ethernetBroadcast) {
+			t.Fatal("wrong broadcast")
+		}
+	})
+
+	t.Run("ipoib", func(t *testing.T) {
+		bcast := "00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff:00:11:22:33\n"
+		writeIface("ib0", "32\n", bcast)
+		p, err := getARPLinkParams("ib0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if p.hardwareType != unix.ARPHRD_INFINIBAND || p.hwLen != ipoibHwLen {
+			t.Fatalf("%+v", p)
+		}
+	})
+
+	t.Run("ipoib bad broadcast length", func(t *testing.T) {
+		writeIface("ib1", "32\n", "aa:bb:cc:dd:ee:ff\n")
+		if _, err := getARPLinkParams("ib1"); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("missing type falls back to ethernet", func(t *testing.T) {
+		p, err := getARPLinkParams("missing0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if p.hardwareType != unix.ARPHRD_ETHER {
+			t.Fatalf("got hwType %d", p.hardwareType)
+		}
+	})
+
+	t.Run("unknown type falls back to ethernet", func(t *testing.T) {
+		writeIface("wlan0", "801\n", "")
+		p, err := getARPLinkParams("wlan0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if p.hardwareType != unix.ARPHRD_ETHER {
+			t.Fatalf("got hwType %d", p.hardwareType)
+		}
+	})
+}


### PR DESCRIPTION
This PR adds support in ipoib infiniband interfaces in ARP mode. It uses a lower-level api for sending raw packets that can handle MAC addresses with more than 8 bytes (20 bytes in the case of ipoib). Existing eth code path remains almost untouched. It also fixes #694. 