### PR TITLE
Fixed route cleanup on startup in RT mode

### DIFF
--- a/pkg/manager/worker/table.go
+++ b/pkg/manager/worker/table.go
@@ -100,7 +100,7 @@ func (t *Table) cleanRoutes() error {
 		if t.config.EnableControlPlane {
 			found = (routes[i].Dst.IP.String() == t.config.Address)
 		} else {
-			found = t.routeMgr.Check(routes[i].String())
+			found = t.routeMgr.Check(vip.NetlinkHash(&(routes[i])))
 		}
 
 		if !found {

--- a/pkg/vip/address.go
+++ b/pkg/vip/address.go
@@ -328,6 +328,10 @@ func (configurator *network) PrepareRoute() *netlink.Route {
 
 func (configurator *network) RouteHash() string {
 	r := configurator.PrepareRoute()
+	return NetlinkHash(r)
+}
+
+func NetlinkHash(r *netlink.Route) string {
 	h := fnv.New32a()
 	h.Write([]byte(r.String()))
 


### PR DESCRIPTION
This PR fixes #1678 

It turned out that the `cleanRoutes` function is fine, but it used `route.String()` as a key to check if the route is known to the manager and should be preserved. However routes were added to the manager with hash as a key, so no routes were found in the manager using the simple string, which resulted in all the routes being deleted.