### PR TITLE
Use endpointslices for all dualstack tests in ARP mode

### DIFF
--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -941,7 +941,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 					ConfigPath:            configPath,
 					SvcEnable:             "true",
 					SvcElectionEnable:     "true",
-					EnableEndpoints:       "true",
+					EnableEndpoints:       "false",
 					EnableNodeLabeling:    "false",
 					EnableServiceSecurity: "true",
 				}


### PR DESCRIPTION
The ARP e2e test for dualstack common-lease fails in the CI. I believe it's because it uses endpoints instead of endpointslices, unlike the other dualstack tests. This PR should fix this.