### PR TITLE
routing table mode: honor the configured Kubernetes address for backend health checks

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -31,10 +31,10 @@ func (e *Entry) Check() bool {
 	// homeConfigPath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
 
 	var k8sAddr string
-	if utils.IsIPv4(e.Addr) {
-		k8sAddr = fmt.Sprintf("%s:%v", e.Addr, e.Port)
-	} else {
+	if utils.IsIPv6(e.Addr) {
 		k8sAddr = fmt.Sprintf("[%s]:%v", e.Addr, e.Port)
+	} else {
+		k8sAddr = fmt.Sprintf("%s:%v", e.Addr, e.Port)
 	}
 
 	switch {

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io/fs"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -144,29 +146,41 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 		backendMapV6 := backend.Map{}
 		// only check localhost
 
-		ips := []string{}
-		if c.NodeName != "" {
-			if ips, err = getNodeIPs(ctx, c.NodeName, em.KubernetesClient); err != nil && !apierrors.IsNotFound(err) {
-				log.Error("failed to get IP of control-plane node", "err", err)
+		// An explicitly configured Kubernetes API address (static-pod
+		// deployments point it at the local API server, whose loopback
+		// listener is often the only certificate-valid local endpoint)
+		// takes precedence over the Node object's addresses: the check
+		// answers "is the local API server healthy" for every VIP family,
+		// regardless of the transport family of the override itself.
+		if entry := kubernetesAddrBackendEntry(c.KubernetesAddr, c.Port); entry != nil {
+			log.Info("using configured Kubernetes address for backend health checks", "address", c.KubernetesAddr)
+			backendMapV4[*entry] = false
+			backendMapV6[*entry] = false
+		} else {
+			ips := []string{}
+			if c.NodeName != "" {
+				if ips, err = getNodeIPs(ctx, c.NodeName, em.KubernetesClient); err != nil && !apierrors.IsNotFound(err) {
+					log.Error("failed to get IP of control-plane node", "err", err)
+				}
 			}
-		}
 
-		if len(ips) == 0 {
-			if !utils.IsIPv6(cluster.Network[0].IP()) {
-				ips = append(ips, "127.0.0.1")
-			} else {
-				ips = append(ips, "::1")
+			if len(ips) == 0 {
+				if !utils.IsIPv6(cluster.Network[0].IP()) {
+					ips = append(ips, "127.0.0.1")
+				} else {
+					ips = append(ips, "::1")
+				}
+
+				log.Info("no IP address found for node - will fallback to use localhost address", "addresses", ips)
 			}
 
-			log.Info("no IP address found for node - will fallback to use localhost address", "addresses", ips)
-		}
-
-		for _, ip := range ips {
-			entry := backend.Entry{Addr: ip, Port: c.Port}
-			if !utils.IsIPv6(ip) {
-				backendMapV4[entry] = false
-			} else {
-				backendMapV6[entry] = false
+			for _, ip := range ips {
+				entry := backend.Entry{Addr: ip, Port: c.Port}
+				if !utils.IsIPv6(ip) {
+					backendMapV4[entry] = false
+				} else {
+					backendMapV6[entry] = false
+				}
 			}
 		}
 
@@ -317,6 +331,27 @@ func (cluster *Cluster) bgpHealthCheckLoop(ctx context.Context, c *kubevip.Confi
 		case <-ticker.C:
 		}
 	}
+}
+
+// kubernetesAddrBackendEntry converts an explicitly configured Kubernetes
+// API address override (config.KubernetesAddr, e.g. "https://127.0.0.1:6443"
+// on static-pod deployments) into a backend health-check entry. Returns nil
+// when no usable override is configured.
+func kubernetesAddrBackendEntry(kubernetesAddr string, defaultPort uint16) *backend.Entry {
+	if kubernetesAddr == "" {
+		return nil
+	}
+	u, err := url.Parse(kubernetesAddr)
+	if err != nil || u.Hostname() == "" {
+		return nil
+	}
+	port := defaultPort
+	if p := u.Port(); p != "" {
+		if parsed, err := strconv.ParseUint(p, 10, 16); err == nil {
+			port = uint16(parsed)
+		}
+	}
+	return &backend.Entry{Addr: u.Hostname(), Port: port}
 }
 
 func getNodeIPs(ctx context.Context, nodename string, client *kubernetes.Clientset) ([]string, error) {

--- a/pkg/cluster/service_internal_test.go
+++ b/pkg/cluster/service_internal_test.go
@@ -1,0 +1,61 @@
+package cluster
+
+import (
+	"testing"
+)
+
+func TestKubernetesAddrBackendEntry(t *testing.T) {
+	cases := []struct {
+		name     string
+		addr     string
+		port     uint16
+		wantAddr string
+		wantPort uint16
+		wantNil  bool
+	}{
+		{
+			name:     "explicit v4 loopback with port",
+			addr:     "https://127.0.0.1:6443",
+			port:     9999,
+			wantAddr: "127.0.0.1",
+			wantPort: 6443,
+		},
+		{
+			name:     "hostname without port falls back to config port",
+			addr:     "https://localhost",
+			port:     6443,
+			wantAddr: "localhost",
+			wantPort: 6443,
+		},
+		{
+			name:    "empty override",
+			addr:    "",
+			port:    6443,
+			wantNil: true,
+		},
+		{
+			name:    "garbage override",
+			addr:    "://not-a-url",
+			port:    6443,
+			wantNil: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := kubernetesAddrBackendEntry(tc.addr, tc.port)
+			if tc.wantNil {
+				if entry != nil {
+					t.Fatalf("expected nil entry, got %+v", entry)
+				}
+				return
+			}
+			if entry == nil {
+				t.Fatal("expected an entry, got nil")
+			}
+			if entry.Addr != tc.wantAddr || entry.Port != tc.wantPort {
+				t.Fatalf("got %+v, want addr %q port %d", entry, tc.wantAddr, tc.wantPort)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In the RT-mode with cp_enable, health check resolves the node address via getNodeIPs and calls https://node-ip:6443.

In deployments where apiserver does not have a certificate for the node IP this fails with "failed to verify certificate: x509: [...]"

When an explicit k8s address is configured via KubernetesAddr, we want to use it for the backend health check instead of the node addresses.

Fixes: #1670