### PR TITLE
services: recreate the lease when the service context was cancelled

### DIFF
--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -165,6 +165,7 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 		metrics.ServiceReconcileErrorsTotal.WithLabelValues(svc.Namespace, svc.Name, "service_context").Inc()
 		return fmt.Errorf("failed to get service context: %w", err)
 	}
+	svcCtx = p.dropCancelledServiceContext(svc.UID, svcCtx)
 
 	// The modified event should only be triggered if the service has been modified (i.e. moved somewhere else)
 	if event.Type == watch.Modified {
@@ -363,6 +364,28 @@ func (p *Processor) getServiceContext(uid types.UID) (*servicecontext.Context, e
 		return nil, fmt.Errorf("failed to cast service context pointer - UID: %s", uid)
 	}
 	return ctx, nil
+}
+
+// dropCancelledServiceContext discards a service context whose context has already been
+// cancelled, removing it from svcMap and returning nil so that callers create a fresh one.
+//
+// This matters because the in-memory lease and the service context are removed independently.
+// The cleanup goroutine started by StartServicesLeaderElection calls leaseMgr.Delete once
+// svcCtx.Ctx is done, and Manager.Delete drops the lease entirely when its last object goes
+// away. Several paths cancel the service context without also removing it from svcMap - for
+// example the deferred close(stopChan) in watchEndpoint, and the utils.PanicError branch in
+// AddOrModify.
+//
+// If such a cancelled context were reused, AddOrModify would skip its `if svcCtx == nil`
+// branch and therefore never call leaseMgr.Add again, so StartServicesLeaderElection would
+// fail with "no existing lease found" on every subsequent event and the VIP would never be
+// advertised again.
+func (p *Processor) dropCancelledServiceContext(uid types.UID, svcCtx *servicecontext.Context) *servicecontext.Context {
+	if svcCtx == nil || svcCtx.Ctx.Err() == nil {
+		return svcCtx
+	}
+	p.svcMap.Delete(uid)
+	return nil
 }
 
 func serviceChanged(i *instance.Instance, svc *v1.Service) bool {

--- a/pkg/services/processor_lease_test.go
+++ b/pkg/services/processor_lease_test.go
@@ -1,0 +1,119 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/lease"
+	"github.com/kube-vip/kube-vip/pkg/servicecontext"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// TestDropCancelledServiceContext is a regression test for the lease/svcMap desync that
+// permanently stops a LoadBalancer VIP from being advertised.
+//
+// AddOrModify only calls leaseMgr.Add inside its `if svcCtx == nil` branch, while the
+// in-memory lease is removed independently by the cleanup goroutine in
+// StartServicesLeaderElection (leaseMgr.Delete once svcCtx.Ctx is done). Paths that cancel
+// the service context without also removing it from svcMap - the deferred close(stopChan)
+// in watchEndpoint, and the utils.PanicError branch in AddOrModify - therefore leave a
+// cancelled context behind. Every later watch event then reuses it, skips leaseMgr.Add, and
+// StartServicesLeaderElection fails with "no existing lease found for service ..." forever.
+//
+// Dropping a cancelled context restores the invariant that a service context in svcMap
+// always has a matching lease in the lease manager.
+func TestDropCancelledServiceContext(t *testing.T) {
+	newProcessor := func() *Processor {
+		return &Processor{
+			config:   &kubevip.Config{},
+			leaseMgr: lease.NewManager(),
+		}
+	}
+
+	uid := types.UID("service-uid")
+
+	t.Run("cancelled context is dropped and removed from svcMap", func(t *testing.T) {
+		p := newProcessor()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		svcCtx := servicecontext.New(ctx)
+		p.svcMap.Store(uid, svcCtx)
+		cancel()
+
+		if got := p.dropCancelledServiceContext(uid, svcCtx); got != nil {
+			t.Fatalf("expected a cancelled service context to be dropped, got %v", got)
+		}
+		if _, ok := p.svcMap.Load(uid); ok {
+			t.Fatal("expected the cancelled service context to be removed from svcMap")
+		}
+	})
+
+	t.Run("live context is kept", func(t *testing.T) {
+		p := newProcessor()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		svcCtx := servicecontext.New(ctx)
+		p.svcMap.Store(uid, svcCtx)
+
+		if got := p.dropCancelledServiceContext(uid, svcCtx); got != svcCtx {
+			t.Fatalf("expected a live service context to be kept, got %v", got)
+		}
+		if _, ok := p.svcMap.Load(uid); !ok {
+			t.Fatal("expected a live service context to stay in svcMap")
+		}
+	})
+
+	t.Run("nil context is a no-op", func(t *testing.T) {
+		p := newProcessor()
+		if got := p.dropCancelledServiceContext(uid, nil); got != nil {
+			t.Fatalf("expected nil to be returned for a nil service context, got %v", got)
+		}
+	})
+}
+
+// TestDropCancelledServiceContextAllowsLeaseRecreation shows the consequence of the fix: once the
+// cancelled context has been dropped, the caller takes the `svcCtx == nil` branch and a lease is
+// created again, so StartServicesLeaderElection no longer fails with "no existing lease found".
+func TestDropCancelledServiceContextAllowsLeaseRecreation(t *testing.T) {
+	p := &Processor{
+		config:   &kubevip.Config{},
+		leaseMgr: lease.NewManager(),
+	}
+
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example",
+			Namespace: "default",
+			UID:       types.UID("service-uid"),
+		},
+	}
+
+	leaseNamespace, serviceLease := lease.ServiceName(svc)
+	id := lease.NewID(p.config.LeaderElectionType, leaseNamespace, serviceLease)
+
+	// A previous election created a lease and a service context, then both the lease and the
+	// service context went away - but only the lease was removed from the manager.
+	ctx, cancel := context.WithCancel(context.Background())
+	svcCtx := servicecontext.New(ctx)
+	p.svcMap.Store(svc.UID, svcCtx)
+	cancel()
+
+	if p.leaseMgr.Get(id) != nil {
+		t.Fatal("precondition failed: the lease manager should not hold a lease yet")
+	}
+
+	if got := p.dropCancelledServiceContext(svc.UID, svcCtx); got != nil {
+		t.Fatalf("expected the stale service context to be dropped, got %v", got)
+	}
+
+	// This mirrors the `if svcCtx == nil` branch in AddOrModify.
+	p.leaseMgr.Add(context.Background(), id)
+
+	if p.leaseMgr.Get(id) == nil {
+		t.Fatal("expected a new lease to be created once the cancelled service context was dropped")
+	}
+}


### PR DESCRIPTION
Fixes #1663.

`AddOrModify` only calls `leaseMgr.Add` inside its `if svcCtx == nil` branch, but the in-memory lease is removed independently: the cleanup goroutine started by `StartServicesLeaderElection` calls `leaseMgr.Delete` once `svcCtx.Ctx` is done, and `Manager.Delete` drops the lease once its last object goes away.

Several paths cancel the service context **without** also removing it from `svcMap` — the deferred `close(stopChan)` in `watchEndpoint`, and the `utils.PanicError` branch in `AddOrModify`. Afterwards `svcMap` still holds a cancelled context for that UID, so every later watch event reuses it, skips `leaseMgr.Add`, and `StartServicesLeaderElection` fails on

```
no existing lease found for service %q with UID %q
```

for the lifetime of the process. Leader election never restarts and the address is never re-advertised; only restarting the pod clears it.

This is distinct from #1650, which removed the `wg.Wait()` deadlock but not this `svcMap` ↔ `leaseMgr` desync. Both **v1.2.1 and v1.2.2** are affected.

## Change

`dropCancelledServiceContext` discards a service context whose context has already been cancelled, removing it from `svcMap` and returning `nil`, so the existing `if svcCtx == nil` branch creates a fresh context and a fresh lease. That restores the invariant that a service context in `svcMap` always has a matching lease in the lease manager.

It is a separate small method rather than an inline `if` specifically so the behaviour is directly unit-testable.

### Rejected alternative

Having `StartServicesLeaderElection` call `leaseMgr.Add` when `Get` returns `nil` would also stop the error, but it attaches the lease lifetime to the *service* context rather than the *watcher* context, inverting the intended ownership model. The `svcMap` purge keeps the existing ownership intact.

## Tests

`pkg/services/processor_lease_test.go`:

- `TestDropCancelledServiceContext` — a cancelled context is dropped **and** removed from `svcMap`; a live context is kept; `nil` is a no-op.
- `TestDropCancelledServiceContextAllowsLeaseRecreation` — demonstrates the consequence: with the stale context dropped, the caller takes the `svcCtx == nil` branch and a lease exists again, so `StartServicesLeaderElection` no longer fails with `no existing lease found`.

```
go build ./...                                  ok
go vet   ./pkg/services/                        ok
go test  ./pkg/services/... ./pkg/lease/...     ok  (both packages)
go test  ./pkg/services/ -run TestDropCancelledServiceContext -v
    --- PASS: TestDropCancelledServiceContext
    --- PASS: TestDropCancelledServiceContext/cancelled_context_is_dropped_and_removed_from_svcMap
    --- PASS: TestDropCancelledServiceContext/live_context_is_kept
    --- PASS: TestDropCancelledServiceContext/nil_context_is_a_no-op
    --- PASS: TestDropCancelledServiceContextAllowsLeaseRecreation
```

## Notes

Opened as a draft: the fix and tests are complete and validated locally, but I would welcome maintainer input on whether you would rather see the guard inline in `AddOrModify`, and on whether any of the other `svcCtx.Cancel()` call sites should instead be purging `svcMap` themselves.
