### PR TITLE
E2E Test Helper functions to reduce duplication

### DIFF
--- a/testing/e2e/e2e_bgp_ds_test.go
+++ b/testing/e2e/e2e_bgp_ds_test.go
@@ -45,9 +45,7 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 		})
 
 		BeforeAll(func() {
-			var err error
-			tempDirPathRoot, err = os.MkdirTemp("", fmt.Sprintf("%s-bgp-ds", testDirPrefix))
-			Expect(err).NotTo(HaveOccurred())
+			tempDirPathRoot = MustMkdirTemp("", fmt.Sprintf("%s-bgp-ds", testDirPrefix))
 		})
 
 		AfterAll(func() {
@@ -68,11 +66,7 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 				networking := &kindconfigv1alpha4.Networking{
 					IPFamily: kindconfigv1alpha4.IPv4Family,
 				}
-
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, fmt.Sprintf("%s-ds", testDirPrefix))
-				Expect(err).NotTo(HaveOccurred())
-
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, fmt.Sprintf("%s-ds", testDirPrefix))
 				clusterName, client, _ = prepareClusterForDS(tempDirPath, "bgp-ds", imagePath, k8sImagePath,
 					logger, networking, 1, nil)
 			})
@@ -246,9 +240,7 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 					IPFamily: kindconfigv1alpha4.IPv6Family,
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, fmt.Sprintf("%s-bgp-v6", testDirPrefix))
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, fmt.Sprintf("%s-bgp-v6", testDirPrefix))
 
 				clusterName, client, _ = prepareClusterForDS(tempDirPath, "bgp-ds-v6", imagePath, k8sImagePath,
 					logger, networking, 1, nil)

--- a/testing/e2e/e2e_bgp_healthcheck_test.go
+++ b/testing/e2e/e2e_bgp_healthcheck_test.go
@@ -42,9 +42,7 @@ var _ = Describe("kube-vip BGP ControlPlane health-check", Ordered, func() {
 		server = sharedBGPServer
 		Expect(server).ToNot(BeNil(), "SharedBGPServer not initialized")
 
-		var err error
-		tempDirRoot, err = os.MkdirTemp("", fmt.Sprintf("%s-bgp-hc", testDirPrefix))
-		Expect(err).NotTo(HaveOccurred())
+		tempDirRoot = MustMkdirTemp("", fmt.Sprintf("%s-bgp-hc", testDirPrefix))
 
 		cpVIP = e2e.GenerateVIP(utils.IPv4Family, SOffset.Get(), defaultNetwork)
 		kvPeers := []*e2e.BGPPeerValues{

--- a/testing/e2e/e2e_bgp_test.go
+++ b/testing/e2e/e2e_bgp_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -65,14 +64,11 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 				gobgpClient api.GoBgpServiceClient
 				gobgpPeers  []*e2e.BGPPeerValues
 				tempDirPath string
-
 				nodesNumber = 1
 			)
 
 			BeforeAll(func() {
-				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(server.TempDir, testDirPrefix)
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, utils.IPv4Family, utils.IPv4Family,
 					[]string{utils.IPv4Family}, &gobgpPeers,
@@ -80,11 +76,10 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, kindCluster.Client, tempDirPath, kindCluster.Name)
-				Expect(err).ToNot(HaveOccurred())
-				server.RemovePeers(ctx, gobgpPeers)
-				kindCluster.Delete()
+				SaveLogsAndCleanup(ctx, kindCluster.Client, tempDirPath, kindCluster.Name, func() {
+					server.RemovePeers(ctx, gobgpPeers)
+					kindCluster.Delete()
+				})
 			})
 
 			It("should add paths", func() {
@@ -100,14 +95,11 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 				gobgpClient api.GoBgpServiceClient
 				gobgpPeers  []*e2e.BGPPeerValues
 				tempDirPath string
-
 				nodesNumber = 1
 			)
 
 			BeforeAll(func() {
-				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(server.TempDir, testDirPrefix)
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, utils.IPv6Family, utils.IPv6Family,
 					[]string{utils.IPv6Family}, &gobgpPeers,
@@ -115,11 +107,10 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, kindCluster.Client, tempDirPath, kindCluster.Name)
-				Expect(err).ToNot(HaveOccurred())
-				server.RemovePeers(ctx, gobgpPeers)
-				kindCluster.Delete()
+				SaveLogsAndCleanup(ctx, kindCluster.Client, tempDirPath, kindCluster.Name, func() {
+					server.RemovePeers(ctx, gobgpPeers)
+					kindCluster.Delete()
+				})
 			})
 
 			It("should add paths", func() {
@@ -140,9 +131,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(server.TempDir, testDirPrefix)
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamily, utils.IPv4Family,
 					[]string{utils.IPv4Family}, &gobgpPeers,
@@ -150,11 +139,10 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, kindCluster.Client, tempDirPath, kindCluster.Name)
-				Expect(err).ToNot(HaveOccurred())
-				server.RemovePeers(ctx, gobgpPeers)
-				kindCluster.Delete()
+				SaveLogsAndCleanup(ctx, kindCluster.Client, tempDirPath, kindCluster.Name, func() {
+					server.RemovePeers(ctx, gobgpPeers)
+					kindCluster.Delete()
+				})
 			})
 
 			It("should add paths", func() {
@@ -175,9 +163,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(server.TempDir, testDirPrefix)
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamilyIPv6, utils.IPv6Family,
 					[]string{utils.IPv6Family}, &gobgpPeers,
@@ -185,11 +171,10 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, kindCluster.Client, tempDirPath, kindCluster.Name)
-				Expect(err).ToNot(HaveOccurred())
-				server.RemovePeers(ctx, gobgpPeers)
-				kindCluster.Delete()
+				SaveLogsAndCleanup(ctx, kindCluster.Client, tempDirPath, kindCluster.Name, func() {
+					server.RemovePeers(ctx, gobgpPeers)
+					kindCluster.Delete()
+				})
 			})
 
 			It("should add paths", func() {
@@ -209,9 +194,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(server.TempDir, testDirPrefix)
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, utils.IPv4Family, utils.IPv4Family,
 					[]string{utils.IPv4Family}, &gobgpPeers,
@@ -219,11 +202,10 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, kindCluster.Client, tempDirPath, kindCluster.Name)
-				Expect(err).ToNot(HaveOccurred())
-				server.RemovePeers(ctx, gobgpPeers)
-				kindCluster.Delete()
+				SaveLogsAndCleanup(ctx, kindCluster.Client, tempDirPath, kindCluster.Name, func() {
+					server.RemovePeers(ctx, gobgpPeers)
+					kindCluster.Delete()
+				})
 			})
 
 			DescribeTable("advertise IPv4 routes for services",
@@ -256,9 +238,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(server.TempDir, testDirPrefix)
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, utils.IPv6Family, utils.IPv6Family,
 					[]string{utils.IPv6Family}, &gobgpPeers,
@@ -266,11 +246,10 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, kindCluster.Client, tempDirPath, kindCluster.Name)
-				Expect(err).ToNot(HaveOccurred())
-				server.RemovePeers(ctx, gobgpPeers)
-				kindCluster.Delete()
+				SaveLogsAndCleanup(ctx, kindCluster.Client, tempDirPath, kindCluster.Name, func() {
+					server.RemovePeers(ctx, gobgpPeers)
+					kindCluster.Delete()
+				})
 			})
 
 			DescribeTable("advertise IPv6 routes for services",
@@ -303,9 +282,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(server.TempDir, testDirPrefix)
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamily, utils.IPv4Family,
 					[]string{utils.IPv4Family}, &gobgpPeers,
@@ -313,11 +290,10 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, kindCluster.Client, tempDirPath, kindCluster.Name)
-				Expect(err).ToNot(HaveOccurred())
-				server.RemovePeers(ctx, gobgpPeers)
-				kindCluster.Delete()
+				SaveLogsAndCleanup(ctx, kindCluster.Client, tempDirPath, kindCluster.Name, func() {
+					server.RemovePeers(ctx, gobgpPeers)
+					kindCluster.Delete()
+				})
 			})
 
 			DescribeTable("advertise IPv6 routes over IPv4 session",
@@ -350,9 +326,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(server.TempDir, testDirPrefix)
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamilyIPv6, utils.IPv6Family,
 					[]string{utils.IPv6Family}, &gobgpPeers,
@@ -360,11 +334,10 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, kindCluster.Client, tempDirPath, kindCluster.Name)
-				Expect(err).ToNot(HaveOccurred())
-				server.RemovePeers(ctx, gobgpPeers)
-				kindCluster.Delete()
+				SaveLogsAndCleanup(ctx, kindCluster.Client, tempDirPath, kindCluster.Name, func() {
+					server.RemovePeers(ctx, gobgpPeers)
+					kindCluster.Delete()
+				})
 			})
 
 			DescribeTable("advertise IPv4 routes over IPv6 session",
@@ -398,9 +371,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(server.TempDir, testDirPrefix)
 				kindCluster, _, containerIP = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamily, utils.IPv4Family,
 					[]string{utils.IPv4Family}, &gobgpPeers,
@@ -408,11 +379,10 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, kindCluster.Client, tempDirPath, kindCluster.Name)
-				Expect(err).ToNot(HaveOccurred())
-				server.RemovePeers(ctx, gobgpPeers)
-				kindCluster.Delete()
+				SaveLogsAndCleanup(ctx, kindCluster.Client, tempDirPath, kindCluster.Name, func() {
+					server.RemovePeers(ctx, gobgpPeers)
+					kindCluster.Delete()
+				})
 			})
 
 			DescribeTable("advertise IPv6 routes over IPv4 session",
@@ -446,9 +416,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(server.TempDir, testDirPrefix)
 				kindCluster, containerIP, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamilyIPv6, utils.IPv6Family,
 					[]string{utils.IPv6Family}, &gobgpPeers,
@@ -456,11 +424,10 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, kindCluster.Client, tempDirPath, kindCluster.Name)
-				Expect(err).ToNot(HaveOccurred())
-				server.RemovePeers(ctx, gobgpPeers)
-				kindCluster.Delete()
+				SaveLogsAndCleanup(ctx, kindCluster.Client, tempDirPath, kindCluster.Name, func() {
+					server.RemovePeers(ctx, gobgpPeers)
+					kindCluster.Delete()
+				})
 			})
 
 			DescribeTable("advertise IPv4 routes over IPv6 session",
@@ -493,9 +460,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(server.TempDir, testDirPrefix)
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, utils.IPv4Family, utils.IPv4Family,
 					[]string{utils.IPv4Family}, &gobgpPeers,
@@ -503,11 +468,10 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, kindCluster.Client, tempDirPath, kindCluster.Name)
-				Expect(err).ToNot(HaveOccurred())
-				server.RemovePeers(ctx, gobgpPeers)
-				kindCluster.Delete()
+				SaveLogsAndCleanup(ctx, kindCluster.Client, tempDirPath, kindCluster.Name, func() {
+					server.RemovePeers(ctx, gobgpPeers)
+					kindCluster.Delete()
+				})
 			})
 
 			DescribeTable("advertise IPv4 routes for services",
@@ -548,9 +512,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(server.TempDir, testDirPrefix)
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, utils.IPv6Family, utils.IPv6Family,
 					[]string{utils.IPv6Family}, &gobgpPeers,
@@ -558,11 +520,10 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, kindCluster.Client, tempDirPath, kindCluster.Name)
-				Expect(err).ToNot(HaveOccurred())
-				server.RemovePeers(ctx, gobgpPeers)
-				kindCluster.Delete()
+				SaveLogsAndCleanup(ctx, kindCluster.Client, tempDirPath, kindCluster.Name, func() {
+					server.RemovePeers(ctx, gobgpPeers)
+					kindCluster.Delete()
+				})
 			})
 
 			DescribeTable("advertise IPv6 routes for services",
@@ -603,9 +564,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(server.TempDir, testDirPrefix)
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamily, utils.IPv4Family,
 					[]string{utils.IPv4Family}, &gobgpPeers,
@@ -613,11 +572,10 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, kindCluster.Client, tempDirPath, kindCluster.Name)
-				Expect(err).ToNot(HaveOccurred())
-				server.RemovePeers(ctx, gobgpPeers)
-				kindCluster.Delete()
+				SaveLogsAndCleanup(ctx, kindCluster.Client, tempDirPath, kindCluster.Name, func() {
+					server.RemovePeers(ctx, gobgpPeers)
+					kindCluster.Delete()
+				})
 			})
 
 			DescribeTable("advertise IPv6 routes over IPv4 session",
@@ -658,9 +616,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(server.TempDir, testDirPrefix)
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamilyIPv6, utils.IPv6Family,
 					[]string{utils.IPv6Family}, &gobgpPeers,
@@ -668,11 +624,10 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, kindCluster.Client, tempDirPath, kindCluster.Name)
-				Expect(err).ToNot(HaveOccurred())
-				server.RemovePeers(ctx, gobgpPeers)
-				kindCluster.Delete()
+				SaveLogsAndCleanup(ctx, kindCluster.Client, tempDirPath, kindCluster.Name, func() {
+					server.RemovePeers(ctx, gobgpPeers)
+					kindCluster.Delete()
+				})
 			})
 
 			DescribeTable("advertise IPv4 routes over IPv6 session",
@@ -714,9 +669,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(server.TempDir, testDirPrefix)
 				kindCluster, _, containerIP = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamily, utils.IPv4Family,
 					[]string{utils.IPv4Family}, &gobgpPeers,
@@ -724,11 +677,10 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, kindCluster.Client, tempDirPath, kindCluster.Name)
-				Expect(err).ToNot(HaveOccurred())
-				server.RemovePeers(ctx, gobgpPeers)
-				kindCluster.Delete()
+				SaveLogsAndCleanup(ctx, kindCluster.Client, tempDirPath, kindCluster.Name, func() {
+					server.RemovePeers(ctx, gobgpPeers)
+					kindCluster.Delete()
+				})
 			})
 
 			DescribeTable("advertise IPv6 routes over IPv4 session",
@@ -770,9 +722,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(server.TempDir, testDirPrefix)
 				kindCluster, containerIP, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamilyIPv6, utils.IPv6Family,
 					[]string{utils.IPv6Family}, &gobgpPeers,
@@ -780,11 +730,10 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, kindCluster.Client, tempDirPath, kindCluster.Name)
-				Expect(err).ToNot(HaveOccurred())
-				server.RemovePeers(ctx, gobgpPeers)
-				kindCluster.Delete()
+				SaveLogsAndCleanup(ctx, kindCluster.Client, tempDirPath, kindCluster.Name, func() {
+					server.RemovePeers(ctx, gobgpPeers)
+					kindCluster.Delete()
+				})
 			})
 
 			DescribeTable("advertise IPv4 routes over IPv6 session",
@@ -823,9 +772,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				var err error
-				tempDirPath, err = os.MkdirTemp(server.TempDir, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(server.TempDir, testDirPrefix)
 
 				kindCluster = e2e.CreateCluster(ctx, &e2e.ClusterSpec{
 					Name:         "bgp-annotations",
@@ -852,11 +799,10 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, kindCluster.Client, tempDirPath, kindCluster.Name)
-				Expect(err).ToNot(HaveOccurred())
-				server.RemovePeers(ctx, gobgpPeers)
-				kindCluster.Delete()
+				SaveLogsAndCleanup(ctx, kindCluster.Client, tempDirPath, kindCluster.Name, func() {
+					server.RemovePeers(ctx, gobgpPeers)
+					kindCluster.Delete()
+				})
 			})
 
 			DescribeTable("advertise IPv4 routes for services",

--- a/testing/e2e/e2e_ds_test.go
+++ b/testing/e2e/e2e_ds_test.go
@@ -53,9 +53,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 		})
 
 		BeforeAll(func() {
-			var err error
-			tempDirPathRoot, err = os.MkdirTemp("", fmt.Sprintf("%s-arp-ds", testDirPrefix))
-			Expect(err).NotTo(HaveOccurred())
+			tempDirPathRoot = MustMkdirTemp("", fmt.Sprintf("%s-arp-ds", testDirPrefix))
 		})
 
 		AfterAll(func() {
@@ -77,9 +75,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 					IPFamily: kindconfigv1alpha4.IPv4Family,
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareClusterForDS(tempDirPath, "ipv4-ds", imagePath, k8sImagePath,
 					logger, networking, 1, nil)
@@ -205,9 +201,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 					IPFamily: kindconfigv1alpha4.IPv6Family,
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareClusterForDS(tempDirPath, "ipv6-ds", imagePath, k8sImagePath,
 					logger, networking, 1, nil)
@@ -333,9 +327,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 					IPFamily: kindconfigv1alpha4.DualStackFamily,
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareClusterForDS(tempDirPath, "ipdual-ds", imagePath, k8sImagePath,
 					logger, networking, 1, nil)

--- a/testing/e2e/e2e_rt_ds_test.go
+++ b/testing/e2e/e2e_rt_ds_test.go
@@ -45,10 +45,7 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 		})
 
 		BeforeAll(func() {
-			var err error
-			tempDirPathRoot, err = os.MkdirTemp("", fmt.Sprintf("%s-rt-ds", testDirPrefix))
-			Expect(err).NotTo(HaveOccurred())
-
+			tempDirPathRoot = MustMkdirTemp("", fmt.Sprintf("%s-rt-ds", testDirPrefix))
 		})
 
 		AfterAll(func() {
@@ -70,9 +67,7 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 					IPFamily: kindconfigv1alpha4.IPv4Family,
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareClusterForDS(tempDirPath, "rt-ds", imagePath, k8sImagePath,
 					logger, networking, 1, nil)

--- a/testing/e2e/e2e_rt_test.go
+++ b/testing/e2e/e2e_rt_test.go
@@ -46,9 +46,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 		ctx, cancel := context.WithCancel(context.TODO())
 
 		BeforeAll(func() {
-			var err error
-			tempDirPathRoot, err = os.MkdirTemp("", fmt.Sprintf("%s-rt", testDirPrefix))
-			Expect(err).NotTo(HaveOccurred())
+			tempDirPathRoot = MustMkdirTemp("", fmt.Sprintf("%s-rt", testDirPrefix))
 		})
 
 		BeforeEach(func() {
@@ -104,19 +102,16 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					EnableNodeLabeling: "false",
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ipv4", k8sImagePath, v129,
 					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			It("setups IPv4 address and route on control-plane node", func() {
@@ -165,19 +160,16 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					EnableNodeLabeling: "false",
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ipv6", k8sImagePath, v129,
 					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			It("setups IPv6 address and route on control-plane node", func() {
@@ -237,18 +229,16 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					ipnet: localIPv6Net,
 				}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-ipv4", k8sImagePath, v129,
 					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, addSAN, dsNumber)
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			It("setups DualStack addresses and routes on control-plane nodes", func() {
@@ -314,18 +304,16 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					ipnet: localIPv4Net,
 				}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-ipv6", k8sImagePath, v129,
 					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, addSAN, dsNumber)
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			It("setups DualStack addresses and routes on control-plane nodes", func() {
@@ -352,13 +340,12 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 		Describe("kube-vip IPv4 services routing table mode functionality", Ordered, func() {
 			var (
-				cpVIP          string
-				clusterName    string
-				client         kubernetes.Interface
-				manifestValues *e2e.KubevipManifestValues
-				svcElection    bool
-				ipFamily       []corev1.IPFamily
-				tempDirPath    string
+				cpVIP       string
+				clusterName string
+				client      kubernetes.Interface
+				svcElection bool
+				ipFamily    []corev1.IPFamily
+				tempDirPath string
 
 				nodesNumber = 1
 			)
@@ -370,7 +357,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					IPFamily: kindconfigv1alpha4.IPv4Family,
 				}
 
-				manifestValues = &e2e.KubevipManifestValues{
+				manifestValues := &e2e.KubevipManifestValues{
 					ControlPlaneVIP:    cpVIP,
 					ImagePath:          imagePath,
 					ConfigPath:         configPath,
@@ -385,18 +372,16 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 				ipFamily = []corev1.IPFamily{corev1.IPv4Protocol}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-svc-ipv4", k8sImagePath, v129,
 					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an IPv4 routes for services",
@@ -422,13 +407,12 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 		Describe("kube-vip IPv6 services routing table mode functionality", Ordered, func() {
 			var (
-				cpVIP          string
-				clusterName    string
-				client         kubernetes.Interface
-				manifestValues *e2e.KubevipManifestValues
-				svcElection    bool
-				ipFamily       []corev1.IPFamily
-				tempDirPath    string
+				cpVIP       string
+				clusterName string
+				client      kubernetes.Interface
+				svcElection bool
+				ipFamily    []corev1.IPFamily
+				tempDirPath string
 
 				nodesNumber = 1
 			)
@@ -440,7 +424,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					IPFamily: kindconfigv1alpha4.IPv6Family,
 				}
 
-				manifestValues = &e2e.KubevipManifestValues{
+				manifestValues := &e2e.KubevipManifestValues{
 					ControlPlaneVIP:    cpVIP,
 					ImagePath:          imagePath,
 					ConfigPath:         configPath,
@@ -455,18 +439,16 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 				ipFamily = []corev1.IPFamily{corev1.IPv6Protocol}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-svc-ipv6", k8sImagePath, v129,
 					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an IPv6 routes for services",
@@ -492,13 +474,12 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 		Describe("kube-vip DualStack services routing table mode functionality - IPv4 primary", Ordered, func() {
 			var (
-				cpVIP          string
-				clusterName    string
-				client         kubernetes.Interface
-				manifestValues *e2e.KubevipManifestValues
-				svcElection    bool
-				ipFamily       []corev1.IPFamily
-				tempDirPath    string
+				cpVIP       string
+				clusterName string
+				client      kubernetes.Interface
+				svcElection bool
+				ipFamily    []corev1.IPFamily
+				tempDirPath string
 
 				nodesNumber = 1
 			)
@@ -510,7 +491,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					IPFamily: kindconfigv1alpha4.DualStackFamily,
 				}
 
-				manifestValues = &e2e.KubevipManifestValues{
+				manifestValues := &e2e.KubevipManifestValues{
 					ControlPlaneVIP:    cpVIP,
 					ImagePath:          imagePath,
 					ConfigPath:         configPath,
@@ -526,18 +507,16 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 				ipFamily = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-svc-ipv4", k8sImagePath, v129,
 					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an IPv4 and IPv6 routes for services",
@@ -563,13 +542,12 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 		Describe("kube-vip DualStack services routing table mode functionality - IPv6 primary", Ordered, func() {
 			var (
-				cpVIP          string
-				clusterName    string
-				client         kubernetes.Interface
-				manifestValues *e2e.KubevipManifestValues
-				svcElection    bool
-				ipFamily       []corev1.IPFamily
-				tempDirPath    string
+				cpVIP       string
+				clusterName string
+				client      kubernetes.Interface
+				svcElection bool
+				ipFamily    []corev1.IPFamily
+				tempDirPath string
 
 				nodesNumber = 1
 			)
@@ -583,7 +561,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					ServiceSubnet: "fd00:10:96::/112,10.96.0.0/16",
 				}
 
-				manifestValues = &e2e.KubevipManifestValues{
+				manifestValues := &e2e.KubevipManifestValues{
 					ControlPlaneVIP:    cpVIP,
 					ImagePath:          imagePath,
 					ConfigPath:         configPath,
@@ -599,18 +577,16 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 				ipFamily = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-svc-ipv6", k8sImagePath, v129,
 					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an IPv4 and IPv6 routes for services",
@@ -636,13 +612,12 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 		Describe("kube-vip IPv4 services routing table mode functionality with services election", Ordered, func() {
 			var (
-				cpVIP          string
-				clusterName    string
-				client         kubernetes.Interface
-				manifestValues *e2e.KubevipManifestValues
-				svcElection    bool
-				ipFamily       []corev1.IPFamily
-				tempDirPath    string
+				cpVIP       string
+				clusterName string
+				client      kubernetes.Interface
+				svcElection bool
+				ipFamily    []corev1.IPFamily
+				tempDirPath string
 
 				nodesNumber = 1
 			)
@@ -654,7 +629,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					IPFamily: kindconfigv1alpha4.IPv4Family,
 				}
 
-				manifestValues = &e2e.KubevipManifestValues{
+				manifestValues := &e2e.KubevipManifestValues{
 					ControlPlaneVIP:    cpVIP,
 					ImagePath:          imagePath,
 					ConfigPath:         configPath,
@@ -669,18 +644,16 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 				ipFamily = []corev1.IPFamily{corev1.IPv4Protocol}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-svc-ipv4", k8sImagePath, v129,
 					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an IPv4 routes for services",
@@ -715,13 +688,12 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 		Describe("kube-vip IPv6 services routing table mode functionality with services election", Ordered, func() {
 			var (
-				cpVIP          string
-				clusterName    string
-				client         kubernetes.Interface
-				manifestValues *e2e.KubevipManifestValues
-				svcElection    bool
-				ipFamily       []corev1.IPFamily
-				tempDirPath    string
+				cpVIP       string
+				clusterName string
+				client      kubernetes.Interface
+				svcElection bool
+				ipFamily    []corev1.IPFamily
+				tempDirPath string
 
 				nodesNumber = 1
 			)
@@ -733,7 +705,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					IPFamily: kindconfigv1alpha4.IPv6Family,
 				}
 
-				manifestValues = &e2e.KubevipManifestValues{
+				manifestValues := &e2e.KubevipManifestValues{
 					ControlPlaneVIP:    cpVIP,
 					ImagePath:          imagePath,
 					ConfigPath:         configPath,
@@ -748,18 +720,16 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 				ipFamily = []corev1.IPFamily{corev1.IPv6Protocol}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-svc-ipv6", k8sImagePath, v129,
 					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an IPv6 routes for services",
@@ -794,13 +764,12 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 		Describe("kube-vip DualStack services routing table mode functionality - IPv4 primary with services election", Ordered, func() {
 			var (
-				cpVIP          string
-				clusterName    string
-				client         kubernetes.Interface
-				manifestValues *e2e.KubevipManifestValues
-				svcElection    bool
-				ipFamily       []corev1.IPFamily
-				tempDirPath    string
+				cpVIP       string
+				clusterName string
+				client      kubernetes.Interface
+				svcElection bool
+				ipFamily    []corev1.IPFamily
+				tempDirPath string
 
 				nodesNumber = 1
 			)
@@ -812,7 +781,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					IPFamily: kindconfigv1alpha4.DualStackFamily,
 				}
 
-				manifestValues = &e2e.KubevipManifestValues{
+				manifestValues := &e2e.KubevipManifestValues{
 					ControlPlaneVIP:    cpVIP,
 					ImagePath:          imagePath,
 					ConfigPath:         configPath,
@@ -828,18 +797,16 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 				ipFamily = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-svc-ipv4", k8sImagePath, v129,
 					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an IPv4 and IPv6 routes for services",
@@ -874,13 +841,12 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 		Describe("kube-vip DualStack services routing table mode functionality - IPv6 primary with services election", Ordered, func() {
 			var (
-				cpVIP          string
-				clusterName    string
-				client         kubernetes.Interface
-				manifestValues *e2e.KubevipManifestValues
-				svcElection    bool
-				ipFamily       []corev1.IPFamily
-				tempDirPath    string
+				cpVIP       string
+				clusterName string
+				client      kubernetes.Interface
+				svcElection bool
+				ipFamily    []corev1.IPFamily
+				tempDirPath string
 
 				nodesNumber = 1
 			)
@@ -894,7 +860,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					ServiceSubnet: "fd00:10:96::/112,10.96.0.0/16",
 				}
 
-				manifestValues = &e2e.KubevipManifestValues{
+				manifestValues := &e2e.KubevipManifestValues{
 					ControlPlaneVIP:    cpVIP,
 					ImagePath:          imagePath,
 					ConfigPath:         configPath,
@@ -910,18 +876,16 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 				ipFamily = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-svc-ipv6", k8sImagePath, v129,
 					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an IPv4 and IPv6 routes for services",
@@ -956,13 +920,12 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 		Describe("kube-vip IPv4 services routing table mode functionality with global election", Ordered, func() {
 			var (
-				cpVIP          string
-				clusterName    string
-				client         kubernetes.Interface
-				manifestValues *e2e.KubevipManifestValues
-				svcElection    bool
-				ipFamily       []corev1.IPFamily
-				tempDirPath    string
+				cpVIP       string
+				clusterName string
+				client      kubernetes.Interface
+				svcElection bool
+				ipFamily    []corev1.IPFamily
+				tempDirPath string
 
 				nodesNumber = 1
 			)
@@ -974,7 +937,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					IPFamily: kindconfigv1alpha4.IPv4Family,
 				}
 
-				manifestValues = &e2e.KubevipManifestValues{
+				manifestValues := &e2e.KubevipManifestValues{
 					ControlPlaneVIP:    cpVIP,
 					ImagePath:          imagePath,
 					ConfigPath:         configPath,
@@ -990,18 +953,16 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 				ipFamily = []corev1.IPFamily{corev1.IPv4Protocol}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-svc-ipv4-global", k8sImagePath, v129,
 					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an IPv4 routes for services",
@@ -1037,13 +998,12 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 		Describe("kube-vip IPv6 services routing table mode functionality with global election", Ordered, func() {
 			var (
-				cpVIP          string
-				clusterName    string
-				client         kubernetes.Interface
-				manifestValues *e2e.KubevipManifestValues
-				svcElection    bool
-				ipFamily       []corev1.IPFamily
-				tempDirPath    string
+				cpVIP       string
+				clusterName string
+				client      kubernetes.Interface
+				svcElection bool
+				ipFamily    []corev1.IPFamily
+				tempDirPath string
 
 				nodesNumber = 1
 			)
@@ -1055,7 +1015,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					IPFamily: kindconfigv1alpha4.IPv6Family,
 				}
 
-				manifestValues = &e2e.KubevipManifestValues{
+				manifestValues := &e2e.KubevipManifestValues{
 					ControlPlaneVIP:    cpVIP,
 					ImagePath:          imagePath,
 					ConfigPath:         configPath,
@@ -1071,18 +1031,16 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 				ipFamily = []corev1.IPFamily{corev1.IPv6Protocol}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-svc-ipv6-global", k8sImagePath, v129,
 					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an IPv6 routes for services",
@@ -1118,13 +1076,12 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 		Describe("kube-vip DualStack services routing table mode functionality - IPv4 primary with global election", Ordered, func() {
 			var (
-				cpVIP          string
-				clusterName    string
-				client         kubernetes.Interface
-				manifestValues *e2e.KubevipManifestValues
-				svcElection    bool
-				ipFamily       []corev1.IPFamily
-				tempDirPath    string
+				cpVIP       string
+				clusterName string
+				client      kubernetes.Interface
+				svcElection bool
+				ipFamily    []corev1.IPFamily
+				tempDirPath string
 
 				nodesNumber = 1
 			)
@@ -1136,7 +1093,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					IPFamily: kindconfigv1alpha4.DualStackFamily,
 				}
 
-				manifestValues = &e2e.KubevipManifestValues{
+				manifestValues := &e2e.KubevipManifestValues{
 					ControlPlaneVIP:    cpVIP,
 					ImagePath:          imagePath,
 					ConfigPath:         configPath,
@@ -1153,18 +1110,16 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 				ipFamily = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-svc-ipv4-global", k8sImagePath, v129,
 					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an IPv4 and IPv6 routes for services",
@@ -1200,13 +1155,12 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 		Describe("kube-vip DualStack services routing table mode functionality - IPv6 primary with global election", Ordered, func() {
 			var (
-				cpVIP          string
-				clusterName    string
-				client         kubernetes.Interface
-				manifestValues *e2e.KubevipManifestValues
-				svcElection    bool
-				ipFamily       []corev1.IPFamily
-				tempDirPath    string
+				cpVIP       string
+				clusterName string
+				client      kubernetes.Interface
+				svcElection bool
+				ipFamily    []corev1.IPFamily
+				tempDirPath string
 
 				nodesNumber = 1
 			)
@@ -1218,7 +1172,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					IPFamily: kindconfigv1alpha4.DualStackFamily,
 				}
 
-				manifestValues = &e2e.KubevipManifestValues{
+				manifestValues := &e2e.KubevipManifestValues{
 					ControlPlaneVIP:    cpVIP,
 					ImagePath:          imagePath,
 					ConfigPath:         configPath,
@@ -1235,18 +1189,16 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 				ipFamily = []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}
 
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-svc-ipv6-global", k8sImagePath, v129,
 					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an IPv4 and IPv6 routes for services",

--- a/testing/e2e/e2e_suite_test.go
+++ b/testing/e2e/e2e_suite_test.go
@@ -71,8 +71,7 @@ var _ = SynchronizedBeforeSuite(
 			return nil
 		}
 
-		tmpDir, err := os.MkdirTemp("", fmt.Sprintf("%s-bgp-shared", testDirPrefix))
-		Expect(err).NotTo(HaveOccurred())
+		tmpDir := MustMkdirTemp("", fmt.Sprintf("%s-bgp-shared", testDirPrefix))
 
 		srv := bgp.NewServer(tmpDir)
 

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -102,9 +102,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 		})
 
 		BeforeAll(func() {
-			var err error
-			tempDirPathRoot, err = os.MkdirTemp("", fmt.Sprintf("%s-arp", testDirPrefix))
-			Expect(err).NotTo(HaveOccurred())
+			tempDirPathRoot = MustMkdirTemp("", fmt.Sprintf("%s-arp", testDirPrefix))
 		})
 
 		AfterAll(func() {
@@ -140,20 +138,16 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 					EnableNodeLabeling: "false",
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "ipv4", k8sImagePath, v129,
 					kubeVIPManifestTemplate, logger, manifestValues, networking, 3, nil, 1)
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				Eventually(func() error {
-					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			It(clusterName+" provides an IPv4 VIP address for the Kubernetes control plane nodes", func() {
@@ -188,9 +182,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 					EnableNodeLabeling: "false",
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				dsNumber = 1
 
@@ -199,11 +191,9 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				Eventually(func() error {
-					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an IPv4 VIP address for service",
@@ -275,9 +265,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 					EnableNodeLabeling: "false",
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				dsNumber = 1
 
@@ -286,11 +274,9 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				Eventually(func() error {
-					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an IPv4 VIP address for service",
@@ -309,7 +295,6 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				cpVIP       string
 				client      kubernetes.Interface
 				clusterName string
-				clusterCfg  *rest.Config
 				tempDirPath string
 				dsNumber    int
 			)
@@ -332,24 +317,18 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 					EnableNodeLabeling: "false",
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				dsNumber = 1
 
-				clusterName, client, clusterCfg = prepareCluster(ctx, tempDirPath, "ipv6", k8sImagePath, v129,
+				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "ipv6", k8sImagePath, v129,
 					kubeVIPManifestTemplate, logger, manifestValues, networking, 3, nil, dsNumber)
 			})
 
 			AfterAll(func() {
-				c, err := kubernetes.NewForConfig(clusterCfg)
-				Expect(err).ToNot(HaveOccurred())
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				Eventually(func() error {
-					return e2e.GetLogs(ctx, c, tempDirPath, clusterName)
-				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			It(clusterName+"provides an IPv6 VIP address for the Kubernetes control plane nodes", func() {
@@ -384,9 +363,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 					EnableNodeLabeling: "false",
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				dsNumber = 1
 
@@ -395,11 +372,9 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				Eventually(func() error {
-					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an IPv6 VIP address for service",
@@ -459,9 +434,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 					EnableNodeLabeling: "false",
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				dsNumber = 1
 
@@ -470,11 +443,9 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				Eventually(func() error {
-					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an IPv6 VIP address for service",
@@ -515,9 +486,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 					EnableNodeLabeling: "false",
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				dsNumber = 1
 
@@ -526,11 +495,9 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				Eventually(func() error {
-					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			It(clusterName+" provides a DualStack VIP addresses for the Kubernetes control plane nodes", func() {
@@ -565,9 +532,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 					EnableNodeLabeling: "false",
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				dsNumber = 1
 
@@ -576,11 +541,9 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				Eventually(func() error {
-					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an IPv4 and IPv6 VIP addresses for service",
@@ -641,9 +604,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 					EnableNodeLabeling: "false",
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				dsNumber = 1
 
@@ -652,11 +613,9 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				Eventually(func() error {
-					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an IPv4 and IPv6 VIP addresses for service",
@@ -699,9 +658,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 					EnableNodeLabeling: "false",
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				dsNumber = 1
 
@@ -710,11 +667,9 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				Eventually(func() error {
-					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			It(clusterName+" provides a DualStack VIP addresses for the Kubernetes control plane nodes", func() {
@@ -751,9 +706,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 					EnableNodeLabeling: "false",
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				dsNumber = 1
 
@@ -762,11 +715,9 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				Eventually(func() error {
-					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an IPv4 and IPv6 VIP addresses for service",
@@ -829,9 +780,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 					EnableNodeLabeling: "false",
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				dsNumber = 1
 
@@ -840,11 +789,9 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				Eventually(func() error {
-					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an IPv6 VIP address for service",
@@ -885,9 +832,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 					EnableNodeLabeling: "false",
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				dsNumber = 1
 
@@ -896,11 +841,9 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				Eventually(func() error {
-					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			It(clusterName+" uses hostname fallback while providing an IPv4 VIP address for the Kubernetes control plane nodes", func() {
@@ -935,9 +878,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 					EnableNodeLabeling: "false",
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				dsNumber = 3
 
@@ -946,11 +887,9 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				Eventually(func() error {
-					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an single IPv6 VIP address for multiple services",
@@ -992,20 +931,16 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 					EnableNodeLabeling: "false",
 				}
 
-				var err error
-				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
-				Expect(err).NotTo(HaveOccurred())
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
 				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "svc-el-m-ds", k8sImagePath, v129,
 					kubeVIPManifestTemplate, logger, manifestValues, networking, 2, nil, 3)
 			})
 
 			AfterAll(func() {
-				By(fmt.Sprintf("saving logs to %q", tempDirPath))
-				Eventually(func() error {
-					return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
-				}, "60s", "5s").Should(Succeed())
-				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
 			})
 
 			DescribeTable("configures an single IPv4 and IPv6 VIP address for multiple services",
@@ -1680,4 +1615,18 @@ func testServiceCommonLease(ctx context.Context, svcName, lbAddress, leaseNamesp
 			}
 		}
 	}
+}
+
+func SaveLogsAndCleanup(ctx context.Context, client kubernetes.Interface, tempDirPath, clusterName string, cleanup func()) {
+	By(fmt.Sprintf("saving logs to %q", tempDirPath))
+	Eventually(func() error {
+		return e2e.GetLogs(ctx, client, tempDirPath, clusterName)
+	}, "60s", "5s").Should(Succeed())
+	cleanup()
+}
+
+func MustMkdirTemp(dir, prefix string) string {
+	tempDirPath, err := os.MkdirTemp(dir, prefix)
+	Expect(err).NotTo(HaveOccurred())
+	return tempDirPath
 }


### PR DESCRIPTION
This PR adds two helper functions `SaveLogsAndCleanup` and `MustMkdirTemp` to reduce code duplication.

These changes are purely mechanical and do not impact any test logic. 