### PR TITLE
services: start the leader-election restart loop at most once per service

### DIFF
--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -247,10 +247,21 @@ func (p *Processor) updateAnnotations(service *v1.Service, lastKnownGoodEndpoint
 func (p *Processor) startServiceHandlingIfNeeded(svcCtx *servicecontext.Context, service *v1.Service,
 	serviceFunc func(*servicecontext.Context, *v1.Service, *sync.WaitGroup, bool) error, wg *sync.WaitGroup, les *atomic.Int64) error {
 	if p.config.EnableServicesElection {
-		wg.Go(func() {
-			les.Add(1)
-			p.startLeaderElection(svcCtx, service, serviceFunc, wg)
-		})
+		// startLeaderElection runs a forever loop (until svcCtx.Ctx is
+		// cancelled) that re-attempts election on its own whenever the lease
+		// becomes free, so it must only ever be spawned once per service.
+		// AddOrModify is invoked repeatedly for the same service (every
+		// endpoint-slice add/modify/resync event, including transitions back
+		// from zero endpoints), so without this guard a duplicate restart-loop
+		// goroutine gets spawned on every such event, piling up concurrent,
+		// redundant loops racing on the same shared Lease.
+		if !svcCtx.LeaderElectionStarted {
+			svcCtx.LeaderElectionStarted = true
+			wg.Go(func() {
+				les.Add(1)
+				p.startLeaderElection(svcCtx, service, serviceFunc, wg)
+			})
+		}
 		return nil
 	}
 

--- a/pkg/endpoints/endpoints_test.go
+++ b/pkg/endpoints/endpoints_test.go
@@ -3,10 +3,13 @@ package endpoints
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/kube-vip/kube-vip/pkg/endpoints/providers"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/servicecontext"
 	v1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -130,4 +133,94 @@ func TestAddOrModify_ZeroEndpointsBehavior(t *testing.T) {
 		}
 		run(t, service, true, false, true, false)
 	})
+}
+
+// TestAddOrModify_ServicesElectionStartsLeaderElectionOnce guards against a
+// regression where startServiceHandlingIfNeeded spawns a new, permanently
+// running startLeaderElection goroutine on every AddOrModify call that sees
+// non-zero endpoints, instead of exactly once per service lifetime. Before
+// the fix, repeated endpoint churn (endpoints flipping non-zero -> zero ->
+// non-zero, e.g. during a backend pod's rolling restart) accumulates
+// duplicate restart-loop goroutines racing on the same shared Lease; one of
+// the observed effects in production was a service Lease that never
+// reacquired a holder after a legitimate teardown, even though a healthy
+// endpoint had come back.
+func TestAddOrModify_ServicesElectionStartsLeaderElectionOnce(t *testing.T) {
+	service := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc-under-test", Namespace: "default"},
+	}
+
+	leaseNamespace, leaseName := lease.ServiceName(service)
+	config := &kubevip.Config{EnableServicesElection: true}
+	id := lease.NewID(config.LeaderElectionType, leaseNamespace, leaseName)
+
+	leaseMgr := lease.NewManager()
+	l := leaseMgr.Add(context.Background(), id)
+
+	worker := &fakeWorker{endpoints: []string{"10.0.0.5"}}
+	p := &Processor{
+		config:   config,
+		provider: providers.NewEndpointslices(),
+		worker:   worker,
+		leaseMgr: leaseMgr,
+	}
+
+	svcCtx := servicecontext.New(l.Ctx)
+
+	var calls int32
+	started := make(chan struct{}, 8)
+	block := make(chan struct{})
+	// Stands in for services.StartServicesLeaderElection: records that a
+	// leader-election attempt started, then blocks - simulating a goroutine
+	// that has become (or is trying to become) the active leader and won't
+	// return until it loses leadership or is torn down.
+	serviceFunc := func(*servicecontext.Context, *v1.Service, *sync.WaitGroup, bool) error {
+		atomic.AddInt32(&calls, 1)
+		started <- struct{}{}
+		<-block
+		return nil
+	}
+
+	wg := &sync.WaitGroup{}
+	lastKnownGoodEndpoint := new(string)
+
+	// Simulate the endpoint being (re-)observed as non-zero three times in a
+	// row, as happens across repeated EndpointSlice add/modify/resync events
+	// for the same still-healthy service.
+	for range 3 {
+		if _, err := p.AddOrModify(
+			svcCtx,
+			watch.Event{Type: watch.Modified, Object: &discoveryv1.EndpointSlice{}},
+			lastKnownGoodEndpoint,
+			service,
+			"node-1",
+			serviceFunc,
+			wg,
+			nil,
+			nil,
+		); err != nil {
+			t.Fatalf("AddOrModify returned error: %v", err)
+		}
+	}
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the first leader-election attempt to start")
+	}
+
+	select {
+	case <-started:
+		t.Fatalf("a second leader-election restart-loop goroutine started for the same service (got %d serviceFunc calls) - startServiceHandlingIfNeeded must only spawn it once per service lifetime", atomic.LoadInt32(&calls))
+	case <-time.After(200 * time.Millisecond):
+		// No second spawn observed - expected.
+	}
+
+	close(block)
+	svcCtx.Cancel()
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected exactly 1 leader-election attempt across 3 AddOrModify calls, got %d", got)
+	}
 }

--- a/pkg/servicecontext/servicecontext.go
+++ b/pkg/servicecontext/servicecontext.go
@@ -15,6 +15,12 @@ type Context struct {
 	epReady            sync.Once
 	Signalled          atomic.Bool
 	LeaderCancel       context.CancelFunc
+	// LeaderElectionStarted tracks whether the per-service leader-election
+	// restart-loop goroutine has already been spawned for this context's
+	// lifetime. That goroutine runs until Ctx is cancelled, re-attempting
+	// election forever on its own, so it must be started at most once per
+	// service - not once per AddOrModify call with non-zero endpoints.
+	LeaderElectionStarted bool
 }
 
 func New(ctx context.Context) *Context {


### PR DESCRIPTION
## What

`startServiceHandlingIfNeeded`'s `EnableServicesElection` branch spawned a new `startLeaderElection` goroutine on every `AddOrModify` call that saw non-zero endpoints, unlike the ARP-only branch right below it, which guards the equivalent spawn with `svcCtx.Signalled`. `startLeaderElection` already loops forever internally (until `svcCtx.Ctx` is cancelled), re-attempting election on its own whenever the service's `Lease` becomes free, so it only needs to be started once per service lifetime, not once per endpoint event.

Adds `LeaderElectionStarted` to `servicecontext.Context`: a one-time flag set right before the restart-loop goroutine is spawned and checked before spawning again, mirroring the existing `IsWatched` field's once-per-lifetime usage pattern elsewhere in this same struct.

## Why

`AddOrModify` runs on every EndpointSlice add/modify/resync event for a service, including transitions back from zero endpoints (e.g. a backend pod's readiness or role flipping during a rolling upgrade). Without this guard, each such event spawns another duplicate, permanently-running restart-loop goroutine for the same service, all contending on the same shared `Lease`.

We hit this in production: after a legitimate zero-endpoint teardown (VIP correctly deleted, leadership correctly released via `OnStoppedLeading`) followed by the endpoint becoming healthy again, the service's `Lease` never reacquired a holder: `kubectl get lease` showed `holderIdentity: ""` with `acquireTime == renewTime` frozen at the teardown timestamp for 11+ minutes, while the VIP kept accepting TCP connections but returned EOF on read (no active leader serving traffic). Full logs, the `Lease` YAML, and the RCA are in the linked issue.

Distinguished from the superficially similar #1664 (`dropCancelledServiceContext`, stale-`svcCtx` desync): that bug's distinctive symptom, `"no existing lease found for service..."`, was never observed in our logs. This is a different root cause in the same subsystem.

## Testing

Adds `TestAddOrModify_ServicesElectionStartsLeaderElectionOnce` in `pkg/endpoints/endpoints_test.go`, which drives `AddOrModify` three times in a row with non-zero endpoints and asserts the leader-election attempt only starts once. Verified (via a Linux container, since this package needs `GOOS=linux`) that this test:
- **fails** against the pre-fix code, a second restart-loop goroutine starts and is observed
- **passes** with the fix applied, including under `-race`

Built an image with the fix, the EOF issue is no longer observed.

Fixes #1665