### PR TITLE
routing table mode: re-assert the VIP route on every healthy check cycle

### DIFF
--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -220,6 +220,16 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 							log.Warn(err.Error())
 						} else if err == nil && !(*backendMap)[entry] {
 							log.Info("added route", "route", network.PrepareRoute())
+						} else if err == nil || errors.Is(err, fs.ErrExist) {
+							// Re-assert the route on every healthy cycle: routing daemons
+							// (e.g. zebra) can miss the single netlink event for the route,
+							// leaving it unadvertised even though it exists in the kernel.
+							// RouteReplace is idempotent and regenerates that event.
+							if replaceErr := network.ReplaceRoute(); replaceErr != nil {
+								log.Warn("re-asserting route", "err", replaceErr)
+							} else {
+								log.Debug("re-asserted route", "route", network.PrepareRoute())
+							}
 						}
 
 						(*backendMap)[entry] = true

--- a/pkg/cluster/service_test.go
+++ b/pkg/cluster/service_test.go
@@ -345,6 +345,7 @@ func (m *mockNetwork) isPresent() bool {
 	return m.present
 }
 func (m *mockNetwork) AddRoute(bool) (bool, error)     { return false, nil }
+func (m *mockNetwork) ReplaceRoute() error             { return nil }
 func (m *mockNetwork) DeleteRoute() error              { return nil }
 func (m *mockNetwork) UpdateRoutes() (bool, error)     { return false, nil }
 func (m *mockNetwork) IsSet() (*netlink.Addr, error)   { return nil, nil }

--- a/pkg/vip/address.go
+++ b/pkg/vip/address.go
@@ -48,6 +48,7 @@ const (
 type Network interface {
 	AddIP(precheck bool, skipDAD bool, minLifetime ...int) (bool, error)
 	AddRoute(precheck bool) (bool, error)
+	ReplaceRoute() error
 	DeleteIP() (bool, error)
 	DeleteRoute() error
 	UpdateRoutes() (bool, error)
@@ -93,6 +94,11 @@ type network struct {
 	routeTable       int
 	routingTableType int
 	routingProtocol  int
+
+	// reassertToggle alternates the inert realm attribute between two values
+	// on every ReplaceRoute so each re-assertion is a real kernel change and
+	// therefore a netlink event visible to listening routing daemons.
+	reassertToggle bool
 
 	ipvsEnabled bool
 
@@ -358,6 +364,25 @@ func (configurator *network) routeExists(route *netlink.Route) (bool, error) {
 	}
 
 	return false, nil
+}
+
+// ReplaceRoute - (re-)assert the route in the route table. The kernel emits
+// no netlink notification for a no-op replace, so alternate an inert
+// attribute (the routing realm) to make every re-assertion a visible event:
+// routing daemons (e.g. FRR's zebra) can lose the original route event when
+// the same-prefix interface address is processed in the same netlink batch,
+// leaving the route in the kernel but never redistributed.
+func (configurator *network) ReplaceRoute() error {
+	configurator.link.Lock.Lock()
+	defer configurator.link.Lock.Unlock()
+	route := configurator.PrepareRoute()
+	configurator.reassertToggle = !configurator.reassertToggle
+	if configurator.reassertToggle {
+		route.Realm = 1
+	} else {
+		route.Realm = 2
+	}
+	return netlink.RouteReplace(route)
 }
 
 // DeleteRoute - Delete an IP address from a route table


### PR DESCRIPTION
In order to workaround https://github.com/FRRouting/frr/issues/22654 where zebra misses updates if multiple are bundled in the same netlink event, we are introducing a new mechanism.

On every cycle we are re-asserting the route with an idempotent RouteReplace. Because for a no-op replace kernel emits no notification, we are alternating the realm attribute on every cycle. Thanks to this, every re-asstertion is a real change which emits the notification.

Wire impact of this change is none. The prefix, nexthop, metric never change so BGP daemons do not send UPDATE to peers.

Another option was delete+add but that one would have a real wire impact if performed too slow.