### PR TITLE
Honor the explicitly configured kubeconfig path in manager and backend health checks

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -21,6 +21,16 @@ type Entry struct {
 
 type Map map[Entry]bool
 
+// kubeConfigPath is an explicitly configured kubeconfig used by Check when
+// set; static pod deployments configure it since neither admin.conf nor
+// in-cluster config are available there.
+var kubeConfigPath string
+
+// SetKubeConfigPath configures the kubeconfig used by backend health checks.
+func SetKubeConfigPath(path string) {
+	kubeConfigPath = path
+}
+
 func (e *Entry) Check() bool {
 	var client *kubernetes.Clientset
 	var err error
@@ -38,6 +48,12 @@ func (e *Entry) Check() bool {
 	}
 
 	switch {
+	case kubeConfigPath != "" && utils.FileExists(kubeConfigPath):
+		config, err = k8s.NewRestConfig(kubeConfigPath, false, k8sAddr)
+		if err != nil {
+			log.Error("create k8s REST config", "path", kubeConfigPath, "err", err)
+			return false
+		}
 	case utils.FileExists(adminConfigPath):
 		config, err = k8s.NewRestConfig(adminConfigPath, false, k8sAddr)
 		if err != nil {

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -172,6 +172,7 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 			}
 		}
 
+		backend.SetKubeConfigPath(c.K8sConfigFile)
 		backend.Watch(ctx, c.BackendHealthCheckInterval, func() {
 			for i := range cluster.Network {
 				network := cluster.Network[i]

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -118,6 +118,20 @@ func New(ctx context.Context, configMap string, config *kubevip.Config) (*Manage
 	switch {
 	case config.LeaderElectionType == "etcd":
 		// Do nothing, we don't construct a k8s client for etcd leader election
+	case config.K8sConfigFile != "" && utils.FileExists(config.K8sConfigFile):
+		// An explicitly configured kubeconfig (k8s_config_file env or
+		// --k8sConfigPath) takes precedence over the well-known host paths.
+		// KubernetesAddr, when set, overrides the API endpoint - static pods
+		// on control plane hosts use it to reach their local API server
+		// instead of a VIP that may not be up yet.
+		clientConfig, err = k8s.NewRestConfig(config.K8sConfigFile, false, config.KubernetesAddr)
+		if err != nil {
+			return nil, fmt.Errorf("could not create k8s REST config from file %q: %w", config.K8sConfigFile, err)
+		}
+		if clientset, err = k8s.NewClientset(clientConfig); err != nil {
+			return nil, fmt.Errorf("could not create k8s clientset: %w", err)
+		}
+		log.Info("Using Kubernetes configuration from explicit file", "path", config.K8sConfigFile, "address", config.KubernetesAddr)
 	case utils.FileExists(adminConfigPath):
 		if config.KubernetesAddr != "" {
 			log.Info("k8s address", "address", config.KubernetesAddr)


### PR DESCRIPTION
`kubeConfigPath` from `--k8sConfigPath` is now ignored in manager.go and backend.go; we have noticed it when running a POC with kube-vip in routing table mode deployed as a static pod with kubeconfig in a custom path `/etc/kubernetes/kubeconfig`

The patch has been tested using out downstream fork of kube-vip.