### PR TITLE
Update service on common lease change

### DIFF
--- a/pkg/lease/lease.go
+++ b/pkg/lease/lease.go
@@ -92,8 +92,7 @@ func newLease(ctx context.Context, cancel context.CancelFunc) *Lease {
 // Add adds the object to the lease and increments counter
 // it will return true if object was added
 func (l *Lease) Add(name string) bool {
-	if _, exists := l.services.Load(name); !exists {
-		l.services.Store(name, true)
+	if _, exists := l.services.LoadOrStore(name, true); !exists {
 		l.cnt.Add(1)
 		return true
 	}

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -402,7 +402,9 @@ func serviceChanged(i *instance.Instance, svc *v1.Service) bool {
 		!reflect.DeepEqual(svc.Spec.IPFamilies, i.ServiceSnapshot.Spec.IPFamilies) ||
 		*svc.Spec.IPFamilyPolicy != *i.ServiceSnapshot.Spec.IPFamilyPolicy ||
 		// DDNS was disabled/enabled
-		svc.Annotations[kubevip.ServiceDDNS] != i.ServiceSnapshot.Annotations[kubevip.ServiceDDNS]
+		svc.Annotations[kubevip.ServiceDDNS] != i.ServiceSnapshot.Annotations[kubevip.ServiceDDNS] ||
+		// lease name was changed
+		svc.Annotations[kubevip.ServiceLease] != i.ServiceSnapshot.Annotations[kubevip.ServiceLease]
 }
 
 func (p *Processor) updateActiveServicesMetric() {


### PR DESCRIPTION
While testing #1669 I've noticed that changing the common lease specified with an annotation `kube-vip.io/leaseName` does not trigger service update. This PR should fix this.

Additional change:

After comment in the discussion in #1665, I've decided to change consecutive calls to `Load` and `Store` in lease manager for atomic `LoadOrStore` call. With upcoming merges this race condition should rather never happen anyway, but better safe than sorry. I think that the non-atomicity of the counter increment should not be an issue, as it's guarded by this atomic call now.