### PR TITLE
Refactored healthcheck backend code

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -3,89 +3,90 @@ package backend
 import (
 	"context"
 	"fmt"
-	"sync"
+	"net/http"
+	"net/url"
+	"strconv"
 	"time"
 
-	log "log/slog"
-
-	"github.com/kube-vip/kube-vip/pkg/k8s"
 	"github.com/kube-vip/kube-vip/pkg/utils"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
-type Entry struct {
-	Addr    string
-	Port    uint16
-	IsLocal bool
-}
+type BackendType string
 
-type Map map[Entry]bool
-
-// kubeConfigPath is an explicitly configured kubeconfig used by Check when
-// set; static pod deployments configure it since neither admin.conf nor
-// in-cluster config are available there.
-var (
-	kubeConfigPath string
-	pathMtx        sync.Mutex
+const (
+	Discovery BackendType = "discovery"
+	HTTP      BackendType = "http"
 )
 
-// SetKubeConfigPath configures the kubeconfig used by backend health checks.
-func SetKubeConfigPath(path string) {
-	pathMtx.Lock()
-	defer pathMtx.Unlock()
-	kubeConfigPath = path
+type Backend interface {
+	Check(context.Context) bool
+	Address() string
+	Port() uint16
+	IsSameFamily(string) bool
+	IsLocal() bool
 }
 
-func (e *Entry) Check() bool {
-	var client *kubernetes.Clientset
-	var err error
-	var config *rest.Config
-
-	adminConfigPath := "/etc/kubernetes/admin.conf"
-	// TODO: add one more switch case of homeConfigPath if there is such scenario in future
-	// homeConfigPath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
-
-	var k8sAddr string
-	if utils.IsIPv6(e.Addr) {
-		k8sAddr = fmt.Sprintf("[%s]:%v", e.Addr, e.Port)
-	} else {
-		k8sAddr = fmt.Sprintf("%s:%v", e.Addr, e.Port)
-	}
-
-	switch {
-	case kubeConfigPath != "" && utils.FileExists(kubeConfigPath):
-		config, err = k8s.NewRestConfig(kubeConfigPath, false, k8sAddr)
-		if err != nil {
-			log.Error("create k8s REST config", "path", kubeConfigPath, "err", err)
-			return false
-		}
-	case utils.FileExists(adminConfigPath):
-		config, err = k8s.NewRestConfig(adminConfigPath, false, k8sAddr)
-		if err != nil {
-			log.Error("create k8s REST config", "path", adminConfigPath, "err", err)
-			return false
-		}
+func New(config *Config) (Backend, error) {
+	switch config.Type {
+	case Discovery:
+		return newDiscoveryBackend(config), nil
+	case HTTP:
+		return kubernetesAddrBackend(config), nil
 	default:
-		config, err = k8s.NewRestConfig("", true, k8sAddr)
-		if err != nil {
-			log.Error("create k8s REST config", "err", err)
-			return false
+		return nil, fmt.Errorf("backend of type %q is currently not supported", config.Type)
+	}
+}
+
+type Config struct {
+	Type           BackendType
+	Address        string
+	Port           uint16
+	KubeConfigPath string
+	Client         *http.Client
+	KeepAddress    bool
+	IsLocal        bool
+}
+
+type generic struct {
+	addr           string
+	port           uint16
+	kubeConfigPath string
+	isLocal        bool
+}
+
+func (g *generic) Address() string {
+	return g.addr
+}
+
+func (g *generic) Port() uint16 {
+	return g.port
+}
+
+func (g *generic) IsSameFamily(addr string) bool {
+	a, err := url.Parse(g.addr)
+	if err != nil {
+		return false
+	}
+	if a.Hostname() != "" {
+		return true
+	}
+
+	return utils.IsIPv6(addr) == utils.IsIPv6(g.addr)
+}
+
+func (g *generic) IsLocal() bool {
+	return g.isLocal
+}
+
+type Map map[Backend]bool
+
+func (m *Map) Find(addr string, port uint16) Backend {
+	for b := range *m {
+		if b.Address() == addr && b.Port() == port {
+			return b
 		}
 	}
-
-	client, err = k8s.NewClientset(config)
-	if err != nil {
-		log.Error("create k8s client", "err", err)
-		return false
-	}
-
-	_, err = client.DiscoveryClient.ServerVersion()
-	if err != nil {
-		log.Error("discover k8s version", "err", err)
-		return false
-	}
-	return true
+	return nil
 }
 
 func Watch(ctx context.Context, interval int, tickAction func()) {
@@ -104,4 +105,34 @@ func Watch(ctx context.Context, interval int, tickAction func()) {
 			tickAction()
 		}
 	}
+}
+
+// kubernetesAddrBackend converts an explicitly configured Kubernetes
+// API address override (config.KubernetesAddr, e.g. "https://127.0.0.1:6443"
+// on static-pod deployments) into a backend health-check entry. Returns nil
+// when no usable override is configured.
+func kubernetesAddrBackend(config *Config) Backend {
+	if config.Address == "" {
+		return nil
+	}
+
+	if config.KeepAddress {
+		config.Port = 0
+		return newHTTPBackend(config)
+	}
+
+	u, err := url.Parse(config.Address)
+	if err != nil || u.Hostname() == "" {
+		return nil
+	}
+
+	if p := u.Port(); p != "" {
+		if parsed, err := strconv.ParseUint(p, 10, 16); err == nil {
+			config.Port = uint16(parsed)
+		}
+	}
+
+	config.Address = u.Hostname()
+
+	return newHTTPBackend(config)
 }

--- a/pkg/backend/discovery.go
+++ b/pkg/backend/discovery.go
@@ -1,0 +1,76 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	log "log/slog"
+
+	"github.com/kube-vip/kube-vip/pkg/k8s"
+	"github.com/kube-vip/kube-vip/pkg/utils"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type discoveryBackend struct {
+	generic
+}
+
+func newDiscoveryBackend(config *Config) *discoveryBackend {
+	return &discoveryBackend{generic{
+		addr:           config.Address,
+		port:           config.Port,
+		kubeConfigPath: config.KubeConfigPath,
+		isLocal:        config.IsLocal,
+	}}
+}
+
+func (d *discoveryBackend) Check(_ context.Context) bool {
+	var client *kubernetes.Clientset
+	var err error
+	var config *rest.Config
+
+	adminConfigPath := "/etc/kubernetes/admin.conf"
+	// TODO: add one more switch case of homeConfigPath if there is such scenario in future
+	// homeConfigPath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
+
+	var k8sAddr string
+	if utils.IsIPv6(d.addr) {
+		k8sAddr = fmt.Sprintf("[%s]:%v", d.addr, d.port)
+	} else {
+		k8sAddr = fmt.Sprintf("%s:%v", d.addr, d.port)
+	}
+
+	switch {
+	case d.kubeConfigPath != "" && utils.FileExists(d.kubeConfigPath):
+		config, err = k8s.NewRestConfig(d.kubeConfigPath, false, k8sAddr)
+		if err != nil {
+			log.Error("create k8s REST config", "path", d.kubeConfigPath, "err", err)
+			return false
+		}
+	case utils.FileExists(adminConfigPath):
+		config, err = k8s.NewRestConfig(adminConfigPath, false, k8sAddr)
+		if err != nil {
+			log.Error("create k8s REST config", "path", adminConfigPath, "err", err)
+			return false
+		}
+	default:
+		config, err = k8s.NewRestConfig("", true, k8sAddr)
+		if err != nil {
+			log.Error("create k8s REST config", "err", err)
+			return false
+		}
+	}
+
+	client, err = k8s.NewClientset(config)
+	if err != nil {
+		log.Error("create k8s client", "err", err)
+		return false
+	}
+
+	_, err = client.DiscoveryClient.ServerVersion()
+	if err != nil {
+		log.Error("discover k8s version", "err", err)
+		return false
+	}
+	return true
+}

--- a/pkg/backend/http.go
+++ b/pkg/backend/http.go
@@ -1,0 +1,51 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	log "log/slog"
+	"net/http"
+)
+
+type httpBackend struct {
+	generic
+	client *http.Client
+}
+
+func newHTTPBackend(config *Config) *httpBackend {
+	return &httpBackend{
+		generic: generic{
+			addr:           config.Address,
+			port:           config.Port,
+			kubeConfigPath: config.KubeConfigPath,
+			isLocal:        config.IsLocal,
+		},
+		client: config.Client,
+	}
+}
+
+func (h *httpBackend) Check(ctx context.Context) bool {
+	addr := h.addr
+	if h.port != 0 {
+		addr = fmt.Sprintf("%s:%d", h.addr, h.port)
+	}
+	req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, addr, nil)
+	if reqErr != nil {
+		log.Error("create health check request", "err", reqErr)
+		return false
+	}
+	resp, err := h.client.Do(req)
+	if err != nil {
+		log.Error("health check request failed", "url", addr, "err", err)
+		return false
+	}
+
+	resp.Body.Close()
+	healthy := resp.StatusCode == http.StatusOK
+	if !healthy {
+		log.Warn("health check returned non-200 status", "url", addr, "status", resp.StatusCode)
+		return false
+	}
+	return true
+
+}

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io/fs"
 	"net/http"
-	"net/url"
-	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -98,7 +96,7 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 
 		if c.EnableLoadBalancer {
 			lb, err := loadbalancer.NewIPVSLB(ctx, network, c.LoadBalancerPort, c.LoadBalancerForwardingMethod,
-				c.BackendHealthCheckInterval, c.EgressWithNftables, killFunc, &wg)
+				c.BackendHealthCheckInterval, c.EgressWithNftables, killFunc, &wg, c.K8sConfigFile)
 			if err != nil {
 				killFunc()
 				return fmt.Errorf("creating IPVS LoadBalancer: %w", err)
@@ -144,8 +142,7 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 	}
 
 	if c.EnableRoutingTable {
-		backendMapV4 := backend.Map{}
-		backendMapV6 := backend.Map{}
+		backendMap := backend.Map{}
 		// only check localhost
 
 		// An explicitly configured Kubernetes API address (static-pod
@@ -154,85 +151,94 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 		// takes precedence over the Node object's addresses: the check
 		// answers "is the local API server healthy" for every VIP family,
 		// regardless of the transport family of the override itself.
-		if entry := kubernetesAddrBackendEntry(c.KubernetesAddr, c.Port); entry != nil {
+		entry, err := backend.New(&backend.Config{
+			Type:           backend.HTTP,
+			Address:        c.KubernetesAddr,
+			Port:           c.Port,
+			KubeConfigPath: c.K8sConfigFile,
+			Client:         cluster.healthCheckHTTPClient,
+			KeepAddress:    false,
+		})
+		if err != nil {
+			return fmt.Errorf("unable to create backend: %w", err)
+		}
+		if entry != nil {
 			log.Info("using configured Kubernetes address for backend health checks", "address", c.KubernetesAddr)
-			backendMapV4[*entry] = false
-			backendMapV6[*entry] = false
+			backendMap[entry] = false
 		} else {
-			ips := []string{}
-			if c.NodeName != "" {
-				if ips, err = getNodeIPs(ctx, c.NodeName, em.KubernetesClient); err != nil && !apierrors.IsNotFound(err) {
-					log.Error("failed to get IP of control-plane node", "err", err)
+			if c.ControlPlaneHealthCheck.Address != "" {
+				entry, err = backend.New(&backend.Config{
+					Type:           backend.HTTP,
+					Address:        c.ControlPlaneHealthCheck.Address,
+					Port:           c.Port,
+					KubeConfigPath: c.K8sConfigFile,
+					Client:         cluster.healthCheckHTTPClient,
+					KeepAddress:    true,
+				})
+				if err != nil {
+					return fmt.Errorf("unable to create backend: %w", err)
 				}
-			}
-
-			if len(ips) == 0 {
-				if !utils.IsIPv6(cluster.Network[0].IP()) {
-					ips = append(ips, "127.0.0.1")
-				} else {
-					ips = append(ips, "::1")
+				backendMap[entry] = false
+			} else {
+				ips := []string{}
+				if c.NodeName != "" {
+					if ips, err = getNodeIPs(ctx, c.NodeName, em.KubernetesClient); err != nil && !apierrors.IsNotFound(err) {
+						log.Error("failed to get IP of control-plane node", "err", err)
+					}
 				}
 
-				log.Info("no IP address found for node - will fallback to use localhost address", "addresses", ips)
-			}
+				if len(ips) == 0 {
+					if !utils.IsIPv6(cluster.Network[0].IP()) {
+						ips = append(ips, "127.0.0.1")
+					} else {
+						ips = append(ips, "::1")
+					}
 
-			for _, ip := range ips {
-				entry := backend.Entry{Addr: ip, Port: c.Port}
-				if !utils.IsIPv6(ip) {
-					backendMapV4[entry] = false
-				} else {
-					backendMapV6[entry] = false
+					log.Info("no IP address found for node - will fallback to use localhost address", "addresses", ips)
+				}
+
+				for _, ip := range ips {
+					entry, err := backend.New(&backend.Config{
+						Type:           backend.Discovery,
+						Address:        ip,
+						Port:           c.Port,
+						KubeConfigPath: c.K8sConfigFile,
+						Client:         nil,
+						KeepAddress:    false,
+					})
+					if err != nil {
+						return fmt.Errorf("failed to crate backend for address %q on port %d: %w", ip, c.Port, err)
+					}
+					backendMap[entry] = false
 				}
 			}
 		}
 
-		backend.SetKubeConfigPath(c.K8sConfigFile)
 		backend.Watch(ctx, c.BackendHealthCheckInterval, func() {
 			for i := range cluster.Network {
 				network := cluster.Network[i]
 				networkIP := network.IP()
-				isNetworkV6 := utils.IsIPv6(networkIP)
+
 				log.Debug("current ip to process", "ip", networkIP)
 
-				backendMap := &backendMapV4
-				if isNetworkV6 {
-					backendMap = &backendMapV6
-				}
-
-				for entry := range *backendMap {
-					log.Debug("entry.Check() for entry", "entry", entry)
-					var healthy bool
-					if c.ControlPlaneHealthCheck.Address != "" {
-						req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, c.ControlPlaneHealthCheck.Address, nil)
-						if reqErr != nil {
-							log.Error("create health check request", "err", reqErr)
-						} else if resp, doErr := cluster.healthCheckHTTPClient.Do(req); doErr != nil {
-							log.Error("health check request failed", "url", c.ControlPlaneHealthCheck.Address, "err", doErr)
-						} else {
-							resp.Body.Close()
-							healthy = resp.StatusCode == http.StatusOK
-							if !healthy {
-								log.Warn("health check returned non-200 status", "url", c.ControlPlaneHealthCheck.Address, "status", resp.StatusCode)
-							}
-						}
-					} else {
-						healthy = entry.Check()
+				for entry := range backendMap {
+					if !entry.IsSameFamily(networkIP) {
+						continue
 					}
-					if healthy {
-						log.Debug("entry.Check() true")
+					if entry.Check(ctx) {
 						// Normal VIP addition with precheck, use skipDAD=false for normal DAD process
 						_, err = network.AddIP(true, false)
 						if err != nil {
 							log.Error("error adding address", "err", err)
 						}
-						if !(*backendMap)[entry] {
+						if !backendMap[entry] {
 							log.Info("added backend", "ip", network.IP())
 						}
 
 						err = cluster.routeMgr.Add(c.NodeName, network, true, false)
 						if err != nil && !errors.Is(err, fs.ErrExist) && !errors.Is(err, syscall.ESRCH) {
 							log.Warn(err.Error())
-						} else if err == nil && !(*backendMap)[entry] {
+						} else if err == nil && !backendMap[entry] {
 							log.Info("added route", "route", network.PrepareRoute())
 						} else if err == nil || errors.Is(err, fs.ErrExist) {
 							// Re-assert the route on every healthy cycle: routing daemons
@@ -246,15 +252,15 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 							}
 						}
 
-						(*backendMap)[entry] = true
+						backendMap[entry] = true
 						break
 					}
-					(*backendMap)[entry] = false
+					backendMap[entry] = false
 				}
 
 				deleteAddress := true
-				for entry := range *backendMap {
-					if (*backendMap)[entry] {
+				for entry := range backendMap {
+					if backendMap[entry] {
 						deleteAddress = false
 						break
 					}
@@ -361,27 +367,6 @@ func (cluster *Cluster) bgpHealthCheckLoop(ctx context.Context, c *kubevip.Confi
 		case <-ticker.C:
 		}
 	}
-}
-
-// kubernetesAddrBackendEntry converts an explicitly configured Kubernetes
-// API address override (config.KubernetesAddr, e.g. "https://127.0.0.1:6443"
-// on static-pod deployments) into a backend health-check entry. Returns nil
-// when no usable override is configured.
-func kubernetesAddrBackendEntry(kubernetesAddr string, defaultPort uint16) *backend.Entry {
-	if kubernetesAddr == "" {
-		return nil
-	}
-	u, err := url.Parse(kubernetesAddr)
-	if err != nil || u.Hostname() == "" {
-		return nil
-	}
-	port := defaultPort
-	if p := u.Port(); p != "" {
-		if parsed, err := strconv.ParseUint(p, 10, 16); err == nil {
-			port = uint16(parsed)
-		}
-	}
-	return &backend.Entry{Addr: u.Hostname(), Port: port}
 }
 
 func getNodeIPs(ctx context.Context, nodename string, client *kubernetes.Clientset) ([]string, error) {

--- a/pkg/cluster/service_internal_test.go
+++ b/pkg/cluster/service_internal_test.go
@@ -2,48 +2,74 @@ package cluster
 
 import (
 	"testing"
+
+	"github.com/kube-vip/kube-vip/pkg/backend"
 )
 
-func TestKubernetesAddrBackendEntry(t *testing.T) {
+func TestHTTPBackendCreation(t *testing.T) {
 	cases := []struct {
-		name     string
-		addr     string
-		port     uint16
-		wantAddr string
-		wantPort uint16
-		wantNil  bool
+		name        string
+		addr        string
+		port        uint16
+		wantAddr    string
+		wantPort    uint16
+		wantNil     bool
+		keepAddress bool
 	}{
 		{
-			name:     "explicit v4 loopback with port",
-			addr:     "https://127.0.0.1:6443",
-			port:     9999,
-			wantAddr: "127.0.0.1",
-			wantPort: 6443,
+			name:        "explicit v4 loopback with port",
+			addr:        "https://127.0.0.1:6443",
+			port:        9999,
+			wantAddr:    "127.0.0.1",
+			wantPort:    6443,
+			keepAddress: false,
 		},
 		{
-			name:     "hostname without port falls back to config port",
-			addr:     "https://localhost",
-			port:     6443,
-			wantAddr: "localhost",
-			wantPort: 6443,
+			name:        "explicit v4 loopback with port and livez endpoint",
+			addr:        "https://127.0.0.1:6443/livez",
+			port:        9999,
+			wantAddr:    "https://127.0.0.1:6443/livez",
+			wantPort:    0,
+			keepAddress: true,
 		},
 		{
-			name:    "empty override",
-			addr:    "",
-			port:    6443,
-			wantNil: true,
+			name:        "hostname without port falls back to config port",
+			addr:        "https://localhost",
+			port:        6443,
+			wantAddr:    "localhost",
+			wantPort:    6443,
+			keepAddress: false,
 		},
 		{
-			name:    "garbage override",
-			addr:    "://not-a-url",
-			port:    6443,
-			wantNil: true,
+			name:        "empty override",
+			addr:        "",
+			port:        6443,
+			wantNil:     true,
+			keepAddress: false,
+		},
+		{
+			name:        "garbage override",
+			addr:        "://not-a-url",
+			port:        6443,
+			wantNil:     true,
+			keepAddress: false,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			entry := kubernetesAddrBackendEntry(tc.addr, tc.port)
+			cfg := &backend.Config{
+				Type:           backend.HTTP,
+				Address:        tc.addr,
+				Port:           tc.port,
+				KubeConfigPath: "/fake/path",
+				Client:         nil,
+				KeepAddress:    tc.keepAddress,
+			}
+			entry, err := backend.New(cfg)
+			if err != nil {
+				t.Fatalf("unable to create backend: %s", err.Error())
+			}
 			if tc.wantNil {
 				if entry != nil {
 					t.Fatalf("expected nil entry, got %+v", entry)
@@ -53,7 +79,7 @@ func TestKubernetesAddrBackendEntry(t *testing.T) {
 			if entry == nil {
 				t.Fatal("expected an entry, got nil")
 			}
-			if entry.Addr != tc.wantAddr || entry.Port != tc.wantPort {
+			if entry.Address() != tc.wantAddr || entry.Port() != tc.wantPort {
 				t.Fatalf("got %+v, want addr %q port %d", entry, tc.wantAddr, tc.wantPort)
 			}
 		})

--- a/pkg/loadbalancer/ipvs.go
+++ b/pkg/loadbalancer/ipvs.go
@@ -54,10 +54,11 @@ type IPVSLoadBalancer struct {
 	killFunc            func()
 	address             string
 	family              ipvs.AddressFamily
+	kubeConfigPath      string
 }
 
 func NewIPVSLB(ctx context.Context, network vip.Network, port uint16, forwardingMethod string, backendHealthCheckInterval int,
-	nftables bool, killFunc func(), wg *sync.WaitGroup) (*IPVSLoadBalancer, error) {
+	nftables bool, killFunc func(), wg *sync.WaitGroup, kubeConfigPath string) (*IPVSLoadBalancer, error) {
 	log.Info("Starting IPVS LoadBalancer", "network", network)
 
 	address := network.IP()
@@ -150,6 +151,7 @@ func NewIPVSLB(ctx context.Context, network vip.Network, port uint16, forwarding
 		killFunc:            killFunc,
 		address:             address,
 		family:              family,
+		kubeConfigPath:      kubeConfigPath,
 	}
 
 	wg.Go(func() {
@@ -198,12 +200,23 @@ func (lb *IPVSLoadBalancer) AddBackend(address string, port uint16) error {
 		log.Info("checked if backend is local", "addr", address, "local", isLocal)
 	}
 
-	backend := backend.Entry{Addr: address, Port: port, IsLocal: isLocal}
+	backend, err := backend.New(&backend.Config{
+		Type:           backend.Discovery,
+		Address:        address,
+		Port:           port,
+		KubeConfigPath: lb.kubeConfigPath,
+		Client:         nil,
+		KeepAddress:    false,
+		IsLocal:        isLocal,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create IPVS backend for address %q, port %d: %w", address, port, err)
+	}
 
 	lb.lock.Lock()
 	defer lb.lock.Unlock()
 	if _, ok := lb.backendMap[backend]; !ok {
-		isHealth := backend.Check()
+		isHealth := backend.Check(context.Background())
 		if isHealth {
 			err := lb.addBackend(address, port)
 			if err != nil {
@@ -216,7 +229,17 @@ func (lb *IPVSLoadBalancer) AddBackend(address string, port uint16) error {
 }
 
 func (lb *IPVSLoadBalancer) addBackend(address string, port uint16) error {
-	backend := backend.Entry{Addr: address, Port: port}
+	backend, err := backend.New(&backend.Config{
+		Type:           backend.Discovery,
+		Address:        address,
+		Port:           port,
+		KubeConfigPath: lb.kubeConfigPath,
+		Client:         nil,
+		KeepAddress:    false,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create IPVS backend for address %q, port %d: %w", address, port, err)
+	}
 	// Check if this is the first backend
 	backends, err := lb.client.Destinations(lb.loadBalancerService)
 	if err != nil && strings.Contains(err.Error(), "file does not exist") {
@@ -246,7 +269,7 @@ func (lb *IPVSLoadBalancer) addBackend(address string, port uint16) error {
 		log.Info("load-Balancer services created", "address", lb.addrString(), "port", lb.Port)
 	}
 
-	ip, family := ipAndFamily(backend.Addr)
+	ip, family := ipAndFamily(backend.Address())
 
 	// Ignore backends that use a different address family.
 	// Looks like different families could be supported in tunnel mode...
@@ -256,7 +279,7 @@ func (lb *IPVSLoadBalancer) addBackend(address string, port uint16) error {
 
 	dst := ipvs.Destination{
 		Address:   ip,
-		Port:      backend.Port,
+		Port:      backend.Port(),
 		Family:    family,
 		Weight:    1,
 		FwdMethod: lb.forwardingMethod,
@@ -272,18 +295,17 @@ func (lb *IPVSLoadBalancer) addBackend(address string, port uint16) error {
 		// file exists is fine, we will just return at this point
 		return nil
 	}
-	log.Info("backend added", "src addr", lb.addrString(), "src port", lb.Port, "dst addr", backend.Addr, "dst port", backend.Port)
+	log.Info("backend added", "src addr", lb.addrString(), "src port", lb.Port, "dst addr", backend.Address(), "dst port", backend.Port())
 
 	return nil
 }
 
 func (lb *IPVSLoadBalancer) RemoveBackend(address string, port uint16) error {
-	backend := backend.Entry{Addr: address, Port: port}
-
 	lb.lock.Lock()
 	defer lb.lock.Unlock()
 
-	if _, ok := lb.backendMap[backend]; ok {
+	backend := lb.backendMap.Find(address, port)
+	if backend != nil {
 		err := lb.removeBackend(address, port)
 		if err != nil {
 			return err
@@ -330,11 +352,11 @@ func (lb *IPVSLoadBalancer) healthCheck(ctx context.Context) {
 		lb.lock.Lock()
 		defer lb.lock.Unlock()
 		for backend, oldStatus := range lb.backendMap {
-			newStatus := backend.Check()
+			newStatus := backend.Check(ctx)
 			if newStatus {
 				// old status -> health
 				if !oldStatus {
-					err := lb.addBackend(backend.Addr, backend.Port)
+					err := lb.addBackend(backend.Address(), backend.Port())
 					if err != nil {
 						log.Error("add backend", "err", err)
 					}
@@ -343,10 +365,10 @@ func (lb *IPVSLoadBalancer) healthCheck(ctx context.Context) {
 			} else {
 				// old status -> not health
 				if oldStatus {
-					log.Info("healthCheck failed - removing backend", "address", backend.Addr, "port", backend.Port)
-					err := lb.removeBackend(backend.Addr, backend.Port)
+					log.Info("healthCheck failed - removing backend", "address", backend.Address(), "port", backend.Port())
+					err := lb.removeBackend(backend.Address(), backend.Port())
 					if err != nil {
-						log.Error("failed to remove backend", "address", backend.Addr, "port", backend.Port, "err", err)
+						log.Error("failed to remove backend", "address", backend.Address(), "port", backend.Port(), "err", err)
 					}
 					lb.backendMap[backend] = newStatus
 				}
@@ -402,8 +424,8 @@ func (lb *IPVSLoadBalancer) isLocal(address string) (bool, error) {
 }
 
 func (lb *IPVSLoadBalancer) localBackendExists() bool {
-	for backend, isHealthy := range lb.backendMap {
-		if backend.IsLocal && isHealthy {
+	for b, isHealthy := range lb.backendMap {
+		if b.IsLocal() && isHealthy {
 			return true
 		}
 	}


### PR DESCRIPTION
Before implementing #1236 I have decided to take a look at what we already have in terms of healthchecking code. Decided to do a little refactor for the `pkg/backend` and moved some logic for backend healthcheck creation from `pkg/cluster/service.go` to `pkg/backend`.

This adds a common interface for HTTP and Discovery API based healthchecks, so those could be easily switched (for example we could add an option to IPVS to use HTTP healthcheck instead of Discovery healthcheck).

This was not fully tested, so I am opening this as a draft for now, and will test this after 31st August.