### PR TITLE
fix: align GO_VERSION with go.mod toolchain requirement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ TARGETOS=linux
 LDFLAGS=-ldflags "-s -w -X=main.Version=$(VERSION) -X=main.Build=$(BUILD) -extldflags -static"
 DOCKERTAG ?= $(VERSION)
 REPOSITORY ?= docker.io/plndr
-GO_VERSION := 1.25.6
+GO_VERSION := 1.26.6
 K8S_VERSION ?= v1.35.0
 GINKGO_ARGS ?=
 GINKGO_PROCS ?=
@@ -136,7 +136,7 @@ unit-tests:
 	go test -race ./...
 
 unit-tests-docker:
-	docker run --rm -w /kube-vip -v $$(pwd):/kube-vip -v kube-vip-gomod-cache:/go/pkg/mod -v kube-vip-gobuild-cache:/root/.cache/go-build golang:$(GO_VERSION) make unit-tests
+	docker run --rm -w /kube-vip -v $$(pwd):/kube-vip -v kube-vip-gomod-cache:/go/pkg/mod -v kube-vip-gobuild-cache:/root/.cache/go-build golang:$(GO_VERSION) sh -c "make unit-tests; status=$$?; chmod 666 coverage.out 2>/dev/null || true; exit $$status"
 
 integration-tests:
 	go test -tags=integration,e2e -v ./pkg/etcd

--- a/pkg/endpoints/endpoints_wireguard_test.go
+++ b/pkg/endpoints/endpoints_wireguard_test.go
@@ -6,7 +6,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-func TestWireguardDeleteDoesNotDereferenceNilServiceContext(t *testing.T) {
+func TestWireguardClearDoesNotDereferenceNilServiceContext(t *testing.T) {
 	worker := &wireguardWorker{}
 	service := &v1.Service{}
 


### PR DESCRIPTION
go.mod requires go >= 1.26.4 but the Makefile pins GO_VERSION := 1.25.6, so make unit-tests-docker fails immediately (go: go.mod requires go >= 1.26.4, running go 1.25.6; GOTOOLCHAIN=local) before running a single test. Bumps to golang:1.26.6 and stops leaving a root-owned coverage.out in the working tree on Linux hosts, preserving the test exit status.

Found while expanding test coverage on my fork; full make unit-tests-docker verified green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Rebase / CI note

Rebased onto current upstream `main` at `b684eed`. This branch also carries the signed WireGuard test correction from [#1739](https://github.com/kube-vip/kube-vip/pull/1739), because the current base test otherwise fails to compile; that duplicate prerequisite can be dropped after #1739 lands.