### PR TITLE
Make unnumbered peers BGP test more stable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.4
 
 require (
 	github.com/cloudflare/ipvs v0.12.0
+	github.com/containernetworking/plugins v1.9.1
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/florianl/go-conntrack v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,10 @@ github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151X
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
+github.com/containernetworking/cni v1.3.0 h1:v6EpN8RznAZj9765HhXQrtXgX+ECGebEYEmnuFjskwo=
+github.com/containernetworking/cni v1.3.0/go.mod h1:Bs8glZjjFfGPHMw6hQu82RUgEPNGEaBb9KS5KtNMnJ4=
+github.com/containernetworking/plugins v1.9.1 h1:8oU6WsIsU3bpnNZuvHp74a6cE1MJwbj2P7s4/yTUNlA=
+github.com/containernetworking/plugins v1.9.1/go.mod h1:fj7kS55qg3o/RgS+WGsF3+ZxwIImMPusQZKzBpcSr4c=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=

--- a/testing/e2e/e2e_ds_test.go
+++ b/testing/e2e/e2e_ds_test.go
@@ -8,10 +8,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 
+	docker "github.com/docker/docker/client"
+	"github.com/osrg/gobgp/v4/pkg/config/oc"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,6 +24,8 @@ import (
 	kindconfigv1alpha4 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 	"sigs.k8s.io/kind/pkg/log"
 
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/docker/docker/api/types/container"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -541,6 +546,43 @@ func testDS(ctx context.Context, manifestValues *e2e.KubevipManifestValues, clie
 		families = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
 	}
 
+	// wait for neighbor to be discovered
+	bgpPeers := strings.Split(manifestValues.BGPPeers, ":")
+	if bgpPeers[0] == "unnumbered" {
+		cli, err := docker.NewClientWithOpts(docker.FromEnv)
+		Expect(err).ToNot(HaveOccurred())
+
+		cnts, err := cli.ContainerList(ctx, container.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		id := ""
+		for _, c := range cnts {
+			if slices.ContainsFunc(c.Names, func(s string) bool {
+				return strings.Contains(s, clusterName)
+			}) {
+				id = c.ID
+			}
+		}
+		Expect(id).ToNot(BeEmpty())
+
+		inspect, err := cli.ContainerInspect(ctx, id)
+		Expect(err).ToNot(HaveOccurred())
+
+		containerNs, err := ns.GetNS(inspect.NetworkSettings.SandboxKey)
+		Expect(err).ToNot(HaveOccurred())
+		defer containerNs.Close()
+
+		By(withTimestamp("waiting for the neighbor to be discovered"))
+
+		Eventually(func() error {
+			return containerNs.Do(func(ns.NetNS) error {
+				_, err := oc.GetIPv6LinkLocalNeighborAddress(bgpPeers[1])
+				return err
+			})
+		}, "120s").Should(Succeed())
+
+	}
+
 	var cpVips, svcVips, services []string
 	var cpHost, svcHost, svcVip string
 
@@ -988,7 +1030,7 @@ func prepareClusterForDS(tempDirPath, clusterNameSuffix, kvImagePath, k8sImagePa
 	err := os.Setenv(kindNetworkEnv, clusterName)
 	Expect(err).ToNot(HaveOccurred())
 
-	By(withTimestamp("creating a kind cluster with multiple control plane nodes"))
+	By(withTimestamp("creating a kind cluster with multiple control plane nodes, name " + clusterName))
 	client, cfg, err := createKindCluster(logger, &clusterConfig, clusterName)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
This PR aims to stabilize flaky unnumbered BGP e2e test.

Currently this particular test fails randomly. Added a code that waits for the required neighbor IP to be discovered before the test starts.