### PR TITLE
Feat: Add help text to kubeadm and manifest subcommands

### DIFF
--- a/cmd/kube-vip-kubeadm.go
+++ b/cmd/kube-vip-kubeadm.go
@@ -23,20 +23,36 @@ func init() {
 var kubeKubeadm = &cobra.Command{
 	Use:   "kubeadm",
 	Short: "Kubeadm functions",
-	Run: func(cmd *cobra.Command, args []string) { //nolint TODO
+	Long: `This command group provides utilities for generating static Pod manifests specifically tailored for the kubeadm bootstrapping process.
+	It contains two subcommands:
+  		- init:  Generates a manifest to be used during 'kubeadm init' on the first control-plane node.
+  		- join:  Generates a manifest to be used during 'kubeadm join' for additional control-plane nodes.
+
+The generated YAML manifest should be saved to the kubeadm static Pod directory (typically /etc/kubernetes/manifests/) so that kubeadm launches the kube-vip static Pod automatically.`,
+	Run: func(cmd *cobra.Command, _ []string) {
 		_ = cmd.Help()
-		// TODO - A load of text detailing what's actually happening
 	},
 }
 
 var kubeKubeadmInit = &cobra.Command{
 	Use:   "init",
 	Short: "kube-vip init",
-	Long:  "The \"init\" subcommand will generate the Kubernetes manifest that will be started by kubeadm through the kubeadm init process",
-	Run: func(cmd *cobra.Command, args []string) { //nolint TODO
+	Long: `The 'init' subcommand generates a Kubernetes Pod manifest that kubeadm will start as a static Pod during the cluster initialisation phase.
+
+This manifest runs kube-vip on the first control-plane node to advertise the Virtual IP (VIP) for the API server. The VIP is typically configured using ARP (Layer 2) or BGP (dynamic routing).
+
+Required flags for this command:
+  --interface   : The network interface to bind the VIP to (e.g., eth0).
+  --vip or --address : The Virtual IP address or DNS name to use.
+
+Example:
+  kube-vip kubeadm init --interface eth0 --vip 192.168.1.100 --controlplane
+
+The output YAML should be written to the kubeadm manifests directory, e.g.:
+  kube-vip kubeadm init ... > /etc/kubernetes/manifests/kube-vip.yaml`,
+	Run: func(cmd *cobra.Command, _ []string) {
 
 		initConfig.LoadBalancers = append(initConfig.LoadBalancers, initLoadBalancer)
-		// TODO - A load of text detailing what's actually happening
 		err := kubevip.ParseEnvironment(&initConfig)
 		if err != nil {
 			log.Error("parsing environment", "err", err)
@@ -81,10 +97,21 @@ var kubeKubeadmInit = &cobra.Command{
 var kubeKubeadmJoin = &cobra.Command{
 	Use:   "join",
 	Short: "kube-vip join",
-	Run: func(cmd *cobra.Command, args []string) { //nolint TODO
+	Long: `The 'join' subcommand generates a Kubernetes Pod manifest for additional control-plane nodes joining an existing cluster via 'kubeadm join'.
+
+It functions identically to the 'init' subcommand, but is intended for secondary control-plane nodes. It validates that the kubeconfig file (specified by --config, defaulting to /etc/kubernetes/admin.conf) exists on the node to ensure the node can authenticate with the cluster.
+
+Required flags for this command:
+  --interface   : The network interface to bind the VIP to.
+  --vip or --address : The Virtual IP address or DNS name (must match the VIP used during 'init').
+
+Example:
+  kube-vip kubeadm join --interface eth0 --vip 192.168.1.100
+
+The output YAML should be saved to the kubeadm manifests directory on the joining node.`,
+	Run: func(cmd *cobra.Command, _ []string) {
 
 		initConfig.LoadBalancers = append(initConfig.LoadBalancers, initLoadBalancer)
-		// TODO - A load of text detailing what's actually happening
 		err := kubevip.ParseEnvironment(&initConfig)
 		if err != nil {
 			log.Error("parsing environment", "err", err)

--- a/cmd/kube-vip-manifests.go
+++ b/cmd/kube-vip-manifests.go
@@ -32,20 +32,41 @@ func init() {
 var kubeManifest = &cobra.Command{
 	Use:   "manifest",
 	Short: "Manifest functions",
-	Run: func(cmd *cobra.Command, args []string) { //nolint TODO
+	Long: `This command group provides flexible manifest generation for deploying kube-vip in various Kubernetes environments.
+
+Unlike the 'kubeadm' subcommands, which are tightly coupled to kubeadm's static Pod requirements, these generators produce standard Kubernetes manifests (Pod, DaemonSet, RBAC) that can be used with any Kubernetes distribution (e.g., k3s, RKE, or vanilla Kubernetes).
+
+Subcommands:
+  pod        : Generates a standalone Pod manifest (similar to a static pod).
+  daemonset  : Generates a DaemonSet manifest to run kube-vip on selected nodes.
+  rbac       : Generates the necessary ServiceAccount, Role/ClusterRole, and Binding manifests.
+
+All output is written to stdout as YAML, typically piped to 'kubectl apply -f -' or saved to a file.`,
+	Run: func(cmd *cobra.Command, _ []string) {
 		_ = cmd.Help()
-		// TODO - A load of text detailing what's actually happening
 	},
 }
 
 var kubeManifestPod = &cobra.Command{
 	Use:   "pod",
 	Short: "Generate a Pod Manifest",
-	Run: func(cmd *cobra.Command, args []string) { //nolint TODO
+	Long: `Generate a standalone Pod manifest for kube-vip.
+
+This is ideal for environments that do not use DaemonSets or where you want to run kube-vip as a static Pod (similar to the 'kubeadm' subcommand, but without kubeadm-specific assumptions). It includes all the necessary container specifications, volumes, and environment variables derived from the provided flags.
+
+Key flags:
+  --interface : Network interface for the VIP.
+  --vip or --address : The Virtual IP address or DNS name.
+  --image     : Override the container image (default: ghcr.io/kube-vip/kube-vip).
+
+The manifest is generated based on the current configuration flags set on the root command.
+
+Example:
+  kube-vip manifest pod --interface eth0 --vip 10.0.0.100 --controlplane | kubectl apply -f -`,
+	Run: func(cmd *cobra.Command, _ []string) {
 		var err error
 
 		initConfig.LoadBalancers = append(initConfig.LoadBalancers, initLoadBalancer)
-		// TODO - A load of text detailing what's actually happening
 		if err := kubevip.ParseEnvironment(&initConfig); err != nil {
 			log.Error("parsing environment", "err", err)
 			return
@@ -83,11 +104,21 @@ var kubeManifestPod = &cobra.Command{
 var kubeManifestDaemon = &cobra.Command{
 	Use:   "daemonset",
 	Short: "Generate a Daemonset Manifest",
-	Run: func(cmd *cobra.Command, args []string) { //nolint TODO
+	Long: `Generate a DaemonSet manifest to run kube-vip across multiple nodes.
+
+This is the recommended deployment method for production clusters running kube-vip as a service. It ensures that kube-vip runs on all control-plane nodes (or selected nodes via tolerations) and can handle both control-plane HA and service load-balancing.
+
+Flags specific to this subcommand:
+  --taint  : Adds a toleration to the DaemonSet so that pods are scheduled only on nodes with the control-plane taint (node-role.kubernetes.io/control-plane:NoSchedule). This is essential for control-plane-only deployments.
+
+All other standard kube-vip flags (--interface, --vip, --enableARP, --enableBGP, etc.) are respected and embedded into the DaemonSet pod template.
+
+Example:
+  kube-vip manifest daemonset --interface eth0 --vip 192.168.1.100 --controlplane --taint | kubectl apply -f -`,
+	Run: func(cmd *cobra.Command, _ []string) {
 		var err error
 
 		initConfig.LoadBalancers = append(initConfig.LoadBalancers, initLoadBalancer)
-		// TODO - A load of text detailing what's actually happening
 		if err := kubevip.ParseEnvironment(&initConfig); err != nil {
 			log.Error("parsing environment", "err", err)
 			return
@@ -124,11 +155,20 @@ var kubeManifestDaemon = &cobra.Command{
 var kubeManifestRbac = &cobra.Command{
 	Use:   "rbac",
 	Short: "Generate an RBAC Manifest",
-	Run: func(cmd *cobra.Command, args []string) { //nolint TODO
-		var err error
+	Long: `Generate the RBAC (Role-Based Access Control) manifests required for kube-vip to interact with the Kubernetes API.
 
+kube-vip needs permissions to watch services, endpoints, configmaps, and manage leader election leases. This command outputs the minimum required ServiceAccount, Role (or ClusterRole), and the corresponding binding.
+
+Flags:
+  --role        : If true, generates a namespaced Role instead of a ClusterRole. The namespace is taken from the root --namespace flag (default: kube-system).
+  --rolebinding : If true, generates a RoleBinding (if --role is also true). If --role is false, a ClusterRoleBinding is generated automatically.
+
+The output is a multi-document YAML (separated by '---'). It is safe to apply directly:
+  kube-vip manifest rbac --role --rolebinding | kubectl apply -f -
+
+Without --role, it generates a ClusterRole and ClusterRoleBinding, which is the default behaviour and suitable for most cluster-wide deployments.`,
+	Run: func(cmd *cobra.Command, _ []string) {
 		initConfig.LoadBalancers = append(initConfig.LoadBalancers, initLoadBalancer)
-		// TODO - A load of text detailing what's actually happening
 		if err := kubevip.ParseEnvironment(&initConfig); err != nil {
 			log.Error("parsing environment", "err", err)
 			return
@@ -147,6 +187,7 @@ var kubeManifestRbac = &cobra.Command{
 
 		// Ensure there is an address to generate the CIDR from
 		if initConfig.VIPSubnet == "" && initConfig.Address != "" {
+			var err error
 			initConfig.VIPSubnet, err = GenerateCidrRange(initConfig.Address, initConfig.DNSMode)
 			if err != nil {
 				log.Error("generating VIPSubnet", "err", err)


### PR DESCRIPTION
In an effort to handle `TODO` comments in the codebase, this PR adds help text to `kubeadm` and `manifest` subcommands.