### PR TITLE
fix(egress): prevent stale active-endpoint overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Prevent stale Service snapshots from clearing active endpoint annotations during egress initialization, preserve empty snapshots across zero-endpoint transitions, and clear the correct address family when EndpointSlices become empty.
 - Add a configurable kube-vip instance name and use it to isolate internal nftables egress tables, persist table ownership on Services, and migrate per-Service chains without affecting other deployments. Fixes #1634.
 - Retry on 403 Forbidden and 401 Unauthorized in `ServicesWatcher` at startup with exponential backoff. Fixes #1464.
 - Reintroduce BGP config via node annotations. Fixes #1488.

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -179,28 +179,37 @@ func (p *Processor) updateAnnotations(service *v1.Service, lastKnownGoodEndpoint
 	egressUpdateFunc func(context.Context, *v1.Service) error) {
 	// Set the service accordingly
 	if service.Annotations[kubevip.Egress] == "true" {
-		ip := net.ParseIP(*lastKnownGoodEndpoint)
-
 		// Store old values from ServiceSnapshot to detect if annotation actually changed
 		// We use the ServiceSnapshot instead of the service parameter because the service parameter
 		// may have stale annotations if the last update failed
 		var oldEndpoint, oldEndpointIPv6 string
+		snapshotFound := false
 		if p.instances != nil {
 			serviceInstance := instance.FindServiceInstance(service, *p.instances)
-			if serviceInstance != nil {
+			if serviceInstance != nil && serviceInstance.ServiceSnapshot != nil {
+				snapshotFound = true
 				oldEndpoint = serviceInstance.ServiceSnapshot.Annotations[kubevip.ActiveEndpoint]
 				oldEndpointIPv6 = serviceInstance.ServiceSnapshot.Annotations[kubevip.ActiveEndpointIPv6]
 			}
 		}
-		// Fall back to service annotations if we couldn't find the instance
-		if oldEndpoint == "" && oldEndpointIPv6 == "" {
+		// Fall back to service annotations only if we couldn't find the instance.
+		// Empty annotations in an existing snapshot are meaningful after a
+		// zero-endpoint transition and must not be replaced with values from the
+		// older Service object captured when the endpoint watcher started.
+		if !snapshotFound {
 			oldEndpoint = service.Annotations[kubevip.ActiveEndpoint]
 			oldEndpointIPv6 = service.Annotations[kubevip.ActiveEndpointIPv6]
 		}
 
 		// Determine which annotation to update based on IP version
 		var endpoint, endpointIPv6 string
-		if ip.To4() == nil && !p.config.EnableEndpoints {
+		// Use the configured egress family instead of parsing
+		// lastKnownGoodEndpoint: an empty endpoint is not an IPv6 address, but
+		// net.ParseIP("") returns nil and used to make us preserve a stale IPv4
+		// annotation when EndpointSlices temporarily contained no endpoints.
+		// The legacy Endpoints provider continues to use ActiveEndpoint for
+		// both families.
+		if service.Annotations[kubevip.EgressIPv6] == "true" && !p.config.EnableEndpoints {
 			// IPv6
 			endpointIPv6 = *lastKnownGoodEndpoint
 			endpoint = oldEndpoint // Preserve existing IPv4 if any

--- a/pkg/endpoints/endpoints_test.go
+++ b/pkg/endpoints/endpoints_test.go
@@ -2,12 +2,14 @@ package endpoints
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/kube-vip/kube-vip/pkg/endpoints/providers"
+	"github.com/kube-vip/kube-vip/pkg/instance"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/metrics"
@@ -17,6 +19,7 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
 )
 
 func TestShouldAllowReconcileWithoutEndpoints(t *testing.T) {
@@ -45,6 +48,254 @@ type fakeWorker struct {
 	endpoints     []string
 	clearCalled   bool
 	processCalled bool
+}
+
+type annotationUpdate struct {
+	endpoint     string
+	endpointIPv6 string
+}
+
+type recordingProvider struct {
+	providers.Provider
+	updates   []annotationUpdate
+	updateErr error
+}
+
+func (p *recordingProvider) UpdateServiceAnnotation(_ context.Context, endpoint, endpointIPv6 string,
+	_ *v1.Service, _ *kubernetes.Clientset) error {
+	p.updates = append(p.updates, annotationUpdate{endpoint: endpoint, endpointIPv6: endpointIPv6})
+	return p.updateErr
+}
+
+func TestUpdateAnnotations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		enableEndpoints    bool
+		annotations        map[string]string
+		selectedEndpoint   string
+		providerError      bool
+		wantUpdate         *annotationUpdate
+		wantEgressCallback bool
+	}{
+		{
+			name:               "Endpoints writes initial IPv4 endpoint",
+			enableEndpoints:    true,
+			annotations:        map[string]string{kubevip.Egress: "true"},
+			selectedEndpoint:   "10.0.0.2",
+			wantUpdate:         &annotationUpdate{endpoint: "10.0.0.2"},
+			wantEgressCallback: true,
+		},
+		{
+			name:            "EndpointSlices updates IPv4 and preserves IPv6",
+			enableEndpoints: false,
+			annotations: map[string]string{
+				kubevip.Egress:             "true",
+				kubevip.ActiveEndpoint:     "10.0.0.1",
+				kubevip.ActiveEndpointIPv6: "fd00::1",
+			},
+			selectedEndpoint:   "10.0.0.2",
+			wantUpdate:         &annotationUpdate{endpoint: "10.0.0.2", endpointIPv6: "fd00::1"},
+			wantEgressCallback: true,
+		},
+		{
+			name:            "EndpointSlices updates IPv6 and preserves IPv4",
+			enableEndpoints: false,
+			annotations: map[string]string{
+				kubevip.Egress:             "true",
+				kubevip.EgressIPv6:         "true",
+				kubevip.ActiveEndpoint:     "10.0.0.1",
+				kubevip.ActiveEndpointIPv6: "fd00::1",
+			},
+			selectedEndpoint:   "fd00::2",
+			wantUpdate:         &annotationUpdate{endpoint: "10.0.0.1", endpointIPv6: "fd00::2"},
+			wantEgressCallback: true,
+		},
+		{
+			name:            "EndpointSlices clears IPv4 and preserves IPv6",
+			enableEndpoints: false,
+			annotations: map[string]string{
+				kubevip.Egress:             "true",
+				kubevip.ActiveEndpoint:     "10.0.0.1",
+				kubevip.ActiveEndpointIPv6: "fd00::1",
+			},
+			wantUpdate:         &annotationUpdate{endpointIPv6: "fd00::1"},
+			wantEgressCallback: true,
+		},
+		{
+			name:            "EndpointSlices clears IPv6 and preserves IPv4",
+			enableEndpoints: false,
+			annotations: map[string]string{
+				kubevip.Egress:             "true",
+				kubevip.EgressIPv6:         "true",
+				kubevip.ActiveEndpoint:     "10.0.0.1",
+				kubevip.ActiveEndpointIPv6: "fd00::1",
+			},
+			wantUpdate:         &annotationUpdate{endpoint: "10.0.0.1"},
+			wantEgressCallback: true,
+		},
+		{
+			name:            "unchanged endpoint does not write or reconfigure egress",
+			enableEndpoints: true,
+			annotations: map[string]string{
+				kubevip.Egress:         "true",
+				kubevip.ActiveEndpoint: "10.0.0.1",
+			},
+			selectedEndpoint: "10.0.0.1",
+		},
+		{
+			name:             "failed annotation update does not reconfigure egress",
+			enableEndpoints:  true,
+			annotations:      map[string]string{kubevip.Egress: "true"},
+			selectedEndpoint: "10.0.0.2",
+			providerError:    true,
+			wantUpdate:       &annotationUpdate{endpoint: "10.0.0.2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := providers.NewEndpointslices()
+			if tt.enableEndpoints {
+				provider = providers.NewEndpoints()
+			}
+			recorder := &recordingProvider{Provider: provider}
+			if tt.providerError {
+				recorder.updateErr = errors.New("update failed")
+			}
+
+			p := &Processor{
+				config:   &kubevip.Config{EnableEndpoints: tt.enableEndpoints},
+				provider: recorder,
+			}
+			service := &v1.Service{ObjectMeta: metav1.ObjectMeta{
+				Name: "test-service", Namespace: "default", Annotations: tt.annotations,
+			}}
+
+			callbackCalls := 0
+			var callbackService *v1.Service
+			p.updateAnnotations(service, &tt.selectedEndpoint, nil, func(_ context.Context, svc *v1.Service) error {
+				callbackCalls++
+				callbackService = svc
+				return nil
+			})
+
+			if tt.wantUpdate == nil {
+				if len(recorder.updates) != 0 {
+					t.Fatalf("got %d annotation updates, want none", len(recorder.updates))
+				}
+			} else {
+				if len(recorder.updates) != 1 {
+					t.Fatalf("got %d annotation updates, want one", len(recorder.updates))
+				}
+				if got := recorder.updates[0]; got != *tt.wantUpdate {
+					t.Fatalf("annotation update = %+v, want %+v", got, *tt.wantUpdate)
+				}
+			}
+
+			wantCallbackCalls := 0
+			if tt.wantEgressCallback {
+				wantCallbackCalls = 1
+			}
+			if callbackCalls != wantCallbackCalls {
+				t.Fatalf("egress callback called %d times, want %d", callbackCalls, wantCallbackCalls)
+			}
+			if callbackService != nil && tt.wantUpdate != nil {
+				if got := callbackService.Annotations[kubevip.ActiveEndpoint]; got != tt.wantUpdate.endpoint {
+					t.Errorf("callback IPv4 endpoint = %q, want %q", got, tt.wantUpdate.endpoint)
+				}
+				if got := callbackService.Annotations[kubevip.ActiveEndpointIPv6]; got != tt.wantUpdate.endpointIPv6 {
+					t.Errorf("callback IPv6 endpoint = %q, want %q", got, tt.wantUpdate.endpointIPv6)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateAnnotations_ZeroEndpointsThenSameEndpoint(t *testing.T) {
+	t.Parallel()
+
+	for _, enableEndpoints := range []bool{true, false} {
+		name := "EndpointSlices"
+		if enableEndpoints {
+			name = "Endpoints"
+		}
+		t.Run(name, func(t *testing.T) {
+			const endpoint = "10.0.0.1"
+			service := &v1.Service{ObjectMeta: metav1.ObjectMeta{
+				Name: "test-service", Namespace: "default", UID: "test-uid",
+				Annotations: map[string]string{
+					kubevip.Egress:         "true",
+					kubevip.ActiveEndpoint: endpoint,
+				},
+			}}
+			serviceInstance := &instance.Instance{ServiceSnapshot: service.DeepCopy()}
+			instances := []*instance.Instance{serviceInstance}
+			provider := providers.NewEndpointslices()
+			if enableEndpoints {
+				provider = providers.NewEndpoints()
+			}
+			recorder := &recordingProvider{Provider: provider}
+			p := &Processor{
+				config:    &kubevip.Config{EnableEndpoints: enableEndpoints},
+				provider:  recorder,
+				instances: &instances,
+			}
+
+			updateSnapshot := func(_ context.Context, svc *v1.Service) error {
+				serviceInstance.ServiceSnapshot = svc
+				return nil
+			}
+
+			noEndpoint := ""
+			p.updateAnnotations(service, &noEndpoint, nil, updateSnapshot)
+			repopulatedEndpoint := endpoint
+			p.updateAnnotations(service, &repopulatedEndpoint, nil, updateSnapshot)
+
+			want := []annotationUpdate{{}, {endpoint: endpoint}}
+			if len(recorder.updates) != len(want) {
+				t.Fatalf("got %d annotation updates, want %d", len(recorder.updates), len(want))
+			}
+			for i := range want {
+				if recorder.updates[i] != want[i] {
+					t.Errorf("annotation update %d = %+v, want %+v", i, recorder.updates[i], want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateLastKnownGoodEndpoint_SelectsConfiguredFamily(t *testing.T) {
+	t.Parallel()
+
+	endpoints := []string{"fd00::20", "172.30.2.40"}
+	for _, tt := range []struct {
+		name        string
+		annotations map[string]string
+		want        string
+	}{
+		{
+			name:        "IPv4 egress on dual-stack pods",
+			annotations: map[string]string{kubevip.Egress: "true"},
+			want:        "172.30.2.40",
+		},
+		{
+			name:        "IPv6 egress on dual-stack pods",
+			annotations: map[string]string{kubevip.Egress: "true", kubevip.EgressIPv6: "true"},
+			want:        "fd00::20",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Processor{worker: &fakeWorker{}}
+			service := &v1.Service{ObjectMeta: metav1.ObjectMeta{Annotations: tt.annotations}}
+			selected := ""
+			p.updateLastKnownGoodEndpoint(&selected, endpoints, service)
+			if selected != tt.want {
+				t.Fatalf("selected endpoint = %q, want %q", selected, tt.want)
+			}
+		})
+	}
 }
 
 func (f *fakeWorker) processInstance(_ *servicecontext.Context, _ *v1.Service) error {

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/kube-vip/kube-vip/pkg/egress"
 	"github.com/kube-vip/kube-vip/pkg/endpoints"
-	"github.com/kube-vip/kube-vip/pkg/endpoints/providers"
 	"github.com/kube-vip/kube-vip/pkg/instance"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
@@ -368,16 +367,11 @@ func (p *Processor) configureService(ctx context.Context, inst *instance.Instanc
 				}
 			}
 
-			var provider providers.Provider
-			if p.config.EnableEndpoints {
-				provider = providers.NewEndpoints()
-			} else {
-				provider = providers.NewEndpointslices()
-			}
-			err := provider.UpdateServiceAnnotation(ctx, svc.Annotations[kubevip.ActiveEndpoint], svc.Annotations[kubevip.ActiveEndpointIPv6], svc, p.clientSet)
-			if err != nil {
-				log.Warn("[service] configuring egress", "service", svc.Name, "namespace", svc.Namespace, "err", err)
-			}
+			// The endpoint watcher owns the active-endpoint annotations. Do not
+			// persist them from here: svc is the Service snapshot captured when
+			// service handling started and can be stale by the time endpoint
+			// discovery completes. Writing it here can overwrite the endpoint
+			// watcher's newer value with an old or empty one.
 		}
 	}
 

--- a/pkg/services/services_test.go
+++ b/pkg/services/services_test.go
@@ -1,13 +1,98 @@
 package services
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	"github.com/kube-vip/kube-vip/pkg/instance"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
 )
+
+func TestConfigureServiceDoesNotOverwriteActiveEndpoint(t *testing.T) {
+	const selectedEndpoint = "172.30.2.40"
+
+	staleService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hpeocsnf",
+			Namespace: "default",
+			UID:       "test-uid",
+			Annotations: map[string]string{
+				kubevip.Egress:         "true",
+				kubevip.ActiveEndpoint: "",
+			},
+		},
+		Spec: v1.ServiceSpec{LoadBalancerIP: "10.114.44.149"},
+	}
+	currentService := staleService.DeepCopy()
+	currentService.Annotations[kubevip.ActiveEndpoint] = selectedEndpoint
+	currentService.ResourceVersion = "2"
+
+	var mu sync.Mutex
+	updateRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			if err := json.NewEncoder(w).Encode(currentService); err != nil {
+				t.Errorf("encode Service response: %v", err)
+			}
+		case http.MethodPut:
+			updatedService := &v1.Service{}
+			if err := json.NewDecoder(r.Body).Decode(updatedService); err != nil {
+				t.Errorf("decode Service update: %v", err)
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			updateRequests++
+			currentService = updatedService
+			if err := json.NewEncoder(w).Encode(currentService); err != nil {
+				t.Errorf("encode updated Service response: %v", err)
+			}
+		default:
+			http.Error(w, "unexpected request", http.StatusMethodNotAllowed)
+		}
+	}))
+	defer server.Close()
+
+	clientSet, err := kubernetes.NewForConfig(&rest.Config{Host: server.URL})
+	if err != nil {
+		t.Fatalf("create Kubernetes client: %v", err)
+	}
+
+	p := &Processor{
+		config: &kubevip.Config{
+			DisableServiceUpdates:  true,
+			EnableEndpoints:        true,
+			EnableServicesElection: true,
+		},
+		clientSet: clientSet,
+	}
+	inst := &instance.Instance{ServiceSnapshot: staleService}
+	if err := p.configureService(context.Background(), inst, staleService, &sync.WaitGroup{}); err != nil {
+		t.Fatalf("configureService returned error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if updateRequests != 0 {
+		t.Fatalf("configureService sent %d stale Service updates, want none", updateRequests)
+	}
+	if got := currentService.Annotations[kubevip.ActiveEndpoint]; got != selectedEndpoint {
+		t.Fatalf("active endpoint = %q, want %q", got, selectedEndpoint)
+	}
+}
 
 // Test_upnpLeaseDurationForService tests whether the default lease duration is used, and whether the annotation
 // overrides it correctly.


### PR DESCRIPTION
## What this PR does

This PR prevents an egress Service's active endpoint annotation from being overwritten by an older Service snapshot during startup or failover.

It:

- removes the duplicate active-endpoint persistence from `configureService`, leaving the endpoint watcher as the authoritative writer;
- distinguishes an existing snapshot with intentionally empty endpoint values from a missing snapshot, so an endpoint can be restored after an endpoint-to-zero-to-same-endpoint transition;
- uses the configured egress address family when EndpointSlices become empty, instead of treating `net.ParseIP("") == nil` as evidence that the empty endpoint is IPv6;
- preserves the annotation for the other address family;
- adds regression coverage for the stale overwrite, zero-endpoint transitions, both endpoint providers, dual-stack endpoint selection, failed updates, and single-shot egress callbacks.

## Root cause

The Service handler and endpoint watcher start concurrently for the same Service.

The endpoint watcher selects the current Pod IP, persists it through `UpdateServiceAnnotation`, and invokes direct egress reconfiguration with an updated Service copy. `configureService` subsequently performed another `UpdateServiceAnnotation` call using the `svc` object captured when service handling started.

That captured object can still contain an empty or previous active endpoint. Although the provider fetches the latest Service inside `RetryOnConflict`, it assigns the endpoint value supplied by the stale caller. The second update can therefore succeed without a Kubernetes conflict and replace the newly persisted endpoint with an empty value.

The endpoint watcher already owns persistence and direct egress reconfiguration, so the second writer is unnecessary.

## Behavioral impact

The active endpoint is persisted reliably after initial endpoint discovery and ordinary zero-endpoint transitions. This state is used for egress rule setup, teardown, restart, and failover; it is not required for every inbound VIP forwarding path.

The legacy Endpoints provider continues to store both address families in `kube-vip.io/active-endpoint`. EndpointSlices continue to use separate IPv4 and IPv6 annotations.

## Testing

- Cross-compiled the `pkg/endpoints` and `pkg/services` test binaries for `linux/amd64`.
- Ran the complete `pkg/endpoints` test binary under Debian WSL: PASS.
- Ran the complete `pkg/services` test binary under Debian WSL: PASS.
- Ran `GOOS=linux GOARCH=amd64 go vet ./pkg/endpoints ./pkg/services`: PASS.
- Ran `golangci-lint run --new-from-rev=upstream/main ./pkg/endpoints/... ./pkg/services/...`: 0 issues.
- Ran `git diff --check`: PASS.

## Follow-ups

This change fixes the deterministic stale overwrite described in the issue. It does not change the broader ownership semantics between multiple kube-vip replicas: endpoint watchers with `externalTrafficPolicy: Local` can still contend on the cluster-wide annotation. A true `Endpoints` object `Deleted` event also currently stops the watcher without following the ordinary zero-endpoint clear/repopulate path. Those behaviors require separate leader-transition and integration-test work.

Closes #1673
