### PR TITLE
Fix minor error handling issue in pkg/bgp/peer.go

### DIFF
--- a/pkg/bgp/peers.go
+++ b/pkg/bgp/peers.go
@@ -280,7 +280,8 @@ func getIPv6LinkLocalNeighborAddress(ctx context.Context, peerInterface string) 
 			return "", fmt.Errorf("failed to get link-local address of interface %s: %w", peerInterface, neighCtx.Err())
 		default:
 			dur := bo.Duration()
-			neighborAddress, err := oc.GetIPv6LinkLocalNeighborAddress(peerInterface)
+			var neighborAddress string
+			neighborAddress, err = oc.GetIPv6LinkLocalNeighborAddress(peerInterface)
 			if err != nil && bo.Attempt() >= maxAttempts {
 				return "", fmt.Errorf("failed to get link-local address of interface %s: %w", peerInterface, err)
 			}


### PR DESCRIPTION
In case of `oc.GetIPv6LinkLocalNeighborAddress` returning error and  `neighCtx.Done()` it was intended that this error will be propagated, but it was assigned to a separate `err` variable, which resulted in `if nil == nil` comparison.