### PR TITLE
Fixed IP updater for DNS

### DIFF
--- a/pkg/loadbalancer/ipvs.go
+++ b/pkg/loadbalancer/ipvs.go
@@ -58,8 +58,9 @@ type IPVSLoadBalancer struct {
 
 func NewIPVSLB(ctx context.Context, network vip.Network, port uint16, forwardingMethod string, backendHealthCheckInterval int,
 	nftables bool, killFunc func(), wg *sync.WaitGroup) (*IPVSLoadBalancer, error) {
+	log.Info("Starting IPVS LoadBalancer", "network", network)
+
 	address := network.IP()
-	log.Info("Starting IPVS LoadBalancer", "address", network)
 
 	// Create IPVS client
 	c, err := ipvs.New()

--- a/pkg/utils/dns.go
+++ b/pkg/utils/dns.go
@@ -25,7 +25,7 @@ func LookupHost(dnsName, dnsMode string, requireDualStack bool) ([]string, error
 		return nil, errors.Errorf("empty address for %s", dnsName)
 	}
 	addrs := []string{}
-	switch dnsMode {
+	switch strings.ToLower(dnsMode) {
 	case strings.ToLower(IPv4Family), strings.ToLower(IPv6Family), DualFamily:
 		a, err := getIPbyFamily(result, dnsMode, requireDualStack)
 		if err != nil {

--- a/pkg/vip/dns.go
+++ b/pkg/vip/dns.go
@@ -31,21 +31,25 @@ func NewIPUpdater(vip Network) IPUpdater {
 
 // Run runs the IP updater
 func (d *ipUpdater) Run(ctx context.Context) {
+	mode := utils.IPv4Family
+	if utils.IsIPv6(d.vip.IP()) {
+		mode = utils.IPv6Family
+	}
+
+	dnsName := d.vip.DNSName()
+
+	t := time.NewTicker(defaultInterval * time.Second)
+	defer t.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
 			log.Info("stop ipUpdater")
 			return
-		default:
-			mode := "ipv4"
-			if utils.IsIPv6(d.vip.IP()) {
-				mode = "ipv6"
-			}
-
-			ip, err := utils.LookupHost(d.vip.DNSName(), mode, true)
+		case <-t.C:
+			ip, err := utils.LookupHost(dnsName, mode, true)
 			if err != nil {
-				log.Warn("cannot lookup", "name", d.vip.DNSName(), "err", err)
+				log.Warn("cannot lookup", "name", dnsName, "err", err)
 				// fallback to renewing the existing IP
 				ip = []string{d.vip.IP()}
 			}
@@ -58,8 +62,6 @@ func (d *ipUpdater) Run(ctx context.Context) {
 			if _, err := d.vip.AddIP(true, false, defaultInterval); err != nil {
 				log.Error("error adding virtual IP", "err", err)
 			}
-
 		}
-		time.Sleep(defaultInterval * time.Second)
 	}
 }


### PR DESCRIPTION
This PR reworks the `ipUpdater` used with DNS, which, according to the reports fixes #1655

The change is to move two of the locking functions outside of the `for` loop, and using a ticker instead of a sleep.