### PR TITLE
Discard BGP metrics events of invalid types

### DIFF
--- a/pkg/manager/worker/bgp.go
+++ b/pkg/manager/worker/bgp.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	log "log/slog"
+	"net"
+	"strconv"
 	"sync"
 	"sync/atomic"
 
@@ -53,9 +55,14 @@ func (b *BGP) Configure(ctx context.Context, _ *sync.WaitGroup) error {
 
 	log.Info("Starting the BGP server to advertise VIP routes to BGP peers")
 	if err := b.bgpServer.Start(ctx, func(p *apiutil.WatchEventMessage_PeerEvent) {
+		if p.Type != apiutil.PEER_EVENT_STATE {
+			return
+		}
+
 		ipaddr := p.Peer.State.NeighborAddress.String()
-		port := uint64(179)
-		peerDescription := fmt.Sprintf("%s:%d", ipaddr, port)
+
+		port := 179
+		peerDescription := net.JoinHostPort(ipaddr, strconv.Itoa(port))
 
 		for stateName, stateValue := range api.PeerState_SessionState_value {
 			metricValue := 0.0


### PR DESCRIPTION
This PR discards `invalid IP` reported by gobgp on server start from the metrics, which should fix #1637 

Before
```
# TYPE kube_vip_manager_bgp_session_info gauge
kube_vip_manager_bgp_session_info{peer="172.18.0.1:179",state="SESSION_STATE_ACTIVE"} 0
kube_vip_manager_bgp_session_info{peer="172.18.0.1:179",state="SESSION_STATE_CONNECT"} 0
kube_vip_manager_bgp_session_info{peer="172.18.0.1:179",state="SESSION_STATE_ESTABLISHED"} 1
kube_vip_manager_bgp_session_info{peer="172.18.0.1:179",state="SESSION_STATE_IDLE"} 0
kube_vip_manager_bgp_session_info{peer="172.18.0.1:179",state="SESSION_STATE_OPENCONFIRM"} 0
kube_vip_manager_bgp_session_info{peer="172.18.0.1:179",state="SESSION_STATE_OPENSENT"} 0
kube_vip_manager_bgp_session_info{peer="172.18.0.1:179",state="SESSION_STATE_UNSPECIFIED"} 0
kube_vip_manager_bgp_session_info{peer="invalid IP:179",state="SESSION_STATE_ACTIVE"} 0
kube_vip_manager_bgp_session_info{peer="invalid IP:179",state="SESSION_STATE_CONNECT"} 0
kube_vip_manager_bgp_session_info{peer="invalid IP:179",state="SESSION_STATE_ESTABLISHED"} 0
kube_vip_manager_bgp_session_info{peer="invalid IP:179",state="SESSION_STATE_IDLE"} 1
kube_vip_manager_bgp_session_info{peer="invalid IP:179",state="SESSION_STATE_OPENCONFIRM"} 0
kube_vip_manager_bgp_session_info{peer="invalid IP:179",state="SESSION_STATE_OPENSENT"} 0
kube_vip_manager_bgp_session_info{peer="invalid IP:179",state="SESSION_STATE_UNSPECIFIED"} 0
```
After:
```
# TYPE kube_vip_manager_bgp_session_info gauge
kube_vip_manager_bgp_session_info{peer="172.18.0.1:179",state="SESSION_STATE_ACTIVE"} 0
kube_vip_manager_bgp_session_info{peer="172.18.0.1:179",state="SESSION_STATE_CONNECT"} 0
kube_vip_manager_bgp_session_info{peer="172.18.0.1:179",state="SESSION_STATE_ESTABLISHED"} 1
kube_vip_manager_bgp_session_info{peer="172.18.0.1:179",state="SESSION_STATE_IDLE"} 0
kube_vip_manager_bgp_session_info{peer="172.18.0.1:179",state="SESSION_STATE_OPENCONFIRM"} 0
kube_vip_manager_bgp_session_info{peer="172.18.0.1:179",state="SESSION_STATE_OPENSENT"} 0
kube_vip_manager_bgp_session_info{peer="172.18.0.1:179",state="SESSION_STATE_UNSPECIFIED"} 0
```