### PR TITLE
Add an opt-in flag/env var to allow kube-vip to start when interface exists but is not up 

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -60,6 +60,7 @@ func init() {
 	// Basic flags
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.Interface, "interface", "", "Name of the interface to bind to")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.ServicesInterface, "serviceInterface", "", "Name of the interface to bind to (for services)")
+	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.AllowInterfaceNotUp, "allowInterfaceNotUp", false, "Allow kube-vip to start even if the interface is not up")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.VIP, "vip", "", "The Virtual IP address")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.VIPSubnet, "vipSubnet", "", "The Virtual IP address subnet e.g. /32 /24 /8 etc.. (Default to 32 for IPv4 and 128 for IPv6)")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.NodeName, "nodeName", "", "Name to be used for lease holder. Must be unique for each node/instance")

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -70,6 +70,16 @@ func ParseEnvironment(c *Config) error {
 		c.ServicesInterface = env
 	}
 
+	// Tolerate a down interface
+	env = os.Getenv(vipAllowInterfaceNotUp)
+	if env != "" {
+		b, err := strconv.ParseBool(env)
+		if err != nil {
+			return err
+		}
+		c.AllowInterfaceNotUp = b
+	}
+
 	// Find Kubernetes Leader Election configuration
 	env = os.Getenv(vipLeaderElection)
 	if env != "" {

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -48,6 +48,9 @@ const (
 	// vipServicesInterface - defines the interface that the service vips should bind too
 	vipServicesInterface = "vip_servicesinterface"
 
+	// vipAllowInterfaceNotUp - defines if kube-vip should tolerate a down interface
+	vipAllowInterfaceNotUp = "vip_allow_interface_not_up"
+
 	// vipSubnet - defines the subnet that the vip will use
 	vipSubnet = "vip_subnet"
 

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -233,6 +233,17 @@ func generatePodSpec(c *Config, image, imageVersion string, inCluster bool) (*co
 		newEnvironment = append(newEnvironment, svcInterface...)
 	}
 
+	// Tolerate a down interface
+	if c.AllowInterfaceNotUp {
+		allowIface := []corev1.EnvVar{
+			{
+				Name:  vipAllowInterfaceNotUp,
+				Value: strconv.FormatBool(c.AllowInterfaceNotUp),
+			},
+		}
+		newEnvironment = append(newEnvironment, allowIface...)
+	}
+
 	// If a subnet is required for the VIP
 	if c.VIPSubnet != "" {
 		// build environment variables

--- a/pkg/kubevip/config_manager.go
+++ b/pkg/kubevip/config_manager.go
@@ -1,6 +1,7 @@
 package kubevip
 
 import (
+	"errors"
 	"fmt"
 
 	log "log/slog"
@@ -11,6 +12,8 @@ import (
 const (
 	Auto = "auto"
 )
+
+var ErrInterfaceNotUp = errors.New("interface is not up")
 
 func (c *Config) CheckSubnetExists() error {
 	if c.VIPSubnet == "" && c.VIP != "" && c.Address == "" {
@@ -23,13 +26,21 @@ func (c *Config) CheckSubnetExists() error {
 func (c *Config) CheckInterface() error {
 	if c.Interface != "" {
 		if err := isValidInterface(c.Interface); err != nil {
-			return fmt.Errorf("%s is not valid interface, reason: %w", c.Interface, err)
+			if errors.Is(err, ErrInterfaceNotUp) && c.AllowInterfaceNotUp {
+				log.Warn("interface is not up, continuing as allowInterfaceNotUp is set", "interface", c.Interface)
+			} else {
+				return fmt.Errorf("%s is not valid interface, reason: %w", c.Interface, err)
+			}
 		}
 	}
 
 	if c.ServicesInterface != "" {
 		if err := isValidInterface(c.ServicesInterface); err != nil {
-			return fmt.Errorf("%s is not valid interface, reason: %w", c.ServicesInterface, err)
+			if errors.Is(err, ErrInterfaceNotUp) && c.AllowInterfaceNotUp {
+				log.Warn("interface is not up, continuing as allowInterfaceNotUp is set", "interface", c.ServicesInterface)
+			} else {
+				return fmt.Errorf("%s is not valid interface, reason: %w", c.ServicesInterface, err)
+			}
 		}
 	}
 
@@ -58,7 +69,7 @@ func isValidInterface(iface string) error {
 			iface,
 		)
 	} else if attrs.OperState != netlink.OperUp {
-		return fmt.Errorf("%s is not up", iface)
+		return fmt.Errorf("%s %w", iface, ErrInterfaceNotUp)
 	}
 
 	return nil

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -112,6 +112,9 @@ type Config struct {
 	// ServicesInterface is the network interface to bind to for services (optional)
 	ServicesInterface string `yaml:"servicesInterface,omitempty"`
 
+	// AllowInterfaceNotUp allows kube-vip to start even when the interface is not up
+	AllowInterfaceNotUp bool `yaml:"allowInterfaceNotUp,omitempty"`
+
 	// EnableLoadBalancer, provides the flexibility to make the load-balancer optional
 	EnableLoadBalancer bool `yaml:"enableLoadBalancer"`
 


### PR DESCRIPTION
Add an opt-in flag/env var ( `--allowInterfaceNotUp`  /  `vip_allow_interface_not_up` ) that lets kube-vip continue operating even when its bind interface exists but is not yet UP .

Currently, kube-vip fails immediately if the configured interface is down at startup. This can be problematic on single-node, edge, and bare-metal clusters where network interfaces may become operational only after kube-vip starts. In some cases this may be a transient condition that resolves on its own, so failing immediately isn't always desirable.

With this change, when `allowInterfaceNotUp` is enabled, kube-vip logs a warning and continues instead of erroring out.

This is disabled by default and introduces no change to existing behavior. Users who want the more tolerant startup behavior must explicitly opt in via the new flag or environment variable.
