### PR TITLE
Added force per-service election feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin
 testing/e2e/etcd/certs
 pkg/etcd/etcd.pid
 pkg/etcd/etcd-data
+testing/e2e/e2e.test

--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -172,6 +172,8 @@ func init() {
 
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EgressWithNftables, "egressWithNftables", true, "Use nftables-based egress implementation")
 
+	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.PerServiceElectionOnDemand, "perServiceElectionOnDemand", false, "Allow kube-vip to use per-service election for annotated services")
+
 	kubeVipCmd.AddCommand(kubeKubeadm)
 	kubeVipCmd.AddCommand(kubeManifest)
 	kubeVipCmd.AddCommand(kubeVipManager)

--- a/pkg/kubevip/annotations.go
+++ b/pkg/kubevip/annotations.go
@@ -71,6 +71,9 @@ const (
 	// Name of the service lease object
 	ServiceLease = "kube-vip.io/leaseName"
 
+	// Forces kube-vip to use per service election for this particular service
+	ForcePerServiceElection = "kube-vip.io/forcePerServiceElection"
+
 	// Allow service reconciliation even when no endpoints are present (Cluster policy only)
 	AllowReconcileWithoutEndpoints = "kube-vip.io/allow-reconcile-without-endpoints"
 

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -708,6 +708,15 @@ func ParseEnvironment(c *Config) error {
 		c.EgressWithNftables = b
 	}
 
+	env = os.Getenv(perServiceElectionOnDemand)
+	if env != "" {
+		b, err := strconv.ParseBool(env)
+		if err != nil {
+			return err
+		}
+		c.PerServiceElectionOnDemand = b
+	}
+
 	// check to see if we're using a specific path to the Kubernetes config file
 	env = os.Getenv(k8sConfigFile)
 	if env != "" {

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -66,6 +66,9 @@ const (
 	// egressWithNftables - enables using nftables over iptables
 	egressWithNftables = "egress_withnftables"
 
+	// perServiceElectionOnDemand - enables kube-vip to use per-service election for annotated services
+	perServiceElectionOnDemand = "per_service_election_on_demand"
+
 	/////////////////////////////////////
 	// TO DO:
 	// Determine how to tidy this mess up

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -221,6 +221,9 @@ type Config struct {
 
 	// DebounceTime defines how long will event debouncer wait for the events to arrive
 	DebounceTime string `yaml:"debounceTime"`
+
+	// PerServiceElectionOnDemand will enable kube-vip to handle services with per-service election when annotation is used
+	PerServiceElectionOnDemand bool `yaml:"perServiceElectionOnDemand"`
 }
 
 // KubernetesLeaderElection defines all of the settings for Kubernetes KubernetesLeaderElection

--- a/pkg/manager/worker/arp.go
+++ b/pkg/manager/worker/arp.go
@@ -59,7 +59,7 @@ func (a *ARP) StartServices(ctx context.Context) error {
 	// Start a services watcher (all kube-vip pods will watch services), upon a new service
 	// a lock based upon that service is created that they will all leaderElection on
 	if a.config.EnableServicesElection {
-		if err := a.PerServiceLeader(ctx); err != nil {
+		if err := a.PerServiceLeader(ctx, false); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/manager/worker/bgp.go
+++ b/pkg/manager/worker/bgp.go
@@ -103,7 +103,7 @@ func (b *BGP) ConfigureServices() {
 
 func (b *BGP) StartServices(ctx context.Context) error {
 	if b.config.EnableServicesElection {
-		if err := b.PerServiceLeader(ctx); err != nil {
+		if err := b.PerServiceLeader(ctx, false); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/manager/worker/common.go
+++ b/pkg/manager/worker/common.go
@@ -66,9 +66,14 @@ func (c *Common) InitControlPlane() error {
 	return nil
 }
 
-func (c *Common) PerServiceLeader(ctx context.Context) error {
-	log.Info("beginning watching services, leaderelection will happen for every service")
-	err := c.svcProcessor.StartServicesWatchForLeaderElection(ctx)
+func (c *Common) PerServiceLeader(ctx context.Context, forcedOnly bool) error {
+	if forcedOnly {
+		log.Info(fmt.Sprintf("beginning watching services, leaderelection will happen for services annotated with '%s = \"true\"'", kubevip.ForcePerServiceElection))
+	} else {
+		log.Info("beginning watching services, leaderelection will happen for every service")
+	}
+
+	err := c.svcProcessor.StartServicesWatchForLeaderElection(ctx, forcedOnly)
 	if err != nil {
 		return err
 	}
@@ -76,12 +81,42 @@ func (c *Common) PerServiceLeader(ctx context.Context) error {
 }
 
 func (c *Common) GlobalLeader(ctx context.Context, leaseName string) {
-	c.runGlobalElection(ctx, c, leaseName, c.config, c.electionMgr)
+	wg := sync.WaitGroup{}
+	defer wg.Wait()
+
+	servicesCtx, servicesCtxCancel := context.WithCancel(ctx)
+	defer servicesCtxCancel()
+
+	if c.config.PerServiceElectionOnDemand {
+		wg.Go(func() {
+			if err := c.PerServiceLeader(servicesCtx, true); err != nil {
+				log.Error("per-service leader election failed with", "error", err)
+				servicesCtxCancel()
+			}
+		})
+	}
+
+	c.runGlobalElection(servicesCtx, c, leaseName, c.config, c.electionMgr)
 }
 
 func (c *Common) ServicesNoLeader(ctx context.Context) error {
+	wg := sync.WaitGroup{}
+	defer wg.Wait()
+
+	servicesCtx, servicesCtxCancel := context.WithCancel(ctx)
+	defer servicesCtxCancel()
+
+	if c.config.PerServiceElectionOnDemand {
+		wg.Go(func() {
+			if err := c.PerServiceLeader(servicesCtx, true); err != nil {
+				log.Error("per-service leader election failed with", "error", err)
+				servicesCtxCancel()
+			}
+		})
+	}
+
 	log.Info("beginning watching services without leader election")
-	err := c.svcProcessor.ServicesWatcher(ctx, services.NewCallback(c.svcProcessor.SyncServices, false))
+	err := c.svcProcessor.ServicesWatcher(servicesCtx, services.NewCallback(c.svcProcessor.SyncServices, false), false)
 	if err != nil {
 		return fmt.Errorf("error while watching services: %w", err)
 	}
@@ -93,7 +128,7 @@ func (c *Common) Cleanup() {
 }
 
 func (c *Common) OnStartedLeading(ctx context.Context) {
-	err := c.svcProcessor.ServicesWatcher(ctx, services.NewCallback(c.svcProcessor.SyncServices, false))
+	err := c.svcProcessor.ServicesWatcher(ctx, services.NewCallback(c.svcProcessor.SyncServices, false), false)
 	if err != nil {
 		log.Error("service watcher", "err", err)
 		c.killFunc()
@@ -122,6 +157,7 @@ func (c *Common) OnNewLeader(identity string) {
 func (c *Common) runGlobalElection(ctx context.Context, a election.Actions, leaseName string,
 	config *kubevip.Config, electionManager *election.Manager) {
 
+	log.Debug("starting global election")
 	ns, leaseName := lease.NamespaceName(leaseName, config)
 
 	leaseID := lease.NewID(config.LeaderElectionType, ns, leaseName)

--- a/pkg/manager/worker/table.go
+++ b/pkg/manager/worker/table.go
@@ -70,7 +70,7 @@ func (t *Table) StartServices(ctx context.Context) error {
 	log.Debug("starting Services")
 
 	if t.config.EnableServicesElection {
-		if err := t.PerServiceLeader(ctx); err != nil {
+		if err := t.PerServiceLeader(ctx, false); err != nil {
 			return err
 		}
 	} else if t.config.EnableLeaderElection {

--- a/pkg/manager/worker/wireguard.go
+++ b/pkg/manager/worker/wireguard.go
@@ -104,7 +104,7 @@ func (w *WireGuard) ConfigureServices() {
 func (w *WireGuard) StartServices(ctx context.Context) error {
 	if w.config.EnableServicesElection {
 		log.Info("beginning watching services, leaderelection will happen for every service")
-		err := w.svcProcessor.StartServicesWatchForLeaderElection(ctx)
+		err := w.svcProcessor.StartServicesWatchForLeaderElection(ctx, false)
 		if err != nil {
 			return err
 		}
@@ -149,7 +149,7 @@ func (w *WireGuard) OnStartedLeading(ctx context.Context) {
 	})
 
 	if w.config.EnableServices && !w.config.EnableServicesElection {
-		if err := w.svcProcessor.ServicesWatcher(ctx, services.NewCallback(w.svcProcessor.SyncServices, false)); err != nil {
+		if err := w.svcProcessor.ServicesWatcher(ctx, services.NewCallback(w.svcProcessor.SyncServices, false), false); err != nil {
 			log.Error("failed to start services watcher", "err", err)
 		}
 	}

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -15,8 +15,8 @@ import (
 )
 
 // The StartServicesWatchForLeaderElection function will start a services watcher, the
-func (p *Processor) StartServicesWatchForLeaderElection(ctx context.Context) error {
-	err := p.ServicesWatcher(ctx, NewCallback(p.StartServicesLeaderElection, true))
+func (p *Processor) StartServicesWatchForLeaderElection(ctx context.Context, forcedOnly bool) error {
+	err := p.ServicesWatcher(ctx, NewCallback(p.StartServicesLeaderElection, true), forcedOnly)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -91,7 +91,7 @@ func NewServicesProcessor(config *kubevip.Config, bgpServer *bgp.Server,
 	}
 }
 
-func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceFunc *Callback, wg *sync.WaitGroup) error {
+func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceFunc *Callback, forcedOnly bool, wg *sync.WaitGroup) error {
 	svc, ok := event.Object.(*v1.Service)
 	if !ok {
 		return fmt.Errorf("unable to parse Kubernetes services from API watcher")
@@ -99,6 +99,11 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 
 	timer := prometheus.NewTimer(metrics.ServiceReconcileDuration.WithLabelValues(svc.Namespace))
 	defer timer.ObserveDuration()
+
+	if forcedOnly && svc.Annotations[kubevip.ForcePerServiceElection] != "true" ||
+		!forcedOnly && svc.Annotations[kubevip.ForcePerServiceElection] == "true" {
+		return nil
+	}
 
 	// We only care about LoadBalancer services
 	if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
@@ -284,10 +289,15 @@ func (p *Processor) waitForAddress(ctx context.Context, svc *v1.Service) (*v1.Se
 	}
 }
 
-func (p *Processor) Delete(event watch.Event) error {
+func (p *Processor) Delete(event watch.Event, forcedOnly bool) error {
 	svc, ok := event.Object.(*v1.Service)
 	if !ok {
 		return fmt.Errorf("(svcs) unable to parse Kubernetes services from API watcher")
+	}
+
+	if forcedOnly && svc.Annotations[kubevip.ForcePerServiceElection] != "true" ||
+		!forcedOnly && svc.Annotations[kubevip.ForcePerServiceElection] == "true" {
+		return nil
 	}
 
 	svcCtx, err := p.getServiceContext(svc.UID)

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -413,19 +413,19 @@ func (p *Processor) deleteService(ctx context.Context, uid types.UID) error {
 		}
 	}
 
-	if serviceInstance.LabelAdded {
-		labels := generateLabelsFromService(serviceInstance.ServiceSnapshot, kubevip.ServiceProvided)
-		if err := p.nodeLabelManager.RemoveLabel(labels); err != nil {
-			return fmt.Errorf("error removing label from node: %w", err)
-		}
-	}
-
 	// If we've been through all services and not found the correct one then error
 	if !found {
 		// TODO: - fix UX
 		// return fmt.Errorf("unable to find/stop service [%s]", uid)
 		log.Warn("unable to find/stop service", "uid", uid)
 		return nil
+	}
+
+	if serviceInstance.LabelAdded {
+		labels := generateLabelsFromService(serviceInstance.ServiceSnapshot, kubevip.ServiceProvided)
+		if err := p.nodeLabelManager.RemoveLabel(labels); err != nil {
+			return fmt.Errorf("error removing label from node: %w", err)
+		}
 	}
 
 	for _, c := range serviceInstance.Clusters {

--- a/pkg/services/watch_services.go
+++ b/pkg/services/watch_services.go
@@ -24,7 +24,7 @@ import (
 )
 
 // This function handles the watching of a services endpoints and updates a load balancers endpoint configurations accordingly
-func (p *Processor) ServicesWatcher(ctx context.Context, serviceFunc *Callback) error {
+func (p *Processor) ServicesWatcher(ctx context.Context, serviceFunc *Callback, forcedOnly bool) error {
 	// first start port mirroring if enabled
 	if err := p.startTrafficMirroringIfEnabled(); err != nil {
 		return err
@@ -102,7 +102,7 @@ func (p *Processor) ServicesWatcher(ctx context.Context, serviceFunc *Callback) 
 		// We need to inspect the event and get ResourceVersion out of it
 		switch event.Type {
 		case watch.Added, watch.Modified:
-			if err := p.AddOrModify(watcherCtx, event, serviceFunc, &wg); err != nil {
+			if err := p.AddOrModify(watcherCtx, event, serviceFunc, forcedOnly, &wg); err != nil {
 				if errors.Is(err, &utils.PanicError{}) {
 					return fmt.Errorf("add/modify service error: %w", err)
 				} else {
@@ -110,7 +110,7 @@ func (p *Processor) ServicesWatcher(ctx context.Context, serviceFunc *Callback) 
 				}
 			}
 		case watch.Deleted:
-			if err := p.Delete(event); err != nil {
+			if err := p.Delete(event, forcedOnly); err != nil {
 				if errors.Is(err, &utils.PanicError{}) {
 					return fmt.Errorf("delete service error: %w", err)
 				} else {

--- a/testing/e2e/e2e_bgp_ds_test.go
+++ b/testing/e2e/e2e_bgp_ds_test.go
@@ -84,18 +84,19 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when only control plane is enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "true",
-					VipElectionEnable:     "false",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "false",
-					SvcElectionEnable:     "false",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					BGPPeers:              "127.0.0.1:1::false",
-					BGPAS:                 2,
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "true",
+					VipElectionEnable:          "false",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "false",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					BGPPeers:                   "127.0.0.1:1::false",
+					BGPAS:                      2,
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -103,18 +104,19 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when only control plane is enabled with leader election", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "true",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "false",
-					SvcElectionEnable:     "false",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					BGPPeers:              "127.0.0.1:1::false",
-					BGPAS:                 2,
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "true",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "false",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					BGPPeers:                   "127.0.0.1:1::false",
+					BGPAS:                      2,
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -122,18 +124,19 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when only services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "false",
-					VipElectionEnable:     "false",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "false",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					BGPPeers:              "127.0.0.1:1::false",
-					BGPAS:                 2,
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "false",
+					VipElectionEnable:          "false",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					BGPPeers:                   "127.0.0.1:1::false",
+					BGPAS:                      2,
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -141,18 +144,19 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when only services are enabled with leader election", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "false",
-					VipElectionEnable:     "false",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "true",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					BGPPeers:              "127.0.0.1:1::false",
-					BGPAS:                 2,
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "false",
+					VipElectionEnable:          "false",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "true",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					BGPPeers:                   "127.0.0.1:1::false",
+					BGPAS:                      2,
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -160,18 +164,19 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when control plane services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "true",
-					VipElectionEnable:     "false",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "false",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					BGPPeers:              "127.0.0.1:1::false",
-					BGPAS:                 2,
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "true",
+					VipElectionEnable:          "false",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					BGPPeers:                   "127.0.0.1:1::false",
+					BGPAS:                      2,
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -179,18 +184,19 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when control plane w/ leader election and services w/o leader election are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "true",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "false",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					BGPPeers:              "127.0.0.1:1::false",
-					BGPAS:                 2,
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "true",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					BGPPeers:                   "127.0.0.1:1::false",
+					BGPAS:                      2,
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -198,18 +204,19 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when control plane w/o leader election and services w/ leader election are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "true",
-					VipElectionEnable:     "false",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "true",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					BGPPeers:              "127.0.0.1:1::false",
-					BGPAS:                 2,
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "true",
+					VipElectionEnable:          "false",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "true",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					BGPPeers:                   "127.0.0.1:1::false",
+					BGPAS:                      2,
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -217,18 +224,19 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when control plane and services w/ leader election are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "true",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "true",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					BGPPeers:              "127.0.0.1:1::false",
-					BGPAS:                 2,
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "true",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "true",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					BGPPeers:                   "127.0.0.1:1::false",
+					BGPAS:                      2,
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -267,17 +275,18 @@ var _ = Describe("kube-vip BGP when deployed as a regular pod", Ordered, func() 
 
 			It(clusterName+" exits gracefully when unnumbered BGP peers are configured", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:               Mode,
-					ControlPlaneEnable: "true",
-					VipElectionEnable:  "false",
-					ImagePath:          imagePath,
-					ConfigPath:         configPath,
-					SvcEnable:          "true",
-					SvcElectionEnable:  "false",
-					EnableEndpoints:    "false",
-					EnableNodeLabeling: "false",
-					BGPPeers:           "unnumbered:eth0",
-					BGPAS:              2,
+					Mode:                       Mode,
+					ControlPlaneEnable:         "true",
+					VipElectionEnable:          "false",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					BGPPeers:                   "unnumbered:eth0",
+					BGPAS:                      2,
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv6Family, clusterName)

--- a/testing/e2e/e2e_bgp_test.go
+++ b/testing/e2e/e2e_bgp_test.go
@@ -72,7 +72,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, utils.IPv4Family, utils.IPv4Family,
 					[]string{utils.IPv4Family}, &gobgpPeers,
-					&gobgpClient, logger, nodesNumber, "", "bgp-cp-ipv4", false, true, false)
+					&gobgpClient, logger, nodesNumber, "", "bgp-cp-ipv4", false, true, false, false)
 			})
 
 			AfterAll(func() {
@@ -103,7 +103,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, utils.IPv6Family, utils.IPv6Family,
 					[]string{utils.IPv6Family}, &gobgpPeers,
-					&gobgpClient, logger, nodesNumber, "", "bgp-cp-ipv4", false, true, false)
+					&gobgpClient, logger, nodesNumber, "", "bgp-cp-ipv4", false, true, false, false)
 			})
 
 			AfterAll(func() {
@@ -135,7 +135,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamily, utils.IPv4Family,
 					[]string{utils.IPv4Family}, &gobgpPeers,
-					&gobgpClient, logger, nodesNumber, "fixed", "cp-mpbgp-ipv4", false, true, false)
+					&gobgpClient, logger, nodesNumber, "fixed", "cp-mpbgp-ipv4", false, true, false, false)
 			})
 
 			AfterAll(func() {
@@ -167,7 +167,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamilyIPv6, utils.IPv6Family,
 					[]string{utils.IPv6Family}, &gobgpPeers,
-					&gobgpClient, logger, nodesNumber, "fixed", "cp-mpbgp-ipv6", false, true, false)
+					&gobgpClient, logger, nodesNumber, "fixed", "cp-mpbgp-ipv6", false, true, false, false)
 			})
 
 			AfterAll(func() {
@@ -198,7 +198,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, utils.IPv4Family, utils.IPv4Family,
 					[]string{utils.IPv4Family}, &gobgpPeers,
-					&gobgpClient, logger, nodesNumber, "", "bgp-ipv4", false, false, true)
+					&gobgpClient, logger, nodesNumber, "", "bgp-ipv4", false, false, true, false)
 			})
 
 			AfterAll(func() {
@@ -227,6 +227,42 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 		})
 
+		Describe("kube-vip IPv4 services BGP mode functionality with mixed election", Ordered, func() {
+			var (
+				cpVIP       string
+				kindCluster *e2e.Cluster
+				gobgpClient api.GoBgpServiceClient
+				gobgpPeers  []*e2e.BGPPeerValues
+				tempDirPath string
+				nodesNumber = 1
+			)
+
+			BeforeAll(func() {
+				tempDirPath = MustMkdirTemp(server.TempDir, testDirPrefix)
+				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
+					server, utils.IPv4Family, utils.IPv4Family,
+					[]string{utils.IPv4Family}, &gobgpPeers,
+					&gobgpClient, logger, nodesNumber, "", "bgp-ipv4-mixed", false, false, true, true)
+			})
+
+			AfterAll(func() {
+				SaveLogsAndCleanup(ctx, kindCluster.Client, tempDirPath, kindCluster.Name, func() {
+					server.RemovePeers(ctx, gobgpPeers)
+					kindCluster.Delete()
+				})
+			})
+
+			DescribeTable("advertise IPv4 routes for services",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					testBGPMixedElection(ctx, offset, utils.IPv4Family, api.Family_AFI_IP,
+						[]corev1.IPFamily{corev1.IPv4Protocol}, svcName,
+						trafficPolicy, kindCluster.Client, gobgpClient, "")
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+		})
+
 		Describe("kube-vip IPv6 services BGP mode functionality", Ordered, func() {
 			var (
 				cpVIP       string
@@ -242,7 +278,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, utils.IPv6Family, utils.IPv6Family,
 					[]string{utils.IPv6Family}, &gobgpPeers,
-					&gobgpClient, logger, nodesNumber, "", "bgp-ipv4", false, false, true)
+					&gobgpClient, logger, nodesNumber, "", "bgp-ipv4", false, false, true, false)
 			})
 
 			AfterAll(func() {
@@ -271,6 +307,42 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			)
 		})
 
+		Describe("kube-vip IPv6 services BGP mode functionality with mixed election", Ordered, func() {
+			var (
+				cpVIP       string
+				kindCluster *e2e.Cluster
+				gobgpClient api.GoBgpServiceClient
+				gobgpPeers  []*e2e.BGPPeerValues
+				tempDirPath string
+				nodesNumber = 1
+			)
+
+			BeforeAll(func() {
+				tempDirPath = MustMkdirTemp(server.TempDir, testDirPrefix)
+				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
+					server, utils.IPv6Family, utils.IPv6Family,
+					[]string{utils.IPv6Family}, &gobgpPeers,
+					&gobgpClient, logger, nodesNumber, "", "bgp-ipv6-mixed", false, false, true, true)
+			})
+
+			AfterAll(func() {
+				SaveLogsAndCleanup(ctx, kindCluster.Client, tempDirPath, kindCluster.Name, func() {
+					server.RemovePeers(ctx, gobgpPeers)
+					kindCluster.Delete()
+				})
+			})
+
+			DescribeTable("advertise IPv6 routes for services",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					testBGPMixedElection(ctx, offset, utils.IPv6Family, api.Family_AFI_IP6,
+						[]corev1.IPFamily{corev1.IPv6Protocol}, svcName,
+						trafficPolicy, kindCluster.Client, gobgpClient, "")
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+		})
+
 		Describe("kube-vip DualStack services BGP mode functionality with MP-BGP IPv6 over IPv4 - fixed nexthop", Ordered, func() {
 			var (
 				cpVIP       string
@@ -286,7 +358,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamily, utils.IPv4Family,
 					[]string{utils.IPv4Family}, &gobgpPeers,
-					&gobgpClient, logger, nodesNumber, "fixed", "mpbgp-ipv4", false, false, true)
+					&gobgpClient, logger, nodesNumber, "fixed", "mpbgp-ipv4", false, false, true, false)
 			})
 
 			AfterAll(func() {
@@ -330,7 +402,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamilyIPv6, utils.IPv6Family,
 					[]string{utils.IPv6Family}, &gobgpPeers,
-					&gobgpClient, logger, nodesNumber, "fixed", "mpbgp-ipv6", false, false, true)
+					&gobgpClient, logger, nodesNumber, "fixed", "mpbgp-ipv6", false, false, true, false)
 			})
 
 			AfterAll(func() {
@@ -375,7 +447,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 				kindCluster, _, containerIP = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamily, utils.IPv4Family,
 					[]string{utils.IPv4Family}, &gobgpPeers,
-					&gobgpClient, logger, nodesNumber, "auto_sourceif", "mpbgp-if-ipv4", false, false, true)
+					&gobgpClient, logger, nodesNumber, "auto_sourceif", "mpbgp-if-ipv4", false, false, true, false)
 			})
 
 			AfterAll(func() {
@@ -420,7 +492,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 				kindCluster, containerIP, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamilyIPv6, utils.IPv6Family,
 					[]string{utils.IPv6Family}, &gobgpPeers,
-					&gobgpClient, logger, nodesNumber, "auto_sourceif", "mpbgp-if-ipv6", false, false, true)
+					&gobgpClient, logger, nodesNumber, "auto_sourceif", "mpbgp-if-ipv6", false, false, true, false)
 			})
 
 			AfterAll(func() {
@@ -464,7 +536,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, utils.IPv4Family, utils.IPv4Family,
 					[]string{utils.IPv4Family}, &gobgpPeers,
-					&gobgpClient, logger, nodesNumber, "", "bgp-ipv4", true, false, true)
+					&gobgpClient, logger, nodesNumber, "", "bgp-ipv4", true, false, true, false)
 			})
 
 			AfterAll(func() {
@@ -516,7 +588,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, utils.IPv6Family, utils.IPv6Family,
 					[]string{utils.IPv6Family}, &gobgpPeers,
-					&gobgpClient, logger, nodesNumber, "", "bgp-ipv4", true, false, true)
+					&gobgpClient, logger, nodesNumber, "", "bgp-ipv4", true, false, true, false)
 			})
 
 			AfterAll(func() {
@@ -568,7 +640,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamily, utils.IPv4Family,
 					[]string{utils.IPv4Family}, &gobgpPeers,
-					&gobgpClient, logger, nodesNumber, "fixed", "mpbgp-ipv4", true, false, true)
+					&gobgpClient, logger, nodesNumber, "fixed", "mpbgp-ipv4", true, false, true, false)
 			})
 
 			AfterAll(func() {
@@ -620,7 +692,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamilyIPv6, utils.IPv6Family,
 					[]string{utils.IPv6Family}, &gobgpPeers,
-					&gobgpClient, logger, nodesNumber, "fixed", "mpbgp-ipv6", true, false, true)
+					&gobgpClient, logger, nodesNumber, "fixed", "mpbgp-ipv6", true, false, true, false)
 			})
 
 			AfterAll(func() {
@@ -673,7 +745,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 				kindCluster, _, containerIP = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamily, utils.IPv4Family,
 					[]string{utils.IPv4Family}, &gobgpPeers,
-					&gobgpClient, logger, nodesNumber, "auto_sourceif", "mpbgp-if-ipv4", true, false, true)
+					&gobgpClient, logger, nodesNumber, "auto_sourceif", "mpbgp-if-ipv4", true, false, true, false)
 			})
 
 			AfterAll(func() {
@@ -726,7 +798,7 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 				kindCluster, containerIP, _ = setupEnv(ctx, &cpVIP,
 					server, e2e.DualstackFamilyIPv6, utils.IPv6Family,
 					[]string{utils.IPv6Family}, &gobgpPeers,
-					&gobgpClient, logger, nodesNumber, "auto_sourceif", "mpbgp-if-ipv6", true, false, true)
+					&gobgpClient, logger, nodesNumber, "auto_sourceif", "mpbgp-if-ipv6", true, false, true, false)
 			})
 
 			AfterAll(func() {
@@ -829,12 +901,29 @@ func testBGP(ctx context.Context, offset uint, lbFamily string, afiFamily api.Fa
 	testServiceBGP(ctx, svcName, lbAddress, trafficPolicy, client, svcFamily, numberOfServices, gobgpClient, routeCheckFamily, expectedNexthop, serviceLease)
 }
 
+func testBGPMixedElection(ctx context.Context, offset uint, lbFamily string, afiFamily api.Family_Afi, svcFamily []corev1.IPFamily,
+	svcName string, trafficPolicy corev1.ServiceExternalTrafficPolicy, client kubernetes.Interface,
+	gobgpClient api.GoBgpServiceClient, expectedNexthop string,
+) {
+	lbAddresses := []string{}
+	for range 2 {
+		lbAddresses = append(lbAddresses, e2e.GenerateVIP(lbFamily, offset, defaultNetwork))
+	}
+	routeCheckFamily := &api.Family{
+		Afi:  afiFamily,
+		Safi: api.Family_SAFI_UNICAST,
+	}
+	testServiceBGPMixedElection(ctx, svcName, lbAddresses,
+		"plndr-svcs-lock", "kube-system", fmt.Sprintf("kubevip-%s", svcName), dsNamespace,
+		trafficPolicy, client, svcFamily, 1, 1, gobgpClient, routeCheckFamily, expectedNexthop)
+}
+
 func setupEnv(ctx context.Context, cpVIP *string,
 	server *bgp.Server, clusterAddrFamily, bgpClientAddrFamily string,
 	peerAddrFamily []string, gobgpPeers *[]*e2e.BGPPeerValues,
 	gobgpClient *api.GoBgpServiceClient, logger log.Logger,
 	nodesNumber int, mpbgpnexthop, clusterNameSuffix string,
-	serviceElection, cpEnable, svcEnable bool,
+	serviceElection, cpEnable, svcEnable, perServiceElectionOnDemand bool,
 ) (*e2e.Cluster, string, string) {
 	*cpVIP = e2e.GenerateVIP(clusterAddrFamily, SOffset.Get(), defaultNetwork)
 
@@ -868,17 +957,18 @@ func setupEnv(ctx context.Context, cpVIP *string,
 	}
 
 	manifestValues := e2e.KubevipManifestValues{
-		ControlPlaneVIP:       *cpVIP,
-		ControlPlaneEnable:    fmt.Sprintf("%t", cpEnable),
-		SvcEnable:             fmt.Sprintf("%t", svcEnable),
-		SvcElectionEnable:     fmt.Sprintf("%t", serviceElection),
-		EnableNodeLabeling:    "false",
-		BGPAS:                 bgp.KubevipAS,
-		BGPPeers:              bgp.PeerStrings(kvPeers),
-		MPBGPNexthop:          mpbgpnexthop,
-		MPBGPNexthopIPv4:      defaultFixedNexthopv4,
-		MPBGPNexthopIPv6:      defaultFixedNexthopv6,
-		EnableServiceSecurity: "true",
+		ControlPlaneVIP:            *cpVIP,
+		ControlPlaneEnable:         fmt.Sprintf("%t", cpEnable),
+		SvcEnable:                  fmt.Sprintf("%t", svcEnable),
+		SvcElectionEnable:          fmt.Sprintf("%t", serviceElection),
+		EnableNodeLabeling:         "false",
+		BGPAS:                      bgp.KubevipAS,
+		BGPPeers:                   bgp.PeerStrings(kvPeers),
+		MPBGPNexthop:               mpbgpnexthop,
+		MPBGPNexthopIPv4:           defaultFixedNexthopv4,
+		MPBGPNexthopIPv6:           defaultFixedNexthopv6,
+		EnableServiceSecurity:      "true",
+		PerServiceElectionOnDemand: fmt.Sprintf("%t", perServiceElectionOnDemand),
 	}
 
 	By(manifestValues.BGPPeers)
@@ -926,7 +1016,7 @@ func testServiceBGP(ctx context.Context, svcName, lbAddress string, trafficPolic
 
 	for _, svc := range services {
 		createTestService(ctx, svc, dsNamespace, dsName, lbAddress,
-			client, corev1.IPFamilyPolicyPreferDualStack, serviceAddrFamily, trafficPolicy, serviceLease, 80, false)
+			client, corev1.IPFamilyPolicyPreferDualStack, serviceAddrFamily, trafficPolicy, serviceLease, 80, false, false)
 		time.Sleep(time.Second)
 	}
 
@@ -963,6 +1053,85 @@ func testServiceBGP(ctx context.Context, svcName, lbAddress string, trafficPolic
 	for _, addr := range lbAddresses {
 		By(withTimestamp(fmt.Sprintf("checking bgp route for address %q - should be deleted", addr)))
 		bgp.CheckPaths(ctx, gobgpClient, gobgpFamily, []*api.TableLookupPrefix{{Prefix: addr}}, 0)
+	}
+}
+
+func testServiceBGPMixedElection(ctx context.Context, svcName string, lbAddress []string,
+	globalLeaseName, globalLeaseNamespace, leaseName, leaseNamespace string,
+	trafficPolicy corev1.ServiceExternalTrafficPolicy,
+	client kubernetes.Interface, serviceAddrFamily []corev1.IPFamily,
+	numberOfGlobalServices, numberOfElectedServices int,
+	gobgpClient api.GoBgpServiceClient, gobgpFamily *api.Family, expectedNexthop string,
+) {
+	services := []serviceWithLease{}
+	for i := range numberOfGlobalServices {
+		services = append(services, serviceWithLease{
+			name:           fmt.Sprintf("%s-global-%d", svcName, i),
+			lease:          globalLeaseName,
+			leaseNamespace: globalLeaseNamespace,
+			election:       false,
+			lbAddress:      lbAddress[i],
+		})
+	}
+
+	for i := range numberOfElectedServices {
+		services = append(services, serviceWithLease{
+			name:           fmt.Sprintf("%s-%d", svcName, i),
+			lease:          fmt.Sprintf("%s-%d", leaseName, i),
+			leaseNamespace: leaseNamespace,
+			election:       true,
+			lbAddress:      lbAddress[i+numberOfGlobalServices],
+		})
+	}
+
+	for _, svc := range services {
+		svcLease := ""
+		if svc.election && trafficPolicy != corev1.ServiceExternalTrafficPolicyLocal {
+			svcLease = svc.lease
+		}
+		createTestService(ctx, svc.name, dsNamespace, dsName, svc.lbAddress,
+			client, corev1.IPFamilyPolicyPreferDualStack, serviceAddrFamily, trafficPolicy, svcLease, 80, false, svc.election)
+		time.Sleep(time.Second)
+	}
+
+	for _, svc := range services {
+		if svc.election {
+			Expect(e2e.CheckLeasePresence(ctx, svc.lease, svc.leaseNamespace, client, true)).ToNot(BeNil())
+		}
+
+		for addr := range strings.SplitSeq(svc.lbAddress, ",") {
+			By(withTimestamp(fmt.Sprintf("checking bgp route for address %q", addr)))
+			paths := bgp.CheckPaths(ctx, gobgpClient, gobgpFamily, []*api.TableLookupPrefix{{Prefix: addr}}, 1)
+			Expect(paths).ToNot(BeNil())
+			Expect(paths).ToNot(BeEmpty())
+			Expect(strings.Contains(paths[0].Prefix, addr)).To(BeTrue())
+			if expectedNexthop != "" {
+				Expect(strings.Contains(paths[0].String(), fmt.Sprintf("next_hop:\"%s\"", expectedNexthop)) || strings.Contains(paths[0].String(), fmt.Sprintf("next_hops:\"%s\"", expectedNexthop))).To(BeTrue())
+			}
+		}
+	}
+
+	for i, svc := range services {
+		By(withTimestamp(fmt.Sprintf("deleting service '%s/%s'", dsNamespace, svc.name)))
+		err := client.CoreV1().Services(dsNamespace).Delete(ctx, svc.name, metav1.DeleteOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		time.Sleep(time.Second)
+
+		for addr := range strings.SplitSeq(svc.lbAddress, ",") {
+			if i < len(services)-1 {
+				By(withTimestamp(fmt.Sprintf("checking bgp route for address %q", addr)))
+				paths := bgp.CheckPaths(ctx, gobgpClient, gobgpFamily, []*api.TableLookupPrefix{{Prefix: addr}}, 1)
+				Expect(paths).ToNot(BeNil())
+				Expect(paths).ToNot(BeEmpty())
+				Expect(strings.Contains(paths[0].Prefix, addr)).To(BeTrue())
+				if expectedNexthop != "" {
+					Expect(strings.Contains(paths[0].String(), fmt.Sprintf("next_hop:\"%s\"", expectedNexthop)) || strings.Contains(paths[0].String(), fmt.Sprintf("next_hops:\"%s\"", expectedNexthop))).To(BeTrue())
+				}
+			} else {
+				By(withTimestamp(fmt.Sprintf("checking bgp route for address %q - should be deleted", addr)))
+				bgp.CheckPaths(ctx, gobgpClient, gobgpFamily, []*api.TableLookupPrefix{{Prefix: addr}}, 0)
+			}
+		}
 	}
 }
 

--- a/testing/e2e/e2e_ds_test.go
+++ b/testing/e2e/e2e_ds_test.go
@@ -94,16 +94,17 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv4 addresses on exit when only control plane is enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "true",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "false",
-					SvcElectionEnable:     "false",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "true",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "false",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -111,16 +112,17 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv4 addresses on exit when only services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "false",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "false",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "false",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -128,16 +130,17 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv4 addresses on exit when only services with per-service leaderelection are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "false",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "true",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "false",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "true",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -145,16 +148,17 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv4 addresses on exit when control-plane and services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "true",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "false",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "true",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -162,16 +166,17 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv4 addresses on exit when control plane and services with per-service leaderelection are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "true",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "true",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "true",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "true",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -179,16 +184,17 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" is able to pick up leaderelection when all endpoints for the service were deleted", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "false",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "true",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "false",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "true",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testEndpoints(ctx, manifestValues, client, utils.IPv4Family, clusterName, corev1.ServiceExternalTrafficPolicyLocal)
@@ -226,16 +232,17 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv6 addresses on exit when only control plane is enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "true",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "false",
-					SvcElectionEnable:     "false",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "true",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "false",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv6Family, clusterName)
@@ -243,16 +250,17 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv6 addresses on exit when only services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "false",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "false",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "false",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv6Family, clusterName)
@@ -260,16 +268,17 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv6 addresses on exit when only services with per-service leaderelection are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "false",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "true",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "false",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "true",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv6Family, clusterName)
@@ -277,16 +286,17 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv6 addresses on exit when control-plane and services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "true",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "false",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "true",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv6Family, clusterName)
@@ -294,16 +304,17 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all IPv6 addresses on exit when control plane and services with per-service leaderelection are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "true",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "true",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "true",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "true",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv6Family, clusterName)
@@ -311,16 +322,17 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" is able to pick up leaderelection when all endpoints for the service were deleted", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "false",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "true",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "false",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "true",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testEndpoints(ctx, manifestValues, client, utils.IPv6Family, clusterName, corev1.ServiceExternalTrafficPolicyLocal)
@@ -358,16 +370,17 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all addresses on exit when only control plane is enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "true",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "false",
-					SvcElectionEnable:     "false",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "true",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "false",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.DualFamily, clusterName)
@@ -375,16 +388,17 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all addresses on exit when only services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "false",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "false",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "false",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.DualFamily, clusterName)
@@ -392,16 +406,17 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all addresses on exit when only services with per-service leaderelection are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "false",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "true",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "false",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "true",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.DualFamily, clusterName)
@@ -409,16 +424,17 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all addresses on exit when control-plane and services are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "true",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "false",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "true",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.DualFamily, clusterName)
@@ -426,16 +442,17 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" deletes all addresses on exit when control plane and services with per-service leaderelection are enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "true",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "true",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "true",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "true",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.DualFamily, clusterName)
@@ -443,16 +460,17 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor when deployed as a regular
 
 			It(clusterName+" is able to pick up leaderelection when all endpoints for the service were deleted", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "false",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "true",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "false",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "true",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testEndpoints(ctx, manifestValues, client, utils.DualFamily, clusterName, corev1.ServiceExternalTrafficPolicyLocal)
@@ -818,6 +836,10 @@ func createKubeVipDS(ctx context.Context, name, namespace string, manifestValues
 									Name:  "enable_service_security",
 									Value: "true",
 								},
+								{
+									Name:  "per_service_election_on_demand",
+									Value: manifestValues.PerServiceElectionOnDemand,
+								},
 							},
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
@@ -1000,7 +1022,7 @@ func createTestServiceForDS(ctx context.Context, svcName, lbAddress, leaseName s
 
 	for _, svc := range services {
 		createTestService(ctx, svc, dsNamespace, dsName, lbAddress,
-			client, corev1.IPFamilyPolicyPreferDualStack, ipFamily, trafficPolicy, "", 80, false)
+			client, corev1.IPFamilyPolicyPreferDualStack, ipFamily, trafficPolicy, "", 80, false, false)
 		time.Sleep(time.Second)
 	}
 

--- a/testing/e2e/e2e_rt_ds_test.go
+++ b/testing/e2e/e2e_rt_ds_test.go
@@ -86,29 +86,12 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 
 			It(clusterName+" exits gracefully on exit when only control plane is enabled", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "true",
-					VipElectionEnable:     "false",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "false",
-					SvcElectionEnable:     "false",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
-				}
-
-				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
-			})
-
-			It(clusterName+" exits gracefully on exit when only services are enabled without leaderelection", func() {
-				manifestValues := &e2e.KubevipManifestValues{
 					Mode:               Mode,
-					ControlPlaneEnable: "false",
+					ControlPlaneEnable: "true",
 					VipElectionEnable:  "false",
 					ImagePath:          imagePath,
 					ConfigPath:         configPath,
-					SvcEnable:          "true",
+					SvcEnable:          "false",
 					SvcElectionEnable:  "false",
 					EnableEndpoints:    "false",
 					EnableNodeLabeling: "false",
@@ -117,18 +100,36 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
 			})
 
+			It(clusterName+" exits gracefully on exit when only services are enabled without leaderelection", func() {
+				manifestValues := &e2e.KubevipManifestValues{
+					Mode:                       Mode,
+					ControlPlaneEnable:         "false",
+					VipElectionEnable:          "false",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					PerServiceElectionOnDemand: "true",
+				}
+
+				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
+			})
+
 			It(clusterName+" exits gracefully on exit when only services are enabled with leaderelection", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "false",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "false",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "false",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -136,16 +137,17 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 
 			It(clusterName+" exits gracefully on exit when only services are enabled with leaderelection per service", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "false",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "true",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "false",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "true",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -153,16 +155,17 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 
 			It(clusterName+" exits gracefully on exit when control-plane and services are enabled without leaderelection", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "true",
-					VipElectionEnable:     "false",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "false",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "true",
+					VipElectionEnable:          "false",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -170,16 +173,17 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 
 			It(clusterName+" exits gracefully on exit when control-plane and services are enabled with leaderelection", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "true",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "false",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "true",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)
@@ -187,16 +191,17 @@ var _ = Describe("kube-vip RT functionality when deployed as a regular pod", Ord
 
 			It(clusterName+" exits gracefully when control-plane and services are enabled with leaderelection per service", func() {
 				manifestValues := &e2e.KubevipManifestValues{
-					Mode:                  Mode,
-					ControlPlaneEnable:    "true",
-					VipElectionEnable:     "true",
-					ImagePath:             imagePath,
-					ConfigPath:            configPath,
-					SvcEnable:             "true",
-					SvcElectionEnable:     "true",
-					EnableEndpoints:       "false",
-					EnableNodeLabeling:    "false",
-					EnableServiceSecurity: "true",
+					Mode:                       Mode,
+					ControlPlaneEnable:         "true",
+					VipElectionEnable:          "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "true",
+					EnableEndpoints:            "false",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
 				}
 
 				testDS(ctx, manifestValues, client, utils.IPv4Family, clusterName)

--- a/testing/e2e/e2e_rt_test.go
+++ b/testing/e2e/e2e_rt_test.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"text/template"
 	"time"
 
@@ -553,7 +554,7 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
 
-				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-svc-ipv4", k8sImagePath, v129,
+				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-svc-ipv4-no-election", k8sImagePath, v129,
 					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
 			})
 
@@ -578,6 +579,69 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 2, false, dsNumber, false)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+		})
+
+		Describe("kube-vip IPv4 services routing table mode functionality with mixed election", Ordered, func() {
+			var (
+				cpVIP       string
+				clusterName string
+				client      kubernetes.Interface
+				svcElection bool
+				ipFamily    []corev1.IPFamily
+				tempDirPath string
+
+				nodesNumber = 1
+			)
+
+			BeforeAll(func() {
+				cpVIP = e2e.GenerateVIP(utils.IPv4Family, SOffset.Get(), defaultNetwork)
+
+				networking := &kindconfigv1alpha4.Networking{
+					IPFamily: kindconfigv1alpha4.IPv4Family,
+				}
+
+				manifestValues := &e2e.KubevipManifestValues{
+					ControlPlaneVIP:            cpVIP,
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					ControlPlaneEnable:         "false",
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					VipElectionEnable:          "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
+				}
+
+				var err error
+				svcElection, err = strconv.ParseBool(manifestValues.SvcElectionEnable)
+				Expect(err).ToNot(HaveOccurred())
+
+				ipFamily = []corev1.IPFamily{corev1.IPv4Protocol}
+
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
+
+				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-svc-ipv4-mixed", k8sImagePath, v129,
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
+			})
+
+			AfterAll(func() {
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
+			})
+
+			DescribeTable("configures an IPv4 routes for services",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddresses := []string{}
+					for range 2 {
+						lbAddresses = append(lbAddresses, e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork))
+					}
+					testServiceRTMixedElection(ctx, svcName, lbAddresses, "plndr-svcs-lock", "kube-system", fmt.Sprintf("kubevip-%s", svcName), dsNamespace,
+						trafficPolicy, client, svcElection, ipFamily, 1, 1, dsNumber, false, clusterName)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -646,6 +710,69 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					lbAddress := e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 2, false, dsNumber, false)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+		})
+
+		Describe("kube-vip IPv6 services routing table mode functionality with mixed election", Ordered, func() {
+			var (
+				cpVIP       string
+				clusterName string
+				client      kubernetes.Interface
+				svcElection bool
+				ipFamily    []corev1.IPFamily
+				tempDirPath string
+
+				nodesNumber = 1
+			)
+
+			BeforeAll(func() {
+				cpVIP = e2e.GenerateVIP(utils.IPv6Family, SOffset.Get(), defaultNetwork)
+
+				networking := &kindconfigv1alpha4.Networking{
+					IPFamily: kindconfigv1alpha4.IPv6Family,
+				}
+
+				manifestValues := &e2e.KubevipManifestValues{
+					ControlPlaneVIP:            cpVIP,
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					ControlPlaneEnable:         "false",
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					VipElectionEnable:          "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
+				}
+
+				var err error
+				svcElection, err = strconv.ParseBool(manifestValues.SvcElectionEnable)
+				Expect(err).ToNot(HaveOccurred())
+
+				ipFamily = []corev1.IPFamily{corev1.IPv6Protocol}
+
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
+
+				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-svc-ipv6-mixed", k8sImagePath, v129,
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
+			})
+
+			AfterAll(func() {
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
+			})
+
+			DescribeTable("configures an IPv6 routes for services",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddresses := []string{}
+					for range 2 {
+						lbAddresses = append(lbAddresses, e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork))
+					}
+					testServiceRTMixedElection(ctx, svcName, lbAddresses, "plndr-svcs-lock", "kube-system", fmt.Sprintf("kubevip-%s", svcName), dsNamespace,
+						trafficPolicy, client, svcElection, ipFamily, 1, 1, dsNumber, false, clusterName)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -721,6 +848,69 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 			)
 		})
 
+		Describe("kube-vip DualStack services routing table mode functionality with mixed election - IPv4 primary", Ordered, func() {
+			var (
+				cpVIP       string
+				clusterName string
+				client      kubernetes.Interface
+				svcElection bool
+				ipFamily    []corev1.IPFamily
+				tempDirPath string
+
+				nodesNumber = 1
+			)
+
+			BeforeAll(func() {
+				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get(), defaultNetwork)
+
+				networking := &kindconfigv1alpha4.Networking{
+					IPFamily: kindconfigv1alpha4.DualStackFamily,
+				}
+
+				manifestValues := &e2e.KubevipManifestValues{
+					ControlPlaneVIP:            cpVIP,
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					ControlPlaneEnable:         "false",
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					VipElectionEnable:          "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
+				}
+
+				var err error
+				svcElection, err = strconv.ParseBool(manifestValues.SvcElectionEnable)
+				Expect(err).ToNot(HaveOccurred())
+
+				ipFamily = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
+
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
+
+				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-svc-ipv4-mixed", k8sImagePath, v129,
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
+			})
+
+			AfterAll(func() {
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
+			})
+
+			DescribeTable("configures an IPv4 and IPv6 routes for services",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddresses := []string{}
+					for range 2 {
+						lbAddresses = append(lbAddresses, e2e.GenerateDualStackVIP(offset, defaultNetwork))
+					}
+					testServiceRTMixedElection(ctx, svcName, lbAddresses, "plndr-svcs-lock", "kube-system", fmt.Sprintf("kubevip-%s", svcName), dsNamespace,
+						trafficPolicy, client, svcElection, ipFamily, 1, 1, dsNumber, false, clusterName)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+		})
+
 		Describe("kube-vip DualStack services routing table mode functionality - IPv6 primary", Ordered, func() {
 			var (
 				cpVIP       string
@@ -786,6 +976,71 @@ var _ = Describe("kube-vip routing table mode", Ordered, func() {
 					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testServiceRT(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", clusterName,
 						trafficPolicy, client, svcElection, ipFamily, 2, false, dsNumber, false)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+		})
+
+		Describe("kube-vip DualStack services routing table mode functionality with mixed election - IPv6 primary", Ordered, func() {
+			var (
+				cpVIP       string
+				clusterName string
+				client      kubernetes.Interface
+				svcElection bool
+				ipFamily    []corev1.IPFamily
+				tempDirPath string
+
+				nodesNumber = 1
+			)
+
+			BeforeAll(func() {
+				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get(), defaultNetwork)
+
+				networking := &kindconfigv1alpha4.Networking{
+					IPFamily:      kindconfigv1alpha4.DualStackFamily,
+					PodSubnet:     "fd00:10:244::/56,10.244.0.0/16",
+					ServiceSubnet: "fd00:10:96::/112,10.96.0.0/16",
+				}
+
+				manifestValues := &e2e.KubevipManifestValues{
+					ControlPlaneVIP:            cpVIP,
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					ControlPlaneEnable:         "false",
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					VipElectionEnable:          "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
+				}
+
+				var err error
+				svcElection, err = strconv.ParseBool(manifestValues.SvcElectionEnable)
+				Expect(err).ToNot(HaveOccurred())
+
+				ipFamily = []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}
+
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
+
+				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "rt-ds-svc-ipv6-mixed", k8sImagePath, v129,
+					kubeVIPRoutingTableManifestTemplate, logger, manifestValues, networking, nodesNumber, nil, dsNumber)
+			})
+
+			AfterAll(func() {
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
+			})
+
+			DescribeTable("configures an IPv6 and IPv4 routes for services",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddresses := []string{}
+					for range 2 {
+						lbAddresses = append(lbAddresses, e2e.GenerateDualStackVIP(offset, defaultNetwork))
+					}
+					testServiceRTMixedElection(ctx, svcName, lbAddresses, "plndr-svcs-lock", "kube-system", fmt.Sprintf("kubevip-%s", svcName), dsNamespace,
+						trafficPolicy, client, svcElection, ipFamily, 1, 1, dsNumber, false, clusterName)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -1439,7 +1694,7 @@ func testServiceRT(ctx context.Context, svcName, lbAddress, leaseName, leaseName
 			svcLease = leaseName
 		}
 		createTestService(ctx, svc, dsNamespace, dsName, lbAddress,
-			client, corev1.IPFamilyPolicyPreferDualStack, ipFamily, trafficPolicy, svcLease, dsNumber, false)
+			client, corev1.IPFamilyPolicyPreferDualStack, ipFamily, trafficPolicy, svcLease, dsNumber, false, false)
 		time.Sleep(time.Second)
 	}
 
@@ -1498,6 +1753,68 @@ func testServiceRT(ctx context.Context, svcName, lbAddress, leaseName, leaseName
 				By(withTimestamp(fmt.Sprintf("getting lease holder for lease '%s/%s' - expected: %t", leaseNamespace, leaseName, expected)))
 				e2e.CheckLeasePresence(ctx, leaseName, leaseNamespace, client, expected)
 			}
+		}
+	}
+}
+
+func testServiceRTMixedElection(ctx context.Context, svcName string, lbAddress []string, globalLeaseName, globalLeaseNamespace, leaseName, leaseNamespace string, trafficPolicy corev1.ServiceExternalTrafficPolicy,
+	client kubernetes.Interface, serviceElection bool, ipFamily []corev1.IPFamily, numberOfGlobalServices, numberOfElectedServices int, dsNumber int, deleteDS bool, clusterName string) {
+	services := []serviceWithLease{}
+	for i := range numberOfGlobalServices {
+		services = append(services, serviceWithLease{
+			name:           fmt.Sprintf("%s-global-%d", svcName, i),
+			lease:          globalLeaseName,
+			leaseNamespace: globalLeaseNamespace,
+			election:       false,
+			lbAddress:      lbAddress[i],
+		})
+	}
+
+	for i := range numberOfElectedServices {
+		services = append(services, serviceWithLease{
+			name:           fmt.Sprintf("%s-%d", svcName, i),
+			lease:          fmt.Sprintf("%s-%d", leaseName, i),
+			leaseNamespace: leaseNamespace,
+			election:       true,
+			lbAddress:      lbAddress[i+numberOfGlobalServices],
+		})
+	}
+
+	for _, svc := range services {
+		createTestService(ctx, svc.name, dsNamespace, dsName, svc.lbAddress,
+			client, corev1.IPFamilyPolicyPreferDualStack, ipFamily, trafficPolicy, "", dsNumber, false, svc.election)
+		time.Sleep(time.Second)
+	}
+
+	for _, svc := range services {
+		container := fmt.Sprintf("%s-control-plane", clusterName)
+		if svc.election {
+			By(withTimestamp(fmt.Sprintf("getting lease holder for lease '%s/%s'", svc.leaseNamespace, svc.lease)))
+			container = e2e.GetLeaseHolder(ctx, svc.lease, leaseNamespace, client)
+		}
+
+		for addr := range strings.SplitSeq(svc.lbAddress, ",") {
+			By(withTimestamp(fmt.Sprintf("checking route presence for address %q on container %q", addr, container)))
+			e2e.CheckRoutePresence(addr, container, true)
+		}
+	}
+
+	for i, svc := range services {
+		By(withTimestamp(fmt.Sprintf("deleting service %s/%s\n", dsNamespace, svc.name)))
+
+		container := fmt.Sprintf("%s-control-plane", clusterName)
+		if svc.election {
+			container = e2e.GetLeaseHolder(ctx, svc.lease, svc.leaseNamespace, client)
+		}
+
+		err := client.CoreV1().Services(dsNamespace).Delete(ctx, svc.name, metav1.DeleteOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		time.Sleep(time.Second)
+
+		expected := i < len(services)-1
+		for addr := range strings.SplitSeq(svc.lbAddress, ",") {
+			By(withTimestamp(fmt.Sprintf("checking route presence for address %q on container %q - expected: %t", addr, container, expected)))
+			e2e.CheckRoutePresence(addr, container, expected)
 		}
 	}
 }

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -230,7 +230,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 					lbAddress := e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
 					createTestService(ctx, svcName, dsNamespace, dsName, lbAddress,
 						client, corev1.IPFamilyPolicyPreferDualStack, []corev1.IPFamily{corev1.IPv4Protocol},
-						corev1.ServiceExternalTrafficPolicyCluster, "", 80, dhcpBroadcast)
+						corev1.ServiceExternalTrafficPolicyCluster, "", 80, dhcpBroadcast, false)
 					checkDHCPBroadcastAnnotation(ctx, svcName, dsNamespace, dhcpBroadcast, client)
 					err := client.CoreV1().Services(dsNamespace).Delete(ctx, svcName, metav1.DeleteOptions{})
 					Expect(err).ToNot(HaveOccurred())
@@ -291,6 +291,64 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
 			)
+		})
+
+		Describe("kube-vip IPv4 functionality, svc_enable=true, with per-service election on demand", Ordered, func() {
+			var (
+				cpVIP       string
+				client      kubernetes.Interface
+				clusterName string
+				tempDirPath string
+				dsNumber    int
+			)
+
+			BeforeAll(func() {
+				cpVIP = e2e.GenerateVIP(utils.IPv4Family, SOffset.Get(), defaultNetwork)
+
+				networking := &kindconfigv1alpha4.Networking{
+					IPFamily: kindconfigv1alpha4.IPv4Family,
+				}
+
+				manifestValues := &e2e.KubevipManifestValues{
+					ControlPlaneVIP:            cpVIP,
+					ControlPlaneEnable:         "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "true",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
+				}
+
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
+
+				dsNumber = 1
+
+				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "svc-ipv4-mixed", k8sImagePath, v129,
+					kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil, dsNumber)
+			})
+
+			AfterAll(func() {
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
+			})
+
+			DescribeTable("configures an IPv4 VIP address for services when per-service election on demand is used",
+				func(svcName string, currentOffset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddresses := []string{}
+					for range 2 {
+						lbAddresses = append(lbAddresses, e2e.GenerateVIP(utils.IPv4Family, currentOffset, defaultNetwork))
+					}
+					testServiceMixedElection(ctx, svcName, lbAddresses, "plndr-svcs-lock", "kube-system", fmt.Sprintf("kubevip-%s", svcName), dsNamespace,
+						trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol}, 1, 1, false, dsNumber)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+
 		})
 
 		Describe("kube-vip IPv6 functionality, vip_leaderelection=true", Ordered, func() {
@@ -465,6 +523,64 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 			)
 		})
 
+		Describe("kube-vip IPv6 functionality, svc_enable=true, with per-service election on demand", Ordered, func() {
+			var (
+				cpVIP       string
+				client      kubernetes.Interface
+				clusterName string
+				tempDirPath string
+				dsNumber    int
+			)
+
+			BeforeAll(func() {
+				cpVIP = e2e.GenerateVIP(utils.IPv6Family, SOffset.Get(), defaultNetwork)
+
+				networking := &kindconfigv1alpha4.Networking{
+					IPFamily: kindconfigv1alpha4.IPv6Family,
+				}
+
+				manifestValues := &e2e.KubevipManifestValues{
+					ControlPlaneVIP:            cpVIP,
+					ControlPlaneEnable:         "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "true",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
+				}
+
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
+
+				dsNumber = 1
+
+				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "svc-ipv6-mixed", k8sImagePath, v129,
+					kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil, dsNumber)
+			})
+
+			AfterAll(func() {
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
+			})
+
+			DescribeTable("configures an IPv6 VIP address for services when per-service election on demand is used",
+				func(svcName string, currentOffset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddresses := []string{}
+					for range 2 {
+						lbAddresses = append(lbAddresses, e2e.GenerateVIP(utils.IPv6Family, currentOffset, defaultNetwork))
+					}
+					testServiceMixedElection(ctx, svcName, lbAddresses, "plndr-svcs-lock", "kube-system", fmt.Sprintf("kubevip-%s", svcName), dsNamespace,
+						trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv6Protocol}, 1, 1, false, dsNumber)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+
+		})
+
 		Describe("kube-vip DualStack functionality - IPv4 primary, vip_leaderelection=true", Ordered, func() {
 			var (
 				cpVIP       string
@@ -632,6 +748,63 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testService(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, trafficPolicy, client, true,
 						[]corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}, 1, false, dsNumber)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+		})
+
+		Describe("kube-vip DualStack functionality - IPv4 primary, svc_enable=true, with per-service election on demand", Ordered, func() {
+			var (
+				cpVIP       string
+				client      kubernetes.Interface
+				clusterName string
+				tempDirPath string
+				dsNumber    int
+			)
+
+			BeforeAll(func() {
+				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get(), defaultNetwork)
+
+				networking := &kindconfigv1alpha4.Networking{
+					IPFamily: kindconfigv1alpha4.DualStackFamily,
+				}
+
+				manifestValues := &e2e.KubevipManifestValues{
+					ControlPlaneVIP:            cpVIP,
+					ControlPlaneEnable:         "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "true",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
+				}
+
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
+
+				dsNumber = 1
+
+				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "svc-dual-ipv4-mixed", k8sImagePath, v129,
+					kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil, dsNumber)
+			})
+
+			AfterAll(func() {
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
+			})
+
+			DescribeTable("configures an IPv4 and IPv6 VIP address for services when per-service election on demand is used",
+				func(svcName string, currentOffset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddresses := []string{}
+					for range 2 {
+						lbAddresses = append(lbAddresses, e2e.GenerateDualStackVIP(currentOffset, defaultNetwork))
+					}
+					testServiceMixedElection(ctx, svcName, lbAddresses, "plndr-svcs-lock", "kube-system", fmt.Sprintf("kubevip-%s", svcName), dsNamespace,
+						trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}, 1, 1, false, dsNumber)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -811,6 +984,63 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", Ordered, func() {
 					lbAddress := e2e.GenerateDualStackVIP(offset, defaultNetwork)
 					testService(ctx, svcName, lbAddress, fmt.Sprintf("kubevip-%s", svcName), dsNamespace, trafficPolicy, client, true,
 						[]corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}, 1, false, dsNumber)
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+		})
+
+		Describe("kube-vip DualStack functionality - IPv6 primary, svc_enable=true, with per-service election on demand", Ordered, func() {
+			var (
+				cpVIP       string
+				client      kubernetes.Interface
+				clusterName string
+				tempDirPath string
+				dsNumber    int
+			)
+
+			BeforeAll(func() {
+				cpVIP = e2e.GenerateDualStackVIP(SOffset.Get(), defaultNetwork)
+
+				networking := &kindconfigv1alpha4.Networking{
+					IPFamily: kindconfigv1alpha4.DualStackFamily,
+				}
+
+				manifestValues := &e2e.KubevipManifestValues{
+					ControlPlaneVIP:            cpVIP,
+					ControlPlaneEnable:         "true",
+					ImagePath:                  imagePath,
+					ConfigPath:                 configPath,
+					SvcEnable:                  "true",
+					SvcElectionEnable:          "false",
+					EnableEndpoints:            "true",
+					EnableNodeLabeling:         "false",
+					EnableServiceSecurity:      "true",
+					PerServiceElectionOnDemand: "true",
+				}
+
+				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
+
+				dsNumber = 1
+
+				clusterName, client, _ = prepareCluster(ctx, tempDirPath, "svc-dual-ipv6-mixed", k8sImagePath, v129,
+					kubeVIPManifestTemplate, logger, manifestValues, networking, 1, nil, dsNumber)
+			})
+
+			AfterAll(func() {
+				SaveLogsAndCleanup(ctx, client, tempDirPath, clusterName, func() {
+					cleanupCluster(clusterName, defaultNetwork, ConfigMtx, logger)
+				})
+			})
+
+			DescribeTable("configures an IPv6 and IPv4 VIP address for services when per-service election on demand is used",
+				func(svcName string, currentOffset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					lbAddresses := []string{}
+					for range 2 {
+						lbAddresses = append(lbAddresses, e2e.GenerateDualStackVIP(currentOffset, defaultNetwork))
+					}
+					testServiceMixedElection(ctx, svcName, lbAddresses, "plndr-svcs-lock", "kube-system", fmt.Sprintf("kubevip-%s", svcName), dsNamespace,
+						trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}, 1, 1, false, dsNumber)
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -1239,7 +1469,7 @@ func removePod(ctx context.Context, name, namespace string, client kubernetes.In
 }
 
 func createTestService(ctx context.Context, name, namespace, target, lbAddress string, client kubernetes.Interface, ipfPolicy corev1.IPFamilyPolicy,
-	ipFamiles []corev1.IPFamily, externalPolicy corev1.ServiceExternalTrafficPolicy, leaseName string, port int, dhcpBroadcast bool,
+	ipFamiles []corev1.IPFamily, externalPolicy corev1.ServiceExternalTrafficPolicy, leaseName string, port int, dhcpBroadcast bool, forceElection bool,
 ) {
 	svcAnnotations := make(map[string]string)
 	svcAnnotations[kubevip.LoadbalancerIPAnnotation] = lbAddress
@@ -1248,6 +1478,10 @@ func createTestService(ctx context.Context, name, namespace, target, lbAddress s
 	}
 	if dhcpBroadcast {
 		svcAnnotations[kubevip.DHCPBroadcast] = "true"
+	}
+
+	if forceElection {
+		svcAnnotations[kubevip.ForcePerServiceElection] = "true"
 	}
 
 	labels := make(map[string]string)
@@ -1510,7 +1744,7 @@ func testService(ctx context.Context, svcName, lbAddress, leaseName, leaseNamesp
 
 	for _, svc := range services {
 		createTestService(ctx, svc, dsNamespace, dsName, lbAddress,
-			client, corev1.IPFamilyPolicyPreferDualStack, ipFamily, trafficPolicy, "", 80, false)
+			client, corev1.IPFamilyPolicyPreferDualStack, ipFamily, trafficPolicy, "", 80, false, false)
 		time.Sleep(time.Second)
 	}
 
@@ -1567,6 +1801,75 @@ func testService(ctx context.Context, svcName, lbAddress, leaseName, leaseNamesp
 
 }
 
+type serviceWithLease struct {
+	name           string
+	lease          string
+	leaseNamespace string
+	election       bool
+	lbAddress      string
+}
+
+func testServiceMixedElection(ctx context.Context, svcName string, lbAddress []string, globalLeaseName, globalLeaseNamespace, leaseName, leaseNamespace string, trafficPolicy corev1.ServiceExternalTrafficPolicy,
+	client kubernetes.Interface, serviceElection bool, ipFamily []corev1.IPFamily, numberOfGlobalServices, numberOfElectedServices int, deleteDS bool, dsNumber int,
+) {
+	services := []serviceWithLease{}
+	for i := range numberOfGlobalServices {
+		services = append(services, serviceWithLease{
+			name:           fmt.Sprintf("%s-global-%d", svcName, i),
+			lease:          globalLeaseName,
+			leaseNamespace: globalLeaseNamespace,
+			election:       false,
+			lbAddress:      lbAddress[i],
+		})
+	}
+
+	for i := range numberOfElectedServices {
+		services = append(services, serviceWithLease{
+			name:           fmt.Sprintf("%s-%d", svcName, i),
+			lease:          fmt.Sprintf("%s-%d", leaseName, i),
+			leaseNamespace: leaseNamespace,
+			election:       true,
+			lbAddress:      lbAddress[i+numberOfGlobalServices],
+		})
+	}
+
+	for _, svc := range services {
+		createTestService(ctx, svc.name, dsNamespace, dsName, svc.lbAddress,
+			client, corev1.IPFamilyPolicyPreferDualStack, ipFamily, trafficPolicy, "", 80, false, svc.election)
+		time.Sleep(time.Second)
+	}
+
+	for _, svc := range services {
+		for addr := range strings.SplitSeq(svc.lbAddress, ",") {
+			Expect(checkIPAddressByLease(ctx, svc.lease, svc.leaseNamespace, addr, true, client)).To(BeTrue())
+			assertConnection("http", addr, "80", "", 3*time.Second, 60*time.Second)
+		}
+	}
+
+	for i := range services {
+		expected := i < len(services)-1
+
+		container := e2e.GetLeaseHolder(ctx, services[i].lease, services[i].leaseNamespace, client)
+
+		err := client.CoreV1().Services(dsNamespace).Delete(ctx, services[i].name, metav1.DeleteOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		time.Sleep(time.Second)
+
+		for addr := range strings.SplitSeq(services[i].lbAddress, ",") {
+			if serviceElection {
+				Expect(checkIPAddress(addr, container, expected)).To(BeTrue())
+			}
+
+			if expected {
+				assertConnection("http", addr, "80", "", 3*time.Second, 60*time.Second)
+			} else {
+				assertConnectionError("http", addr, "80", "", 3*time.Second, 30*time.Second)
+			}
+		}
+	}
+
+}
+
 func testServiceCommonLease(ctx context.Context, svcName, lbAddress, leaseNamespace string, trafficPolicy corev1.ServiceExternalTrafficPolicy,
 	client kubernetes.Interface, ipFamily []corev1.IPFamily, numberOfServices int,
 ) {
@@ -1585,7 +1888,7 @@ func testServiceCommonLease(ctx context.Context, svcName, lbAddress, leaseNamesp
 			tmpDsName = fmt.Sprintf("%s-%d", tmpDsName, i)
 		}
 		createTestService(ctx, svc, dsNamespace, tmpDsName, lbAddress,
-			client, corev1.IPFamilyPolicyPreferDualStack, ipFamily, trafficPolicy, lease, 80+i, false)
+			client, corev1.IPFamilyPolicyPreferDualStack, ipFamily, trafficPolicy, lease, 80+i, false, false)
 		time.Sleep(time.Second)
 	}
 

--- a/testing/e2e/kube-vip-routing-table.yaml.tmpl
+++ b/testing/e2e/kube-vip-routing-table.yaml.tmpl
@@ -69,10 +69,14 @@ spec:
     - name: control_plane_health_check_ca_path
       value: "{{ .ControlPlaneHealthCheckCAPath }}"
 {{- end }}
+{{- end }}
 {{- if .EnableServiceSecurity }}
     - name: enable_service_security
       value: "{{ .EnableServiceSecurity }}"
 {{- end }}
+{{- if .PerServiceElectionOnDemand }}
+    - name: per_service_election_on_demand
+      value: "{{ .PerServiceElectionOnDemand }}"
 {{- end }}
     image: "{{ .ImagePath }}"
     imagePullPolicy: Never

--- a/testing/e2e/kube-vip.yaml.tmpl
+++ b/testing/e2e/kube-vip.yaml.tmpl
@@ -110,6 +110,10 @@ spec:
     - name: enable_service_security
       value: "{{ .EnableServiceSecurity }}"
 {{- end }}
+{{- if .PerServiceElectionOnDemand }}
+    - name: per_service_election_on_demand
+      value: "{{ .PerServiceElectionOnDemand }}"
+{{- end }}
     image: "{{ .ImagePath }}"
     imagePullPolicy: Never
     securityContext:

--- a/testing/e2e/template.go
+++ b/testing/e2e/template.go
@@ -31,6 +31,7 @@ type KubevipManifestValues struct {
 	ControlPlaneHealthCheckFailureThreshold int
 	ControlPlaneHealthCheckCAPath           string
 	EnableServiceSecurity                   string
+	PerServiceElectionOnDemand              string
 }
 
 type BGPPeerValues struct {


### PR DESCRIPTION
This PR introduces a new feature, that enables cluster operator to force a particular service to use per-service leader election even if no leader election or global leader election is enabled. This will work in every mode, except `Wireguard`.

Enabling feature:

Feature can be enabled with env variable `per_service_election_on_demand: true` or with CLI flag `perServiceElectionOnDemand`.

How to use:

When kube-vip's service reconciliation is used with no leader election or with global lease, simply annotate service with an annotation: `kube-vip.io/forcePerServiceElection: "true"`

Now kube-vip will perform separate leader election for this particular service.