### PR TITLE
fix: logrus required by our test-cases, now only transient because of containerd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/osrg/gobgp/v4 v4.8.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.24.1
-	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/vishvananda/netlink v1.3.1

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -290,7 +290,12 @@ func (p *Processor) startLeaderElection(svcCtx *servicecontext.Context, service 
 		default:
 			leaseNamespace, serviceLease := lease.ServiceName(service)
 			id := lease.NewID(p.config.LeaderElectionType, leaseNamespace, serviceLease)
+			// The lease is only dropped once its last service is gone, which races
+			// with this loop noticing its own service context is done.
 			l := p.leaseMgr.Get(id)
+			if l == nil {
+				return
+			}
 			l.Lock()
 
 			if !l.Elected.Load() {

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -290,8 +290,8 @@ func (p *Processor) startLeaderElection(svcCtx *servicecontext.Context, service 
 		default:
 			leaseNamespace, serviceLease := lease.ServiceName(service)
 			id := lease.NewID(p.config.LeaderElectionType, leaseNamespace, serviceLease)
-			// The lease is only dropped once its last service is gone, which races
-			// with this loop noticing its own service context is done.
+			// The lease is retired once its last service is gone, so an absent one means
+			// this loop has nothing left to elect for.
 			l := p.leaseMgr.Get(id)
 			if l == nil {
 				return

--- a/pkg/etcd/etcd_suite_test.go
+++ b/pkg/etcd/etcd_suite_test.go
@@ -14,8 +14,6 @@ import (
 	"testing"
 	"time"
 
-	log "log/slog"
-
 	"github.com/pkg/errors"
 )
 
@@ -29,7 +27,6 @@ const (
 )
 
 func TestMain(m *testing.M) {
-	log.SetLogLoggerLevel(log.LevelDebug)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	expectSuccess(startEtcd(ctx), "starting etcd")

--- a/pkg/etcd/etcd_suite_test.go
+++ b/pkg/etcd/etcd_suite_test.go
@@ -14,8 +14,9 @@ import (
 	"testing"
 	"time"
 
+	log "log/slog"
+
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -28,7 +29,7 @@ const (
 )
 
 func TestMain(m *testing.M) {
-	logrus.SetLevel(logrus.DebugLevel)
+	log.SetLogLoggerLevel(log.LevelDebug)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	expectSuccess(startEtcd(ctx), "starting etcd")

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -46,6 +46,14 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 		return fmt.Errorf("no existing lease found for service %q with UID %q", service.Name, service.UID)
 	}
 
+	// A cancelled service context means this call belongs to a torn-down incarnation of
+	// the service. Its replacement is built as Cancel -> Delete -> Add, so the lease
+	// fetched above may already be the replacement's. Registering on it here would let
+	// the cleanup goroutine below retire a lease that is still in use.
+	if err := svcCtx.Ctx.Err(); err != nil {
+		return fmt.Errorf("service context cancelled before election start: %w", err)
+	}
+
 	isNew := svcLease.Add(objectName)
 
 	svcLease.Lock()

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -196,9 +196,9 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 				}
 				// in theory this should never fail
 				p.svcMap.Delete(svc.UID)
-				// Drop this service from its lease now, so the replacement context
-				// below is not parented to a lease the pending cleanup is about to
-				// cancel. A lease shared with other services stays alive for them.
+				// Retire the lease before the replacement context is built, so Add below
+				// cannot hand back an instance the pending cleanup is about to cancel.
+				// A lease shared with other services keeps their references and survives.
 				ns, name := lease.ServiceName(svc)
 				leaseID := lease.NewID(p.config.LeaderElectionType, ns, name)
 				p.leaseMgr.Delete(leaseID, lease.ServiceNamespacedName(svc), nil)
@@ -216,8 +216,10 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 	if svcCtx == nil {
 		ns, name := lease.ServiceName(svc)
 		leaseID := lease.NewID(p.config.LeaderElectionType, ns, name)
-		lease := p.leaseMgr.Add(ctx, leaseID)
-		svcCtx = servicecontext.New(lease.Ctx)
+		p.leaseMgr.Add(ctx, leaseID)
+		// The service context is parented to the watcher, not to the lease: losing a
+		// lease must not tear the service down, it has to let the election restart.
+		svcCtx = servicecontext.New(ctx)
 		p.svcMap.Store(svc.UID, svcCtx)
 	}
 


### PR DESCRIPTION
* should fix #1692 
* during this fix I found a flaky test introduced into main a week ago.
* I think it is fixed now, as service and lease context were bound to each other, which caused a weird side-effect on either the lease cleaning up the service or the service cleaning up the lease.

I am not sure, but it seems:
* related #1695 
* alternative fix for #1685? (I am not sure if it is the same issue, to be honest)