### PR TITLE
Fixed tables creation when nftables is used, IP deletion on leadership loss and race condition in backend

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	log "log/slog"
@@ -24,10 +25,15 @@ type Map map[Entry]bool
 // kubeConfigPath is an explicitly configured kubeconfig used by Check when
 // set; static pod deployments configure it since neither admin.conf nor
 // in-cluster config are available there.
-var kubeConfigPath string
+var (
+	kubeConfigPath string
+	pathMtx        sync.Mutex
+)
 
 // SetKubeConfigPath configures the kubeconfig used by backend health checks.
 func SetKubeConfigPath(path string) {
+	pathMtx.Lock()
+	defer pathMtx.Unlock()
 	kubeConfigPath = path
 }
 

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -408,7 +408,7 @@ func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip
 			if _, err = network.AddIP(false, false); err != nil {
 				log.Warn(err.Error())
 			} else {
-				log.Info("successful add IP")
+				log.Info("successful add IP", "address", network.IP())
 			}
 		}
 

--- a/pkg/manager/worker/common.go
+++ b/pkg/manager/worker/common.go
@@ -193,18 +193,23 @@ func (c *Common) runGlobalElection(ctx context.Context, a election.Actions, leas
 		c.leaseMgr.Delete(leaseID, objectName)
 	}()
 
+	wg := sync.WaitGroup{}
+	defer wg.Wait()
+
 	run := &election.RunConfig{
 		Config:           config,
 		LeaseID:          leaseID,
 		LeaseAnnotations: map[string]string{},
 		Mgr:              electionManager,
 		OnStartedLeading: func(ctx context.Context) {
-			objLease.Elected.Store(true)
-			objLease.Unlock()
-			close(objLease.Started)
-			a.OnStartedLeading(ctx)
-			metrics.LeaderTransitionsTotal.WithLabelValues(leaseID.Name()).Inc()
-			metrics.IsLeader.WithLabelValues(config.NodeName, leaseID.Name()).Set(1)
+			wg.Go(func() {
+				objLease.Elected.Store(true)
+				objLease.Unlock()
+				close(objLease.Started)
+				a.OnStartedLeading(ctx)
+				metrics.LeaderTransitionsTotal.WithLabelValues(leaseID.Name()).Inc()
+				metrics.IsLeader.WithLabelValues(config.NodeName, leaseID.Name()).Set(1)
+			})
 		},
 		OnStoppedLeading: func() {
 			objLease.Elected.Store(false)

--- a/pkg/nftables/client.go
+++ b/pkg/nftables/client.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"reflect"
 	"slices"
+	"strings"
 
 	"github.com/google/nftables"
 	"github.com/google/nftables/expr"
@@ -60,8 +61,13 @@ func (c *Client) GetTable(name string) *nftables.Table {
 }
 
 func (c *Client) GetChain(table, chain string) (*nftables.Chain, error) {
-	ch, err := c.conn.ListChain(c.GetTable(table), chain)
+	t := c.GetTable(table)
+	ch, err := c.conn.ListChain(t, chain)
 	if err != nil {
+		log.Error(err.Error())
+		if strings.Contains(err.Error(), "no such file") {
+			return nil, ErrChainNotFound
+		}
 		return nil, err
 	}
 	return ch, nil
@@ -73,9 +79,10 @@ func (c *Client) CheckChain(table, chain string) bool {
 }
 
 func (c *Client) AddChain(chain *nftables.Chain) *nftables.Chain {
-	ch, _ := c.GetChain(chain.Table.Name, chain.Name)
+	ch, err := c.GetChain(chain.Table.Name, chain.Name)
 
-	if ch == nil {
+	if errors.Is(err, ErrChainNotFound) {
+		log.Debug("adding chain", "name", chain.Name)
 		ch = c.conn.AddChain(chain)
 		c.Flush()
 	}
@@ -368,3 +375,5 @@ func exprEqual[V *expr.Meta | *expr.Lookup | *expr.Verdict | *expr.Cmp | *expr.P
 func UserDataComment(comment string) []byte {
 	return userdata.AppendString([]byte{}, userdata.TypeComment, comment)
 }
+
+var ErrChainNotFound = errors.New("chain not found")

--- a/pkg/vip/address.go
+++ b/pkg/vip/address.go
@@ -443,8 +443,6 @@ func (configurator *network) AddIP(precheck bool, skipDAD bool, minLifetime ...i
 		}
 	}
 
-	log.Debug("IP CONFIGURED", "address", configurator.address)
-
 	return true, nil
 }
 
@@ -466,8 +464,8 @@ func (configurator *network) configureIPTables() error {
 }
 
 func (configurator *network) configureNFTables() error {
-	log.Debug("configureNFTables", "security enabled", configurator.enableSecurity, "ignore security", configurator.ignoreSecurity,
-		"ports", configurator.ports)
+	log.Debug("configure nftables", "security enabled", configurator.enableSecurity, "ignore security", configurator.ignoreSecurity,
+		"ports", configurator.ports, "service-name", configurator.serviceName)
 
 	opt := nftables.TableFamilyIPv4
 	if utils.IsIPv6(configurator.IP()) {
@@ -480,6 +478,9 @@ func (configurator *network) configureNFTables() error {
 	}
 
 	comment := fmt.Sprintf(iptablesComment, "control-plane")
+	if configurator.serviceName != "" {
+		comment = fmt.Sprintf(iptablesComment, configurator.serviceName)
+	}
 
 	if configurator.enableSecurity && !configurator.ignoreSecurity && len(configurator.ports) > 0 {
 		if err := configurator.addNftablesRulesToLimitTrafficPorts(c, comment); err != nil {
@@ -526,6 +527,23 @@ func (configurator *network) addIptablesRulesToLimitTrafficPorts() error {
 }
 
 func (configurator *network) addNftablesRulesToLimitTrafficPorts(c *nfinternal.Client, comment string) error {
+	if _, err := c.GetChain(nfinternal.TableFilter, iptables.ChainInput); err != nil {
+		if errors.Is(err, nfinternal.ErrChainNotFound) {
+			p := nftables.ChainPolicyAccept
+			ch := &nftables.Chain{
+				Table:    c.GetTable(nfinternal.TableFilter),
+				Name:     iptables.ChainInput,
+				Hooknum:  nftables.ChainHookInput,
+				Type:     nftables.ChainTypeFilter,
+				Priority: nftables.ChainPriorityFilter,
+				Policy:   &p,
+			}
+			_ = c.AddChain(ch)
+			c.Flush()
+		} else {
+			return fmt.Errorf("failed to get table: %s", nfinternal.TableFilter)
+		}
+	}
 
 	firstRule, err := insertCommonNFTablesRules(c, configurator.IP(), comment)
 	if err != nil {
@@ -534,10 +552,6 @@ func (configurator *network) addNftablesRulesToLimitTrafficPorts(c *nfinternal.C
 
 	if err := configurator.insertNFTablesRulesForServicePorts(c, configurator.IP(), comment, firstRule.Handle); err != nil {
 		return fmt.Errorf("could not add nftables rules for service ports: %v", err)
-	}
-
-	if err := c.Close(); err != nil {
-		return fmt.Errorf("failed to close client: %w", err)
 	}
 
 	return nil
@@ -714,7 +728,9 @@ func addNFTPortRule(c *nfinternal.Client, chain *nftables.Chain, vip string,
 				SourceRegister: 0x1,
 			},
 			&expr.Counter{},
-			&expr.Meta{Key: expr.MetaKeyMARK, SourceRegister: true, Register: 0x1},
+			&expr.Verdict{
+				Kind: expr.VerdictAccept,
+			},
 		},
 	}
 
@@ -870,12 +886,14 @@ func deleteCommonIPTablesRules(ipt *iptables.IPTables, vip, comment string) erro
 }
 
 func deleteCommonNFTablesRules(c *nfinternal.Client, comment string) error {
-
 	table := c.GetTable(iptables.TableFilter)
-
 	chain, err := c.GetChain(table.Name, iptables.ChainInput)
 	if err != nil {
-		return fmt.Errorf("failed to find chain: %w", err)
+		// if there is no chain there's nothing to delete
+		if errors.Is(err, nfinternal.ErrChainNotFound) {
+			return nil
+		}
+		return fmt.Errorf("failed to find chain %q: %w", iptables.ChainInput, err)
 	}
 
 	ruleDHCP, err := c.FindRuleByComment(table, chain, fmt.Sprintf("%s - DHCP", comment))
@@ -912,16 +930,19 @@ func deleteCommonNFTablesRules(c *nfinternal.Client, comment string) error {
 func deleteNFTPortRule(c *nfinternal.Client, comment string) error {
 
 	table := c.GetTable(iptables.TableFilter)
-
 	chain, err := c.GetChain(table.Name, iptables.ChainInput)
 	if err != nil {
-		return fmt.Errorf("failed to find chain: %w", err)
+		// if there is no chain there's nothing to delete
+		if errors.Is(err, nfinternal.ErrChainNotFound) {
+			return nil
+		}
+		return fmt.Errorf("failed to find chain %q: %w", iptables.ChainInput, err)
 	}
 
 	for _, t := range []string{"TCP", "UDP", "SCTP"} {
 		rule, err := c.FindRuleByComment(table, chain, fmt.Sprintf("%s - %s ports", comment, t))
 		if err != nil {
-			return fmt.Errorf("failed to find the rule: %w", err)
+			log.Warn("failed to find the rule", "error", err)
 		}
 
 		if rule == nil {
@@ -971,11 +992,12 @@ func (configurator *network) removeNftablesRuleToLimitTrafficPorts(c *nfinternal
 	vip := configurator.address.IP.String()
 	comment := fmt.Sprintf(iptablesComment, configurator.serviceName)
 
+	log.Debug("remove nftables common rules", "vip", vip)
 	if err := deleteCommonNFTablesRules(c, comment); err != nil {
-		return fmt.Errorf("could not delete common iptables rules: %w", err)
+		return fmt.Errorf("could not delete common nftables rules: %w", err)
 	}
 
-	log.Debug("remove nftables rules", "vip", vip, "ports", configurator.ports)
+	log.Debug("remove nftables port rules", "vip", vip, "ports", configurator.ports)
 	if err := deleteNFTPortRule(c, comment); err != nil {
 		return fmt.Errorf("faield to remove port rule: %w", err)
 	}
@@ -1016,13 +1038,13 @@ func (configurator *network) DeleteIP() (bool, error) {
 
 		if configurator.enableSecurity && !configurator.ignoreSecurity {
 			if err := configurator.removeNftablesRuleToLimitTrafficPorts(c); err != nil {
-				return true, errors.Wrap(err, "could not remove nftables rules to limit traffic ports")
+				log.Warn("could not remove nftables rules to limit traffic ports", "error", err)
 			}
 		}
 
 		if configurator.serviceName == "" && configurator.ipvsEnabled && configurator.forwardMethod == "masquerade" && configurator.address.IP.To4() != nil {
 			if err := configurator.removeNftablesRulesForMasquerade(c); err != nil {
-				return true, errors.Wrap(err, "could not remove nftables masquerade rules")
+				log.Warn("could not remove nftables masquerade rules", "error", err)
 			}
 		}
 
@@ -1070,11 +1092,9 @@ func (configurator *network) addIptablesRulesForMasquerade() error {
 func (configurator *network) addNftablesRulesForMasquerade(c *nfinternal.Client, comment string) error {
 	cmt := fmt.Sprintf("%s - IPVS, VIP %s, MARK %d", comment, configurator.IP(), configurator.IPVSMark())
 
-	table := c.GetTable(iptables.TableMangle)
-
 	markChain := &nftables.Chain{
 		Name:     "ipvs_prerouting",
-		Table:    table,
+		Table:    c.GetTable(iptables.TableMangle),
 		Type:     nftables.ChainTypeFilter,
 		Hooknum:  nftables.ChainHookPrerouting,
 		Priority: nftables.ChainPriorityMangle,
@@ -1139,6 +1159,19 @@ func (configurator *network) addNftablesRulesForMasquerade(c *nfinternal.Client,
 
 	chain, err := c.GetChain(iptables.TableNat, iptables.ChainPOSTROUTING)
 	if err != nil {
+		if errors.Is(err, nfinternal.ErrChainNotFound) {
+			p := nftables.ChainPolicyAccept
+			ch := &nftables.Chain{
+				Table:    c.GetTable(iptables.TableNat),
+				Name:     iptables.ChainPOSTROUTING,
+				Hooknum:  nftables.ChainHookPostrouting,
+				Type:     nftables.ChainTypeFilter,
+				Priority: nftables.ChainPriorityMangle,
+				Policy:   &p,
+			}
+			_ = c.AddChain(ch)
+		}
+
 		return fmt.Errorf("failed to get chain %s in table %s: %w", iptables.ChainPOSTROUTING, iptables.TableNat, err)
 	}
 
@@ -1200,6 +1233,9 @@ func (configurator *network) removeNftablesRulesForMasquerade(c *nfinternal.Clie
 	}
 
 	comment := fmt.Sprintf(iptablesComment, "control-plane")
+	if configurator.serviceName != "" {
+		comment = fmt.Sprintf(iptablesComment, configurator.serviceName)
+	}
 	cmt := fmt.Sprintf("%s - IPVS, VIP %s, MARK %d", comment, configurator.IP(), configurator.IPVSMark())
 
 	r, err := c.FindRuleByComment(chain.Table, chain, cmt)

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -1589,9 +1589,11 @@ func testServiceCommonLease(ctx context.Context, svcName, lbAddress, leaseNamesp
 		time.Sleep(time.Second)
 	}
 
-	for i, addr := range lbAddresses {
-		checkIPAddressByLease(ctx, lease, leaseNamespace, addr, true, client)
-		assertConnection("http", addr, strconv.Itoa(80+i), "", 3*time.Second, 60*time.Second)
+	for i := range services {
+		for _, addr := range lbAddresses {
+			checkIPAddressByLease(ctx, lease, leaseNamespace, addr, true, client)
+			assertConnection("http", addr, strconv.Itoa(80+i), "", 3*time.Second, 60*time.Second)
+		}
 	}
 
 	container := e2e.GetLeaseHolder(ctx, lease, leaseNamespace, client)


### PR DESCRIPTION
It seems that there might be an issue if nftables is used and the chain (e.g. `INPUT`) does not exist:

```
2026/07/08 19:13:15 WARN could not configure NFTables: could not add nftables rules to limit traffic ports: could not add common nftables rules: failed to get chain "INPUT" in table "filter": conn.Execute failed: netlink receive: no such file or directory
...
2026/07/08 19:13:15 WARN attempted to clean existing VIP err="could not delete common iptables rules: failed to find chain: conn.Execute failed: netlink receive: no such file or directory\ncould not remove nftables rules to limit traffic ports\ngithub.com/kube-vip/kube-vip/pkg/vip.(*network).DeleteIP\n\t/src/pkg/vip/address.go:1019\ngithub.com/kube-vip/kube-vip/pkg/cluster.(*Cluster).StartLoadBalancerService\n\t/src/pkg/cluster/service.go:388\ngithub.com/kube-vip/kube-vip/pkg/services.(*Processor).configureService\n\t/src/pkg/services/services.go:200\ngithub.com/kube-vip/kube-vip/pkg/services.(*Processor).addService\n\t/src/pkg/services/services.go:178\ngithub.com/kube-vip/kube-vip/pkg/services.(*Processor).SyncServices\n\t/src/pkg/services/services.go:72\ngithub.com/kube-vip/kube-vip/pkg/services.(*Processor).onStartedLeading\n\t/src/pkg/services/leader.go:173\ngithub.com/kube-vip/kube-vip/pkg/services.(*Processor).StartServicesLeaderElection\n\t/src/pkg/services/leader.go:101\ngithub.com/kube-vip/kube-vip/pkg/services.(*Callback).Run\n\t/src/pkg/services/callback.go:23\ngithub.com/kube-vip/kube-vip/pkg/services.(*Processor).AddOrModify.func1.2\n\t/src/pkg/services/processor.go:217\nsync.(*WaitGroup).Go.func1\n\t/usr/local/go/src/sync/waitgroup.go:258\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1771"
```

This PR should fix that by adding chains if those not exist. It also introduces minor improvements for error handling.

UPDATE:

This PR evolved a bit. It also fixes an issue where service VIP was not deleted on exit in ARP mode with global leader election. I think this should fix #1579.

I have also encountered a race condition in unit tests when accessing `kubeConfigPath` in `pkg/backend`, so I've added a mutex to fix that.