### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Additionally it is now relatively easy and quick to develop with [skaffold](http
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=kube-vip/kube-vip&type=Date)](https://star-history.com/#kube-vip/kube-vip&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=kube-vip/kube-vip&type=Date)](https://star-history.dera.page/#kube-vip/kube-vip&type=date)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fkube-vip%2Fkube-vip.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fkube-vip%2Fkube-vip?ref=badge_shield)
 
 


### PR DESCRIPTION
The star history chart embedded in the README is currently broken because the provider it used was affected by GitHub's stargazer API restrictions. This change updates the chart image and its surrounding link to use an alternative provider that serves the same data without requiring an API token, restoring a working star history chart for kube-vip.