### PR TITLE
Fallback to regular BGP if MP-BGP cannot be configured

### DIFF
--- a/pkg/bgp/peers.go
+++ b/pkg/bgp/peers.go
@@ -3,7 +3,7 @@ package bgp
 import (
 	"context"
 	"fmt"
-	"log/slog"
+	log "log/slog"
 	"net"
 	"net/netip"
 	"strconv"
@@ -75,58 +75,64 @@ func (b *Server) AddPeer(ctx context.Context, peer kubevip.BGPPeer) (err error) 
 		}
 	}
 
-	if b.c.MpbgpNexthop != "" {
-		p.AfiSafis = []*api.AfiSafi{
-			{
-				Config: &api.AfiSafiConfig{
-					Family: &api.Family{
-						Afi:  api.Family_AFI_IP,
-						Safi: api.Family_SAFI_UNICAST,
-					},
-					Enabled: true,
-				},
-			},
-			{
-				Config: &api.AfiSafiConfig{
-					Family: &api.Family{
-						Afi:  api.Family_AFI_IP6,
-						Safi: api.Family_SAFI_UNICAST,
-					},
-					Enabled: true,
-				},
-			},
-		}
+	mpBGP := b.c.MpbgpNexthop
 
-		peer.SetMpbgpOptions(b.c)
+	if peer.MpbgpNexthop != "" {
+		mpBGP = peer.MpbgpNexthop
+	}
 
+	if mpBGP != "" {
 		ipv4Address, ipv6Address, err := peer.FindMpbgpAddresses(p, b.c)
 		if err != nil {
-			return fmt.Errorf("failed to get MP-BGP addresses: %w", err)
-		}
+			log.Error("failed to get MP-BGP addresses, will not us MP-BGP for this host", "error", err)
+		} else {
+			p.AfiSafis = []*api.AfiSafi{
+				{
+					Config: &api.AfiSafiConfig{
+						Family: &api.Family{
+							Afi:  api.Family_AFI_IP,
+							Safi: api.Family_SAFI_UNICAST,
+						},
+						Enabled: true,
+					},
+				},
+				{
+					Config: &api.AfiSafiConfig{
+						Family: &api.Family{
+							Afi:  api.Family_AFI_IP6,
+							Safi: api.Family_SAFI_UNICAST,
+						},
+						Enabled: true,
+					},
+				},
+			}
 
-		mask := strconv.Itoa(vip.DefaultMaskIPv6)
-		address := ipv4Address
-		family := api.Family_AFI_IP
-		if utils.IsIPv4(p.Conf.NeighborAddress) {
-			mask = strconv.Itoa(vip.DefaultMaskIPv4)
-			address = ipv6Address
-			family = api.Family_AFI_IP6
-		}
+			peer.SetMpbgpOptions(b.c)
 
-		err = b.s.AddDefinedSet(ctx, &api.AddDefinedSetRequest{
-			DefinedSet: &api.DefinedSet{
-				DefinedType: api.DefinedType_DEFINED_TYPE_NEIGHBOR,
-				Name:        fmt.Sprintf("peer-%s", p.Conf.NeighborAddress),
-				List:        []string{fmt.Sprintf("%s/%s", p.Conf.NeighborAddress, mask)},
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("failed to add defined set: %v", err)
-		}
+			mask := strconv.Itoa(vip.DefaultMaskIPv6)
+			address := ipv4Address
+			family := api.Family_AFI_IP
+			if utils.IsIPv4(p.Conf.NeighborAddress) {
+				mask = strconv.Itoa(vip.DefaultMaskIPv4)
+				address = ipv6Address
+				family = api.Family_AFI_IP6
+			}
 
-		if address != "" {
-			if err := insertPolicy(ctx, b.s, address, p, family); err != nil {
-				return fmt.Errorf("failed to add policy: %w", err)
+			err = b.s.AddDefinedSet(ctx, &api.AddDefinedSetRequest{
+				DefinedSet: &api.DefinedSet{
+					DefinedType: api.DefinedType_DEFINED_TYPE_NEIGHBOR,
+					Name:        fmt.Sprintf("peer-%s", p.Conf.NeighborAddress),
+					List:        []string{fmt.Sprintf("%s/%s", p.Conf.NeighborAddress, mask)},
+				},
+			})
+			if err != nil {
+				return fmt.Errorf("failed to add defined set: %v", err)
+			}
+
+			if address != "" {
+				if err := insertPolicy(ctx, b.s, address, p, family); err != nil {
+					return fmt.Errorf("failed to add policy: %w", err)
+				}
 			}
 		}
 	} else {
@@ -142,7 +148,7 @@ func (b *Server) AddPeer(ctx context.Context, peer kubevip.BGPPeer) (err error) 
 	if err := b.s.AddPeer(ctx, &api.AddPeerRequest{Peer: p}); err != nil {
 		return fmt.Errorf("failed to add peer: %v", err)
 	}
-	slog.Info("[BGP]", "peer", p.Conf.NeighborAddress, "AS", p.Conf.PeerAsn, "BFD", p.Bfd)
+	log.Info("[BGP]", "peer", p.Conf.NeighborAddress, "AS", p.Conf.PeerAsn, "BFD", p.Bfd)
 	return nil
 }
 

--- a/pkg/kubevip/config_bgp.go
+++ b/pkg/kubevip/config_bgp.go
@@ -234,27 +234,44 @@ func ParseBGPPeerConfig(config string) (bgpPeers []BGPPeer, err error) {
 
 func (p *BGPPeer) FindMpbgpAddresses(ap *api.Peer, server *BGPConfig) (string, string, error) {
 	var ipv4Address, ipv6Address string
-	switch p.MpbgpNexthop {
+
+	mode := server.MpbgpNexthop
+	if p.MpbgpNexthop != "" {
+		mode = p.MpbgpNexthop
+	}
+
+	switch mode {
 	case "fixed":
 		ap.Transport.LocalAddress = server.SourceIP
-		if p.MpbgpIPv4 == "" && p.MpbgpIPv6 == "" {
-			return "", "", fmt.Errorf("to use MP-BGP with fixed address at least one IPv4 or IPv6 address has to be provided [current - IPv4: %s, IPv6: %s]",
-				p.MpbgpIPv4, p.MpbgpIPv6)
-		}
 
+		ipv4 := server.MpbgpIPv4
 		if p.MpbgpIPv4 != "" {
-			if net.ParseIP(p.MpbgpIPv4) == nil {
-				return "", "", fmt.Errorf("provided address '%s' is not a valid IPv4 address", p.MpbgpIPv4)
+			ipv4 = p.MpbgpIPv4
+		}
+
+		ipv6 := server.MpbgpIPv6
+		if p.MpbgpIPv6 != "" {
+			ipv6 = p.MpbgpIPv6
+		}
+
+		if ipv4 == "" && ipv6 == "" {
+			return "", "", fmt.Errorf("to use MP-BGP with fixed address at least one IPv4 or IPv6 address has to be provided [current - IPv4: %s, IPv6: %s]",
+				ipv4, ipv6)
+		}
+
+		if ipv4 != "" {
+			if net.ParseIP(ipv4) == nil {
+				return "", "", fmt.Errorf("provided address '%s' is not a valid IPv4 address", ipv4)
 			}
 		}
-		if p.MpbgpIPv6 != "" {
-			if net.ParseIP(p.MpbgpIPv6) == nil {
-				return "", "", fmt.Errorf("provided address '%s' is not a valid IPv6 address", p.MpbgpIPv6)
+		if ipv6 != "" {
+			if net.ParseIP(ipv6) == nil {
+				return "", "", fmt.Errorf("provided address '%s' is not a valid IPv6 address", ipv6)
 			}
 		}
 
-		ipv4Address = p.MpbgpIPv4
-		ipv6Address = p.MpbgpIPv6
+		ipv4Address = ipv4
+		ipv6Address = ipv6
 	case "auto_sourceip":
 		ap.Transport.LocalAddress = server.SourceIP
 
@@ -297,7 +314,7 @@ func (p *BGPPeer) FindMpbgpAddresses(ap *api.Peer, server *BGPConfig) (string, s
 			return "", "", fmt.Errorf("failed to get non link-local IPv6 address: %v", err)
 		}
 	default:
-		return "", "", fmt.Errorf("option %s for MP-BPG nexthop is not supported", server.MpbgpNexthop)
+		return "", "", fmt.Errorf("option %q for MP-BPG nexthop is not supported", mode)
 	}
 
 	return ipv4Address, ipv6Address, nil

--- a/testing/e2e/e2e_bgp_test.go
+++ b/testing/e2e/e2e_bgp_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 const (
+	fixedInvalidNexthop   = "invalid"
 	defaultFixedNexthopv6 = "fc00:1000:1000:1000::100"
 	defaultFixedNexthopv4 = "172.18.0.100"
 )
@@ -146,6 +147,38 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 			})
 
 			It("should add paths", func() {
+				addresses := strings.Split(cpVIP, ",")
+				testControlPlaneBGP(ctx, gobgpClient, addresses)
+			})
+		})
+
+		Describe("kube-vip IPv4 control-plane BGP mode functionality, misconfigured MP-BGP failover", Ordered, func() {
+			var (
+				cpVIP       string
+				kindCluster *e2e.Cluster
+				gobgpClient api.GoBgpServiceClient
+				gobgpPeers  []*e2e.BGPPeerValues
+				tempDirPath string
+
+				nodesNumber = 1
+			)
+
+			BeforeAll(func() {
+				tempDirPath = MustMkdirTemp(server.TempDir, testDirPrefix)
+				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
+					server, utils.IPv4Family, utils.IPv4Family,
+					[]string{utils.IPv4Family}, &gobgpPeers,
+					&gobgpClient, logger, nodesNumber, fixedInvalidNexthop, "cp-mpbgp-failover", false, true, false, false)
+			})
+
+			AfterAll(func() {
+				SaveLogsAndCleanup(ctx, kindCluster.Client, tempDirPath, kindCluster.Name, func() {
+					server.RemovePeers(ctx, gobgpPeers)
+					kindCluster.Delete()
+				})
+			})
+
+			It("advertise IPv4 routes even if MP-BGP is misconfigured", func() {
 				addresses := strings.Split(cpVIP, ",")
 				testControlPlaneBGP(ctx, gobgpClient, addresses)
 			})
@@ -425,6 +458,41 @@ var _ = Describe("kube-vip BGP mode", Ordered, func() {
 				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					testBGP(ctx, offset, utils.IPv4Family, api.Family_AFI_IP, []corev1.IPFamily{corev1.IPv4Protocol}, svcName,
 						trafficPolicy, kindCluster.Client, 2, gobgpClient, defaultFixedNexthopv4, "")
+				},
+				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
+				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
+			)
+		})
+
+		Describe("kube-vip IPv4 services BGP mode functionality with misconfigured MP-BGP", Ordered, func() {
+			var (
+				cpVIP       string
+				kindCluster *e2e.Cluster
+				gobgpClient api.GoBgpServiceClient
+				gobgpPeers  []*e2e.BGPPeerValues
+				tempDirPath string
+				nodesNumber = 1
+			)
+
+			BeforeAll(func() {
+				tempDirPath = MustMkdirTemp(server.TempDir, testDirPrefix)
+				kindCluster, _, _ = setupEnv(ctx, &cpVIP,
+					server, utils.IPv4Family, utils.IPv4Family,
+					[]string{utils.IPv4Family}, &gobgpPeers,
+					&gobgpClient, logger, nodesNumber, fixedInvalidNexthop, "svc-mpbgp-failover", false, false, true, false)
+			})
+
+			AfterAll(func() {
+				SaveLogsAndCleanup(ctx, kindCluster.Client, tempDirPath, kindCluster.Name, func() {
+					server.RemovePeers(ctx, gobgpPeers)
+					kindCluster.Delete()
+				})
+			})
+
+			DescribeTable("advertise IPv4 routes even if MP-BGP is misconfigured",
+				func(svcName string, offset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
+					testBGP(ctx, offset, utils.IPv4Family, api.Family_AFI_IP, []corev1.IPFamily{corev1.IPv4Protocol}, svcName,
+						trafficPolicy, kindCluster.Client, 1, gobgpClient, "", "")
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -956,6 +1024,13 @@ func setupEnv(ctx context.Context, cpVIP *string,
 		kvPeers = append(kvPeers, &e2e.BGPPeerValues{IP: server.LocalIPv6, AS: bgp.GoBGPAS, IPFamily: utils.IPv6Family})
 	}
 
+	fixedV4Nexthop := defaultFixedNexthopv4
+	fixedV6Nexthop := defaultFixedNexthopv6
+	if mpbgpnexthop == fixedInvalidNexthop {
+		fixedV4Nexthop = fixedInvalidNexthop
+		fixedV6Nexthop = fixedInvalidNexthop
+	}
+
 	manifestValues := e2e.KubevipManifestValues{
 		ControlPlaneVIP:            *cpVIP,
 		ControlPlaneEnable:         fmt.Sprintf("%t", cpEnable),
@@ -965,8 +1040,8 @@ func setupEnv(ctx context.Context, cpVIP *string,
 		BGPAS:                      bgp.KubevipAS,
 		BGPPeers:                   bgp.PeerStrings(kvPeers),
 		MPBGPNexthop:               mpbgpnexthop,
-		MPBGPNexthopIPv4:           defaultFixedNexthopv4,
-		MPBGPNexthopIPv6:           defaultFixedNexthopv6,
+		MPBGPNexthopIPv4:           fixedV4Nexthop,
+		MPBGPNexthopIPv6:           fixedV6Nexthop,
 		EnableServiceSecurity:      "true",
 		PerServiceElectionOnDemand: fmt.Sprintf("%t", perServiceElectionOnDemand),
 	}


### PR DESCRIPTION
This PR fixes #1682 

Instead of returning error if the nexthop address for MP-BGP cannot be found, we will now just log an error, but proceed with using just a regular BGP. Added E2E tests for such scenario.

Additionally, while working on this,  I've found an issue with BGP config parameters which could lead to an issue with configuration of BGP for control plane. That was fixed as well - the global variables will be used by default, and will be overridden by per-peer config if needed.