### PR TITLE
Leader election permanently deadlocks after ordinary leadership loss (VIP orphaned until Service is recreated)

### DIFF
--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -72,10 +72,18 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 	// This is important for proper cleanup when a service is deleted - it ensures that
 	// the lease context (svcLease.Ctx) gets cancelled, which causes RunOrDie to return.
 	// Without this, RunOrDie would continue running until leadership is naturally lost.
-	wg.Go(func() {
+	//
+	// This must NOT be tracked by wg: it only completes once the service is deleted
+	// (svcCtx.Ctx.Done()), which is normally long after this function itself returns
+	// e.g. on an ordinary leadership loss such as a lease renewal failure. If it were
+	// added to wg, the deferred wg.Wait() above would block this function and with it
+	// the leader-election restart loop in startLeaderElection that calls it forever,
+	// until the Service was deleted (and recreated), even though the endpoint was still
+	// healthy and a new election should have started immediately.
+	go func() {
 		<-svcCtx.Ctx.Done()
 		p.leaseMgr.Delete(id, objectName)
-	})
+	}()
 
 	select {
 	case <-svcCtx.Ctx.Done():

--- a/pkg/services/leader_test.go
+++ b/pkg/services/leader_test.go
@@ -1,0 +1,71 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/lease"
+	"github.com/kube-vip/kube-vip/pkg/servicecontext"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// TestStartServicesLeaderElection_ReturnsOnLeaseLossWithoutServiceDeletion is a regression test for
+// the issue: StartServicesLeaderElection deadlocked forever whenever it returned for
+// any reason other than the Service itself being deleted.
+//
+// The function starts a lease-cleanup goroutine that only exits once svcCtx.Ctx is cancelled (Service
+// deleted), then defers wg.Wait() on the same WaitGroup that goroutine belonged to. Since the Service
+// stays alive across an ordinary lease loss, that goroutine and therefore the deferred wg.Wait()
+// never returned, permanently wedging the leader-election restart loop in startLeaderElection for that
+// service. The only workaround was to delete and recreate the Service.
+func TestStartServicesLeaderElection_ReturnsOnLeaseLossWithoutServiceDeletion(t *testing.T) {
+	p := &Processor{
+		config:   &kubevip.Config{},
+		leaseMgr: lease.NewManager(),
+	}
+
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "matst-example",
+			Namespace: "dsm-system",
+			UID:       types.UID("test-uid"),
+		},
+	}
+
+	leaseNamespace, serviceLease := lease.ServiceName(svc)
+	id := lease.NewID(p.config.LeaderElectionType, leaseNamespace, serviceLease)
+	svcLease := p.leaseMgr.Add(context.Background(), id)
+
+	// Simulate ordinary leadership/lease loss (e.g. a renewal failure): the lease context ends
+	// but the Service itself is untouched, so svcCtx.Ctx must stay alive.
+	svcLease.Cancel()
+
+	svcCtx := servicecontext.New(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- p.StartServicesLeaderElection(svcCtx, svc, nil, true)
+	}()
+
+	select {
+	case <-done:
+		// Expected: the function must return promptly when only the lease - not the service -
+		// has gone away, so the restart loop can retry the election.
+	case <-time.After(5 * time.Second):
+		t.Fatal("StartServicesLeaderElection did not return after the lease context was " +
+			"cancelled while the service context remained alive; this reproduces the deadlock " +
+			"where leader election could never be retried for a live service")
+	}
+
+	if svcCtx.Ctx.Err() != nil {
+		t.Fatal("service context should not have been cancelled by an ordinary lease loss")
+	}
+
+	// The lease-cleanup goroutine should still be running, waiting for the service to be
+	// deleted; confirm it is not left dangling forever by cancelling the service context now.
+	svcCtx.Cancel()
+}


### PR DESCRIPTION
**Linked Issue:** https://github.com/kube-vip/kube-vip/issues/1651

**Root cause:** 
StartServicesLeaderElection starts a cleanup goroutine tied to the service's lifetime (`<-svcCtx.Ctx.Done()` → delete the lease), but registers it on the same `sync.WaitGroup` that a `defer wg.Wait() `blocks on before the function returns. That goroutine only ever completes when the Kubernetes Service object is deleted, not on ordinary leadership loss (lease renewal failure, etcd timeout, "context canceled", etc.). So every time a node lost leadership normally, the function would try to return, get stuck forever in `wg.Wait()`, and since `startLeaderElection`'s retry loop calls this function synchronously, that node could never retry the election for that service again and the VIP was orphaned permanently.

**Fix:** 
(`pkg/services/leader.go`): detach that cleanup goroutine from the WaitGroup: `wg.Go(func(){...}) `to `go func(){...}() ` so it keeps running independently without gating the function's return. 

Verification:
- Added pkg/services/leader_test.go with a regression test that simulates ordinary lease loss while the service stays alive.
- Confirmed it deadlocks/times out on the original code and passes on the fixed code (ran both ways in a golang:1.26 container).
- In our products I have run the tests that fail with 1.2.1 again with this patch and they are consistently passing, indicating the fix works as intended.