### PR TITLE
fix: optionally attach BGP service VIPs to interface

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -92,6 +92,7 @@ func init() {
 
 	// BGP flags
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableBGP, "bgp", false, "This will enable BGP support within kube-vip")
+	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.BGPAttachIPToInterface, "bgpAttachIPToInterface", false, "Assign BGP service VIPs to the configured interface")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.BGPConfig.RouterID, "bgpRouterID", "", "The routerID for the bgp server")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.BGPConfig.SourceIF, "sourceIF", "", "The source interface for bgp peering (not to be used with sourceIP)")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.BGPConfig.SourceIP, "sourceIP", "", "The source address for bgp peering (not to be used with sourceIF)")

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -411,7 +411,7 @@ func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip
 			}
 		}
 
-		if !c.EnableRoutingTable && !c.EnableBGP && !c.EnableWireguard {
+		if shouldAddServiceIP(c) {
 			// Normal VIP addition, use skipDAD=false for normal DAD process
 			// Note: When WireGuard is enabled, the VIP is added to the tunnel interface
 			// instead of lo, so we skip adding it here.
@@ -478,6 +478,10 @@ func (cluster *Cluster) StartLoadBalancerService(ctx context.Context, c *kubevip
 	})
 
 	return nil
+}
+
+func shouldAddServiceIP(c *kubevip.Config) bool {
+	return !c.EnableRoutingTable && (!c.EnableBGP || c.BGPAttachIPToInterface) && !c.EnableWireguard
 }
 
 // Layer2Update, handles the creation of the

--- a/pkg/cluster/service_config_test.go
+++ b/pkg/cluster/service_config_test.go
@@ -1,0 +1,55 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+)
+
+func TestShouldAddServiceIP(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *kubevip.Config
+		want   bool
+	}{
+		{
+			name:   "BGP default does not attach IP",
+			config: &kubevip.Config{EnableBGP: true},
+			want:   false,
+		},
+		{
+			name: "BGP opt-in attaches IP",
+			config: &kubevip.Config{
+				EnableBGP:              true,
+				BGPAttachIPToInterface: true,
+			},
+			want: true,
+		},
+		{
+			name: "routing table takes precedence",
+			config: &kubevip.Config{
+				EnableBGP:              true,
+				BGPAttachIPToInterface: true,
+				EnableRoutingTable:     true,
+			},
+			want: false,
+		},
+		{
+			name: "WireGuard takes precedence",
+			config: &kubevip.Config{
+				EnableBGP:              true,
+				BGPAttachIPToInterface: true,
+				EnableWireguard:        true,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldAddServiceIP(tt.config); got != tt.want {
+				t.Fatalf("shouldAddServiceIP() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -456,6 +456,15 @@ func ParseEnvironment(c *Config) error {
 		c.EnableBGP = b
 	}
 
+	env = os.Getenv(bgpAttachIPToInterface)
+	if env != "" {
+		b, err := strconv.ParseBool(env)
+		if err != nil {
+			return err
+		}
+		c.BGPAttachIPToInterface = b
+	}
+
 	// BGP Router interface determines an interface that we can use to find an address for
 	env = os.Getenv(bgpRouterInterface)
 	if env != "" {
@@ -877,6 +886,9 @@ func mergeConfigValues(baseConfig, fileConfig *Config) {
 	}
 	if !baseConfig.EnableBGP && fileConfig.EnableBGP {
 		baseConfig.EnableBGP = fileConfig.EnableBGP
+	}
+	if !baseConfig.BGPAttachIPToInterface && fileConfig.BGPAttachIPToInterface {
+		baseConfig.BGPAttachIPToInterface = fileConfig.BGPAttachIPToInterface
 	}
 	if !baseConfig.EnableWireguard && fileConfig.EnableWireguard {
 		baseConfig.EnableWireguard = fileConfig.EnableWireguard

--- a/pkg/kubevip/config_envvar.go
+++ b/pkg/kubevip/config_envvar.go
@@ -100,6 +100,8 @@ const (
 
 	// bgpEnable defines if BGP should be enabled
 	bgpEnable = "bgp_enable"
+	// bgpAttachIPToInterface defines if BGP service VIPs should be assigned to the configured interface
+	bgpAttachIPToInterface = "bgp_attach_ip_to_interface"
 	// bgpRouterID defines the routerID for the BGP server
 	bgpRouterID = "bgp_routerid"
 	// bgpRouterInterface defines the interface that we can find the address for

--- a/pkg/kubevip/config_generator.go
+++ b/pkg/kubevip/config_generator.go
@@ -476,6 +476,12 @@ func generatePodSpec(c *Config, image, imageVersion string, inCluster bool) (*co
 				Value: strconv.FormatBool(c.EnableBGP),
 			},
 		}
+		if c.BGPAttachIPToInterface {
+			bgp = append(bgp, corev1.EnvVar{
+				Name:  bgpAttachIPToInterface,
+				Value: strconv.FormatBool(c.BGPAttachIPToInterface),
+			})
+		}
 		newEnvironment = append(newEnvironment, bgp...)
 	}
 

--- a/pkg/kubevip/config_generator_test.go
+++ b/pkg/kubevip/config_generator_test.go
@@ -54,6 +54,35 @@ func TestParseEnvironmentInstanceName(t *testing.T) {
 	}
 }
 
+func TestParseEnvironmentBGPAttachIPToInterface(t *testing.T) {
+	t.Setenv(bgpAttachIPToInterface, "true")
+
+	config := &Config{}
+	if err := ParseEnvironment(config); err != nil {
+		t.Fatalf("ParseEnvironment() error = %v", err)
+	}
+	if !config.BGPAttachIPToInterface {
+		t.Fatal("BGPAttachIPToInterface = false, want true")
+	}
+}
+
+func TestGeneratePodSpecBGPAttachIPToInterface(t *testing.T) {
+	pod, err := generatePodSpec(&Config{
+		EnableBGP:              true,
+		BGPAttachIPToInterface: true,
+	}, "ghcr.io/kube-vip/kube-vip", "v0.0.0", true)
+	if err != nil {
+		t.Fatalf("generatePodSpec() error = %v", err)
+	}
+
+	for _, env := range pod.Spec.Containers[0].Env {
+		if env.Name == bgpAttachIPToInterface && env.Value == "true" {
+			return
+		}
+	}
+	t.Fatalf("%s=true is missing from generated pod environment", bgpAttachIPToInterface)
+}
+
 func TestGeneratePodSpecInstanceName(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -11,6 +11,9 @@ type Config struct {
 	// EnableBGP, will use BGP to advertise the VIP address
 	EnableBGP bool `yaml:"enableBGP"`
 
+	// BGPAttachIPToInterface assigns BGP-advertised service VIPs to the configured interface
+	BGPAttachIPToInterface bool `yaml:"bgpAttachIPToInterface"`
+
 	// EnableWireguard, will use wireguard to advertise the VIP address
 	EnableWireguard bool `yaml:"enableWireguard"`
 


### PR DESCRIPTION
## What this changes

Adds an opt-in `--bgpAttachIPToInterface` flag that assigns BGP-advertised service VIPs to the configured interface. The same setting is available as `bgp_attach_ip_to_interface=true` for manifest-based deployments and as `bgpAttachIPToInterface: true` in configuration files.

The default remains `false`, so existing BGP behavior does not change. Routing-table and WireGuard modes continue to take precedence and do not attach the service VIP through this path.

## Why this is important

Some consumers require an advertised address to also exist on a local network interface. In particular, Cilium Egress Gateway only selects a configured egress IP when that IP is present on an interface of the gateway node. Without it, matching traffic is dropped with `No Egress IP configured`. This is needed by setups such as `cilium-haegress-operator` that use kube-vip BGP announcements for highly available egress IPs.

Making this opt-in is important for safety. Once a VIP is a local address, a process listening on `0.0.0.0` or `[::]` may also accept traffic sent to that VIP, potentially exposing a node-local service unexpectedly. Operators who need local address assignment can explicitly enable it and choose the intended `vip_interface` (for example, `lo`), while all other BGP users retain the current behavior.

This follows up on the discussion in #1473.

## Testing

- `go test ./pkg/cluster ./pkg/kubevip ./cmd/...`
- Added tests for the default/opt-in service-IP decision, routing-table and WireGuard precedence, environment parsing, and generated manifest configuration.
