### PR TITLE
Fixed BGP metrics

### DIFF
--- a/pkg/manager/worker/bgp.go
+++ b/pkg/manager/worker/bgp.go
@@ -59,7 +59,7 @@ func (b *BGP) Configure(ctx context.Context, _ *sync.WaitGroup) error {
 
 		for stateName, stateValue := range api.PeerState_SessionState_value {
 			metricValue := 0.0
-			if int(p.Peer.State.SessionState) == int(stateValue) {
+			if int(p.Peer.State.SessionState) == int(stateValue)-1 {
 
 				metricValue = 1
 			}


### PR DESCRIPTION
This should fix #1614 

There is a mismatch in the internal state values and API state values by one, as the API also has the value for `unspecified` state.