### PR TITLE
fix(lease): do not let a stale cleanup cancel a recreated lease

### DIFF
--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -37,7 +37,7 @@ func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config,
 	// Without this, RunOrDie would continue running until leadership is naturally lost.
 	wg.Go(func() {
 		<-objLease.Ctx.Done()
-		leaseMgr.Delete(leaseID, objectName)
+		leaseMgr.Delete(leaseID, objectName, objLease)
 	})
 
 	if !isNew {

--- a/pkg/lease/lease.go
+++ b/pkg/lease/lease.go
@@ -37,7 +37,10 @@ func NewManager() *Manager {
 func (m *Manager) Add(ctx context.Context, id ID) *Lease {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	if _, exists := m.leases[id.NamespacedName()]; !exists {
+
+	// A lease whose context is already cancelled cannot be handed out again:
+	// anything derived from it would be cancelled straight away. Replace it.
+	if l, exists := m.leases[id.NamespacedName()]; !exists || l.Ctx.Err() != nil {
 		leaseCtx, leaseCancel := context.WithCancel(ctx)
 		m.leases[id.NamespacedName()] = newLease(leaseCtx, leaseCancel)
 	}
@@ -57,16 +60,49 @@ func (m *Manager) Delete(id ID, objectName string, l *Lease) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	current, exist := m.leases[id.NamespacedName()]
-	if !exist || (l != nil && current != l) {
+	current := m.currentFor(id, l)
+	if current == nil {
 		return
 	}
 
 	current.delete(objectName)
 	if current.cnt.Load() < 1 {
-		current.Cancel()
-		delete(m.leases, id.NamespacedName())
+		m.retire(id, current)
 	}
+}
+
+// Retire drops the lease from the manager and cancels it, so that a later Add
+// creates a fresh instance.
+//
+// Teardown paths have to call this rather than relying on the deferred cleanup
+// goroutine. Until the lease is out of the map, Add hands the same instance back,
+// so a service that is torn down and immediately rebuilt gets parented to a
+// lease that the pending cleanup is about to cancel, and is never handled again.
+func (m *Manager) Retire(id ID, l *Lease) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if current := m.currentFor(id, l); current != nil {
+		m.retire(id, current)
+	}
+}
+
+// currentFor returns the registered lease for id, or nil when the caller is
+// stale, meaning the lease it holds is no longer the registered one. Callers have
+// to hold m.lock.
+func (m *Manager) currentFor(id ID, l *Lease) *Lease {
+	current, exist := m.leases[id.NamespacedName()]
+	if !exist || (l != nil && current != l) {
+		return nil
+	}
+	return current
+}
+
+// retire cancels the lease and drops it from the manager. Callers have to hold
+// m.lock.
+func (m *Manager) retire(id ID, l *Lease) {
+	l.Cancel()
+	delete(m.leases, id.NamespacedName())
 }
 
 // Get returns lease for the service.

--- a/pkg/lease/lease.go
+++ b/pkg/lease/lease.go
@@ -45,16 +45,27 @@ func (m *Manager) Add(ctx context.Context, id ID) *Lease {
 	return m.leases[id.NamespacedName()]
 }
 
-// Delete removes the lease and cancels it if the lease counter equals 0.
-func (m *Manager) Delete(id ID, objectName string) {
+// Delete removes the object from the lease it was added to and cancels that lease
+// once its last object is gone.
+//
+// The lease the caller was given has to be passed in, because cleanup is usually
+// deferred to a goroutine that runs long after the object went away. By then the
+// lease of that name may already have been replaced, for instance because the
+// service was torn down and rebuilt, and cancelling the replacement would leave
+// the service unhandled. A stale caller is therefore ignored.
+func (m *Manager) Delete(id ID, objectName string, l *Lease) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	if _, exist := m.leases[id.NamespacedName()]; exist {
-		m.leases[id.NamespacedName()].delete(objectName)
-		if m.leases[id.NamespacedName()].cnt.Load() < 1 {
-			m.leases[id.NamespacedName()].Cancel()
-			delete(m.leases, id.NamespacedName())
-		}
+
+	current, exist := m.leases[id.NamespacedName()]
+	if !exist || (l != nil && current != l) {
+		return
+	}
+
+	current.delete(objectName)
+	if current.cnt.Load() < 1 {
+		current.Cancel()
+		delete(m.leases, id.NamespacedName())
 	}
 }
 

--- a/pkg/lease/lease.go
+++ b/pkg/lease/lease.go
@@ -49,13 +49,19 @@ func (m *Manager) Add(ctx context.Context, id ID) *Lease {
 }
 
 // Delete removes the object from the lease it was added to and cancels that lease
-// once its last object is gone.
+// once its last object is gone. With a common lease, the siblings that still use
+// it keep it alive.
 //
 // The lease the caller was given has to be passed in, because cleanup is usually
 // deferred to a goroutine that runs long after the object went away. By then the
 // lease of that name may already have been replaced, for instance because the
 // service was torn down and rebuilt, and cancelling the replacement would leave
 // the service unhandled. A stale caller is therefore ignored.
+//
+// Teardown paths have to call this synchronously rather than leaving it to the
+// deferred cleanup: until the lease is out of the map, Add hands the same
+// instance back, so a service that is rebuilt straight away gets parented to a
+// lease that the pending cleanup is about to cancel.
 func (m *Manager) Delete(id ID, objectName string, l *Lease) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
@@ -67,22 +73,6 @@ func (m *Manager) Delete(id ID, objectName string, l *Lease) {
 
 	current.delete(objectName)
 	if current.cnt.Load() < 1 {
-		m.retire(id, current)
-	}
-}
-
-// Retire drops the lease from the manager and cancels it, so that a later Add
-// creates a fresh instance.
-//
-// Teardown paths have to call this rather than relying on the deferred cleanup
-// goroutine. Until the lease is out of the map, Add hands the same instance back,
-// so a service that is torn down and immediately rebuilt gets parented to a
-// lease that the pending cleanup is about to cancel, and is never handled again.
-func (m *Manager) Retire(id ID, l *Lease) {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	if current := m.currentFor(id, l); current != nil {
 		m.retire(id, current)
 	}
 }

--- a/pkg/lease/lease_test.go
+++ b/pkg/lease/lease_test.go
@@ -976,3 +976,43 @@ func TestManager_Delete_DoesNotCancelRecreatedLease(t *testing.T) {
 		t.Error("cleanup for the torn down lease removed the recreated lease")
 	}
 }
+
+// TestManager_Add_AfterCancelWithoutDelete_ReusesDoomedLease reproduces the
+// second half of the service rebuild race.
+//
+// A teardown cancels the service context but leaves the lease in the manager,
+// because the cleanup that removes it is deferred to a goroutine. If the
+// replacement service context is built before that goroutine runs, Add hands
+// back the very same lease instance, so the replacement is parented to a lease
+// that is about to be cancelled. The instance guard in Delete cannot help,
+// because the doomed lease and the current lease are the same object.
+//
+// Retiring the lease synchronously during teardown is what makes Add return a
+// genuinely fresh instance.
+func TestManager_Add_AfterCancelWithoutDelete_ReusesDoomedLease(t *testing.T) {
+	mgr := NewManager()
+	svc := createTestService("test-svc", "default", nil)
+	ctx, id := getSvcData(svc)
+	objectName := ServiceNamespacedName(svc)
+
+	old := mgr.Add(ctx, id)
+	old.Add(objectName)
+
+	// Teardown retires the lease, so the rebuild that follows cannot be parented
+	// to it even though the deferred cleanup has not run yet.
+	mgr.Retire(id, old)
+
+	fresh := mgr.Add(ctx, id)
+	fresh.Add(objectName)
+
+	if fresh == old {
+		t.Fatal("replacement service context would be parented to the doomed lease")
+	}
+
+	// The deferred cleanup for the old lease now runs and must be a no-op.
+	mgr.Delete(id, objectName, old)
+
+	if fresh.Ctx.Err() != nil {
+		t.Error("late cleanup cancelled the replacement lease")
+	}
+}

--- a/pkg/lease/lease_test.go
+++ b/pkg/lease/lease_test.go
@@ -2,6 +2,7 @@ package lease
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -998,9 +999,9 @@ func TestManager_Add_AfterCancelWithoutDelete_ReusesDoomedLease(t *testing.T) {
 	old := mgr.Add(ctx, id)
 	old.Add(objectName)
 
-	// Teardown retires the lease, so the rebuild that follows cannot be parented
-	// to it even though the deferred cleanup has not run yet.
-	mgr.Retire(id, old)
+	// Teardown drops the service from its lease synchronously, so the rebuild that
+	// follows cannot be parented to it even though the deferred cleanup has not run.
+	mgr.Delete(id, objectName, old)
 
 	fresh := mgr.Add(ctx, id)
 	fresh.Add(objectName)
@@ -1014,5 +1015,71 @@ func TestManager_Add_AfterCancelWithoutDelete_ReusesDoomedLease(t *testing.T) {
 
 	if fresh.Ctx.Err() != nil {
 		t.Error("late cleanup cancelled the replacement lease")
+	}
+}
+
+// TestManager_LeaseLifetimeInvariant pins the lifetime rule for the whole
+// Add/Delete surface rather than one scenario: a lease stays usable for exactly as
+// long as at least one object still holds it, and is replaced afterwards.
+//
+// That is the property the common lease depends on, and the one a per-lease
+// teardown breaks: dropping one service must not cancel a lease its siblings are
+// still using. Raised by Patryk in review of #1669.
+func TestManager_LeaseLifetimeInvariant(t *testing.T) {
+	shared := map[string]string{serviceLeaseAnnotation: "shared-lease"}
+
+	for _, tc := range []struct {
+		name    string
+		objects int
+	}{
+		{"single object", 1},
+		{"two objects sharing a lease", 2},
+		{"several objects sharing a lease", 4},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr := NewManager()
+			ctx, id := getSvcData(createTestService("svc0", "default", shared))
+
+			objects := make([]string, tc.objects)
+			for i := range objects {
+				objects[i] = ServiceNamespacedName(createTestService(fmt.Sprintf("svc%d", i), "default", shared))
+			}
+
+			l := mgr.Add(ctx, id)
+			for _, o := range objects {
+				if !l.Add(o) {
+					t.Fatalf("object %q was not added", o)
+				}
+			}
+
+			// Drop the objects one at a time. Every drop but the last has to leave
+			// the lease usable, because the rest still depend on it.
+			for i, o := range objects {
+				mgr.Delete(id, o, l)
+
+				if remaining := len(objects) - i - 1; remaining > 0 {
+					if l.Ctx.Err() != nil {
+						t.Fatalf("lease was cancelled with %d object(s) still holding it", remaining)
+					}
+					if mgr.Get(id) != l {
+						t.Fatalf("lease was dropped with %d object(s) still holding it", remaining)
+					}
+					continue
+				}
+
+				if l.Ctx.Err() == nil {
+					t.Error("lease was not cancelled after its last object went away")
+				}
+				if mgr.Get(id) != nil {
+					t.Error("lease was not removed after its last object went away")
+				}
+			}
+
+			// A rebuild has to get a genuinely fresh lease, so nothing derived from it
+			// is cancelled by the teardown that just happened.
+			if fresh := mgr.Add(ctx, id); fresh == l || fresh.Ctx.Err() != nil {
+				t.Error("rebuild reused the retired lease")
+			}
+		})
 	}
 }

--- a/pkg/lease/lease_test.go
+++ b/pkg/lease/lease_test.go
@@ -99,7 +99,7 @@ func TestManager_Delete_DecrementCounter(t *testing.T) {
 
 	// Delete once - should remove the lease
 
-	mgr.Delete(leaseID1, objectName)
+	mgr.Delete(leaseID1, objectName, nil)
 
 	lease := mgr.Get(getSvcID(svc))
 	if lease != nil {
@@ -127,7 +127,7 @@ func TestManager_Delete_CancelsContext(t *testing.T) {
 	}
 
 	// Delete the lease
-	mgr.Delete(leaseID1, objectName)
+	mgr.Delete(leaseID1, objectName, nil)
 
 	// Verify context is cancelled
 	select {
@@ -149,7 +149,7 @@ func TestManager_Add_AfterDelete_CreatesNewLease(t *testing.T) {
 	lease1 := mgr.Add(ctx1, leaseID1)
 	_ = lease1.Add(objectName)
 
-	mgr.Delete(leaseID1, objectName)
+	mgr.Delete(leaseID1, objectName, nil)
 
 	ctx2, leaseID2 := getSvcData(svc)
 	lease2 := mgr.Add(ctx2, leaseID2)
@@ -244,7 +244,7 @@ func TestManager_ConcurrentAccess(t *testing.T) {
 	}
 	wg.Wait()
 
-	mgr.Delete(leaseID1, objectName1)
+	mgr.Delete(leaseID1, objectName1, nil)
 
 	// After a one delete, lease should be gone
 	lease := mgr.Get(getSvcID(svc))
@@ -427,7 +427,7 @@ func TestManager_LeaderElectionRestartScenario_etcd(t *testing.T) {
 
 	// Simulate leadership lost - the leader election function should delete the lease
 	// This is the fix: delete the lease when RunOrDie returns
-	mgr.Delete(leaseID1, objectName1)
+	mgr.Delete(leaseID1, objectName1, nil)
 
 	// Verify lease is removed
 	if mgr.Get(getSvcID(svc)) != nil {
@@ -496,13 +496,13 @@ func TestManager_CommonLeaseScenario(t *testing.T) {
 	}
 
 	// Delete first service - lease should still exist
-	mgr.Delete(leaseID1, objectName1)
+	mgr.Delete(leaseID1, objectName1, nil)
 	if mgr.Get(getSvcID(svc1)) == nil {
 		t.Error("expected lease to still exist after first delete")
 	}
 
 	// Delete second service - lease should be removed
-	mgr.Delete(leaseID2, objectName2)
+	mgr.Delete(leaseID2, objectName2, nil)
 	if mgr.Get(getSvcID(svc2)) != nil {
 		t.Error("expected lease to be removed after all services deleted")
 	}
@@ -550,7 +550,7 @@ func TestManager_RaceCondition_LeaseExistsBeforeDelete(t *testing.T) {
 	}
 
 	// Now the first goroutine's defer deletes the lease
-	mgr.Delete(leaseID1, objectName1)
+	mgr.Delete(leaseID1, objectName1, nil)
 
 	// The lease should not still exist because same service was processed twice, so we do not increment the counter
 	if mgr.Get(getSvcID(svc)) != nil {
@@ -558,7 +558,7 @@ func TestManager_RaceCondition_LeaseExistsBeforeDelete(t *testing.T) {
 	}
 
 	// Second delete does nothing
-	mgr.Delete(leaseID2, objectName1)
+	mgr.Delete(leaseID2, objectName1, nil)
 	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease to not exist")
 	}
@@ -606,17 +606,17 @@ func TestManager_NonCommonLease_MultipleAdds(t *testing.T) {
 	}
 
 	// Need one delete to remove the lease, another delete runs do nothing
-	mgr.Delete(leaseID1, objectName1)
+	mgr.Delete(leaseID1, objectName1, nil)
 	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease to be deleted")
 	}
 
-	mgr.Delete(leaseID2, objectName1)
+	mgr.Delete(leaseID2, objectName1, nil)
 	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease to be deleted")
 	}
 
-	mgr.Delete(leaseID3, objectName1)
+	mgr.Delete(leaseID3, objectName1, nil)
 	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease to be deleted")
 	}
@@ -668,8 +668,8 @@ func TestManager_LeaseContextCancelledBeforeStarted(t *testing.T) {
 	}
 
 	// Delete should still work
-	mgr.Delete(leaseID1, objectName1)
-	mgr.Delete(leaseID2, objectName1)
+	mgr.Delete(leaseID1, objectName1, nil)
+	mgr.Delete(leaseID2, objectName1, nil)
 
 	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease to be removed")
@@ -693,7 +693,7 @@ func TestManager_RestartAfterLeaseContextCancelled(t *testing.T) {
 	lease1.Cancel()
 
 	// Delete the lease
-	mgr.Delete(leaseID1, objectName1)
+	mgr.Delete(leaseID1, objectName1, nil)
 
 	// Verify lease is gone
 	if mgr.Get(getSvcID(svc)) != nil {
@@ -794,11 +794,11 @@ func TestManager_NonCommonLease_WaitForLeaseContextDone(t *testing.T) {
 	}
 
 	// Now simulate the first leader election ending (defer deletes the lease)
-	mgr.Delete(leaseID1, objectName1)
+	mgr.Delete(leaseID1, objectName1, nil)
 
 	// The lease context should now be cancelled (because counter went to 0)
 	// But we added twice, so we need to delete twice
-	mgr.Delete(leaseID2, objectName1)
+	mgr.Delete(leaseID2, objectName1, nil)
 
 	// Now the goroutine should have completed
 	select {
@@ -878,7 +878,7 @@ func TestManager_NonCommonLease_SpinLoopPrevention(t *testing.T) {
 		t.Errorf("expected 100 adds, got %d", addCount)
 	}
 
-	mgr.Delete(leaseID1, objectName1)
+	mgr.Delete(leaseID1, objectName1, nil)
 	if mgr.Get(getSvcID(svc)) != nil {
 		t.Error("expected lease to be removed after first delete")
 	}
@@ -935,5 +935,44 @@ func TestManager_NonCommonLease_ServiceContextCancellation(t *testing.T) {
 		}
 	case <-time.After(200 * time.Millisecond):
 		t.Error("goroutine should have unblocked")
+	}
+}
+
+// TestManager_Delete_DoesNotCancelRecreatedLease reproduces the stale-cleanup bug.
+//
+// Every service that starts leader election also starts a goroutine that calls
+// Manager.Delete once the service context is cancelled. When a service is torn
+// down and immediately rebuilt, for instance because its externalTrafficPolicy
+// changed, that goroutine runs after the replacement lease was already created.
+// Deleting by name alone then cancels the live replacement, and the service is
+// never handled again.
+func TestManager_Delete_DoesNotCancelRecreatedLease(t *testing.T) {
+	mgr := NewManager()
+	svc := createTestService("test-svc", "default", nil)
+	ctx, id := getSvcData(svc)
+	objectName := ServiceNamespacedName(svc)
+
+	// The service is set up, and its lease is registered.
+	old := mgr.Add(ctx, id)
+	old.Add(objectName)
+
+	// The service is torn down and rebuilt straight away, so a fresh lease for the
+	// same name exists before the old cleanup goroutine gets to run.
+	mgr.Delete(id, objectName, old)
+	fresh := mgr.Add(ctx, id)
+	fresh.Add(objectName)
+
+	if old == fresh {
+		t.Fatal("expected a new lease instance after delete")
+	}
+
+	// Now the cleanup for the *old* lease finally runs. It has to be a no-op.
+	mgr.Delete(id, objectName, old)
+
+	if fresh.Ctx.Err() != nil {
+		t.Error("cleanup for the torn down lease cancelled the recreated lease")
+	}
+	if got := mgr.Get(id); got == nil {
+		t.Error("cleanup for the torn down lease removed the recreated lease")
 	}
 }

--- a/pkg/manager/worker/common.go
+++ b/pkg/manager/worker/common.go
@@ -175,7 +175,7 @@ func (c *Common) runGlobalElection(ctx context.Context, a election.Actions, leas
 		select {
 		case <-ctx.Done():
 			// Service was deleted
-			c.leaseMgr.Delete(leaseID, objectName)
+			c.leaseMgr.Delete(leaseID, objectName, objLease)
 		case <-objLease.Ctx.Done():
 			// Leader election ended (leadership lost or context cancelled)
 		}
@@ -226,7 +226,7 @@ func (c *Common) runGlobalElection(ctx context.Context, a election.Actions, leas
 		// 1. Leadership loss (e.g., network timeout)
 		// 2. Context cancellation
 		// 3. Any other reason RunOrDie returns
-		c.leaseMgr.Delete(leaseID, objectName)
+		c.leaseMgr.Delete(leaseID, objectName, objLease)
 	}()
 
 	wg := sync.WaitGroup{}

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -82,7 +82,7 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 	// healthy and a new election should have started immediately.
 	go func() {
 		<-svcCtx.Ctx.Done()
-		p.leaseMgr.Delete(id, objectName)
+		p.leaseMgr.Delete(id, objectName, svcLease)
 	}()
 
 	select {

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -196,6 +196,10 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 				}
 				// in theory this should never fail
 				p.svcMap.Delete(svc.UID)
+				// Retire the lease as well, so the replacement context below is not
+				// parented to a lease the pending cleanup is about to cancel.
+				ns, name := lease.ServiceName(svc)
+				p.leaseMgr.Retire(lease.NewID(p.config.LeaderElectionType, ns, name), nil)
 				// Reset the the svcCtx when it was garbage collected
 				// As the next function will create a new context when nil
 				svcCtx = nil

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -196,10 +196,12 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 				}
 				// in theory this should never fail
 				p.svcMap.Delete(svc.UID)
-				// Retire the lease as well, so the replacement context below is not
-				// parented to a lease the pending cleanup is about to cancel.
+				// Drop this service from its lease now, so the replacement context
+				// below is not parented to a lease the pending cleanup is about to
+				// cancel. A lease shared with other services stays alive for them.
 				ns, name := lease.ServiceName(svc)
-				p.leaseMgr.Retire(lease.NewID(p.config.LeaderElectionType, ns, name), nil)
+				leaseID := lease.NewID(p.config.LeaderElectionType, ns, name)
+				p.leaseMgr.Delete(leaseID, lease.ServiceNamespacedName(svc), nil)
 				// Reset the the svcCtx when it was garbage collected
 				// As the next function will create a new context when nil
 				svcCtx = nil


### PR DESCRIPTION
Two defects on the same path: a service that is torn down and immediately rebuilt ends up with a lease nobody holds, and is never handled again.

Reachable from an ordinary service update. Flipping `externalTrafficPolicy` makes `serviceChanged` cancel the service context and rebuild it, which reproduced both.

## 1. A late cleanup cancels the replacement

Every object that starts leader election also starts a goroutine that calls `Manager.Delete` once its context is cancelled. `Delete` looked the lease up by name only, so it acted on whatever held that name **when it ran**, not the instance the caller was given. By then the lease may already have been replaced, and the cleanup cancels the live replacement.

Fixed by passing the lease the caller owns and ignoring a stale caller. All four call sites already hold it. Passing `nil` keeps the old behaviour of acting on whichever lease currently holds the name, which is what the existing tests assert.

## 2. The replacement *is* the doomed instance

The instance guard above cannot help when both are the same object. Teardown cancels the service context and leaves the lease registered, because the cleanup that removes it is deferred. The rebuild calls `Add`, finds that lease still in the map, and gets it straight back — so the new service context is parented to a lease the pending cleanup is about to cancel. Observed as a service that cycles acquire / lose / re-acquire every few seconds and never settles:

```
new leader election    service=kube-vip-service lock_name=kubevip-kube-vip-service
leadership lost        service=kube-vip-service
stopping leader election
new leader election    ... repeating, 11 times in 2 minutes
```

Fixed by adding `Manager.Retire` and calling it from the `serviceChanged` teardown next to the `svcMap` purge, so the lease is out of the map before the replacement context is built. `Add` also refuses to hand out a lease whose context is already cancelled, closing the same hazard for any other path that cancels a lease directly.

## Review follow-up

Patryk spotted that the first cut cancelled the lease context outright, so with a common lease a change to one service would tear down every sibling sharing it. `Retire` was only needed to get the lease out of the map before the rebuild, and `Delete` already does that once the last object leaves — so `Retire` is gone, the teardown calls `Delete` with its own object name, and the manager API stays `Add`/`Delete`/`Get`.

## Tests

Three unit tests, each failing without its corresponding fix:

- `TestManager_Delete_DoesNotCancelRecreatedLease` — `cleanup for the torn down lease cancelled the recreated lease`
- `TestManager_Add_AfterCancelWithoutDelete_ReusesDoomedLease` — `replacement service context would be parented to the doomed lease`
- `TestManager_LeaseLifetimeInvariant` — pins the lifetime rule for the whole surface rather than one scenario: a lease stays usable for exactly as long as at least one object holds it, and a rebuild afterwards gets a fresh one. Table driven over 1, 2 and 4 objects; the 2 and 4 cases fail against the reviewed behaviour with `lease was cancelled with N object(s) still holding it`.

#1668 adds the cluster-level counterpart in its `-electionFaults` suite: two services share a lease, one is deleted, and the lease has to stay held for the one that stays.

`go build`, `go vet`, `gofmt`, `golangci-lint v2.12` and `go test -race ./pkg/... ./cmd/...` all clean.

Found while adding fault-injection coverage for the per-service leader election in #1668, which stacks on top of this.
