### PR TITLE
kube-vip: wire HTTP health check into routing table mode

### DIFF
--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -186,7 +186,24 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 
 				for entry := range *backendMap {
 					log.Debug("entry.Check() for entry", "entry", entry)
-					if entry.Check() {
+					var healthy bool
+					if c.ControlPlaneHealthCheck.Address != "" {
+						req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, c.ControlPlaneHealthCheck.Address, nil)
+						if reqErr != nil {
+							log.Error("create health check request", "err", reqErr)
+						} else if resp, doErr := cluster.healthCheckHTTPClient.Do(req); doErr != nil {
+							log.Error("health check request failed", "url", c.ControlPlaneHealthCheck.Address, "err", doErr)
+						} else {
+							resp.Body.Close()
+							healthy = resp.StatusCode == http.StatusOK
+							if !healthy {
+								log.Warn("health check returned non-200 status", "url", c.ControlPlaneHealthCheck.Address, "status", resp.StatusCode)
+							}
+						}
+					} else {
+						healthy = entry.Check()
+					}
+					if healthy {
 						log.Debug("entry.Check() true")
 						// Normal VIP addition with precheck, use skipDAD=false for normal DAD process
 						_, err = network.AddIP(true, false)

--- a/pkg/cluster/service_test.go
+++ b/pkg/cluster/service_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kube-vip/kube-vip/pkg/cluster"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/route"
 	"github.com/kube-vip/kube-vip/pkg/vip"
 	"github.com/vishvananda/netlink"
 	corev1 "k8s.io/api/core/v1"
@@ -154,6 +155,34 @@ func TestBGPHealthCheckLoop_RetriesDelHostOnFailure(t *testing.T) {
 		"route should be withdrawn after clearing DelHost error")
 }
 
+func TestRoutingTableHealthCheck_AddsVIPWhenHealthy(t *testing.T) {
+	t.Parallel()
+	healthcheck := newTestHealthServer(t, http.StatusOK)
+	t.Cleanup(healthcheck.server.Close)
+
+	network := &mockNetwork{ip: "10.0.0.1", cidr: testCIDR}
+	startRoutingTableVipService(t, newRoutingTableConfig(healthcheck.server.URL, healthcheck.caPath), network)
+
+	expectEventually(t, network.isPresent,
+		"VIP should be added while health check is healthy")
+}
+
+func TestRoutingTableHealthCheck_RemovesVIPWhenUnhealthy(t *testing.T) {
+	t.Parallel()
+	healthcheck := newTestHealthServer(t, http.StatusOK)
+	t.Cleanup(healthcheck.server.Close)
+
+	network := &mockNetwork{ip: "10.0.0.1", cidr: testCIDR}
+	startRoutingTableVipService(t, newRoutingTableConfig(healthcheck.server.URL, healthcheck.caPath), network)
+
+	expectEventually(t, network.isPresent,
+		"VIP should be added while health check is healthy")
+
+	healthcheck.setStatus(http.StatusServiceUnavailable)
+	expectEventually(t, func() bool { return !network.isPresent() },
+		"VIP should be removed once health check becomes unhealthy")
+}
+
 var (
 	errTestAddHost = &testError{msg: "mock AddHost error"}
 	errTestDelHost = &testError{msg: "mock DelHost error"}
@@ -189,6 +218,40 @@ func startVipService(t *testing.T, cfg *kubevip.Config, bgpManager *mockBGPRoute
 	})
 
 	return cancel, done
+}
+
+// startRoutingTableVipService launches vipService in routing-table mode with a
+// mock network and a real route.Manager (which only drives the mock network's
+// route methods, so no netlink calls happen). Registers cleanup to stop it.
+func startRoutingTableVipService(t *testing.T, cfg *kubevip.Config, network *mockNetwork) {
+	t.Helper()
+
+	c, err := cluster.InitCluster(cfg, true, nil, nil, route.NewManager(), nil)
+	if err != nil {
+		t.Fatalf("InitCluster: %v", err)
+	}
+	c.Network = []vip.Network{network}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	go func() {
+		_ = c.StartVipService(ctx, cfg, nil, nil, func() {})
+		close(done)
+	}()
+
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+}
+
+func newRoutingTableConfig(url, caPath string) *kubevip.Config {
+	cfg := newTestConfig(url, caPath)
+	cfg.EnableBGP = false
+	cfg.EnableRoutingTable = true
+	cfg.BackendHealthCheckInterval = 1
+	return cfg
 }
 
 func newTestConfig(url, caPath string) *kubevip.Config {
@@ -259,33 +322,51 @@ func (m *mockBGPRouteManager) setDelErr(err error) {
 type mockNetwork struct {
 	ip   string
 	cidr string
+
+	mu      sync.Mutex
+	present bool
 }
 
-func (m *mockNetwork) AddIP(bool, bool, ...int) (bool, error) { return true, nil }
-func (m *mockNetwork) AddRoute(bool) (bool, error)            { return false, nil }
-func (m *mockNetwork) DeleteIP() (bool, error)                { return false, nil }
-func (m *mockNetwork) DeleteRoute() error                     { return nil }
-func (m *mockNetwork) UpdateRoutes() (bool, error)            { return false, nil }
-func (m *mockNetwork) IsSet() (*netlink.Addr, error)          { return nil, nil }
-func (m *mockNetwork) IP() string                             { return m.ip }
-func (m *mockNetwork) CIDR() string                           { return m.cidr }
-func (m *mockNetwork) IPisLinkLocal() bool                    { return false }
-func (m *mockNetwork) PrepareRoute() *netlink.Route           { return nil }
-func (m *mockNetwork) RouteHash() string                      { return "" }
-func (m *mockNetwork) SetIP(string) error                     { return nil }
-func (m *mockNetwork) SetServicePorts(*corev1.Service)        {}
-func (m *mockNetwork) Interface() string                      { return "eth0" }
-func (m *mockNetwork) IsDADFAIL() bool                        { return false }
-func (m *mockNetwork) IsDNS() bool                            { return false }
-func (m *mockNetwork) IsDDNS() bool                           { return false }
-func (m *mockNetwork) DDNSHostName() string                   { return "" }
-func (m *mockNetwork) DNSName() string                        { return "" }
-func (m *mockNetwork) SetMask(string) error                   { return nil }
-func (m *mockNetwork) SetHasEndpoints(bool)                   {}
-func (m *mockNetwork) HasEndpoints() bool                     { return false }
-func (m *mockNetwork) ARPName() string                        { return "" }
-func (m *mockNetwork) GetPossibleSubnets() string             { return "" }
-func (m *mockNetwork) DHCPFamily() string                     { return "" }
+func (m *mockNetwork) AddIP(bool, bool, ...int) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.present = true
+	return true, nil
+}
+func (m *mockNetwork) DeleteIP() (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.present = false
+	return false, nil
+}
+func (m *mockNetwork) isPresent() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.present
+}
+func (m *mockNetwork) AddRoute(bool) (bool, error)     { return false, nil }
+func (m *mockNetwork) DeleteRoute() error              { return nil }
+func (m *mockNetwork) UpdateRoutes() (bool, error)     { return false, nil }
+func (m *mockNetwork) IsSet() (*netlink.Addr, error)   { return nil, nil }
+func (m *mockNetwork) IP() string                      { return m.ip }
+func (m *mockNetwork) CIDR() string                    { return m.cidr }
+func (m *mockNetwork) IPisLinkLocal() bool             { return false }
+func (m *mockNetwork) PrepareRoute() *netlink.Route    { return nil }
+func (m *mockNetwork) RouteHash() string               { return "" }
+func (m *mockNetwork) SetIP(string) error              { return nil }
+func (m *mockNetwork) SetServicePorts(*corev1.Service) {}
+func (m *mockNetwork) Interface() string               { return "eth0" }
+func (m *mockNetwork) IsDADFAIL() bool                 { return false }
+func (m *mockNetwork) IsDNS() bool                     { return false }
+func (m *mockNetwork) IsDDNS() bool                    { return false }
+func (m *mockNetwork) DDNSHostName() string            { return "" }
+func (m *mockNetwork) DNSName() string                 { return "" }
+func (m *mockNetwork) SetMask(string) error            { return nil }
+func (m *mockNetwork) SetHasEndpoints(bool)            {}
+func (m *mockNetwork) HasEndpoints() bool              { return false }
+func (m *mockNetwork) ARPName() string                 { return "" }
+func (m *mockNetwork) GetPossibleSubnets() string      { return "" }
+func (m *mockNetwork) DHCPFamily() string              { return "" }
 
 // testHealthServer wraps an HTTPS httptest.Server with an atomic status code.
 // caPath is the path to the server's CA cert for client verification.

--- a/testing/e2e/e2e_rt_test.go
+++ b/testing/e2e/e2e_rt_test.go
@@ -4,10 +4,12 @@
 package e2e_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"text/template"
@@ -132,6 +134,92 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 			})
 		})
 
+		Describe("kube-vip IPv4 control-plane routing table mode with control-plane health check", Ordered, func() {
+			var (
+				cpVIP       string
+				clusterName string
+				client      kubernetes.Interface
+				tempDirPath string
+
+				nodesNumber = 3
+			)
+
+			BeforeAll(func() {
+				cpVIP = e2e.GenerateVIP(utils.IPv4Family, SOffset.Get(), defaultNetwork)
+
+				networking := &kindconfigv1alpha4.Networking{
+					IPFamily: kindconfigv1alpha4.IPv4Family,
+				}
+
+				manifestValues := &e2e.KubevipManifestValues{
+					ControlPlaneVIP:                         cpVIP,
+					ImagePath:                               imagePath,
+					ConfigPath:                              configPath,
+					ControlPlaneEnable:                      "true",
+					SvcEnable:                               "false",
+					SvcElectionEnable:                       "false",
+					EnableNodeLabeling:                      "false",
+					ControlPlaneHealthCheckAddress:          "https://localhost:6443/livez",
+					ControlPlaneHealthCheckPeriodSeconds:    1,
+					ControlPlaneHealthCheckTimeoutSeconds:   1,
+					ControlPlaneHealthCheckFailureThreshold: 3,
+					ControlPlaneHealthCheckCAPath:           "/etc/kubernetes/pki/ca.crt",
+				}
+
+				var err error
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
+				Expect(err).NotTo(HaveOccurred())
+
+				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ipv4-hc", k8sImagePath, v129,
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
+			})
+
+			AfterAll(func() {
+				By(fmt.Sprintf("saving logs to %q", tempDirPath))
+				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
+				Expect(err).ToNot(HaveOccurred())
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+			})
+
+			It("withdraws and re-adds the VIP and route when the apiserver health check fails", func() {
+				By(withTimestamp("sitting for a few seconds to hopefully allow kube-vip to start"))
+				time.Sleep(30 * time.Second)
+
+				By("verifying every control-plane node sets up the VIP and route while healthy")
+				for i := 1; i <= nodesNumber; i++ {
+					container := controlPlaneContainerName(clusterName, i)
+					Expect(checkIPAddress(cpVIP, container, true)).To(BeTrue())
+					e2e.CheckRoutePresence(cpVIP, container, true)
+				}
+
+				// Pick a non-first node so the others keep serving the control plane.
+				targetContainer := controlPlaneContainerName(clusterName, 2)
+				otherContainer := controlPlaneContainerName(clusterName, 1)
+
+				By(fmt.Sprintf("stopping the apiserver on %q", targetContainer))
+				setAPIServerState(targetContainer, false)
+
+				By("verifying the unhealthy node withdraws its VIP and route")
+				Expect(checkIPAddress(cpVIP, targetContainer, false)).To(BeTrue())
+				e2e.CheckRoutePresence(cpVIP, targetContainer, false)
+
+				By("verifying a healthy node keeps its VIP and route")
+				Expect(checkIPAddress(cpVIP, otherContainer, true)).To(BeTrue())
+				e2e.CheckRoutePresence(cpVIP, otherContainer, true)
+
+				By(fmt.Sprintf("restoring the apiserver on %q", targetContainer))
+				setAPIServerState(targetContainer, true)
+
+				By("verifying the recovered node re-adds its VIP and route")
+				// Allow extra time here: the apiserver static pod must be restarted
+				// by the kubelet and become healthy again before kube-vip re-adds the VIP.
+				Eventually(func() bool {
+					return e2e.CheckIPAddressPresence(cpVIP, targetContainer, true)
+				}, "180s", "2s").Should(BeTrue(), "VIP should be re-added after apiserver recovery")
+				e2e.CheckRoutePresence(cpVIP, targetContainer, true)
+			})
+		})
+
 		Describe("kube-vip IPv6 control-plane routing table mode functionality", Ordered, func() {
 			var (
 				cpVIP       string
@@ -187,6 +275,92 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					Expect(checkIPAddress(cpVIP, container, true)).To(BeTrue())
 					e2e.CheckRoutePresence(cpVIP, container, true)
 				}
+			})
+		})
+
+		Describe("kube-vip IPv6 control-plane routing table mode with control-plane health check", Ordered, func() {
+			var (
+				cpVIP       string
+				clusterName string
+				client      kubernetes.Interface
+				tempDirPath string
+
+				nodesNumber = 3
+			)
+
+			BeforeAll(func() {
+				cpVIP = e2e.GenerateVIP(utils.IPv6Family, SOffset.Get(), defaultNetwork)
+
+				networking := &kindconfigv1alpha4.Networking{
+					IPFamily: kindconfigv1alpha4.IPv6Family,
+				}
+
+				manifestValues := &e2e.KubevipManifestValues{
+					ControlPlaneVIP:                         cpVIP,
+					ImagePath:                               imagePath,
+					ConfigPath:                              configPath,
+					ControlPlaneEnable:                      "true",
+					SvcEnable:                               "false",
+					SvcElectionEnable:                       "false",
+					EnableNodeLabeling:                      "false",
+					ControlPlaneHealthCheckAddress:          "https://localhost:6443/livez",
+					ControlPlaneHealthCheckPeriodSeconds:    1,
+					ControlPlaneHealthCheckTimeoutSeconds:   1,
+					ControlPlaneHealthCheckFailureThreshold: 3,
+					ControlPlaneHealthCheckCAPath:           "/etc/kubernetes/pki/ca.crt",
+				}
+
+				var err error
+				tempDirPath, err = os.MkdirTemp(tempDirPathRoot, testDirPrefix)
+				Expect(err).NotTo(HaveOccurred())
+
+				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ipv6-hc", k8sImagePath, v129,
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
+			})
+
+			AfterAll(func() {
+				By(fmt.Sprintf("saving logs to %q", tempDirPath))
+				err := e2e.GetLogs(ctx, client, tempDirPath, clusterName)
+				Expect(err).ToNot(HaveOccurred())
+				cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+			})
+
+			It("withdraws and re-adds the VIP and route when the apiserver health check fails", func() {
+				By(withTimestamp("sitting for a few seconds to hopefully allow kube-vip to start"))
+				time.Sleep(30 * time.Second)
+
+				By("verifying every control-plane node sets up the VIP and route while healthy")
+				for i := 1; i <= nodesNumber; i++ {
+					container := controlPlaneContainerName(clusterName, i)
+					Expect(checkIPAddress(cpVIP, container, true)).To(BeTrue())
+					e2e.CheckRoutePresence(cpVIP, container, true)
+				}
+
+				// Pick a non-first node so the others keep serving the control plane.
+				targetContainer := controlPlaneContainerName(clusterName, 2)
+				otherContainer := controlPlaneContainerName(clusterName, 1)
+
+				By(fmt.Sprintf("stopping the apiserver on %q", targetContainer))
+				setAPIServerState(targetContainer, false)
+
+				By("verifying the unhealthy node withdraws its VIP and route")
+				Expect(checkIPAddress(cpVIP, targetContainer, false)).To(BeTrue())
+				e2e.CheckRoutePresence(cpVIP, targetContainer, false)
+
+				By("verifying a healthy node keeps its VIP and route")
+				Expect(checkIPAddress(cpVIP, otherContainer, true)).To(BeTrue())
+				e2e.CheckRoutePresence(cpVIP, otherContainer, true)
+
+				By(fmt.Sprintf("restoring the apiserver on %q", targetContainer))
+				setAPIServerState(targetContainer, true)
+
+				By("verifying the recovered node re-adds its VIP and route")
+				// Allow extra time here: the apiserver static pod must be restarted
+				// by the kubelet and become healthy again before kube-vip re-adds the VIP.
+				Eventually(func() bool {
+					return e2e.CheckIPAddressPresence(cpVIP, targetContainer, true)
+				}, "180s", "2s").Should(BeTrue(), "VIP should be re-added after apiserver recovery")
+				e2e.CheckRoutePresence(cpVIP, targetContainer, true)
 			})
 		})
 
@@ -1315,4 +1489,33 @@ func testServiceRT(ctx context.Context, svcName, lbAddress, leaseName, leaseName
 type san struct {
 	ip    *net.IP
 	ipnet *net.IPNet
+}
+
+// controlPlaneContainerName returns the kind docker container name for the
+// i-th (1-based) control-plane node of the cluster.
+func controlPlaneContainerName(clusterName string, i int) string {
+	if i > 1 {
+		return fmt.Sprintf("%s-control-plane%d", clusterName, i)
+	}
+	return fmt.Sprintf("%s-control-plane", clusterName)
+}
+
+// setAPIServerEnabled stops or starts the static apiserver pod on a control-plane
+// container by moving its manifest in or out of the kubelet manifests directory.
+func setAPIServerState(container string, enabled bool) {
+	const (
+		manifestPath = "/etc/kubernetes/manifests/kube-apiserver.yaml"
+		stashPath    = "/tmp/kube-apiserver.yaml"
+	)
+
+	src, dst := manifestPath, stashPath
+	if enabled {
+		src, dst = stashPath, manifestPath
+	}
+
+	out := new(bytes.Buffer)
+	cmd := exec.Command("docker", "exec", container, "mv", src, dst)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	Expect(cmd.Run()).To(Succeed(), out.String())
 }

--- a/testing/e2e/kube-vip-routing-table.yaml.tmpl
+++ b/testing/e2e/kube-vip-routing-table.yaml.tmpl
@@ -50,6 +50,26 @@ spec:
       value: "{{ .EnableNodeLabeling }}"
     - name: enable_endpoints
       value: "{{ .EnableEndpoints }}"
+{{- if .ControlPlaneHealthCheckAddress }}
+    - name: control_plane_health_check_address
+      value: "{{ .ControlPlaneHealthCheckAddress }}"
+{{- if .ControlPlaneHealthCheckPeriodSeconds }}
+    - name: control_plane_health_check_period_seconds
+      value: "{{ .ControlPlaneHealthCheckPeriodSeconds }}"
+{{- end }}
+{{- if .ControlPlaneHealthCheckTimeoutSeconds }}
+    - name: control_plane_health_check_timeout_seconds
+      value: "{{ .ControlPlaneHealthCheckTimeoutSeconds }}"
+{{- end }}
+{{- if .ControlPlaneHealthCheckFailureThreshold }}
+    - name: control_plane_health_check_failure_threshold
+      value: "{{ .ControlPlaneHealthCheckFailureThreshold }}"
+{{- end }}
+{{- if .ControlPlaneHealthCheckCAPath }}
+    - name: control_plane_health_check_ca_path
+      value: "{{ .ControlPlaneHealthCheckCAPath }}"
+{{- end }}
+{{- end }}
     image: "{{ .ImagePath }}"
     imagePullPolicy: Never
     securityContext:
@@ -60,6 +80,11 @@ spec:
     volumeMounts:
     - mountPath: /etc/kubernetes/admin.conf
       name: kubeconfig
+{{- if .ControlPlaneHealthCheckCAPath }}
+    - mountPath: {{ .ControlPlaneHealthCheckCAPath }}
+      name: health-check-ca
+      readOnly: true
+{{- end }}
   hostAliases:
     - hostnames:
       - kubernetes
@@ -69,3 +94,9 @@ spec:
   - hostPath:
       path: "{{ .ConfigPath }}"
     name: kubeconfig
+{{- if .ControlPlaneHealthCheckCAPath }}
+  - hostPath:
+      path: {{ .ControlPlaneHealthCheckCAPath }}
+      type: File
+    name: health-check-ca
+{{- end }}


### PR DESCRIPTION
Our use case is kube-vip in routing table mode but instead of only checking `client.DiscoveryClient.ServerVersion()`, we prefer ability to explicitly configure HTTP endpoint.

A deeper explanation is that we want to use kube-vip to serve backends which are not only a "proper" k8s servers but arbitrary nodes. So there may be a backend which does not reply to `ServerVersion()`, yet in our lingo it's still a working backend and should serve the VIP.

Given there is already a whole framework for setting `c.ControlPlaneHealthCheck.Address` (only that it's not used in routing table mode), I think it's a fairly small&cheap change to have.