### PR TITLE
build: update the Go builder image to clear stdlib CVEs in the image scan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM golang:1.26.5-alpine3.23 as dev
+FROM golang:1.26.6-alpine3.23 as dev
 RUN apk add --no-cache git ca-certificates make
 RUN adduser -D appuser
 COPY . /src/

--- a/Dockerfile_iptables
+++ b/Dockerfile_iptables
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM golang:1.26.5-alpine3.23 as dev
+FROM golang:1.26.6-alpine3.23 as dev
 RUN apk add --no-cache git make
 RUN adduser -D appuser
 COPY . /src/


### PR DESCRIPTION
The image vulnerability scan builds the container image and runs Trivy against it, and it currently fails on eight HIGH severity CVEs. All eight are in the Go standard library and come from the golang:1.26.5-alpine3.23 builder, not from kube-vip code or its dependencies. Go 1.26.6 fixes every one of them, so this bumps the builder image tag to golang:1.26.6-alpine3.23.

The scan job builds from the default Dockerfile, and the iptables image uses the same builder, so both are bumped to keep them consistent. This is a build-only change: the go.mod language version stays at go 1.26.4 and no application code is touched.

CVEs cleared by Go 1.26.6:

- CVE-2026-33818
- CVE-2026-39821
- CVE-2026-46600
- CVE-2026-56853
- CVE-2026-56858
- CVE-2026-56859
- CVE-2026-56860
- CVE-2026-56862
