### PR TITLE
fix(services): start the leader-election loop once per service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ e2e-tests: e2e-tests-arp e2e-tests-rt e2e-tests-bgp
 
 service-tests:
 	$(MAKE) -C testing/e2e/e2e dockerLocal
-	E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run ./testing/services -Services -simple -deployments -leaderActive -leaderFailover -localDeploy -endpointFlap -egress -egressIPv6 -dualStack -egressInternal
+	E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run ./testing/services -Services -simple -deployments -leaderActive -leaderFailover -localDeploy -electionFaults -egress -egressIPv6 -dualStack -egressInternal
 
 trivy: dockerx86ActionIPTables
 	docker run -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:0.47.0 \

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ e2e-tests: e2e-tests-arp e2e-tests-rt e2e-tests-bgp
 
 service-tests:
 	$(MAKE) -C testing/e2e/e2e dockerLocal
-	E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run ./testing/services -Services -simple -deployments -leaderActive -leaderFailover -localDeploy -egress -egressIPv6 -dualStack -egressInternal
+	E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run ./testing/services -Services -simple -deployments -leaderActive -leaderFailover -localDeploy -endpointFlap -egress -egressIPv6 -dualStack -egressInternal
 
 trivy: dockerx86ActionIPTables
 	docker run -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:0.47.0 \

--- a/go.mod
+++ b/go.mod
@@ -87,6 +87,7 @@ require (
 	github.com/josharian/native v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/k-sone/critbitgo v1.4.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mdlayher/genetlink v1.3.2 // indirect

--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -37,7 +37,7 @@ func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config,
 	// Without this, RunOrDie would continue running until leadership is naturally lost.
 	wg.Go(func() {
 		<-objLease.Ctx.Done()
-		leaseMgr.Delete(leaseID, objectName)
+		leaseMgr.Delete(leaseID, objectName, objLease)
 	})
 
 	if !isNew {

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	log "log/slog"
@@ -74,8 +73,6 @@ func (p *Processor) AddOrModify(svcCtx *servicecontext.Context, event watch.Even
 	// If we have a local endpoint then begin the leader Election, unless it's already running
 	//
 
-	les := atomic.Int64{}
-
 	// Check that we have local endpoints
 	if len(endpoints) != 0 {
 		// Ignore IPv4
@@ -85,7 +82,7 @@ func (p *Processor) AddOrModify(svcCtx *servicecontext.Context, event watch.Even
 
 		p.updateLastKnownGoodEndpoint(lastKnownGoodEndpoint, endpoints, service)
 
-		if err := p.startServiceHandlingIfNeeded(svcCtx, service, serviceFunc, wg, &les); err != nil {
+		if err := p.startServiceHandlingIfNeeded(svcCtx, service, serviceFunc, wg); err != nil {
 			return true, err
 		}
 
@@ -103,7 +100,7 @@ func (p *Processor) AddOrModify(svcCtx *servicecontext.Context, event watch.Even
 	} else {
 		if allowReconcileWithoutEndpoints {
 			// Explicit opt-in for controllers that create LoadBalancer services without endpoints
-			if err := p.startServiceHandlingIfNeeded(svcCtx, service, serviceFunc, wg, &les); err != nil {
+			if err := p.startServiceHandlingIfNeeded(svcCtx, service, serviceFunc, wg); err != nil {
 				return true, err
 			}
 			svcCtx.SignalReadiness()
@@ -245,11 +242,14 @@ func (p *Processor) updateAnnotations(service *v1.Service, lastKnownGoodEndpoint
 }
 
 func (p *Processor) startServiceHandlingIfNeeded(svcCtx *servicecontext.Context, service *v1.Service,
-	serviceFunc func(*servicecontext.Context, *v1.Service, *sync.WaitGroup, bool) error, wg *sync.WaitGroup, les *atomic.Int64) error {
+	serviceFunc func(*servicecontext.Context, *v1.Service, *sync.WaitGroup, bool) error, wg *sync.WaitGroup) error {
 	if p.config.EnableServicesElection {
-		wg.Go(func() {
-			les.Add(1)
-			p.startLeaderElection(svcCtx, service, serviceFunc, wg)
+		// startLeaderElection restarts itself until the service context is cancelled,
+		// so start it only once instead of on every endpoint event.
+		svcCtx.StartLeaderElectionOnce(func() {
+			wg.Go(func() {
+				p.startLeaderElection(svcCtx, service, serviceFunc, wg)
+			})
 		})
 		return nil
 	}

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/instance"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/route"
 	"github.com/kube-vip/kube-vip/pkg/servicecontext"
 	"github.com/kube-vip/kube-vip/pkg/utils"
@@ -273,6 +274,14 @@ func (p *Processor) startServiceHandlingIfNeeded(svcCtx *servicecontext.Context,
 }
 
 func (p *Processor) startLeaderElection(svcCtx *servicecontext.Context, service *v1.Service, serviceFunc func(*servicecontext.Context, *v1.Service, *sync.WaitGroup, bool) error, wg *sync.WaitGroup) {
+	// Track this loop for the lifetime of the goroutine. There has to be at most
+	// one per service, so a value above 1 means loops leaked.
+	loops := metrics.ServiceElectionLoops.WithLabelValues(service.Namespace, service.Name)
+	loops.Inc()
+	defer loops.Dec()
+
+	attempts := metrics.ServiceElectionAttemptsTotal.WithLabelValues(service.Namespace, service.Name)
+
 	// This is a blocking function, that will restart (in the event of failure)
 	for {
 		select {
@@ -286,6 +295,7 @@ func (p *Processor) startLeaderElection(svcCtx *servicecontext.Context, service 
 
 			if !l.Elected.Load() {
 				l.Unlock()
+				attempts.Inc()
 				err := serviceFunc(svcCtx, service, wg, true)
 				if err != nil {
 					log.Error(err.Error())

--- a/pkg/endpoints/endpoints_test.go
+++ b/pkg/endpoints/endpoints_test.go
@@ -3,10 +3,13 @@ package endpoints
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/kube-vip/kube-vip/pkg/endpoints/providers"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/servicecontext"
 	v1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -130,4 +133,79 @@ func TestAddOrModify_ZeroEndpointsBehavior(t *testing.T) {
 		}
 		run(t, service, true, false, true, false)
 	})
+}
+
+// TestAddOrModify_ServicesElectionStartsOnce asserts that repeated endpoint events
+// for the same service start the leader-election restart loop exactly once.
+//
+// AddOrModify runs on every EndpointSlice add/modify/resync event, and the loop it
+// starts only returns once the service context is cancelled. Starting it per event
+// therefore accumulates duplicate goroutines that all contend on the same lease.
+//
+// See https://github.com/kube-vip/kube-vip/issues/1665.
+func TestAddOrModify_ServicesElectionStartsOnce(t *testing.T) {
+	config := &kubevip.Config{
+		EnableServicesElection: true,
+		LeaderElectionType:     "kubernetes",
+	}
+
+	service := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-svc", Namespace: "default", UID: "test-uid"},
+		Spec:       v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	leaseMgr := lease.NewManager()
+	leaseNamespace, serviceLease := lease.ServiceName(service)
+	svcLease := leaseMgr.Add(ctx, lease.NewID(config.LeaderElectionType, leaseNamespace, serviceLease))
+
+	svcCtx := servicecontext.New(svcLease.Ctx)
+
+	// The started loops only return once the service context is cancelled, so it has
+	// to be cancelled before waiting on them.
+	wg := &sync.WaitGroup{}
+	defer wg.Wait()
+	defer svcCtx.Cancel()
+
+	p := &Processor{
+		config:   config,
+		provider: providers.NewEndpointslices(),
+		worker:   &fakeWorker{endpoints: []string{"10.0.0.1"}},
+		leaseMgr: leaseMgr,
+	}
+
+	// starts counts the restart loops. The real StartServicesLeaderElection blocks
+	// until the service context is cancelled, so each loop parks in a single call.
+	var starts atomic.Int64
+	serviceFunc := func(svcCtx *servicecontext.Context, _ *v1.Service, _ *sync.WaitGroup, _ bool) error {
+		starts.Add(1)
+		<-svcCtx.Ctx.Done()
+		return nil
+	}
+
+	// Three endpoint events, as a flapping backend pod would produce.
+	for range 3 {
+		restart, err := p.AddOrModify(svcCtx, watch.Event{Type: watch.Modified, Object: &discoveryv1.EndpointSlice{}},
+			new(string), service, "node-1", serviceFunc, wg, nil, nil)
+		if err != nil {
+			t.Fatalf("AddOrModify returned error: %v", err)
+		}
+		if restart {
+			t.Fatal("AddOrModify unexpectedly requested restart")
+		}
+	}
+
+	// Give every loop that is going to start a chance to reach serviceFunc.
+	for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline); {
+		if starts.Load() > 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if got := starts.Load(); got != 1 {
+		t.Errorf("leader election started %d times, want 1", got)
+	}
 }

--- a/pkg/endpoints/endpoints_test.go
+++ b/pkg/endpoints/endpoints_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/endpoints/providers"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/servicecontext"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	v1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -207,5 +209,10 @@ func TestAddOrModify_ServicesElectionStartsOnce(t *testing.T) {
 
 	if got := starts.Load(); got != 1 {
 		t.Errorf("leader election started %d times, want 1", got)
+	}
+
+	// The gauge the e2e fault tests assert on has to agree with the call count.
+	if got := testutil.ToFloat64(metrics.ServiceElectionLoops.WithLabelValues(service.Namespace, service.Name)); got != 1 {
+		t.Errorf("kube_vip_service_election_loops is %v, want 1", got)
 	}
 }

--- a/pkg/lease/lease.go
+++ b/pkg/lease/lease.go
@@ -37,7 +37,10 @@ func NewManager() *Manager {
 func (m *Manager) Add(ctx context.Context, id ID) *Lease {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	if _, exists := m.leases[id.NamespacedName()]; !exists {
+
+	// A lease whose context is already cancelled cannot be handed out again:
+	// anything derived from it would be cancelled straight away. Replace it.
+	if l, exists := m.leases[id.NamespacedName()]; !exists || l.Ctx.Err() != nil {
 		leaseCtx, leaseCancel := context.WithCancel(ctx)
 		m.leases[id.NamespacedName()] = newLease(leaseCtx, leaseCancel)
 	}
@@ -57,16 +60,49 @@ func (m *Manager) Delete(id ID, objectName string, l *Lease) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	current, exist := m.leases[id.NamespacedName()]
-	if !exist || (l != nil && current != l) {
+	current := m.currentFor(id, l)
+	if current == nil {
 		return
 	}
 
 	current.delete(objectName)
 	if current.cnt.Load() < 1 {
-		current.Cancel()
-		delete(m.leases, id.NamespacedName())
+		m.retire(id, current)
 	}
+}
+
+// Retire drops the lease from the manager and cancels it, so that a later Add
+// creates a fresh instance.
+//
+// Teardown paths have to call this rather than relying on the deferred cleanup
+// goroutine. Until the lease is out of the map, Add hands the same instance back,
+// so a service that is torn down and immediately rebuilt gets parented to a
+// lease that the pending cleanup is about to cancel, and is never handled again.
+func (m *Manager) Retire(id ID, l *Lease) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if current := m.currentFor(id, l); current != nil {
+		m.retire(id, current)
+	}
+}
+
+// currentFor returns the registered lease for id, or nil when the caller is
+// stale, meaning the lease it holds is no longer the registered one. Callers have
+// to hold m.lock.
+func (m *Manager) currentFor(id ID, l *Lease) *Lease {
+	current, exist := m.leases[id.NamespacedName()]
+	if !exist || (l != nil && current != l) {
+		return nil
+	}
+	return current
+}
+
+// retire cancels the lease and drops it from the manager. Callers have to hold
+// m.lock.
+func (m *Manager) retire(id ID, l *Lease) {
+	l.Cancel()
+	delete(m.leases, id.NamespacedName())
 }
 
 // Get returns lease for the service.

--- a/pkg/lease/lease.go
+++ b/pkg/lease/lease.go
@@ -45,16 +45,27 @@ func (m *Manager) Add(ctx context.Context, id ID) *Lease {
 	return m.leases[id.NamespacedName()]
 }
 
-// Delete removes the lease and cancels it if the lease counter equals 0.
-func (m *Manager) Delete(id ID, objectName string) {
+// Delete removes the object from the lease it was added to and cancels that lease
+// once its last object is gone.
+//
+// The lease the caller was given has to be passed in, because cleanup is usually
+// deferred to a goroutine that runs long after the object went away. By then the
+// lease of that name may already have been replaced, for instance because the
+// service was torn down and rebuilt, and cancelling the replacement would leave
+// the service unhandled. A stale caller is therefore ignored.
+func (m *Manager) Delete(id ID, objectName string, l *Lease) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	if _, exist := m.leases[id.NamespacedName()]; exist {
-		m.leases[id.NamespacedName()].delete(objectName)
-		if m.leases[id.NamespacedName()].cnt.Load() < 1 {
-			m.leases[id.NamespacedName()].Cancel()
-			delete(m.leases, id.NamespacedName())
-		}
+
+	current, exist := m.leases[id.NamespacedName()]
+	if !exist || (l != nil && current != l) {
+		return
+	}
+
+	current.delete(objectName)
+	if current.cnt.Load() < 1 {
+		current.Cancel()
+		delete(m.leases, id.NamespacedName())
 	}
 }
 

--- a/pkg/lease/lease.go
+++ b/pkg/lease/lease.go
@@ -49,13 +49,19 @@ func (m *Manager) Add(ctx context.Context, id ID) *Lease {
 }
 
 // Delete removes the object from the lease it was added to and cancels that lease
-// once its last object is gone.
+// once its last object is gone. With a common lease, the siblings that still use
+// it keep it alive.
 //
 // The lease the caller was given has to be passed in, because cleanup is usually
 // deferred to a goroutine that runs long after the object went away. By then the
 // lease of that name may already have been replaced, for instance because the
 // service was torn down and rebuilt, and cancelling the replacement would leave
 // the service unhandled. A stale caller is therefore ignored.
+//
+// Teardown paths have to call this synchronously rather than leaving it to the
+// deferred cleanup: until the lease is out of the map, Add hands the same
+// instance back, so a service that is rebuilt straight away gets parented to a
+// lease that the pending cleanup is about to cancel.
 func (m *Manager) Delete(id ID, objectName string, l *Lease) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
@@ -67,22 +73,6 @@ func (m *Manager) Delete(id ID, objectName string, l *Lease) {
 
 	current.delete(objectName)
 	if current.cnt.Load() < 1 {
-		m.retire(id, current)
-	}
-}
-
-// Retire drops the lease from the manager and cancels it, so that a later Add
-// creates a fresh instance.
-//
-// Teardown paths have to call this rather than relying on the deferred cleanup
-// goroutine. Until the lease is out of the map, Add hands the same instance back,
-// so a service that is torn down and immediately rebuilt gets parented to a
-// lease that the pending cleanup is about to cancel, and is never handled again.
-func (m *Manager) Retire(id ID, l *Lease) {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	if current := m.currentFor(id, l); current != nil {
 		m.retire(id, current)
 	}
 }

--- a/pkg/lease/lease_test.go
+++ b/pkg/lease/lease_test.go
@@ -976,3 +976,43 @@ func TestManager_Delete_DoesNotCancelRecreatedLease(t *testing.T) {
 		t.Error("cleanup for the torn down lease removed the recreated lease")
 	}
 }
+
+// TestManager_Add_AfterCancelWithoutDelete_ReusesDoomedLease reproduces the
+// second half of the service rebuild race.
+//
+// A teardown cancels the service context but leaves the lease in the manager,
+// because the cleanup that removes it is deferred to a goroutine. If the
+// replacement service context is built before that goroutine runs, Add hands
+// back the very same lease instance, so the replacement is parented to a lease
+// that is about to be cancelled. The instance guard in Delete cannot help,
+// because the doomed lease and the current lease are the same object.
+//
+// Retiring the lease synchronously during teardown is what makes Add return a
+// genuinely fresh instance.
+func TestManager_Add_AfterCancelWithoutDelete_ReusesDoomedLease(t *testing.T) {
+	mgr := NewManager()
+	svc := createTestService("test-svc", "default", nil)
+	ctx, id := getSvcData(svc)
+	objectName := ServiceNamespacedName(svc)
+
+	old := mgr.Add(ctx, id)
+	old.Add(objectName)
+
+	// Teardown retires the lease, so the rebuild that follows cannot be parented
+	// to it even though the deferred cleanup has not run yet.
+	mgr.Retire(id, old)
+
+	fresh := mgr.Add(ctx, id)
+	fresh.Add(objectName)
+
+	if fresh == old {
+		t.Fatal("replacement service context would be parented to the doomed lease")
+	}
+
+	// The deferred cleanup for the old lease now runs and must be a no-op.
+	mgr.Delete(id, objectName, old)
+
+	if fresh.Ctx.Err() != nil {
+		t.Error("late cleanup cancelled the replacement lease")
+	}
+}

--- a/pkg/lease/lease_test.go
+++ b/pkg/lease/lease_test.go
@@ -2,6 +2,7 @@ package lease
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -998,9 +999,9 @@ func TestManager_Add_AfterCancelWithoutDelete_ReusesDoomedLease(t *testing.T) {
 	old := mgr.Add(ctx, id)
 	old.Add(objectName)
 
-	// Teardown retires the lease, so the rebuild that follows cannot be parented
-	// to it even though the deferred cleanup has not run yet.
-	mgr.Retire(id, old)
+	// Teardown drops the service from its lease synchronously, so the rebuild that
+	// follows cannot be parented to it even though the deferred cleanup has not run.
+	mgr.Delete(id, objectName, old)
 
 	fresh := mgr.Add(ctx, id)
 	fresh.Add(objectName)
@@ -1014,5 +1015,71 @@ func TestManager_Add_AfterCancelWithoutDelete_ReusesDoomedLease(t *testing.T) {
 
 	if fresh.Ctx.Err() != nil {
 		t.Error("late cleanup cancelled the replacement lease")
+	}
+}
+
+// TestManager_LeaseLifetimeInvariant pins the lifetime rule for the whole
+// Add/Delete surface rather than one scenario: a lease stays usable for exactly as
+// long as at least one object still holds it, and is replaced afterwards.
+//
+// That is the property the common lease depends on, and the one a per-lease
+// teardown breaks: dropping one service must not cancel a lease its siblings are
+// still using. Raised by Patryk in review of #1669.
+func TestManager_LeaseLifetimeInvariant(t *testing.T) {
+	shared := map[string]string{serviceLeaseAnnotation: "shared-lease"}
+
+	for _, tc := range []struct {
+		name    string
+		objects int
+	}{
+		{"single object", 1},
+		{"two objects sharing a lease", 2},
+		{"several objects sharing a lease", 4},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr := NewManager()
+			ctx, id := getSvcData(createTestService("svc0", "default", shared))
+
+			objects := make([]string, tc.objects)
+			for i := range objects {
+				objects[i] = ServiceNamespacedName(createTestService(fmt.Sprintf("svc%d", i), "default", shared))
+			}
+
+			l := mgr.Add(ctx, id)
+			for _, o := range objects {
+				if !l.Add(o) {
+					t.Fatalf("object %q was not added", o)
+				}
+			}
+
+			// Drop the objects one at a time. Every drop but the last has to leave
+			// the lease usable, because the rest still depend on it.
+			for i, o := range objects {
+				mgr.Delete(id, o, l)
+
+				if remaining := len(objects) - i - 1; remaining > 0 {
+					if l.Ctx.Err() != nil {
+						t.Fatalf("lease was cancelled with %d object(s) still holding it", remaining)
+					}
+					if mgr.Get(id) != l {
+						t.Fatalf("lease was dropped with %d object(s) still holding it", remaining)
+					}
+					continue
+				}
+
+				if l.Ctx.Err() == nil {
+					t.Error("lease was not cancelled after its last object went away")
+				}
+				if mgr.Get(id) != nil {
+					t.Error("lease was not removed after its last object went away")
+				}
+			}
+
+			// A rebuild has to get a genuinely fresh lease, so nothing derived from it
+			// is cancelled by the teardown that just happened.
+			if fresh := mgr.Add(ctx, id); fresh == l || fresh.Ctx.Err() != nil {
+				t.Error("rebuild reused the retired lease")
+			}
+		})
 	}
 }

--- a/pkg/lease/lease_test.go
+++ b/pkg/lease/lease_test.go
@@ -99,7 +99,7 @@ func TestManager_Delete_DecrementCounter(t *testing.T) {
 
 	// Delete once - should remove the lease
 
-	mgr.Delete(leaseID1, objectName)
+	mgr.Delete(leaseID1, objectName, nil)
 
 	lease := mgr.Get(getSvcID(svc))
 	if lease != nil {
@@ -127,7 +127,7 @@ func TestManager_Delete_CancelsContext(t *testing.T) {
 	}
 
 	// Delete the lease
-	mgr.Delete(leaseID1, objectName)
+	mgr.Delete(leaseID1, objectName, nil)
 
 	// Verify context is cancelled
 	select {
@@ -149,7 +149,7 @@ func TestManager_Add_AfterDelete_CreatesNewLease(t *testing.T) {
 	lease1 := mgr.Add(ctx1, leaseID1)
 	_ = lease1.Add(objectName)
 
-	mgr.Delete(leaseID1, objectName)
+	mgr.Delete(leaseID1, objectName, nil)
 
 	ctx2, leaseID2 := getSvcData(svc)
 	lease2 := mgr.Add(ctx2, leaseID2)
@@ -244,7 +244,7 @@ func TestManager_ConcurrentAccess(t *testing.T) {
 	}
 	wg.Wait()
 
-	mgr.Delete(leaseID1, objectName1)
+	mgr.Delete(leaseID1, objectName1, nil)
 
 	// After a one delete, lease should be gone
 	lease := mgr.Get(getSvcID(svc))
@@ -427,7 +427,7 @@ func TestManager_LeaderElectionRestartScenario_etcd(t *testing.T) {
 
 	// Simulate leadership lost - the leader election function should delete the lease
 	// This is the fix: delete the lease when RunOrDie returns
-	mgr.Delete(leaseID1, objectName1)
+	mgr.Delete(leaseID1, objectName1, nil)
 
 	// Verify lease is removed
 	if mgr.Get(getSvcID(svc)) != nil {
@@ -496,13 +496,13 @@ func TestManager_CommonLeaseScenario(t *testing.T) {
 	}
 
 	// Delete first service - lease should still exist
-	mgr.Delete(leaseID1, objectName1)
+	mgr.Delete(leaseID1, objectName1, nil)
 	if mgr.Get(getSvcID(svc1)) == nil {
 		t.Error("expected lease to still exist after first delete")
 	}
 
 	// Delete second service - lease should be removed
-	mgr.Delete(leaseID2, objectName2)
+	mgr.Delete(leaseID2, objectName2, nil)
 	if mgr.Get(getSvcID(svc2)) != nil {
 		t.Error("expected lease to be removed after all services deleted")
 	}
@@ -550,7 +550,7 @@ func TestManager_RaceCondition_LeaseExistsBeforeDelete(t *testing.T) {
 	}
 
 	// Now the first goroutine's defer deletes the lease
-	mgr.Delete(leaseID1, objectName1)
+	mgr.Delete(leaseID1, objectName1, nil)
 
 	// The lease should not still exist because same service was processed twice, so we do not increment the counter
 	if mgr.Get(getSvcID(svc)) != nil {
@@ -558,7 +558,7 @@ func TestManager_RaceCondition_LeaseExistsBeforeDelete(t *testing.T) {
 	}
 
 	// Second delete does nothing
-	mgr.Delete(leaseID2, objectName1)
+	mgr.Delete(leaseID2, objectName1, nil)
 	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease to not exist")
 	}
@@ -606,17 +606,17 @@ func TestManager_NonCommonLease_MultipleAdds(t *testing.T) {
 	}
 
 	// Need one delete to remove the lease, another delete runs do nothing
-	mgr.Delete(leaseID1, objectName1)
+	mgr.Delete(leaseID1, objectName1, nil)
 	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease to be deleted")
 	}
 
-	mgr.Delete(leaseID2, objectName1)
+	mgr.Delete(leaseID2, objectName1, nil)
 	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease to be deleted")
 	}
 
-	mgr.Delete(leaseID3, objectName1)
+	mgr.Delete(leaseID3, objectName1, nil)
 	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease to be deleted")
 	}
@@ -668,8 +668,8 @@ func TestManager_LeaseContextCancelledBeforeStarted(t *testing.T) {
 	}
 
 	// Delete should still work
-	mgr.Delete(leaseID1, objectName1)
-	mgr.Delete(leaseID2, objectName1)
+	mgr.Delete(leaseID1, objectName1, nil)
+	mgr.Delete(leaseID2, objectName1, nil)
 
 	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease to be removed")
@@ -693,7 +693,7 @@ func TestManager_RestartAfterLeaseContextCancelled(t *testing.T) {
 	lease1.Cancel()
 
 	// Delete the lease
-	mgr.Delete(leaseID1, objectName1)
+	mgr.Delete(leaseID1, objectName1, nil)
 
 	// Verify lease is gone
 	if mgr.Get(getSvcID(svc)) != nil {
@@ -794,11 +794,11 @@ func TestManager_NonCommonLease_WaitForLeaseContextDone(t *testing.T) {
 	}
 
 	// Now simulate the first leader election ending (defer deletes the lease)
-	mgr.Delete(leaseID1, objectName1)
+	mgr.Delete(leaseID1, objectName1, nil)
 
 	// The lease context should now be cancelled (because counter went to 0)
 	// But we added twice, so we need to delete twice
-	mgr.Delete(leaseID2, objectName1)
+	mgr.Delete(leaseID2, objectName1, nil)
 
 	// Now the goroutine should have completed
 	select {
@@ -878,7 +878,7 @@ func TestManager_NonCommonLease_SpinLoopPrevention(t *testing.T) {
 		t.Errorf("expected 100 adds, got %d", addCount)
 	}
 
-	mgr.Delete(leaseID1, objectName1)
+	mgr.Delete(leaseID1, objectName1, nil)
 	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease to be removed after first delete")
 	}
@@ -935,5 +935,44 @@ func TestManager_NonCommonLease_ServiceContextCancellation(t *testing.T) {
 		}
 	case <-time.After(200 * time.Millisecond):
 		t.Error("goroutine should have unblocked")
+	}
+}
+
+// TestManager_Delete_DoesNotCancelRecreatedLease reproduces the stale-cleanup bug.
+//
+// Every service that starts leader election also starts a goroutine that calls
+// Manager.Delete once the service context is cancelled. When a service is torn
+// down and immediately rebuilt, for instance because its externalTrafficPolicy
+// changed, that goroutine runs after the replacement lease was already created.
+// Deleting by name alone then cancels the live replacement, and the service is
+// never handled again.
+func TestManager_Delete_DoesNotCancelRecreatedLease(t *testing.T) {
+	mgr := NewManager()
+	svc := createTestService("test-svc", "default", nil)
+	ctx, id := getSvcData(svc)
+	objectName := ServiceNamespacedName(svc)
+
+	// The service is set up, and its lease is registered.
+	old := mgr.Add(ctx, id)
+	old.Add(objectName)
+
+	// The service is torn down and rebuilt straight away, so a fresh lease for the
+	// same name exists before the old cleanup goroutine gets to run.
+	mgr.Delete(id, objectName, old)
+	fresh := mgr.Add(ctx, id)
+	fresh.Add(objectName)
+
+	if old == fresh {
+		t.Fatal("expected a new lease instance after delete")
+	}
+
+	// Now the cleanup for the *old* lease finally runs. It has to be a no-op.
+	mgr.Delete(id, objectName, old)
+
+	if fresh.Ctx.Err() != nil {
+		t.Error("cleanup for the torn down lease cancelled the recreated lease")
+	}
+	if got := mgr.Get(id); got == nil {
+		t.Error("cleanup for the torn down lease removed the recreated lease")
 	}
 }

--- a/pkg/manager/worker/common.go
+++ b/pkg/manager/worker/common.go
@@ -175,7 +175,7 @@ func (c *Common) runGlobalElection(ctx context.Context, a election.Actions, leas
 		select {
 		case <-ctx.Done():
 			// Service was deleted
-			c.leaseMgr.Delete(leaseID, objectName)
+			c.leaseMgr.Delete(leaseID, objectName, objLease)
 		case <-objLease.Ctx.Done():
 			// Leader election ended (leadership lost or context cancelled)
 		}
@@ -226,7 +226,7 @@ func (c *Common) runGlobalElection(ctx context.Context, a election.Actions, leas
 		// 1. Leadership loss (e.g., network timeout)
 		// 2. Context cancellation
 		// 3. Any other reason RunOrDie returns
-		c.leaseMgr.Delete(leaseID, objectName)
+		c.leaseMgr.Delete(leaseID, objectName, objLease)
 	}()
 
 	wg := sync.WaitGroup{}

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -35,6 +35,21 @@ var (
 		prometheus.GaugeOpts{Name: "kube_vip_is_leader", Help: "1 if this node currently holds the lease"},
 		[]string{"node", "lease_name"},
 	)
+	ServiceElectionLoops = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "kube_vip_service_election_loops",
+			Help: "Live per-service leader election restart loops on this node; more than 1 per service means loops leaked"},
+		[]string{"namespace", "name"},
+	)
+	ServiceElectionAttemptsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "kube_vip_service_election_attempts_total",
+			Help: "Election attempts made by the per-service leader election restart loop"},
+		[]string{"namespace", "name"},
+	)
+	ServiceElectionErrorsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "kube_vip_service_election_errors_total",
+			Help: "Per-service leader election failures by reason"},
+		[]string{"namespace", "name", "reason"},
+	)
 
 	// This is a prometheus gauge indicating the state of the sessions.
 	// 1 means "ESTABLISHED", 0 means "NOT ESTABLISHED"
@@ -61,6 +76,9 @@ func RegisterPrometheusMetrics() {
 		ServiceReconcileDuration,
 		LeaderTransitionsTotal,
 		IsLeader,
+		ServiceElectionLoops,
+		ServiceElectionAttemptsTotal,
+		ServiceElectionErrorsTotal,
 		BGPSessionInfoGauge,
 		BuildInfo,
 		CountServiceWatchEvent,

--- a/pkg/servicecontext/servicecontext.go
+++ b/pkg/servicecontext/servicecontext.go
@@ -13,6 +13,7 @@ type Context struct {
 	ConfiguredNetworks sync.Map
 	EndpointsReady     chan any
 	epReady            sync.Once
+	leaderElection     sync.Once
 	Signalled          atomic.Bool
 	LeaderCancel       context.CancelFunc
 }
@@ -39,6 +40,14 @@ func (ctx *Context) HasConfiguredNetworks() bool {
 func (ctx *Context) IsNetworkConfigured(ip string) bool {
 	_, exists := ctx.ConfiguredNetworks.Load(ip)
 	return exists
+}
+
+// StartLeaderElectionOnce runs f only on its first call for this service context.
+// The leader-election loop restarts itself internally until the context is
+// cancelled, so it must be started exactly once per service lifetime. Unlike
+// readiness, this is never reset: the loop outlives individual endpoint events.
+func (ctx *Context) StartLeaderElectionOnce(f func()) {
+	ctx.leaderElection.Do(f)
 }
 
 func (ctx *Context) SignalReadiness() {

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -82,7 +82,7 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 	// healthy and a new election should have started immediately.
 	go func() {
 		<-svcCtx.Ctx.Done()
-		p.leaseMgr.Delete(id, objectName)
+		p.leaseMgr.Delete(id, objectName, svcLease)
 	}()
 
 	select {

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -42,6 +42,7 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 
 	svcLease := p.leaseMgr.Get(id)
 	if svcLease == nil {
+		metrics.ServiceElectionErrorsTotal.WithLabelValues(service.Namespace, service.Name, "no_lease").Inc()
 		return fmt.Errorf("no existing lease found for service %q with UID %q", service.Name, service.UID)
 	}
 

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -196,6 +196,10 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 				}
 				// in theory this should never fail
 				p.svcMap.Delete(svc.UID)
+				// Retire the lease as well, so the replacement context below is not
+				// parented to a lease the pending cleanup is about to cancel.
+				ns, name := lease.ServiceName(svc)
+				p.leaseMgr.Retire(lease.NewID(p.config.LeaderElectionType, ns, name), nil)
 				// Reset the the svcCtx when it was garbage collected
 				// As the next function will create a new context when nil
 				svcCtx = nil

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -196,10 +196,12 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 				}
 				// in theory this should never fail
 				p.svcMap.Delete(svc.UID)
-				// Retire the lease as well, so the replacement context below is not
-				// parented to a lease the pending cleanup is about to cancel.
+				// Drop this service from its lease now, so the replacement context
+				// below is not parented to a lease the pending cleanup is about to
+				// cancel. A lease shared with other services stays alive for them.
 				ns, name := lease.ServiceName(svc)
-				p.leaseMgr.Retire(lease.NewID(p.config.LeaderElectionType, ns, name), nil)
+				leaseID := lease.NewID(p.config.LeaderElectionType, ns, name)
+				p.leaseMgr.Delete(leaseID, lease.ServiceNamespacedName(svc), nil)
 				// Reset the the svcCtx when it was garbage collected
 				// As the next function will create a new context when nil
 				svcCtx = nil

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -344,6 +344,8 @@ func (p *Processor) Delete(event watch.Event, forcedOnly bool) error {
 		log.Warn("(svcs) The load balancer was deleted, cancelling context", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
 		svcCtx.Cancel()
 		p.svcMap.Delete(svc.UID)
+		// Drop the per-service election series so a recreated service starts clean.
+		metrics.ServiceElectionLoops.DeleteLabelValues(svc.Namespace, svc.Name)
 		p.updateActiveServicesMetric()
 	}
 

--- a/testing/services/main.go
+++ b/testing/services/main.go
@@ -126,6 +126,12 @@ func main() {
 		if err != nil {
 			slog.Fatalf("could not create k8s REST config from external file: %q: %v", homeConfigPath, err)
 		}
+		// The fault tests poll the API a lot while waiting for convergence, which
+		// exhausts client-go's default 5 QPS budget and turns a slow poll into a
+		// rate limiter timeout. Raise it for the test harness.
+		config.QPS = 50
+		config.Burst = 100
+
 		clientset, err := k8s.NewClientset(config)
 		if err != nil {
 			slog.Fatalf("could not create k8s clientset from external file: %q: %v", homeConfigPath, err)

--- a/testing/services/main.go
+++ b/testing/services/main.go
@@ -37,6 +37,7 @@ func main() {
 	flag.BoolVar(&t.LeaderFailover, "leaderFailover", false, "Perform a failover of the leader test")
 	flag.BoolVar(&t.LeaderActive, "leaderActive", false, "Perform a test on the active leader")
 	flag.BoolVar(&t.LocalDeploy, "localDeploy", false, "Perform a test on the active leader")
+	flag.BoolVar(&t.FlapEndpoints, "endpointFlap", false, "Perform a test that repeatedly removes and restores the endpoints")
 	flag.BoolVar(&t.Egress, "egress", false, "Perform an egress test")
 	flag.BoolVar(&t.EgressInternal, "egressInternal", false, "Perform an egress test, using the internal functionality")
 	flag.BoolVar(&t.EgressIPv6, "egressIPv6", false, "Perform an egress test")

--- a/testing/services/main.go
+++ b/testing/services/main.go
@@ -37,7 +37,7 @@ func main() {
 	flag.BoolVar(&t.LeaderFailover, "leaderFailover", false, "Perform a failover of the leader test")
 	flag.BoolVar(&t.LeaderActive, "leaderActive", false, "Perform a test on the active leader")
 	flag.BoolVar(&t.LocalDeploy, "localDeploy", false, "Perform a test on the active leader")
-	flag.BoolVar(&t.FlapEndpoints, "endpointFlap", false, "Perform a test that repeatedly removes and restores the endpoints")
+	flag.BoolVar(&t.FaultElection, "electionFaults", false, "Perform leader election fault injection tests")
 	flag.BoolVar(&t.Egress, "egress", false, "Perform an egress test")
 	flag.BoolVar(&t.EgressInternal, "egressInternal", false, "Perform an egress test, using the internal functionality")
 	flag.BoolVar(&t.EgressIPv6, "egressIPv6", false, "Perform an egress test")

--- a/testing/services/pkg/deployment/kind.go
+++ b/testing/services/pkg/deployment/kind.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -300,4 +301,70 @@ func checkNodesForDuplicateAddresses(nodes []nodeAddresses, address string) erro
 		return fmt.Errorf("‼️ multiple nodes [%s] have address [%s]", strings.Join(foundOnNode, " "), address)
 	}
 	return nil
+}
+
+// scrapeElectionLoops returns, per node, the value of the
+// kube_vip_service_election_loops gauge for a service. There has to be at most
+// one live election loop per service per node.
+func scrapeElectionLoops(namespace, name string) (map[string]float64, error) {
+	return scrapeServiceGauge("kube_vip_service_election_loops", namespace, name)
+}
+
+// scrapeServiceGauge sums the samples of a {namespace,name}-labelled metric per
+// node, by curl-ing each kind node's kube-vip metrics endpoint from inside it.
+func scrapeServiceGauge(metric, namespace, name string) (map[string]float64, error) {
+	values := map[string]float64{}
+
+	nodes, err := provider.ListNodes("services")
+	if err != nil {
+		return values, err
+	}
+
+	wantLabels := []string{
+		fmt.Sprintf(`namespace="%s"`, namespace),
+		fmt.Sprintf(`name="%s"`, name),
+	}
+
+	for x := range nodes {
+		var out bytes.Buffer
+		cmd := nodes[x].Command("curl", "-s", "--max-time", "5", "http://127.0.0.1:2112/metrics")
+		cmd.SetStdout(&out)
+		cmd.SetStderr(&bytes.Buffer{})
+		if err := cmd.Run(); err != nil {
+			// A node without a kube-vip pod, or one that is restarting, has no
+			// endpoint to scrape. That is not a failure of the metric itself.
+			slog.Debugf("could not scrape metrics on node %s: %v", nodes[x].String(), err)
+			continue
+		}
+
+		total := 0.0
+		for _, line := range strings.Split(out.String(), "\n") {
+			if !strings.HasPrefix(line, metric+"{") {
+				continue
+			}
+			matches := true
+			for _, l := range wantLabels {
+				if !strings.Contains(line, l) {
+					matches = false
+					break
+				}
+			}
+			if !matches {
+				continue
+			}
+			fields := strings.Fields(line)
+			v, err := strconv.ParseFloat(fields[len(fields)-1], 64)
+			if err != nil {
+				return values, fmt.Errorf("failed to parse %q: %w", line, err)
+			}
+			total += v
+		}
+		values[nodes[x].String()] = total
+	}
+
+	if len(values) == 0 {
+		return values, fmt.Errorf("could not scrape %q from any node", metric)
+	}
+
+	return values, nil
 }

--- a/testing/services/pkg/deployment/kubernetes.go
+++ b/testing/services/pkg/deployment/kubernetes.go
@@ -25,9 +25,10 @@ type Service struct {
 	egressIPv6     bool // egress should be IPv6
 	policyLocal    bool // set the policy to local pods
 	testHTTP       bool
-	testDualstack  bool // test dualstack loadbalancer services
-	dhcpBroadcast  bool // test dhcp broadcast flag
-	timeout        int  // how long to wait for the service to be created
+	testDualstack  bool   // test dualstack loadbalancer services
+	dhcpBroadcast  bool   // test dhcp broadcast flag
+	commonLease    string // share a lease with other services under this name
+	timeout        int    // how long to wait for the service to be created
 }
 
 type Deployment struct {
@@ -239,10 +240,16 @@ func (s *Service) CreateService(ctx context.Context, clientset *kubernetes.Clien
 		},
 	}
 
+	svc.Annotations = map[string]string{}
+
 	if s.egress {
-		svc.Annotations = map[string]string{
-			kubevip.Egress: "true",
-		}
+		svc.Annotations[kubevip.Egress] = "true"
+	}
+
+	if s.commonLease != "" {
+		// A common lease is only valid with a cluster traffic policy.
+		svc.Annotations[kubevip.ServiceLease] = s.commonLease
+		svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeCluster
 	}
 
 	if s.egressInternal {

--- a/testing/services/pkg/deployment/services.go
+++ b/testing/services/pkg/deployment/services.go
@@ -88,9 +88,9 @@ func (config *TestConfig) StartServiceTest(ctx context.Context, clientset *kuber
 		}
 	}
 
-	if config.FlapEndpoints {
-		// endpoint churn tests
-		err = config.EndpointFlap(ctx, clientset)
+	if config.FaultElection {
+		// leader election fault injection
+		err = config.ElectionFaults(ctx, clientset)
 		if err != nil {
 			slog.Error(err)
 			errs = append(errs, err)

--- a/testing/services/pkg/deployment/services.go
+++ b/testing/services/pkg/deployment/services.go
@@ -88,6 +88,15 @@ func (config *TestConfig) StartServiceTest(ctx context.Context, clientset *kuber
 		}
 	}
 
+	if config.FlapEndpoints {
+		// endpoint churn tests
+		err = config.EndpointFlap(ctx, clientset)
+		if err != nil {
+			slog.Error(err)
+			errs = append(errs, err)
+		}
+	}
+
 	if config.Egress {
 		// Egress test
 		err = config.EgressDeployment(ctx, clientset, false)

--- a/testing/services/pkg/deployment/tests.go
+++ b/testing/services/pkg/deployment/tests.go
@@ -673,12 +673,12 @@ func deleteDeployment(ctx context.Context, clientset *kubernetes.Clientset, name
 //     it from svcMap, so later events reused a cancelled context and could never
 //     re-add the lease. kube_vip_service_election_errors_total{reason="no_lease"}
 //     must stay at zero.
-//   - lease loss (#1650): deleting the lease, and blanking its holderIdentity,
-//     makes the election client lose leadership the ordinary way. The restart loop
-//     used to wedge on a WaitGroup at that point, so the election attempt counter
-//     must keep advancing and the lease must get a holder back.
-//   - API server loss: the apiserver is blocked from the leader for longer than
-//     the lease duration, exercising the same loss path through a real partition.
+//   - lease object faults: the lease is deleted, and its holderIdentity blanked.
+//     The election client recovers these itself, so these only assert convergence.
+//   - leadership loss (#1650): the apiserver is blocked from the leader for longer
+//     than the lease duration, which drives OnStoppedLeading and returns the
+//     election. The restart loop used to wedge on a WaitGroup exactly there, so
+//     kube_vip_service_election_attempts_total must advance afterwards.
 //
 // After every fault the service has to converge: a live election loop, a held
 // lease, and a VIP that serves traffic.
@@ -774,24 +774,14 @@ func (config *TestConfig) ElectionFaults(ctx context.Context, clientset *kuberne
 		return err
 	}
 
-	// Fault 3 (#1650): ordinary leadership loss, by removing the lease and by
-	// blanking its holder. The election attempt counter has to keep advancing,
-	// which it cannot do if the restart loop is wedged.
-	before, err := scrapeServiceGauge("kube_vip_service_election_attempts_total", v1.NamespaceDefault, config.ServiceName)
-	if err != nil {
-		return err
-	}
-
+	// Fault 3: lease object faults. Deleting the lease and blanking its holder are
+	// recovered by the election client itself, so this only asserts convergence.
 	slog.Infof("💥 deleting lease [%s]", leaseName)
 	if err := clientset.CoordinationV1().Leases(v1.NamespaceDefault).Delete(ctx, leaseName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete lease %q: %w", leaseName, err)
 	}
 
 	if err := config.checkConverged(ctx, clientset, leaseName, lbAddress, "lease deletion"); err != nil {
-		return err
-	}
-
-	if err := waitForElectionProgress(before, v1.NamespaceDefault, config.ServiceName); err != nil {
 		return err
 	}
 
@@ -804,9 +794,16 @@ func (config *TestConfig) ElectionFaults(ctx context.Context, clientset *kuberne
 		return err
 	}
 
-	// Fault 4: partition the leader from the apiserver for longer than the lease
-	// duration, then heal it.
+	// Fault 4 (#1650): a real leadership loss, by partitioning the leader from the
+	// apiserver for longer than the lease duration. That drives OnStoppedLeading
+	// and returns the election, so the restart loop has to make a new attempt
+	// afterwards. A wedged loop never does, which is the #1650 deadlock.
 	leader, err := leaseHolder(ctx, clientset, leaseName)
+	if err != nil {
+		return err
+	}
+
+	before, err := scrapeServiceGauge("kube_vip_service_election_attempts_total", v1.NamespaceDefault, config.ServiceName)
 	if err != nil {
 		return err
 	}
@@ -823,6 +820,10 @@ func (config *TestConfig) ElectionFaults(ctx context.Context, clientset *kuberne
 	}
 
 	if err := config.checkConverged(ctx, clientset, leaseName, lbAddress, "API server disruption"); err != nil {
+		return err
+	}
+
+	if err := waitForElectionProgress(before, v1.NamespaceDefault, config.ServiceName); err != nil {
 		return err
 	}
 

--- a/testing/services/pkg/deployment/tests.go
+++ b/testing/services/pkg/deployment/tests.go
@@ -837,9 +837,8 @@ func (config *TestConfig) ElectionFaults(ctx context.Context, clientset *kuberne
 	}
 
 	// Fault 5: a service change that tears the service down and rebuilds it.
-	// Flipping the external traffic policy makes serviceChanged cancel the service
-	// context and drop it from svcMap, so the next event has to build a fresh
-	// context and a fresh lease. Same desync class as fault 2, different trigger.
+	// Flipping the traffic policy makes serviceChanged cancel the service context,
+	// so the replacement has to get a fresh lease rather than the retired one.
 	for _, policy := range []v1.ServiceExternalTrafficPolicy{
 		v1.ServiceExternalTrafficPolicyCluster,
 		v1.ServiceExternalTrafficPolicyLocal,

--- a/testing/services/pkg/deployment/tests.go
+++ b/testing/services/pkg/deployment/tests.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/gookit/slog"
@@ -12,6 +14,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -655,16 +658,23 @@ func deleteDeployment(ctx context.Context, clientset *kubernetes.Clientset, name
 	}
 }
 
-// EndpointFlap reproduces https://github.com/kube-vip/kube-vip/issues/1665.
+// EndpointFlap exercises the per-service leader election of #1665 under faults.
 //
-// With svc_election enabled, every EndpointSlice event used to start another
-// permanent leader-election restart loop for the same service. Scaling the
-// backend 1 -> 0 -> 1 repeatedly therefore accumulated duplicate loops that all
-// contended on the same lease, and the service could end up with a lease that
-// never reacquired a holder.
+// Three faults are injected in sequence against a svc_election service:
 //
-// The test asserts two things after the flapping: the VIP still serves traffic,
-// and the lease has a holder again.
+//  1. endpoint churn: the backend is scaled 1 -> 0 -> 1 repeatedly, which is
+//     what drove the duplicate election loops reported in the issue.
+//  2. lease faults: the service Lease is deleted, and then blanked by clearing
+//     its holderIdentity, which is the exact state observed in the report.
+//  3. API server faults: the apiserver is made unreachable from the leader for
+//     a while, so every election client on that node loses its backend.
+//
+// After each fault the service has to converge again: the Lease is held by a
+// node and the VIP serves traffic. Those are properties of the feature rather
+// than of the current implementation, so the test stays meaningful if the
+// election internals change. Duplicate election loops are not observable from
+// outside the process; that part is pinned by the unit test in
+// pkg/endpoints/endpoints_test.go.
 func (config *TestConfig) EndpointFlap(ctx context.Context, clientset *kubernetes.Clientset) error {
 	defer func() error {
 		tempDirPath, err := os.MkdirTemp(config.TempDirPath, "endpoint-flap")
@@ -689,7 +699,7 @@ func (config *TestConfig) EndpointFlap(ctx context.Context, clientset *kubernete
 		return nil
 	}() //nolint
 
-	slog.Infof("🧪 ---> endpoint flapping (local policy) <---")
+	slog.Infof("🧪 ---> endpoint and lease faults (local policy) <---")
 	deploy := Deployment{
 		name:         config.DeploymentName,
 		nodeAffinity: config.Affinity,
@@ -714,9 +724,11 @@ func (config *TestConfig) EndpointFlap(ctx context.Context, clientset *kubernete
 		return fmt.Errorf("no load balancer address found for service %s", config.ServiceName)
 	}
 	lbAddress := lbAddresses[0]
+	leaseName := fmt.Sprintf("kubevip-%s", config.ServiceName)
 
-	// Take the endpoints away and bring them back a few times. Each cycle is a
-	// zero-endpoint teardown followed by the endpoint becoming healthy again.
+	// Fault 1: endpoint churn. Each cycle is a zero-endpoint teardown followed by
+	// the endpoint becoming healthy again, which is what accumulated duplicate
+	// election loops before the fix.
 	for i := 1; i <= 5; i++ {
 		slog.Infof("🔁 flap %d: scaling deployment [%s] to zero endpoints", i, config.DeploymentName)
 		if err := scaleDeployment(ctx, clientset, config.DeploymentName, 0); err != nil {
@@ -729,18 +741,128 @@ func (config *TestConfig) EndpointFlap(ctx context.Context, clientset *kubernete
 		}
 	}
 
-	// The VIP has to be served again once the endpoint is healthy.
-	if err := httpTest(lbAddress); err != nil {
-		return fmt.Errorf("service %q did not recover after endpoint flapping: %w", config.ServiceName, err)
+	if err := checkServiceConverged(ctx, clientset, leaseName, lbAddress, "endpoint flapping"); err != nil {
+		return err
 	}
 
-	// A lease without a holder is the symptom reported in issue #1665.
-	if err := waitForLeaseHolder(ctx, clientset, fmt.Sprintf("kubevip-%s", config.ServiceName)); err != nil {
+	// Fault 2a: delete the lease outright and make sure it is recreated and held.
+	slog.Infof("💥 deleting lease [%s]", leaseName)
+	if err := clientset.CoordinationV1().Leases(v1.NamespaceDefault).Delete(ctx, leaseName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete lease %q: %w", leaseName, err)
+	}
+
+	if err := checkServiceConverged(ctx, clientset, leaseName, lbAddress, "lease deletion"); err != nil {
+		return err
+	}
+
+	// Fault 2b: blank the holder. This is the state reported in #1665, where the
+	// lease existed with holderIdentity "" and never got a holder back.
+	slog.Infof("💥 clearing holderIdentity on lease [%s]", leaseName)
+	if err := clearLeaseHolder(ctx, clientset, leaseName); err != nil {
+		return err
+	}
+
+	if err := checkServiceConverged(ctx, clientset, leaseName, lbAddress, "lease holder being cleared"); err != nil {
+		return err
+	}
+
+	// Fault 3: cut the leader off from the API server for longer than the lease
+	// duration, so its election client loses leadership, then restore it.
+	leader, err := leaseHolder(ctx, clientset, leaseName)
+	if err != nil {
+		return err
+	}
+
+	slog.Infof("💥 blocking API server access from node [%s]", leader)
+	if err := setAPIServerReachable(leader, false); err != nil {
+		return err
+	}
+	time.Sleep(time.Second * 20)
+
+	slog.Infof("🔌 restoring API server access on node [%s]", leader)
+	if err := setAPIServerReachable(leader, true); err != nil {
+		return err
+	}
+
+	if err := checkServiceConverged(ctx, clientset, leaseName, lbAddress, "API server disruption"); err != nil {
 		return err
 	}
 
 	config.SuccessCounter++
 
+	return nil
+}
+
+// checkServiceConverged asserts the service is healthy again after a fault: the
+// lease is held by a node and the VIP serves traffic.
+func checkServiceConverged(ctx context.Context, clientset *kubernetes.Clientset, leaseName, lbAddress, fault string) error {
+	holder, err := leaseHolder(ctx, clientset, leaseName)
+	if err != nil {
+		return fmt.Errorf("after %s: %w", fault, err)
+	}
+	slog.Infof("🔎 lease [%s] is held by [%s] after %s", leaseName, holder, fault)
+
+	if err := httpTest(lbAddress); err != nil {
+		return fmt.Errorf("service on %q did not serve traffic after %s: %w", lbAddress, fault, err)
+	}
+	return nil
+}
+
+// leaseHolder waits until the lease exists and reports a holder, and returns it.
+// An empty or missing holder is the symptom reported in #1665.
+func leaseHolder(ctx context.Context, clientset *kubernetes.Clientset, name string) (string, error) {
+	checkCtx, cancel := context.WithTimeout(ctx, time.Second*120)
+	defer cancel()
+
+	t := time.NewTicker(time.Second)
+	defer t.Stop()
+
+	for {
+		l, err := clientset.CoordinationV1().Leases(v1.NamespaceDefault).Get(checkCtx, name, metav1.GetOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return "", fmt.Errorf("failed to get lease %q: %w", name, err)
+		}
+		if err == nil && l.Spec.HolderIdentity != nil && *l.Spec.HolderIdentity != "" {
+			return *l.Spec.HolderIdentity, nil
+		}
+
+		select {
+		case <-checkCtx.Done():
+			return "", fmt.Errorf("lease %q never reacquired a holder", name)
+		case <-t.C:
+		}
+	}
+}
+
+// clearLeaseHolder blanks the holderIdentity of a lease, reproducing the state
+// reported in #1665.
+func clearLeaseHolder(ctx context.Context, clientset *kubernetes.Clientset, name string) error {
+	patch := []byte(`{"spec":{"holderIdentity":null}}`)
+	if _, err := clientset.CoordinationV1().Leases(v1.NamespaceDefault).Patch(ctx, name,
+		types.MergePatchType, patch, metav1.PatchOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to clear holder of lease %q: %w", name, err)
+	}
+	return nil
+}
+
+// setAPIServerReachable blocks or unblocks the kubernetes API server port from
+// inside a kind node, to fault the election clients running on it.
+func setAPIServerReachable(node string, reachable bool) error {
+	// The node hostnames are changed to "<node>-modified", the container keeps
+	// the original name.
+	container := strings.TrimSuffix(node, "-modified")
+
+	action := "-I"
+	if reachable {
+		action = "-D"
+	}
+
+	// kind nodes reach the API server on the control plane's 6443.
+	cmd := exec.Command("docker", "exec", container, "iptables", action, "OUTPUT",
+		"-p", "tcp", "--dport", "6443", "-j", "REJECT") //nolint
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to set apiserver reachable=%t on %q: %w: %s", reachable, container, err, out)
+	}
 	return nil
 }
 
@@ -780,32 +902,6 @@ func waitForReadyEndpoints(ctx context.Context, clientset *kubernetes.Clientset,
 		select {
 		case <-checkCtx.Done():
 			return fmt.Errorf("timed out waiting for deployment %q to have readyEndpoints=%t", name, wantReady)
-		case <-t.C:
-		}
-	}
-}
-
-// waitForLeaseHolder waits until the service lease reports a holder again.
-func waitForLeaseHolder(ctx context.Context, clientset *kubernetes.Clientset, name string) error {
-	checkCtx, cancel := context.WithTimeout(ctx, time.Second*60)
-	defer cancel()
-
-	t := time.NewTicker(time.Second)
-	defer t.Stop()
-
-	for {
-		l, err := clientset.CoordinationV1().Leases(v1.NamespaceDefault).Get(checkCtx, name, metav1.GetOptions{})
-		if err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to get lease %q: %w", name, err)
-		}
-		if err == nil && l.Spec.HolderIdentity != nil && *l.Spec.HolderIdentity != "" {
-			slog.Infof("🔎 lease [%s] is held by [%s]", name, *l.Spec.HolderIdentity)
-			return nil
-		}
-
-		select {
-		case <-checkCtx.Done():
-			return fmt.Errorf("lease %q never reacquired a holder after endpoint flapping", name)
 		case <-t.C:
 		}
 	}

--- a/testing/services/pkg/deployment/tests.go
+++ b/testing/services/pkg/deployment/tests.go
@@ -34,6 +34,7 @@ type TestConfig struct {
 	LeaderFailover     bool
 	LeaderActive       bool
 	LocalDeploy        bool
+	FlapEndpoints      bool
 	DualStack          bool
 	Egress             bool
 	EgressInternal     bool
@@ -650,6 +651,162 @@ func deleteDeployment(ctx context.Context, clientset *kubernetes.Clientset, name
 			} else if err != nil {
 				return fmt.Errorf("failed to wait for the deployment %q to be deleted: %w", name, err)
 			}
+		}
+	}
+}
+
+// EndpointFlap reproduces https://github.com/kube-vip/kube-vip/issues/1665.
+//
+// With svc_election enabled, every EndpointSlice event used to start another
+// permanent leader-election restart loop for the same service. Scaling the
+// backend 1 -> 0 -> 1 repeatedly therefore accumulated duplicate loops that all
+// contended on the same lease, and the service could end up with a lease that
+// never reacquired a holder.
+//
+// The test asserts two things after the flapping: the VIP still serves traffic,
+// and the lease has a holder again.
+func (config *TestConfig) EndpointFlap(ctx context.Context, clientset *kubernetes.Clientset) error {
+	defer func() error {
+		tempDirPath, err := os.MkdirTemp(config.TempDirPath, "endpoint-flap")
+		if err != nil {
+			slog.Fatal(err)
+		}
+
+		slog.Infof("saving logs to %q", tempDirPath)
+		if err = e2e.GetLogs(ctx, clientset, tempDirPath, "services"); err != nil {
+			slog.Infof("🧪 ---> endpoint flap logs err <---: %s", err.Error())
+			return err
+		}
+
+		slog.Infof("🧹 deleting Service [%s], deployment [%s]", config.ServiceName, config.DeploymentName)
+		if err = clientset.CoreV1().Services(v1.NamespaceDefault).Delete(ctx, config.ServiceName, metav1.DeleteOptions{}); err != nil {
+			slog.Fatal(err)
+		}
+
+		if err = deleteDeployment(ctx, clientset, config.DeploymentName); err != nil {
+			slog.Fatal(err)
+		}
+		return nil
+	}() //nolint
+
+	slog.Infof("🧪 ---> endpoint flapping (local policy) <---")
+	deploy := Deployment{
+		name:         config.DeploymentName,
+		nodeAffinity: config.Affinity,
+		replicas:     1,
+		server:       true,
+	}
+	if err := deploy.CreateDeployment(ctx, clientset); err != nil {
+		return err
+	}
+
+	svc := Service{
+		name:        config.ServiceName,
+		policyLocal: true,
+		testHTTP:    true,
+		timeout:     30,
+	}
+	_, lbAddresses, err := svc.CreateService(ctx, clientset)
+	if err != nil {
+		return err
+	}
+	if len(lbAddresses) == 0 {
+		return fmt.Errorf("no load balancer address found for service %s", config.ServiceName)
+	}
+	lbAddress := lbAddresses[0]
+
+	// Take the endpoints away and bring them back a few times. Each cycle is a
+	// zero-endpoint teardown followed by the endpoint becoming healthy again.
+	for i := 1; i <= 5; i++ {
+		slog.Infof("🔁 flap %d: scaling deployment [%s] to zero endpoints", i, config.DeploymentName)
+		if err := scaleDeployment(ctx, clientset, config.DeploymentName, 0); err != nil {
+			return err
+		}
+
+		slog.Infof("🔁 flap %d: scaling deployment [%s] back up", i, config.DeploymentName)
+		if err := scaleDeployment(ctx, clientset, config.DeploymentName, 1); err != nil {
+			return err
+		}
+	}
+
+	// The VIP has to be served again once the endpoint is healthy.
+	if err := httpTest(lbAddress); err != nil {
+		return fmt.Errorf("service %q did not recover after endpoint flapping: %w", config.ServiceName, err)
+	}
+
+	// A lease without a holder is the symptom reported in issue #1665.
+	if err := waitForLeaseHolder(ctx, clientset, fmt.Sprintf("kubevip-%s", config.ServiceName)); err != nil {
+		return err
+	}
+
+	config.SuccessCounter++
+
+	return nil
+}
+
+// scaleDeployment sets the replica count and waits for the endpoints to follow.
+func scaleDeployment(ctx context.Context, clientset *kubernetes.Clientset, name string, replicas int32) error {
+	scale, err := clientset.AppsV1().Deployments(v1.NamespaceDefault).GetScale(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get scale of deployment %q: %w", name, err)
+	}
+
+	scale.Spec.Replicas = replicas
+	if _, err := clientset.AppsV1().Deployments(v1.NamespaceDefault).UpdateScale(ctx, name, scale, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("failed to scale deployment %q to %d: %w", name, replicas, err)
+	}
+
+	return waitForReadyEndpoints(ctx, clientset, name, replicas > 0)
+}
+
+// waitForReadyEndpoints waits until the deployment has ready pods, or none left.
+func waitForReadyEndpoints(ctx context.Context, clientset *kubernetes.Clientset, name string, wantReady bool) error {
+	checkCtx, cancel := context.WithTimeout(ctx, time.Second*60)
+	defer cancel()
+
+	t := time.NewTicker(time.Second)
+	defer t.Stop()
+
+	for {
+		d, err := clientset.AppsV1().Deployments(v1.NamespaceDefault).Get(checkCtx, name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get deployment %q: %w", name, err)
+		}
+
+		if (d.Status.ReadyReplicas > 0) == wantReady {
+			return nil
+		}
+
+		select {
+		case <-checkCtx.Done():
+			return fmt.Errorf("timed out waiting for deployment %q to have readyEndpoints=%t", name, wantReady)
+		case <-t.C:
+		}
+	}
+}
+
+// waitForLeaseHolder waits until the service lease reports a holder again.
+func waitForLeaseHolder(ctx context.Context, clientset *kubernetes.Clientset, name string) error {
+	checkCtx, cancel := context.WithTimeout(ctx, time.Second*60)
+	defer cancel()
+
+	t := time.NewTicker(time.Second)
+	defer t.Stop()
+
+	for {
+		l, err := clientset.CoordinationV1().Leases(v1.NamespaceDefault).Get(checkCtx, name, metav1.GetOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get lease %q: %w", name, err)
+		}
+		if err == nil && l.Spec.HolderIdentity != nil && *l.Spec.HolderIdentity != "" {
+			slog.Infof("🔎 lease [%s] is held by [%s]", name, *l.Spec.HolderIdentity)
+			return nil
+		}
+
+		select {
+		case <-checkCtx.Done():
+			return fmt.Errorf("lease %q never reacquired a holder after endpoint flapping", name)
+		case <-t.C:
 		}
 	}
 }

--- a/testing/services/pkg/deployment/tests.go
+++ b/testing/services/pkg/deployment/tests.go
@@ -679,6 +679,18 @@ func deleteDeployment(ctx context.Context, clientset *kubernetes.Clientset, name
 //     than the lease duration, which drives OnStoppedLeading and returns the
 //     election. The restart loop used to wedge on a WaitGroup exactly there, so
 //     kube_vip_service_election_attempts_total must advance afterwards.
+//   - an externalTrafficPolicy flip: tears the service down and rebuilds it, so the
+//     replacement has to get a fresh lease instead of the retired one.
+//   - a burst of service events: the same spawn-once invariant driven from the
+//     service watch instead of the endpoint watch.
+//   - a common lease sibling teardown: deleting one of two services that share a
+//     lease must leave that lease held for the one that stays.
+//   - a partitioned follower: cutting a non-leader off from the apiserver must not
+//     move the lease, stop traffic, or leak a loop on the node that returns.
+//
+// The endpoint churn fault also asserts the yield half of the cycle: with a local
+// traffic policy and no endpoints anywhere, the address has to stop answering
+// instead of being left to black-hole traffic.
 //
 // After every fault the service has to converge: a live election loop, a held
 // lease, and a VIP that serves traffic.
@@ -868,7 +880,14 @@ func (config *TestConfig) ElectionFaults(ctx context.Context, clientset *kuberne
 		return err
 	}
 
-	// Fault 7: partition a node that is not the leader. The leader has to keep the
+	// Fault 7: a service sharing its lease with another one is torn down. The
+	// sibling keeps using that lease, so it must not be cancelled underneath it.
+	// This is the case that made the per-lease teardown wrong.
+	if err := config.faultCommonLeaseSibling(ctx, clientset); err != nil {
+		return err
+	}
+
+	// Fault 8: partition a node that is not the leader. The leader has to keep the
 	// lease and keep serving, and the returning node must not leak a loop or end up
 	// advertising the same address.
 	follower, err := followerNode(ctx, clientset, leaseName)
@@ -940,6 +959,76 @@ func (config *TestConfig) checkConverged(ctx context.Context, clientset *kuberne
 	if err := httpTest(lbAddress); err != nil {
 		return fmt.Errorf("service on %q did not serve traffic after %s: %w", lbAddress, fault, err)
 	}
+	return nil
+}
+
+// faultCommonLeaseSibling creates two services that share one lease, tears the
+// first one down, and asserts the second keeps serving on that same lease.
+//
+// A teardown that cancels the lease rather than just releasing the leaving
+// service takes the sibling down with it, which is what review of #1669 caught.
+func (config *TestConfig) faultCommonLeaseSibling(ctx context.Context, clientset *kubernetes.Clientset) error {
+	const (
+		leaseName   = "shared-lease"
+		deployName  = "kube-vip-shared"
+		leavingName = "kube-vip-shared-leaving"
+		stayingName = "kube-vip-shared-staying"
+	)
+
+	defer func() {
+		for _, name := range []string{leavingName, stayingName} {
+			if err := clientset.CoreV1().Services(v1.NamespaceDefault).Delete(ctx, name, metav1.DeleteOptions{}); err != nil &&
+				!apierrors.IsNotFound(err) {
+				slog.Errorf("failed to delete service %q: %v", name, err)
+			}
+		}
+		if err := deleteDeployment(ctx, clientset, deployName); err != nil {
+			slog.Errorf("failed to delete deployment %q: %v", deployName, err)
+		}
+	}()
+
+	slog.Infof("🧪 ---> common lease sibling teardown <---")
+	deploy := Deployment{
+		name:         deployName,
+		nodeAffinity: config.Affinity,
+		replicas:     1,
+		server:       true,
+	}
+	if err := deploy.CreateDeployment(ctx, clientset); err != nil {
+		return err
+	}
+
+	// Both services share one lease. A common lease requires a cluster traffic
+	// policy, which CreateService sets alongside the annotation.
+	for _, name := range []string{leavingName, stayingName} {
+		svc := Service{name: name, commonLease: leaseName, testHTTP: true, timeout: 30}
+		if _, _, err := svc.CreateService(ctx, clientset); err != nil {
+			return fmt.Errorf("failed to create service %q on the common lease: %w", name, err)
+		}
+	}
+
+	holder, err := leaseHolder(ctx, clientset, leaseName)
+	if err != nil {
+		return fmt.Errorf("common lease never got a holder: %w", err)
+	}
+	slog.Infof("🔎 common lease [%s] is held by [%s]", leaseName, holder)
+
+	// Tear the first service down. The sibling is untouched and still needs the
+	// lease, so the lease has to stay held.
+	slog.Infof("💥 deleting service [%s], which shares lease [%s] with [%s]", leavingName, leaseName, stayingName)
+	if err := clientset.CoreV1().Services(v1.NamespaceDefault).Delete(ctx, leavingName, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("failed to delete service %q: %w", leavingName, err)
+	}
+
+	if _, err := leaseHolder(ctx, clientset, leaseName); err != nil {
+		return fmt.Errorf("common lease lost its holder when a sibling service was deleted: %w", err)
+	}
+
+	if err := checkNoDuplicateElectionLoops(v1.NamespaceDefault, stayingName, "a sibling on the same lease being deleted"); err != nil {
+		return err
+	}
+
+	slog.Infof("🔎 common lease [%s] still held after [%s] was deleted", leaseName, leavingName)
 	return nil
 }
 

--- a/testing/services/pkg/deployment/tests.go
+++ b/testing/services/pkg/deployment/tests.go
@@ -947,28 +947,33 @@ func (config *TestConfig) checkConverged(ctx context.Context, clientset *kuberne
 // checkNoDuplicateElectionLoops asserts that no node runs more than one election
 // loop for the service. More than one means loops leaked, which is issue #1665.
 func checkNoDuplicateElectionLoops(namespace, name, fault string) error {
-	// Sample a few times: a loop that is about to be started may not be visible
-	// in a single scrape, and a leaked one never goes away.
-	var loops map[string]float64
+	// A fault that rebuilds the service context legitimately has the old and the
+	// new loop alive at the same moment, so poll until the count settles. A leaked
+	// loop only exits with its service context, so it never settles.
+	deadline := time.Now().Add(time.Second * 45)
 
-	for range 3 {
-		var err error
-		loops, err = scrapeElectionLoops(namespace, name)
+	for {
+		loops, err := scrapeElectionLoops(namespace, name)
 		if err != nil {
 			return fmt.Errorf("after %s: %w", fault, err)
 		}
 
-		for node, count := range loops {
-			if count > 1 {
-				return fmt.Errorf("node %q runs %v leader election loops for service %q after %s, want at most 1",
-					node, count, name, fault)
-			}
+		busiest := 0.0
+		for _, count := range loops {
+			busiest = max(busiest, count)
 		}
-		time.Sleep(time.Second * 2)
-	}
 
-	slog.Infof("🔎 election loops per node after %s: %v", fault, loops)
-	return nil
+		if busiest <= 1 {
+			slog.Infof("🔎 election loops per node after %s: %v", fault, loops)
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("a node still runs %v leader election loops for service %q after %s, "+
+				"want at most 1, loops leaked (%v)", busiest, name, fault, loops)
+		}
+		time.Sleep(time.Second * 3)
+	}
 }
 
 // checkLeaseErrorsStable asserts the election error counter stopped growing.

--- a/testing/services/pkg/deployment/tests.go
+++ b/testing/services/pkg/deployment/tests.go
@@ -745,6 +745,15 @@ func (config *TestConfig) ElectionFaults(ctx context.Context, clientset *kuberne
 		if err := scaleDeployment(ctx, clientset, config.DeploymentName, 0); err != nil {
 			return err
 		}
+
+		// With a local traffic policy and no endpoints anywhere, the VIP has to be
+		// given up rather than left black-holing traffic. Only assert this once,
+		// the remaining cycles are there to accumulate election loops.
+		if i == 1 {
+			if err := waitForVIPReleased(lbAddress); err != nil {
+				return err
+			}
+		}
 		time.Sleep(time.Second * 2)
 
 		slog.Infof("🔁 flap %d: scaling deployment [%s] back up", i, config.DeploymentName)
@@ -825,6 +834,85 @@ func (config *TestConfig) ElectionFaults(ctx context.Context, clientset *kuberne
 
 	if err := waitForElectionProgress(before, v1.NamespaceDefault, config.ServiceName); err != nil {
 		return err
+	}
+
+	// Fault 5: a service change that tears the service down and rebuilds it.
+	// Flipping the external traffic policy makes serviceChanged cancel the service
+	// context and drop it from svcMap, so the next event has to build a fresh
+	// context and a fresh lease. Same desync class as fault 2, different trigger.
+	for _, policy := range []v1.ServiceExternalTrafficPolicy{
+		v1.ServiceExternalTrafficPolicyCluster,
+		v1.ServiceExternalTrafficPolicyLocal,
+	} {
+		slog.Infof("💥 setting externalTrafficPolicy of service [%s] to [%s]", config.ServiceName, policy)
+		if err := setExternalTrafficPolicy(ctx, clientset, config.ServiceName, policy); err != nil {
+			return err
+		}
+
+		if err := config.checkConverged(ctx, clientset, leaseName, lbAddress,
+			fmt.Sprintf("externalTrafficPolicy change to %s", policy)); err != nil {
+			return err
+		}
+	}
+
+	// Fault 6: a burst of service events. This drives the same spawn-once
+	// invariant as fault 1 from the service watch instead of the endpoint watch.
+	slog.Infof("💥 annotating service [%s] repeatedly", config.ServiceName)
+	for i := range 15 {
+		if err := annotateServiceValue(ctx, clientset, config.ServiceName, fmt.Sprintf("storm-%d", i)); err != nil {
+			return err
+		}
+		time.Sleep(time.Millisecond * 200)
+	}
+
+	if err := config.checkConverged(ctx, clientset, leaseName, lbAddress, "service event storm"); err != nil {
+		return err
+	}
+
+	// Fault 7: partition a node that is not the leader. The leader has to keep the
+	// lease and keep serving, and the returning node must not leak a loop or end up
+	// advertising the same address.
+	follower, err := followerNode(ctx, clientset, leaseName)
+	if err != nil {
+		return err
+	}
+
+	if follower == "" {
+		slog.Infof("⏭️  no follower node to partition, skipping")
+	} else {
+		holderBefore, err := leaseHolder(ctx, clientset, leaseName)
+		if err != nil {
+			return err
+		}
+
+		slog.Infof("💥 blocking API server access from follower node [%s]", follower)
+		if err := setAPIServerReachable(follower, false); err != nil {
+			return err
+		}
+
+		// The leader must keep serving while the follower is cut off.
+		time.Sleep(time.Second * 25)
+		if err := httpTest(lbAddress); err != nil {
+			return fmt.Errorf("service on %q stopped serving while a follower was partitioned: %w", lbAddress, err)
+		}
+
+		slog.Infof("🔌 restoring API server access on node [%s]", follower)
+		if err := setAPIServerReachable(follower, true); err != nil {
+			return err
+		}
+
+		if err := config.checkConverged(ctx, clientset, leaseName, lbAddress, "follower partition"); err != nil {
+			return err
+		}
+
+		holderAfter, err := leaseHolder(ctx, clientset, leaseName)
+		if err != nil {
+			return err
+		}
+		if holderAfter != holderBefore {
+			return fmt.Errorf("lease moved from %q to %q while only a follower was partitioned",
+				holderBefore, holderAfter)
+		}
 	}
 
 	config.SuccessCounter++
@@ -942,12 +1030,81 @@ func waitForElectionProgress(before map[string]float64, namespace, name string) 
 
 // annotateService writes an annotation to force a service watch event.
 func annotateService(ctx context.Context, clientset *kubernetes.Clientset, name string) error {
-	patch := []byte(`{"metadata":{"annotations":{"e2e.kube-vip.io/probe":"1"}}}`)
+	return annotateServiceValue(ctx, clientset, name, "1")
+}
+
+// annotateServiceValue writes a given annotation value to force a service watch
+// event. The value has to change for the API server to emit a Modified event.
+func annotateServiceValue(ctx context.Context, clientset *kubernetes.Clientset, name, value string) error {
+	patch := fmt.Appendf(nil, `{"metadata":{"annotations":{"e2e.kube-vip.io/probe":%q}}}`, value)
 	if _, err := clientset.CoreV1().Services(v1.NamespaceDefault).Patch(ctx, name,
 		types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
 		return fmt.Errorf("failed to annotate service %q: %w", name, err)
 	}
 	return nil
+}
+
+// setExternalTrafficPolicy changes the traffic policy of a service, which makes
+// kube-vip treat the service as changed and rebuild it.
+func setExternalTrafficPolicy(ctx context.Context, clientset *kubernetes.Clientset, name string,
+	policy v1.ServiceExternalTrafficPolicy) error {
+	patch := fmt.Appendf(nil, `{"spec":{"externalTrafficPolicy":%q}}`, policy)
+	if _, err := clientset.CoreV1().Services(v1.NamespaceDefault).Patch(ctx, name,
+		types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("failed to set externalTrafficPolicy of service %q to %q: %w", name, policy, err)
+	}
+	return nil
+}
+
+// waitForVIPReleased waits until the address stops answering. With a local
+// traffic policy and no endpoints, the VIP has to be given up instead of being
+// left to black-hole traffic.
+func waitForVIPReleased(address string) error {
+	deadline := time.Now().Add(time.Second * 60)
+
+	for {
+		if err := tcpProbe(address); err != nil {
+			slog.Infof("🔎 address [%s] was released after the endpoints went away", address)
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("address %q still answers after all endpoints went away", address)
+		}
+		time.Sleep(time.Second * 2)
+	}
+}
+
+// tcpProbe reports whether the address accepts a connection on the service port.
+func tcpProbe(address string) error {
+	target := net.JoinHostPort(address, "80")
+	conn, err := net.DialTimeout("tcp", target, time.Second*2)
+	if err != nil {
+		return err
+	}
+	return conn.Close()
+}
+
+// followerNode returns a node that runs kube-vip but does not hold the lease.
+func followerNode(ctx context.Context, clientset *kubernetes.Clientset, leaseName string) (string, error) {
+	holder, err := leaseHolder(ctx, clientset, leaseName)
+	if err != nil {
+		return "", err
+	}
+
+	pods, err := clientset.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=kube-vip-ds",
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to list kube-vip pods: %w", err)
+	}
+
+	for x := range pods.Items {
+		if node := pods.Items[x].Spec.NodeName; node != holder {
+			return node, nil
+		}
+	}
+	return "", nil
 }
 
 // leaseHolder waits until the lease exists and reports a holder, and returns it.

--- a/testing/services/pkg/deployment/tests.go
+++ b/testing/services/pkg/deployment/tests.go
@@ -37,7 +37,7 @@ type TestConfig struct {
 	LeaderFailover     bool
 	LeaderActive       bool
 	LocalDeploy        bool
-	FlapEndpoints      bool
+	FaultElection      bool
 	DualStack          bool
 	Egress             bool
 	EgressInternal     bool
@@ -658,33 +658,40 @@ func deleteDeployment(ctx context.Context, clientset *kubernetes.Clientset, name
 	}
 }
 
-// EndpointFlap exercises the per-service leader election of #1665 under faults.
+// ElectionFaults injects the failure modes of the per-service leader election
+// and proves the service recovers from each one.
 //
-// Three faults are injected in sequence against a svc_election service:
+// Each fault targets a specific reported bug, and each is asserted with a signal
+// that is actually broken when the bug is present, so the test fails against
+// unfixed code instead of only documenting the happy path:
 //
-//  1. endpoint churn: the backend is scaled 1 -> 0 -> 1 repeatedly, which is
-//     what drove the duplicate election loops reported in the issue.
-//  2. lease faults: the service Lease is deleted, and then blanked by clearing
-//     its holderIdentity, which is the exact state observed in the report.
-//  3. API server faults: the apiserver is made unreachable from the leader for
-//     a while, so every election client on that node loses its backend.
+//   - endpoint churn (issue #1665): the backend is scaled 1 -> 0 -> 1 five times.
+//     Every EndpointSlice event used to start another permanent election loop, so
+//     kube_vip_service_election_loops must stay at most 1 per node.
+//   - endpoint object deletion (#1663, fixed in #1664): deleting the EndpointSlice
+//     ends the endpoint watcher and cancels the service context without dropping
+//     it from svcMap, so later events reused a cancelled context and could never
+//     re-add the lease. kube_vip_service_election_errors_total{reason="no_lease"}
+//     must stay at zero.
+//   - lease loss (#1650): deleting the lease, and blanking its holderIdentity,
+//     makes the election client lose leadership the ordinary way. The restart loop
+//     used to wedge on a WaitGroup at that point, so the election attempt counter
+//     must keep advancing and the lease must get a holder back.
+//   - API server loss: the apiserver is blocked from the leader for longer than
+//     the lease duration, exercising the same loss path through a real partition.
 //
-// After each fault the service has to converge again: the Lease is held by a
-// node and the VIP serves traffic. Those are properties of the feature rather
-// than of the current implementation, so the test stays meaningful if the
-// election internals change. Duplicate election loops are not observable from
-// outside the process; that part is pinned by the unit test in
-// pkg/endpoints/endpoints_test.go.
-func (config *TestConfig) EndpointFlap(ctx context.Context, clientset *kubernetes.Clientset) error {
+// After every fault the service has to converge: a live election loop, a held
+// lease, and a VIP that serves traffic.
+func (config *TestConfig) ElectionFaults(ctx context.Context, clientset *kubernetes.Clientset) error {
 	defer func() error {
-		tempDirPath, err := os.MkdirTemp(config.TempDirPath, "endpoint-flap")
+		tempDirPath, err := os.MkdirTemp(config.TempDirPath, "election-faults")
 		if err != nil {
 			slog.Fatal(err)
 		}
 
 		slog.Infof("saving logs to %q", tempDirPath)
 		if err = e2e.GetLogs(ctx, clientset, tempDirPath, "services"); err != nil {
-			slog.Infof("🧪 ---> endpoint flap logs err <---: %s", err.Error())
+			slog.Infof("🧪 ---> election faults logs err <---: %s", err.Error())
 			return err
 		}
 
@@ -699,7 +706,7 @@ func (config *TestConfig) EndpointFlap(ctx context.Context, clientset *kubernete
 		return nil
 	}() //nolint
 
-	slog.Infof("🧪 ---> endpoint and lease faults (local policy) <---")
+	slog.Infof("🧪 ---> leader election faults (local policy) <---")
 	deploy := Deployment{
 		name:         config.DeploymentName,
 		nodeAffinity: config.Affinity,
@@ -726,48 +733,79 @@ func (config *TestConfig) EndpointFlap(ctx context.Context, clientset *kubernete
 	lbAddress := lbAddresses[0]
 	leaseName := fmt.Sprintf("kubevip-%s", config.ServiceName)
 
-	// Fault 1: endpoint churn. Each cycle is a zero-endpoint teardown followed by
-	// the endpoint becoming healthy again, which is what accumulated duplicate
-	// election loops before the fix.
+	if err := config.checkConverged(ctx, clientset, leaseName, lbAddress, "startup"); err != nil {
+		return err
+	}
+
+	// Fault 1 (#1665): endpoint churn. Sleep between transitions so the endpoint
+	// debouncer does not coalesce them into a single event, otherwise no duplicate
+	// loop would be started even by the unfixed code.
 	for i := 1; i <= 5; i++ {
 		slog.Infof("🔁 flap %d: scaling deployment [%s] to zero endpoints", i, config.DeploymentName)
 		if err := scaleDeployment(ctx, clientset, config.DeploymentName, 0); err != nil {
 			return err
 		}
+		time.Sleep(time.Second * 2)
 
 		slog.Infof("🔁 flap %d: scaling deployment [%s] back up", i, config.DeploymentName)
 		if err := scaleDeployment(ctx, clientset, config.DeploymentName, 1); err != nil {
 			return err
 		}
+		time.Sleep(time.Second * 2)
 	}
 
-	if err := checkServiceConverged(ctx, clientset, leaseName, lbAddress, "endpoint flapping"); err != nil {
+	if err := config.checkConverged(ctx, clientset, leaseName, lbAddress, "endpoint flapping"); err != nil {
 		return err
 	}
 
-	// Fault 2a: delete the lease outright and make sure it is recreated and held.
+	// Fault 2 (#1664): end the endpoint watcher by deleting the EndpointSlice, then
+	// drive another service event so the stale service context would be reused.
+	slog.Infof("💥 deleting endpointslices of service [%s]", config.ServiceName)
+	if err := clientset.DiscoveryV1().EndpointSlices(v1.NamespaceDefault).DeleteCollection(ctx, metav1.DeleteOptions{},
+		metav1.ListOptions{LabelSelector: "kubernetes.io/service-name=" + config.ServiceName}); err != nil {
+		return fmt.Errorf("failed to delete endpointslices of service %q: %w", config.ServiceName, err)
+	}
+
+	if err := annotateService(ctx, clientset, config.ServiceName); err != nil {
+		return err
+	}
+
+	if err := config.checkConverged(ctx, clientset, leaseName, lbAddress, "endpointslice deletion"); err != nil {
+		return err
+	}
+
+	// Fault 3 (#1650): ordinary leadership loss, by removing the lease and by
+	// blanking its holder. The election attempt counter has to keep advancing,
+	// which it cannot do if the restart loop is wedged.
+	before, err := scrapeServiceGauge("kube_vip_service_election_attempts_total", v1.NamespaceDefault, config.ServiceName)
+	if err != nil {
+		return err
+	}
+
 	slog.Infof("💥 deleting lease [%s]", leaseName)
 	if err := clientset.CoordinationV1().Leases(v1.NamespaceDefault).Delete(ctx, leaseName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete lease %q: %w", leaseName, err)
 	}
 
-	if err := checkServiceConverged(ctx, clientset, leaseName, lbAddress, "lease deletion"); err != nil {
+	if err := config.checkConverged(ctx, clientset, leaseName, lbAddress, "lease deletion"); err != nil {
 		return err
 	}
 
-	// Fault 2b: blank the holder. This is the state reported in #1665, where the
-	// lease existed with holderIdentity "" and never got a holder back.
+	if err := waitForElectionProgress(before, v1.NamespaceDefault, config.ServiceName); err != nil {
+		return err
+	}
+
 	slog.Infof("💥 clearing holderIdentity on lease [%s]", leaseName)
 	if err := clearLeaseHolder(ctx, clientset, leaseName); err != nil {
 		return err
 	}
 
-	if err := checkServiceConverged(ctx, clientset, leaseName, lbAddress, "lease holder being cleared"); err != nil {
+	if err := config.checkConverged(ctx, clientset, leaseName, lbAddress, "lease holder being cleared"); err != nil {
 		return err
 	}
 
-	// Fault 3: cut the leader off from the API server for longer than the lease
-	// duration, so its election client loses leadership, then restore it.
+	// Fault 4: partition the leader from the apiserver for longer than the lease
+	// duration, then heal it.
 	leader, err := leaseHolder(ctx, clientset, leaseName)
 	if err != nil {
 		return err
@@ -784,7 +822,7 @@ func (config *TestConfig) EndpointFlap(ctx context.Context, clientset *kubernete
 		return err
 	}
 
-	if err := checkServiceConverged(ctx, clientset, leaseName, lbAddress, "API server disruption"); err != nil {
+	if err := config.checkConverged(ctx, clientset, leaseName, lbAddress, "API server disruption"); err != nil {
 		return err
 	}
 
@@ -793,9 +831,18 @@ func (config *TestConfig) EndpointFlap(ctx context.Context, clientset *kubernete
 	return nil
 }
 
-// checkServiceConverged asserts the service is healthy again after a fault: the
-// lease is held by a node and the VIP serves traffic.
-func checkServiceConverged(ctx context.Context, clientset *kubernetes.Clientset, leaseName, lbAddress, fault string) error {
+// checkConverged asserts the service is healthy after a fault: at most one
+// election loop per node, no lease lookup failures, a held lease, and a VIP that
+// serves traffic.
+func (config *TestConfig) checkConverged(ctx context.Context, clientset *kubernetes.Clientset, leaseName, lbAddress, fault string) error {
+	if err := checkNoDuplicateElectionLoops(v1.NamespaceDefault, config.ServiceName, fault); err != nil {
+		return err
+	}
+
+	if err := checkNoLeaseErrors(v1.NamespaceDefault, config.ServiceName, fault); err != nil {
+		return err
+	}
+
 	holder, err := leaseHolder(ctx, clientset, leaseName)
 	if err != nil {
 		return fmt.Errorf("after %s: %w", fault, err)
@@ -804,6 +851,77 @@ func checkServiceConverged(ctx context.Context, clientset *kubernetes.Clientset,
 
 	if err := httpTest(lbAddress); err != nil {
 		return fmt.Errorf("service on %q did not serve traffic after %s: %w", lbAddress, fault, err)
+	}
+	return nil
+}
+
+// checkNoDuplicateElectionLoops asserts that no node runs more than one election
+// loop for the service. More than one means loops leaked, which is issue #1665.
+func checkNoDuplicateElectionLoops(namespace, name, fault string) error {
+	loops, err := scrapeElectionLoops(namespace, name)
+	if err != nil {
+		return fmt.Errorf("after %s: %w", fault, err)
+	}
+
+	for node, count := range loops {
+		if count > 1 {
+			return fmt.Errorf("node %q runs %v leader election loops for service %q after %s, want at most 1",
+				node, count, name, fault)
+		}
+	}
+	slog.Infof("🔎 election loops per node after %s: %v", fault, loops)
+	return nil
+}
+
+// checkNoLeaseErrors asserts the election never failed to find its lease, which
+// is the signature of the service context and lease manager desync of #1664.
+func checkNoLeaseErrors(namespace, name, fault string) error {
+	errs, err := scrapeServiceGauge("kube_vip_service_election_errors_total", namespace, name)
+	if err != nil {
+		return fmt.Errorf("after %s: %w", fault, err)
+	}
+
+	for node, count := range errs {
+		if count > 0 {
+			return fmt.Errorf("node %q reported %v leader election errors for service %q after %s, want 0",
+				node, count, name, fault)
+		}
+	}
+	return nil
+}
+
+// waitForElectionProgress asserts the restart loop keeps attempting election
+// after a leadership loss. A wedged loop stops incrementing, which is #1650.
+func waitForElectionProgress(before map[string]float64, namespace, name string) error {
+	deadline := time.Now().Add(time.Second * 60)
+
+	for {
+		after, err := scrapeServiceGauge("kube_vip_service_election_attempts_total", namespace, name)
+		if err != nil {
+			return err
+		}
+
+		for node, count := range after {
+			if count > before[node] {
+				slog.Infof("🔎 node [%s] election attempts advanced %v -> %v", node, before[node], count)
+				return nil
+			}
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("no node made a new leader election attempt for service %q after losing the lease, "+
+				"the restart loop is stuck (before=%v after=%v)", name, before, after)
+		}
+		time.Sleep(time.Second * 2)
+	}
+}
+
+// annotateService writes an annotation to force a service watch event.
+func annotateService(ctx context.Context, clientset *kubernetes.Clientset, name string) error {
+	patch := []byte(`{"metadata":{"annotations":{"e2e.kube-vip.io/probe":"1"}}}`)
+	if _, err := clientset.CoreV1().Services(v1.NamespaceDefault).Patch(ctx, name,
+		types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("failed to annotate service %q: %w", name, err)
 	}
 	return nil
 }
@@ -857,7 +975,6 @@ func setAPIServerReachable(node string, reachable bool) error {
 		action = "-D"
 	}
 
-	// kind nodes reach the API server on the control plane's 6443.
 	cmd := exec.Command("docker", "exec", container, "iptables", action, "OUTPUT",
 		"-p", "tcp", "--dport", "6443", "-j", "REJECT") //nolint
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/testing/services/pkg/deployment/tests.go
+++ b/testing/services/pkg/deployment/tests.go
@@ -839,7 +839,7 @@ func (config *TestConfig) checkConverged(ctx context.Context, clientset *kuberne
 		return err
 	}
 
-	if err := checkNoLeaseErrors(v1.NamespaceDefault, config.ServiceName, fault); err != nil {
+	if err := checkLeaseErrorsStable(v1.NamespaceDefault, config.ServiceName, fault); err != nil {
 		return err
 	}
 
@@ -858,35 +858,58 @@ func (config *TestConfig) checkConverged(ctx context.Context, clientset *kuberne
 // checkNoDuplicateElectionLoops asserts that no node runs more than one election
 // loop for the service. More than one means loops leaked, which is issue #1665.
 func checkNoDuplicateElectionLoops(namespace, name, fault string) error {
-	loops, err := scrapeElectionLoops(namespace, name)
-	if err != nil {
-		return fmt.Errorf("after %s: %w", fault, err)
+	// Sample a few times: a loop that is about to be started may not be visible
+	// in a single scrape, and a leaked one never goes away.
+	var loops map[string]float64
+
+	for range 3 {
+		var err error
+		loops, err = scrapeElectionLoops(namespace, name)
+		if err != nil {
+			return fmt.Errorf("after %s: %w", fault, err)
+		}
+
+		for node, count := range loops {
+			if count > 1 {
+				return fmt.Errorf("node %q runs %v leader election loops for service %q after %s, want at most 1",
+					node, count, name, fault)
+			}
+		}
+		time.Sleep(time.Second * 2)
 	}
 
-	for node, count := range loops {
-		if count > 1 {
-			return fmt.Errorf("node %q runs %v leader election loops for service %q after %s, want at most 1",
-				node, count, name, fault)
-		}
-	}
 	slog.Infof("🔎 election loops per node after %s: %v", fault, loops)
 	return nil
 }
 
-// checkNoLeaseErrors asserts the election never failed to find its lease, which
-// is the signature of the service context and lease manager desync of #1664.
-func checkNoLeaseErrors(namespace, name, fault string) error {
-	errs, err := scrapeServiceGauge("kube_vip_service_election_errors_total", namespace, name)
+// checkLeaseErrorsStable asserts the election error counter stopped growing.
+//
+// The #1664 desync makes every later watch event fail to find the lease, so the
+// counter climbs for the lifetime of the process. A single increment can happen
+// benignly while a service is first being set up, so the assertion is that the
+// counter settles rather than that it is zero.
+func checkLeaseErrorsStable(namespace, name, fault string) error {
+	const metric = "kube_vip_service_election_errors_total"
+
+	first, err := scrapeServiceGauge(metric, namespace, name)
 	if err != nil {
 		return fmt.Errorf("after %s: %w", fault, err)
 	}
 
-	for node, count := range errs {
-		if count > 0 {
-			return fmt.Errorf("node %q reported %v leader election errors for service %q after %s, want 0",
-				node, count, name, fault)
+	time.Sleep(time.Second * 10)
+
+	second, err := scrapeServiceGauge(metric, namespace, name)
+	if err != nil {
+		return fmt.Errorf("after %s: %w", fault, err)
+	}
+
+	for node, count := range second {
+		if count > first[node] {
+			return fmt.Errorf("node %q keeps failing leader election for service %q after %s "+
+				"(%v -> %v errors in 10s), the lease is never re-added", node, name, fault, first[node], count)
 		}
 	}
+	slog.Infof("🔎 election errors per node stable after %s: %v", fault, second)
 	return nil
 }
 

--- a/testing/services/pkg/deployment/tests.go
+++ b/testing/services/pkg/deployment/tests.go
@@ -1117,7 +1117,7 @@ func leaseHolder(ctx context.Context, clientset *kubernetes.Clientset, name stri
 	checkCtx, cancel := context.WithTimeout(ctx, time.Second*120)
 	defer cancel()
 
-	t := time.NewTicker(time.Second)
+	t := time.NewTicker(time.Second * 2)
 	defer t.Stop()
 
 	for {


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #1669.** This branch contains #1669's single commit as its base, so the diff here shows both until that merges. Review #1669 first; this PR's own changes start at `fix(services): start the leader-election loop once per service`.
>
> #1669 is a prerequisite: it fixes a lease cleanup bug on the service teardown path that this PR's fault tests exercise.

Fixes #1665. Alternative to #1666.

## Problem

`startLeaderElection` loops until the service context is cancelled, re-attempting election whenever the lease is free. It only needs to be started once per service lifetime. `startServiceHandlingIfNeeded` started it on every `AddOrModify` call, and `AddOrModify` runs on every EndpointSlice event, so endpoint churn piled up duplicate permanent loops for the same service, all contending on the same lease.

The ARP branch right below already guards its spawn with `svcCtx.Signalled`.

## Change

Guard the spawn with a `sync.Once` on the service context. #1666 review asked whether a new flag would be cleared in the right places: a `Once` has nothing to clear, and the loop is bound to the service context, which is replaced whenever the service is recreated.

## Making the bug observable

The duplicate loops were not observable from outside the process, so there was nothing an e2e test could assert on. `startLeaderElection` carried a `les *atomic.Int64` that was incremented and never read. That is replaced with real instrumentation:

- `kube_vip_service_election_loops{namespace,name}` gauge, tracked for the lifetime of the loop goroutine. More than 1 per service means loops leaked.
- `kube_vip_service_election_attempts_total{namespace,name}`, so a wedged restart loop shows up as a counter that stops advancing.
- `kube_vip_service_election_errors_total{namespace,name,reason}`, with `reason="no_lease"` for the svcMap/leaseMgr desync.

## Fault tests

`-electionFaults` in the service e2e suite injects a fault per failure mode in this subsystem and asserts a signal that is actually broken when that bug is present. Every fault is then followed by the feature contract: at most one election loop, a stable error counter, a held lease, and a VIP that serves traffic.

| fault | assertion | targets |
|---|---|---|
| backend scaled 1->0->1 five times | election loops settle at <= 1 per node | #1665 |
| zero endpoints under a local policy | the address stops answering rather than black-holing | |
| EndpointSlice deleted, then Service annotated | `reason="no_lease"` counter stops growing | #1663 / #1664 |
| lease deleted, then holderIdentity blanked | convergence | |
| apiserver blocked from the leader past the lease duration | election attempts advance afterwards | #1650 |
| 15 rapid Service annotation patches | spawn-once driven from the service watch | #1665 |
| externalTrafficPolicy flipped both ways | loops settle at <= 1, held lease, served VIP | #1669 |
| one of two services sharing a lease deleted | the lease stays held for the one that stays | #1669 |
| apiserver blocked from a follower | lease does not move, traffic continues, no loop leaked | |

### Verified both directions

Every assertion was run against the fixed branch (must pass) and against a branch with only the spawn guard reverted and the metrics kept (must fail).

Unfixed:
```
a node still runs 11 leader election loops for service "kube-vip-service" after endpoint
flapping, want at most 1, loops leaked (map[services-worker:11 services-worker2:0])
Testing Complete [10] passed / [1] failed
```

Fixed: `Testing Complete [11] passed / [0] failed`, loops holding at 1 through every fault and `election attempts advanced 5 -> 6` after the leader partition.

`TestAddOrModify_ServicesElectionStartsOnce` covers the same invariant at unit level and asserts the gauge alongside the call count so both layers agree. It reports `started 3 times, want 1` against unpatched main.

### Assertions that needed correcting

Three first attempts were wrong and each was caught by running the fixed branch, not the unfixed one:

- asserting zero election errors: a single `no_lease` happens benignly during service setup, so this failed on correct code. The #1664 signature is a counter that keeps climbing, so it asserts delta-stability now.
- asserting election progress after deleting the lease object: the election client just recreates the lease on the next renew without losing leadership, so no new attempt follows. Moved to the apiserver partition, which is the fault that actually drives `OnStoppedLeading`.
- asserting the loop count from a single scrape: a fault that rebuilds the service context legitimately has the old and new loop alive at the same instant. It polls until the count settles; a leaked loop only exits with its service context, so it never settles.

## Related

The `externalTrafficPolicy` teardown path had two lease-lifecycle defects, both fixed in #1669 underneath this PR and asserted here as one of the faults.

Also worth flagging from reading the shared-lease path (`kube-vip.io/leaseName`), untested and not touched here: the secondary service's goroutine parks on `svcLease.Ctx.Done()` and leaks if only the secondary is deleted, `svcLease.Started` is reassigned without holding the mutex, and `leaseMgr.Get` can return nil at `endpoints.go` between the context check and `l.Lock()`.

