### PR TITLE
Restart kube-vip on RetryWatcher error

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -256,10 +256,7 @@ func New(ctx context.Context, configMap string, config *kubevip.Config) (*Manage
 	leaseMgr := lease.NewManager()
 	routeMgr := route.NewManager()
 
-	svcProcessor := services.NewServicesProcessor(config, bgpServer, clientset, rwClientSet,
-		intfMgr, arpMgr, nodeLabelManager, electionMgr, leaseMgr, routeMgr)
-
-	return &Manager{
+	m := &Manager{
 		clientSet:   clientset,
 		rwClientSet: rwClientSet,
 		configMap:   configMap,
@@ -271,7 +268,6 @@ func New(ctx context.Context, configMap string, config *kubevip.Config) (*Manage
 			Help:      "Count all events fired by the service watcher categorised by event type",
 		}, []string{"type"}),
 		signalChan:       signalChan,
-		svcProcessor:     svcProcessor,
 		intfMgr:          intfMgr,
 		arpMgr:           arpMgr,
 		bgpServer:        bgpServer,
@@ -279,7 +275,12 @@ func New(ctx context.Context, configMap string, config *kubevip.Config) (*Manage
 		electionMgr:      electionMgr,
 		leaseMgr:         leaseMgr,
 		routeMgr:         routeMgr,
-	}, nil
+	}
+
+	m.svcProcessor = services.NewServicesProcessor(config, bgpServer, clientset, rwClientSet,
+		intfMgr, arpMgr, nodeLabelManager, electionMgr, leaseMgr, routeMgr, m.Kill)
+
+	return m, nil
 }
 
 // Start will begin the Manager, which will start services and watch the configmap

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -61,6 +61,8 @@ type Processor struct {
 	TunnelMgr *wireguard.TunnelManager
 
 	routeMgr *route.Manager
+
+	killFunc func()
 }
 
 // labelManager is the interface for the node label manager to add/remove labels
@@ -68,7 +70,8 @@ type Processor struct {
 func NewServicesProcessor(config *kubevip.Config, bgpServer *bgp.Server,
 	clientSet *kubernetes.Clientset, rwClientSet *kubernetes.Clientset,
 	intfMgr *networkinterface.Manager, arpMgr *arp.Manager, nodeLabelManager node.Labeler,
-	electionMgr *election.Manager, leaseMgr *lease.Manager, routeMgr *route.Manager) *Processor {
+	electionMgr *election.Manager, leaseMgr *lease.Manager, routeMgr *route.Manager,
+	killFunc func()) *Processor {
 	lbClassFilterFunc := lbClassFilter
 	if config.LoadBalancerClassLegacyHandling {
 		lbClassFilterFunc = lbClassFilterLegacy
@@ -88,6 +91,7 @@ func NewServicesProcessor(config *kubevip.Config, bgpServer *bgp.Server,
 		electionMgr:      electionMgr,
 		TunnelMgr:        wireguard.NewTunnelManager(),
 		routeMgr:         routeMgr,
+		killFunc:         killFunc,
 	}
 }
 
@@ -258,6 +262,8 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 				}
 				if err = p.watchEndpoint(svcCtx, p.config.NodeName, svc, provider); err != nil {
 					log.Error(err.Error())
+					// if watch endpoint returns error, kill kube-vip
+					p.killFunc()
 				}
 			})
 

--- a/pkg/services/watch_services.go
+++ b/pkg/services/watch_services.go
@@ -131,6 +131,7 @@ func (p *Processor) ServicesWatcher(ctx context.Context, serviceFunc *Callback, 
 
 			status := statusErr.ErrStatus
 			log.Error("services", "err", status)
+			p.killFunc()
 		default:
 		}
 	}


### PR DESCRIPTION
This PR should fix #1685

This adds a call to `killFunc` when `RetryWatcher` error, which should trigger kube-vip's restart.

This is just a quick fix, that was not tested. If no one will not provide better solution (especially one that would not trigger full kube-vip's restart), I'll look into this once again after 31st August while working on #1236 as this is kind of a similar topic.