### PR TITLE
Fix control-plane leaderelection restart in etcd mode

### DIFF
--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -117,7 +117,7 @@ func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config,
 	}
 
 	if err := election.RunOrDie(objLease.Ctx, run, c); err != nil {
-		objLease.Cancel()
+		cluster.Stop()
 		return fmt.Errorf("leaderelection failed: %w", err)
 	}
 


### PR DESCRIPTION
This PR should fix #1597

It turned out that the exit call was executed and kube-vip should exit and restart,, but the waitgroup waited for either global context cancellation or cluster stop signal. `Cluser.Stop()` is now called in case of error which results in expected bahaviour.