### PR TITLE
fix: merge all config file fields dropped by the field-by-field merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Make `manager` and `service` runtime configuration presence-aware, with explicit CLI flags taking precedence over environment variables, configuration files, and defaults. Strict YAML/JSON loading now preserves explicit false, zero, and empty values and normalizes standalone BGP peer configuration for runtime use.
 - Propagate `bgp_attach_ip_to_interface` into per-service config so it attaches BGP-mode Service VIPs to the interface as configured.
 - Add a configurable kube-vip instance name and use it to isolate internal nftables egress tables, persist table ownership on Services, and migrate per-Service chains without affecting other deployments. Fixes #1634.
 - Retry on 403 Forbidden and 401 Unauthorized in `ServicesWatcher` at startup with exponential backoff. Fixes #1464.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ The idea behind `kube-vip` is a small self-contained Highly-Available option for
 
 For upgrading an existing install in place (static Pod or DaemonSet), see the [upgrade guide](https://kube-vip.io/docs/upgrade/).
 
+### Runtime configuration files
+
+The `manager` and `service` commands accept strict YAML or JSON configuration
+with `--config-file PATH` or the `config_file` environment variable. Values are
+resolved in this order: explicitly supplied CLI flags, environment variables,
+configuration file, then command defaults. An explicitly supplied `false`, `0`,
+or empty string overrides lower-priority sources; an omitted value does not.
+`--config-file` takes precedence over `config_file` when both are set.
+
+Configuration keys use the documented external names (for example `enableARP`,
+`dnsDualStackMode`, and `bgpConfig.routerID`). Unknown keys are rejected. Runtime-
+derived `isDualStack` and `requireDualStack`, the bootstrap `configFile` key, and
+generator-only `loadBalancers`, `bgpPeers`, `singleNode`, `startAsLeader`, and
+`addPeersAsBackends` keys are intentionally not accepted in runtime files.
+Use `bgpConfig.peers` for BGP peers; the legacy single `bgpPeerConfig` form is
+also accepted and normalized into the runtime peer list.
+
 ## Features
 
 Kube-Vip was originally created to provide a HA solution for the Kubernetes control plane, over time it has evolved to incorporate that same functionality into Kubernetes service type [load-balancers](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer).

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/spf13/cobra"
+)
+
+func TestRuntimeCommandConfigPrecedence(t *testing.T) {
+	for _, commandName := range []string{"manager", "service"} {
+		t.Run(commandName, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			content := `enableARP: true
+port: 1111
+prometheusHTTPServer: file
+lbClassNameLegacyHandling: false
+`
+			if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("config_file", path)
+			t.Setenv("vip_arp", "false")
+			t.Setenv("port", "2222")
+			t.Setenv("prometheus_server", "")
+
+			cmd := newRuntimeConfigTestCommand(commandName)
+			if err := cmd.ParseFlags([]string{"--port=0", "--lbClassNameLegacyHandling=true"}); err != nil {
+				t.Fatal(err)
+			}
+			if err := loadRuntimeConfig(cmd); err != nil {
+				t.Fatal(err)
+			}
+
+			if initConfig.EnableARP || initConfig.Port != 0 || initConfig.PrometheusHTTPServer != "" || !initConfig.LoadBalancerClassLegacyHandling {
+				t.Fatalf("wrong precedence result: %#v", initConfig)
+			}
+			if initConfig.ConfigFile != path {
+				t.Fatalf("ConfigFile = %q, want %q", initConfig.ConfigFile, path)
+			}
+		})
+	}
+}
+
+func TestRuntimeCommandConfigFileFlagWins(t *testing.T) {
+	envPath := writeRuntimeConfig(t, "port: 1111\n")
+	flagPath := writeRuntimeConfig(t, "port: 2222\n")
+	t.Setenv("config_file", envPath)
+
+	cmd := newRuntimeConfigTestCommand("manager")
+	if err := cmd.ParseFlags([]string{"--config-file=" + flagPath}); err != nil {
+		t.Fatal(err)
+	}
+	if err := loadRuntimeConfig(cmd); err != nil {
+		t.Fatal(err)
+	}
+	if initConfig.Port != 2222 || initConfig.ConfigFile != flagPath {
+		t.Fatalf("flag config file did not win: %#v", initConfig)
+	}
+}
+
+func TestRuntimeCommandDefaultsWhenSourcesOmitted(t *testing.T) {
+	cmd := newRuntimeConfigTestCommand("service")
+	if err := loadRuntimeConfig(cmd); err != nil {
+		t.Fatal(err)
+	}
+	if initConfig.Port != 6443 || initConfig.DHCPMode != "ipv4" || initConfig.LoadBalancerClassName != kubevip.LBClassName || !initConfig.EgressWithNftables {
+		t.Fatalf("defaults changed: %#v", initConfig)
+	}
+}
+
+func TestRuntimeCommandAbsentEnvironmentPreservesFile(t *testing.T) {
+	path := writeRuntimeConfig(t, "enableARP: true\nport: 1234\nprometheusHTTPServer: file\n")
+	cmd := newRuntimeConfigTestCommand("manager")
+	if err := cmd.ParseFlags([]string{"--config-file=" + path}); err != nil {
+		t.Fatal(err)
+	}
+	if err := loadRuntimeConfig(cmd); err != nil {
+		t.Fatal(err)
+	}
+	if !initConfig.EnableARP || initConfig.Port != 1234 || initConfig.PrometheusHTTPServer != "file" {
+		t.Fatalf("absent environment overwrote file: %#v", initConfig)
+	}
+}
+
+func TestRuntimeCommandExplicitEmptyPeers(t *testing.T) {
+	path := writeRuntimeConfig(t, "bgpConfig:\n  peers:\n    - address: 192.0.2.1\n      as: 65001\n")
+	cmd := newRuntimeConfigTestCommand("manager")
+	cmd.Flags().StringSliceVar(&initConfig.BGPPeers, "bgppeers", nil, "")
+	if err := cmd.ParseFlags([]string{"--config-file=" + path, "--bgppeers="}); err != nil {
+		t.Fatal(err)
+	}
+	if err := loadRuntimeConfig(cmd); err != nil {
+		t.Fatal(err)
+	}
+	if len(initConfig.BGPConfig.Peers) != 0 {
+		t.Fatalf("explicit empty peers did not clear file peers: %#v", initConfig.BGPConfig.Peers)
+	}
+}
+
+func TestRuntimeCommandSliceFlagPrecedence(t *testing.T) {
+	path := writeRuntimeConfig(t, "etcd:\n  endpoints: [file:2379]\n")
+	cmd := newRuntimeConfigTestCommand("manager")
+	cmd.Flags().StringSliceVar(&initConfig.Etcd.Endpoints, "etcdEndpoints", nil, "")
+	if err := cmd.ParseFlags([]string{"--config-file=" + path, "--etcdEndpoints=flag-a:2379,flag-b:2379"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := loadRuntimeConfig(cmd); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"flag-a:2379", "flag-b:2379"}
+	if !slices.Equal(initConfig.Etcd.Endpoints, want) {
+		t.Fatalf("Etcd.Endpoints = %#v, want %#v", initConfig.Etcd.Endpoints, want)
+	}
+}
+
+func newRuntimeConfigTestCommand(name string) *cobra.Command {
+	initConfig = kubevip.Config{ArpBroadcastRate: 3000}
+	cmd := &cobra.Command{Use: name}
+	cmd.Flags().Uint16Var(&initConfig.Port, "port", 6443, "")
+	cmd.Flags().BoolVar(&initConfig.EnableARP, "arp", false, "")
+	cmd.Flags().StringVar(&initConfig.DHCPMode, "dhcpMode", "ipv4", "")
+	cmd.Flags().StringVar(&initConfig.PrometheusHTTPServer, "prometheusHTTPServer", ":2112", "")
+	cmd.Flags().BoolVar(&initConfig.LoadBalancerClassLegacyHandling, "lbClassNameLegacyHandling", true, "")
+	cmd.Flags().StringVar(&initConfig.LoadBalancerClassName, "lbClassName", kubevip.LBClassName, "")
+	cmd.Flags().BoolVar(&initConfig.EgressWithNftables, "egressWithNftables", true, "")
+	cmd.Flags().StringVar(&initConfig.ConfigFile, "config-file", "", "")
+	return cmd
+}
+
+func writeRuntimeConfig(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
@@ -58,6 +59,10 @@ var kubeVipCmd = &cobra.Command{
 }
 
 func init() {
+	// Defaults without a corresponding flag must exist before lower-priority
+	// configuration sources are overlaid.
+	initConfig.ArpBroadcastRate = 3000
+
 	// Basic flags
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.Interface, "interface", "", "Name of the interface to bind to")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.ServicesInterface, "serviceInterface", "", "Name of the interface to bind to (for services)")
@@ -146,7 +151,7 @@ func init() {
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.EnableNodeLabeling, "enableNodeLabeling", false, fmt.Sprintf("Enable leader node labeling with %q, defaults to false", kubevip.HasIP))
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.ServicesLeaseName, "servicesLeaseName", "plndr-svcs-lock", "Name of the lease that is used for leader election for services (in arp mode)")
 	kubeVipCmd.PersistentFlags().StringVar(&initConfig.DNSMode, "dnsMode", "first", "Name of the mode that DNS lookup will be performed (first, ipv4, ipv6, dual)")
-	kubeVipCmd.PersistentFlags().StringVar(&initConfig.DHCPMode, "dhcpMode", "", "Mode DHCP resolving will use to obtain IP addresses (ipv4, ipv6, dual)")
+	kubeVipCmd.PersistentFlags().StringVar(&initConfig.DHCPMode, "dhcpMode", strings.ToLower(utils.IPv4Family), "Mode DHCP resolving will use to obtain IP addresses (ipv4, ipv6, dual)")
 	kubeVipCmd.PersistentFlags().UintVar(&initConfig.DHCPBackoffAttempts, "dhcpBackoffAttempts", kubevip.DefaultDHCPBackoffAttempts,
 		fmt.Sprintf("number of times DHCP client will try to obtain an IP address (defaults to: %d, 0 for unlimited retries)", kubevip.DefaultDHCPBackoffAttempts))
 	kubeVipCmd.PersistentFlags().BoolVar(&initConfig.DisableServiceUpdates, "disableServiceUpdates", false, "If true, kube-vip will process services as usual, but will not update service's Status.LoadBalancer.Ingress slice")
@@ -224,19 +229,10 @@ var kubeVipService = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error { //nolint TODO
 		cmd.SilenceUsage = true
 
-		// Load configuration from file if specified (lowest priority)
-		if initConfig.ConfigFile != "" {
-			err := kubevip.MergeConfigFromFile(&initConfig, initConfig.ConfigFile)
-			if err != nil {
-				return fmt.Errorf("loading config file: %w", err)
-			}
+		if err := loadRuntimeConfig(cmd); err != nil {
+			return err
 		}
-
-		// parse environment variables, these will overwrite anything loaded from config file
-		err := kubevip.ParseEnvironment(&initConfig)
-		if err != nil {
-			return fmt.Errorf("parsing environment: %w", err)
-		}
+		var err error
 		if err := initConfig.Validate(); err != nil {
 			return fmt.Errorf("validating configuration: %w", err)
 		}
@@ -299,19 +295,10 @@ var kubeVipManager = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error { //nolint TODO
 		cmd.SilenceUsage = true
 
-		// Load configuration from file if specified (lowest priority)
-		if initConfig.ConfigFile != "" {
-			err := kubevip.MergeConfigFromFile(&initConfig, initConfig.ConfigFile)
-			if err != nil {
-				return fmt.Errorf("loading config file: %w", err)
-			}
+		if err := loadRuntimeConfig(cmd); err != nil {
+			return err
 		}
-
-		// parse environment variables, these will overwrite anything loaded from config file
-		err := kubevip.ParseEnvironment(&initConfig)
-		if err != nil {
-			return fmt.Errorf("parsing environment: %w", err)
-		}
+		var err error
 		if err := initConfig.Validate(); err != nil {
 			return fmt.Errorf("validating configuration: %w", err)
 		}
@@ -483,6 +470,65 @@ var kubeVipManager = &cobra.Command{
 		}
 		return nil
 	},
+}
+
+// loadRuntimeConfig applies defaults < file < environment < explicitly changed
+// flags. Flag values are captured before lower-priority sources mutate their
+// bound fields and then restored through pflag's normal parsers.
+func loadRuntimeConfig(cmd *cobra.Command) error {
+	changed := map[string]string{}
+	changedSlices := map[string][]string{}
+	cmd.Flags().Visit(func(flag *pflag.Flag) {
+		if value, ok := flag.Value.(pflag.SliceValue); ok {
+			changedSlices[flag.Name] = slices.Clone(value.GetSlice())
+			return
+		}
+		changed[flag.Name] = flag.Value.String()
+	})
+
+	configPath := initConfig.ConfigFile
+	if value, ok := os.LookupEnv("config_file"); ok {
+		configPath = value
+	}
+	if value, ok := changed["config-file"]; ok {
+		configPath = value
+	}
+	if configPath != "" {
+		if err := kubevip.MergeConfigFromFile(&initConfig, configPath); err != nil {
+			return fmt.Errorf("loading config file: %w", err)
+		}
+	}
+	if err := kubevip.ParseEnvironment(&initConfig); err != nil {
+		return fmt.Errorf("parsing environment: %w", err)
+	}
+	for name, value := range changed {
+		if err := cmd.Flags().Set(name, value); err != nil {
+			return fmt.Errorf("restoring --%s: %w", name, err)
+		}
+	}
+	for name, value := range changedSlices {
+		flag := cmd.Flags().Lookup(name)
+		if err := flag.Value.(pflag.SliceValue).Replace(value); err != nil {
+			return fmt.Errorf("restoring --%s: %w", name, err)
+		}
+	}
+	changedBGPPeers, bgpPeersChanged := changedSlices["bgppeers"]
+	if bgpPeersChanged && strings.Join(changedBGPPeers, "") == "" {
+		initConfig.BGPPeers = changedBGPPeers
+		initConfig.BGPConfig.Peers = nil
+	} else if bgpPeersChanged {
+		initConfig.BGPPeers = changedBGPPeers
+		peers, err := kubevip.ParseBGPPeerConfig(strings.Join(initConfig.BGPPeers, ","))
+		if err != nil {
+			return fmt.Errorf("parsing --bgppeers: %w", err)
+		}
+		initConfig.BGPConfig.Peers = peers
+	}
+	if initConfig.BGPPeerConfig.Address != "" {
+		initConfig.BGPConfig.Peers = []kubevip.BGPPeer{initConfig.BGPPeerConfig}
+	}
+	initConfig.ConfigFile = configPath
+	return nil
 }
 
 // PrometheusHTTPServerConfig defines the Prometheus server configuration.

--- a/pkg/kubevip/config_bgp.go
+++ b/pkg/kubevip/config_bgp.go
@@ -13,47 +13,47 @@ import (
 
 // Peer defines a BGP Peer
 type BGPPeer struct {
-	Address      string
-	Port         uint16
-	Interface    string
-	AS           uint32
-	Password     string
-	MultiHop     bool
-	MpbgpNexthop string
-	MpbgpIPv4    string
-	MpbgpIPv6    string
+	Address      string `yaml:"address"`
+	Port         uint16 `yaml:"port"`
+	Interface    string `yaml:"interface"`
+	AS           uint32 `yaml:"as"`
+	Password     string `yaml:"password"`
+	MultiHop     bool   `yaml:"multiHop"`
+	MpbgpNexthop string `yaml:"mpbgpNexthop"`
+	MpbgpIPv4    string `yaml:"mpbgpIPv4"`
+	MpbgpIPv6    string `yaml:"mpbgpIPv6"`
 
 	// BFD Configuration
-	BFDEnabled          bool
-	BFDReceiveInterval  uint32
-	BFDTransmitInterval uint32
-	BFDDetectMultiplier uint32
+	BFDEnabled          bool   `yaml:"bfdEnabled"`
+	BFDReceiveInterval  uint32 `yaml:"bfdReceiveInterval"`
+	BFDTransmitInterval uint32 `yaml:"bfdTransmitInterval"`
+	BFDDetectMultiplier uint32 `yaml:"bfdDetectMultiplier"`
 }
 
 // Config defines the BGP server configuration
 type BGPConfig struct {
-	AS           uint32
-	RouterID     string
-	SourceIP     string
-	SourceIF     string
-	MpbgpNexthop string
-	MpbgpIPv4    string
-	MpbgpIPv6    string
+	AS           uint32 `yaml:"as"`
+	RouterID     string `yaml:"routerID"`
+	SourceIP     string `yaml:"sourceIP"`
+	SourceIF     string `yaml:"sourceIF"`
+	MpbgpNexthop string `yaml:"mpbgpNexthop"`
+	MpbgpIPv4    string `yaml:"mpbgpIPv4"`
+	MpbgpIPv6    string `yaml:"mpbgpIPv6"`
 
-	HoldTime          uint64
-	KeepaliveInterval uint64
+	HoldTime          uint64 `yaml:"holdTime"`
+	KeepaliveInterval uint64 `yaml:"keepaliveInterval"`
 
-	Peers []BGPPeer
+	Peers []BGPPeer `yaml:"peers"`
 
-	Zebra ZebraConfig
+	Zebra ZebraConfig `yaml:"zebra"`
 }
 
 // Defines Zebra connection configuration. More on the topic - https://github.com/osrg/gobgp/blob/master/docs/sources/zebra.md#configuration
 type ZebraConfig struct {
-	Enabled      bool
-	URL          string
-	Version      uint32
-	SoftwareName string
+	Enabled      bool   `yaml:"enabled"`
+	URL          string `yaml:"url"`
+	Version      uint32 `yaml:"version"`
+	SoftwareName string `yaml:"softwareName"`
 }
 
 // BGP Peer layout is as follows:

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -10,10 +10,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/kube-vip/kube-vip/pkg/debouncer"
 	"github.com/kube-vip/kube-vip/pkg/detector"
-	"github.com/kube-vip/kube-vip/pkg/utils"
-	"sigs.k8s.io/yaml"
+	"gopkg.in/yaml.v3"
 )
 
 // ParseEnvironment - will popultate the configuration from environment variables
@@ -212,7 +210,8 @@ func ParseEnvironment(c *Config) error {
 		c.KubernetesAddr = env
 	}
 
-	// Find Services toggle
+	// Find Services toggle. Related settings are independent: an environment
+	// override remains valid when EnableServices came from the config file.
 	env = os.Getenv(svcEnable)
 	if env != "" {
 		b, err := strconv.ParseBool(env)
@@ -220,54 +219,54 @@ func ParseEnvironment(c *Config) error {
 			return err
 		}
 		c.EnableServices = b
+	}
 
-		// Find Services leader Election
-		env = os.Getenv(svcElection)
-		if env != "" {
-			b, err := strconv.ParseBool(env)
-			if err != nil {
-				return err
-			}
-			c.EnableServicesElection = b
+	// Find Services leader Election
+	env = os.Getenv(svcElection)
+	if env != "" {
+		b, err := strconv.ParseBool(env)
+		if err != nil {
+			return err
 		}
+		c.EnableServicesElection = b
+	}
 
-		// Find load-balancer class only
-		env = os.Getenv(lbClassOnly)
-		if env != "" {
-			b, err := strconv.ParseBool(env)
-			if err != nil {
-				return err
-			}
-			c.LoadBalancerClassOnly = b
+	// Find load-balancer class only
+	env = os.Getenv(lbClassOnly)
+	if env != "" {
+		b, err := strconv.ParseBool(env)
+		if err != nil {
+			return err
 		}
+		c.LoadBalancerClassOnly = b
+	}
 
-		// Load-balancer class name
-		env, exists := os.LookupEnv(lbClassName)
-		if exists {
-			c.LoadBalancerClassName = env
-		}
+	// Load-balancer class name
+	env, exists := os.LookupEnv(lbClassName)
+	if exists {
+		c.LoadBalancerClassName = env
+	}
 
-		// Load-balancer class legacy handling
-		env = os.Getenv(lbClassLegacyHandling)
-		if env != "" {
-			b, err := strconv.ParseBool(env)
-			if err != nil {
-				return err
-			}
-			c.LoadBalancerClassLegacyHandling = b
+	// Load-balancer class legacy handling
+	env = os.Getenv(lbClassLegacyHandling)
+	if env != "" {
+		b, err := strconv.ParseBool(env)
+		if err != nil {
+			return err
 		}
+		c.LoadBalancerClassLegacyHandling = b
+	}
 
-		// Find the namespace that the control plane should use (for leaderElection lock)
-		env = os.Getenv(svcNamespace)
-		if env != "" {
-			c.ServiceNamespace = env
-		}
+	// Find the namespace that the control plane should use (for leaderElection lock)
+	env = os.Getenv(svcNamespace)
+	if env != "" {
+		c.ServiceNamespace = env
+	}
 
-		// Gets the leaseName for services in arp mode
-		env = os.Getenv(svcLeaseName)
-		if env != "" {
-			c.ServicesLeaseName = env
-		}
+	// Gets the leaseName for services in arp mode
+	env = os.Getenv(svcLeaseName)
+	if env != "" {
+		c.ServicesLeaseName = env
 	}
 
 	// Find vip address subnet
@@ -322,9 +321,6 @@ func ParseEnvironment(c *Config) error {
 			return err
 		}
 		c.ArpBroadcastRate = i64
-	} else {
-		// default to three seconds
-		c.ArpBroadcastRate = 3000
 	}
 
 	// Determine if VIP should be preserved on leadership loss
@@ -426,12 +422,6 @@ func ParseEnvironment(c *Config) error {
 	env = os.Getenv(dhcpMode)
 	if env != "" {
 		c.DHCPMode = env
-	} else {
-		if c.DNSMode != "first" {
-			c.DHCPMode = c.DNSMode
-		} else {
-			c.DHCPMode = strings.ToLower(utils.IPv4Family)
-		}
 	}
 
 	// DHCP backoff attempts
@@ -519,6 +509,8 @@ func ParseEnvironment(c *Config) error {
 			return err
 		}
 		c.BGPConfig.Peers = peers
+	} else if _, ok := os.LookupEnv(bgpPeers); ok {
+		c.BGPConfig.Peers = nil
 	}
 
 	// MPBGP mode
@@ -818,326 +810,79 @@ func ParseEnvironment(c *Config) error {
 		c.ConfigFile = env
 	}
 
+	// Explicitly empty string variables clear lower-priority file values.
+	stringEnvironment := map[string]*string{
+		vipInterface: &c.Interface, vipServicesInterface: &c.ServicesInterface,
+		vipLeaseName: &c.LeaseName, nodeName: &c.NodeName, vipAddress: &c.VIP, address: &c.Address,
+		cpNamespace: &c.Namespace, kubernetesAddr: &c.KubernetesAddr, svcNamespace: &c.ServiceNamespace,
+		svcLeaseName: &c.ServicesLeaseName, lbClassName: &c.LoadBalancerClassName, vipSubnet: &c.VIPSubnet,
+		annotations: &c.Annotations, dnsMode: &c.DNSMode, dhcpMode: &c.DHCPMode,
+		bgpRouterID: &c.BGPConfig.RouterID, mpbgpNexthop: &c.BGPConfig.MpbgpNexthop,
+		mpbgpIPv4: &c.BGPConfig.MpbgpIPv4, mpbgpIPv6: &c.BGPConfig.MpbgpIPv6,
+		bgpPeerPassword: &c.BGPPeerConfig.Password, bgpSourceIF: &c.BGPConfig.SourceIF,
+		bgpSourceIP: &c.BGPConfig.SourceIP, controlPlaneHealthCheckAddress: &c.ControlPlaneHealthCheck.Address,
+		controlPlaneHealthCheckCAPath: &c.ControlPlaneHealthCheck.CAPath, zebraURL: &c.BGPConfig.Zebra.URL,
+		zebraSoftwareName: &c.BGPConfig.Zebra.SoftwareName, lbForwardingMethod: &c.LoadBalancerForwardingMethod,
+		prometheusServer: &c.PrometheusHTTPServer, egressPodCidr: &c.EgressPodCidr,
+		egressServiceCidr: &c.EgressServiceCidr, k8sConfigFile: &c.K8sConfigFile,
+		mirrorDestInterface: &c.MirrorDestInterface, iptablesBackend: &c.IptablesBackend,
+		configFile: &c.ConfigFile, debounceTime: &c.DebounceTime,
+	}
+	for name, destination := range stringEnvironment {
+		if value, ok := os.LookupEnv(name); ok {
+			*destination = value
+		}
+	}
+	if value, ok := os.LookupEnv(instanceName); ok && value != "" {
+		c.InstanceName = value
+	} else if value, ok := os.LookupEnv(strings.ToUpper(instanceName)); ok {
+		c.InstanceName = value
+	}
+
 	return nil
 }
 
-// LoadConfigFromFile loads configuration from a JSON or YAML file
+// LoadConfigFromFile loads runtime configuration from a JSON or YAML file.
 func LoadConfigFromFile(configFilePath string) (*Config, error) {
+	config := &Config{}
+	if err := MergeConfigFromFile(config, configFilePath); err != nil {
+		return nil, err
+	}
+	return config, nil
+}
+
+// MergeConfigFromFile overlays fields present in a JSON or YAML file. Decoding
+// into the destination preserves defaults for omitted fields and preserves
+// explicit false, zero, empty string, and empty collection values.
+func MergeConfigFromFile(config *Config, configFilePath string) error {
 	if configFilePath == "" {
-		return nil, fmt.Errorf("config file path is empty")
+		return fmt.Errorf("config file path is empty")
 	}
-
-	// Check if file exists
-	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("config file does not exist: %s", configFilePath)
-	}
-
-	// Read file content
 	data, err := os.ReadFile(configFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read config file %s: %v", configFilePath, err)
+		if os.IsNotExist(err) {
+			return fmt.Errorf("config file does not exist: %s", configFilePath)
+		}
+		return fmt.Errorf("failed to read config file %s: %w", configFilePath, err)
 	}
 
-	var config Config
 	ext := strings.ToLower(filepath.Ext(configFilePath))
-
-	switch ext {
-	case ".json":
-		err = json.Unmarshal(data, &config)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse JSON config file %s: %v", configFilePath, err)
-		}
-	case ".yaml", ".yml":
-		err = yaml.Unmarshal(data, &config)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse YAML config file %s: %v", configFilePath, err)
-		}
-	default:
-		return nil, fmt.Errorf("unsupported config file format %s. Supported formats: .json, .yaml, .yml", ext)
+	if ext != ".json" && ext != ".yaml" && ext != ".yml" {
+		return fmt.Errorf("unsupported config file format %s; supported formats: .json, .yaml, .yml", ext)
+	}
+	decoder := yaml.NewDecoder(strings.NewReader(string(data)))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(config); err != nil {
+		format := strings.TrimPrefix(strings.ToUpper(ext), ".")
+		return fmt.Errorf("failed to parse %s config file %s: %w", format, configFilePath, err)
 	}
 
-	return &config, nil
-}
-
-// MergeConfigFromFile merges configuration loaded from file with existing config
-// Priority: command line flags > environment variables > config file
-func MergeConfigFromFile(c *Config, configFilePath string) error {
-	if configFilePath == "" {
-		return nil // No config file specified, nothing to merge
+	// Runtime BGP consumes BGPConfig.Peers. BGPPeerConfig is retained for CLI
+	// and environment compatibility and normalized when supplied by a file.
+	if config.BGPPeerConfig.Address != "" {
+		config.BGPConfig.Peers = append(config.BGPConfig.Peers, config.BGPPeerConfig)
+		config.BGPPeerConfig = BGPPeer{}
 	}
-
-	fileConfig, err := LoadConfigFromFile(configFilePath)
-	if err != nil {
-		return err
-	}
-
-	// Merge file config with existing config
-	// Only set values from file if they haven't been set by flags or env vars
-	mergeConfigValues(c, fileConfig)
-
+	config.ConfigFile = configFilePath
 	return nil
-}
-
-// mergeConfigValues merges values from fileConfig into baseConfig
-// Only overwrites zero values in baseConfig
-func mergeConfigValues(baseConfig, fileConfig *Config) {
-	// Basic configuration
-	if baseConfig.Logging == 0 && fileConfig.Logging != 0 {
-		baseConfig.Logging = fileConfig.Logging
-	}
-
-	// Network configuration
-	if baseConfig.Interface == "" && fileConfig.Interface != "" {
-		baseConfig.Interface = fileConfig.Interface
-	}
-	if baseConfig.ServicesInterface == "" && fileConfig.ServicesInterface != "" {
-		baseConfig.ServicesInterface = fileConfig.ServicesInterface
-	}
-	if baseConfig.VIP == "" && fileConfig.VIP != "" {
-		baseConfig.VIP = fileConfig.VIP
-	}
-	if baseConfig.VIPSubnet == "" && fileConfig.VIPSubnet != "" {
-		baseConfig.VIPSubnet = fileConfig.VIPSubnet
-	}
-	if baseConfig.Address == "" && fileConfig.Address != "" {
-		baseConfig.Address = fileConfig.Address
-	}
-	if baseConfig.Port == 0 && fileConfig.Port != 0 {
-		baseConfig.Port = fileConfig.Port
-	}
-	if baseConfig.NodeName == "" && fileConfig.NodeName != "" {
-		baseConfig.NodeName = fileConfig.NodeName
-	}
-
-	// Boolean flags - only merge if not explicitly set
-	if !baseConfig.EnableARP && fileConfig.EnableARP {
-		baseConfig.EnableARP = fileConfig.EnableARP
-	}
-	if !baseConfig.EnableBGP && fileConfig.EnableBGP {
-		baseConfig.EnableBGP = fileConfig.EnableBGP
-	}
-	if !baseConfig.BGPAttachIPToInterface && fileConfig.BGPAttachIPToInterface {
-		baseConfig.BGPAttachIPToInterface = fileConfig.BGPAttachIPToInterface
-	}
-	if !baseConfig.EnableWireguard && fileConfig.EnableWireguard {
-		baseConfig.EnableWireguard = fileConfig.EnableWireguard
-	}
-	if !baseConfig.EnableRoutingTable && fileConfig.EnableRoutingTable {
-		baseConfig.EnableRoutingTable = fileConfig.EnableRoutingTable
-	}
-	if !baseConfig.EnableControlPlane && fileConfig.EnableControlPlane {
-		baseConfig.EnableControlPlane = fileConfig.EnableControlPlane
-	}
-	if !baseConfig.DetectControlPlane && fileConfig.DetectControlPlane {
-		baseConfig.DetectControlPlane = fileConfig.DetectControlPlane
-	}
-	if !baseConfig.EnableServices && fileConfig.EnableServices {
-		baseConfig.EnableServices = fileConfig.EnableServices
-	}
-	if !baseConfig.EnableServicesElection && fileConfig.EnableServicesElection {
-		baseConfig.EnableServicesElection = fileConfig.EnableServicesElection
-	}
-	if !baseConfig.EnableNodeLabeling && fileConfig.EnableNodeLabeling {
-		baseConfig.EnableNodeLabeling = fileConfig.EnableNodeLabeling
-	}
-	if !baseConfig.EnableLoadBalancer && fileConfig.EnableLoadBalancer {
-		baseConfig.EnableLoadBalancer = fileConfig.EnableLoadBalancer
-	}
-	if !baseConfig.DDNS && fileConfig.DDNS {
-		baseConfig.DDNS = fileConfig.DDNS
-	}
-	if !baseConfig.SingleNode && fileConfig.SingleNode {
-		baseConfig.SingleNode = fileConfig.SingleNode
-	}
-	if !baseConfig.StartAsLeader && fileConfig.StartAsLeader {
-		baseConfig.StartAsLeader = fileConfig.StartAsLeader
-	}
-	if !baseConfig.PreserveVIPOnLeadershipLoss && fileConfig.PreserveVIPOnLeadershipLoss {
-		baseConfig.PreserveVIPOnLeadershipLoss = fileConfig.PreserveVIPOnLeadershipLoss
-	}
-
-	// Service configuration
-	if baseConfig.Namespace == "" && fileConfig.Namespace != "" {
-		baseConfig.Namespace = fileConfig.Namespace
-	}
-	if baseConfig.ServiceNamespace == "" && fileConfig.ServiceNamespace != "" {
-		baseConfig.ServiceNamespace = fileConfig.ServiceNamespace
-	}
-	if baseConfig.ServicesLeaseName == "" && fileConfig.ServicesLeaseName != "" {
-		baseConfig.ServicesLeaseName = fileConfig.ServicesLeaseName
-	}
-	// LoadBalancer configuration
-	if baseConfig.LoadBalancerPort == 0 && fileConfig.LoadBalancerPort != 0 {
-		baseConfig.LoadBalancerPort = fileConfig.LoadBalancerPort
-	}
-	if baseConfig.LoadBalancerForwardingMethod == "" && fileConfig.LoadBalancerForwardingMethod != "" {
-		baseConfig.LoadBalancerForwardingMethod = fileConfig.LoadBalancerForwardingMethod
-	}
-	if baseConfig.LoadBalancerClassName == "" && fileConfig.LoadBalancerClassName != "" {
-		baseConfig.LoadBalancerClassName = fileConfig.LoadBalancerClassName
-	}
-
-	// Routing Table configuration
-	if baseConfig.RoutingTableID == 0 && fileConfig.RoutingTableID != 0 {
-		baseConfig.RoutingTableID = fileConfig.RoutingTableID
-	}
-	if baseConfig.RoutingTableType == 0 && fileConfig.RoutingTableType != 0 {
-		baseConfig.RoutingTableType = fileConfig.RoutingTableType
-	}
-	if baseConfig.RoutingProtocol == 0 && fileConfig.RoutingProtocol != 0 {
-		baseConfig.RoutingProtocol = fileConfig.RoutingProtocol
-	}
-
-	// BGP configuration
-	mergeBGPConfig(&baseConfig.BGPConfig, &fileConfig.BGPConfig)
-
-	// Kubernetes configuration
-	if baseConfig.K8sConfigFile == "" && fileConfig.K8sConfigFile != "" {
-		baseConfig.K8sConfigFile = fileConfig.K8sConfigFile
-	}
-
-	// Leader Election configuration
-	mergeLeaderElectionConfig(&baseConfig.KubernetesLeaderElection, &fileConfig.KubernetesLeaderElection)
-
-	// BGP health check configuration
-	mergeHealthCheck(&baseConfig.ControlPlaneHealthCheck, &fileConfig.ControlPlaneHealthCheck)
-
-	// Prometheus configuration
-	if baseConfig.PrometheusHTTPServer == "" && fileConfig.PrometheusHTTPServer != "" {
-		baseConfig.PrometheusHTTPServer = fileConfig.PrometheusHTTPServer
-	}
-
-	// DNS configuration
-	if baseConfig.DNSMode == "" && fileConfig.DNSMode != "" {
-		baseConfig.DNSMode = fileConfig.DNSMode
-	}
-
-	// DHCP configuration - mode
-	if baseConfig.DHCPMode == "" && fileConfig.DHCPMode != "" {
-		baseConfig.DHCPMode = fileConfig.DHCPMode
-	}
-
-	// DHCP configuration - backoff attempts
-	if baseConfig.DHCPBackoffAttempts == DefaultDHCPBackoffAttempts && fileConfig.DHCPBackoffAttempts != DefaultDHCPBackoffAttempts {
-		baseConfig.DHCPBackoffAttempts = fileConfig.DHCPBackoffAttempts
-	}
-
-	// Health check configuration (HTTP listener for kube-vip readiness)
-	if baseConfig.HealthCheckPort == 0 && fileConfig.HealthCheckPort != 0 {
-		baseConfig.HealthCheckPort = fileConfig.HealthCheckPort
-	}
-
-	// Instance configuration
-	if baseConfig.InstanceName == "" && fileConfig.InstanceName != "" {
-		baseConfig.InstanceName = fileConfig.InstanceName
-	}
-
-	// Egress configuration
-	if baseConfig.EgressPodCidr == "" && fileConfig.EgressPodCidr != "" {
-		baseConfig.EgressPodCidr = fileConfig.EgressPodCidr
-	}
-	if baseConfig.EgressServiceCidr == "" && fileConfig.EgressServiceCidr != "" {
-		baseConfig.EgressServiceCidr = fileConfig.EgressServiceCidr
-	}
-	// Mirror configuration
-	if baseConfig.MirrorDestInterface == "" && fileConfig.MirrorDestInterface != "" {
-		baseConfig.MirrorDestInterface = fileConfig.MirrorDestInterface
-	}
-
-	// Iptables configuration
-	if baseConfig.IptablesBackend == "" && fileConfig.IptablesBackend != "" {
-		baseConfig.IptablesBackend = fileConfig.IptablesBackend
-	}
-
-	// Backend health check interval
-	if baseConfig.BackendHealthCheckInterval == 0 && fileConfig.BackendHealthCheckInterval != 0 {
-		baseConfig.BackendHealthCheckInterval = fileConfig.BackendHealthCheckInterval
-	}
-
-	// ARP broadcast rate
-	if baseConfig.ArpBroadcastRate == 0 && fileConfig.ArpBroadcastRate != 0 {
-		baseConfig.ArpBroadcastRate = fileConfig.ArpBroadcastRate
-	}
-
-	// Annotations
-	if baseConfig.Annotations == "" && fileConfig.Annotations != "" {
-		baseConfig.Annotations = fileConfig.Annotations
-	}
-
-	// Load balancers slice
-	if len(baseConfig.LoadBalancers) == 0 && len(fileConfig.LoadBalancers) > 0 {
-		baseConfig.LoadBalancers = fileConfig.LoadBalancers
-	}
-
-	// Debounce time for watch events
-	if baseConfig.DebounceTime == debouncer.DefaultTime && fileConfig.DebounceTime != debouncer.DefaultTime {
-		baseConfig.DebounceTime = fileConfig.DebounceTime
-	}
-
-	if baseConfig.LoseLeadershipTimeoutSeconds == 0 && fileConfig.LoseLeadershipTimeoutSeconds != 0 {
-		baseConfig.LoseLeadershipTimeoutSeconds = fileConfig.LoseLeadershipTimeoutSeconds
-	}
-}
-
-// mergeBGPConfig merges BGP configuration
-func mergeBGPConfig(base, file *BGPConfig) {
-	if base.RouterID == "" && file.RouterID != "" {
-		base.RouterID = file.RouterID
-	}
-	if base.AS == 0 && file.AS != 0 {
-		base.AS = file.AS
-	}
-	if base.SourceIF == "" && file.SourceIF != "" {
-		base.SourceIF = file.SourceIF
-	}
-	if base.SourceIP == "" && file.SourceIP != "" {
-		base.SourceIP = file.SourceIP
-	}
-	if base.HoldTime == 0 && file.HoldTime != 0 {
-		base.HoldTime = file.HoldTime
-	}
-	if base.KeepaliveInterval == 0 && file.KeepaliveInterval != 0 {
-		base.KeepaliveInterval = file.KeepaliveInterval
-	}
-	if len(base.Peers) == 0 && len(file.Peers) > 0 {
-		base.Peers = file.Peers
-	}
-}
-
-// mergeLeaderElectionConfig merges leader election configuration
-func mergeLeaderElectionConfig(base, file *KubernetesLeaderElection) {
-	if base.LeaseName == "" && file.LeaseName != "" {
-		base.LeaseName = file.LeaseName
-	}
-	if base.LeaseDuration == 0 && file.LeaseDuration != 0 {
-		base.LeaseDuration = file.LeaseDuration
-	}
-	if base.RenewDeadline == 0 && file.RenewDeadline != 0 {
-		base.RenewDeadline = file.RenewDeadline
-	}
-	if base.RetryPeriod == 0 && file.RetryPeriod != 0 {
-		base.RetryPeriod = file.RetryPeriod
-	}
-	if len(base.LeaseAnnotations) == 0 && len(file.LeaseAnnotations) > 0 {
-		base.LeaseAnnotations = file.LeaseAnnotations
-	}
-}
-
-// mergeHealthCheck merges HTTP health check configuration for BGP route advertisement.
-func mergeHealthCheck(base, file *HealthCheck) {
-	if base.Address == "" && file.Address != "" {
-		base.Address = file.Address
-	}
-	if base.PeriodSeconds == 0 && file.PeriodSeconds != 0 {
-		base.PeriodSeconds = file.PeriodSeconds
-	}
-	if base.TimeoutSeconds == 0 && file.TimeoutSeconds != 0 {
-		base.TimeoutSeconds = file.TimeoutSeconds
-	}
-	if base.FailureThreshold == 0 && file.FailureThreshold != 0 {
-		base.FailureThreshold = file.FailureThreshold
-	}
-	if base.CAPath == "" && file.CAPath != "" {
-		base.CAPath = file.CAPath
-	}
 }

--- a/pkg/kubevip/config_file_test.go
+++ b/pkg/kubevip/config_file_test.go
@@ -3,567 +3,144 @@ package kubevip
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
-func TestLoadConfigFromFile(t *testing.T) {
-	// Create temporary directory for test files
-	tmpDir, err := os.MkdirTemp("", "kube-vip-config-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
+func TestMergeConfigFromFilePresence(t *testing.T) {
 	tests := []struct {
-		name           string
-		filename       string
-		content        string
-		expectedConfig *Config
-		wantErr        bool
-		errContains    string
+		name    string
+		ext     string
+		content string
+		check   func(*testing.T, *Config)
 	}{
 		{
-			name:     "Valid YAML config",
-			filename: "config.yaml",
-			content: `
-logging: 2
-enableARP: true
-enableControlPlane: true
-enableServices: true
-address: "192.168.1.100"
-port: 6443
-interface: "eth0"
-namespace: "kube-system"
-instanceName: "release_a"
-vipSubnet: "192.168.1.0/24"
-leaseName: "test-lease"
-leaseDuration: 15
-renewDeadline: 10
-retryPeriod: 2
-prometheusHTTPServer: ":2112"
+			name: "omitted values retain defaults",
+			ext:  ".yaml",
+			content: `enableARP: true
 `,
-			expectedConfig: &Config{
-				Logging:              2,
-				EnableARP:            true,
-				EnableControlPlane:   true,
-				EnableServices:       true,
-				Address:              "192.168.1.100",
-				Port:                 6443,
-				Interface:            "eth0",
-				Namespace:            "kube-system",
-				InstanceName:         "release_a",
-				VIPSubnet:            "192.168.1.0/24",
-				PrometheusHTTPServer: ":2112",
-				KubernetesLeaderElection: KubernetesLeaderElection{
-					LeaseName:     "test-lease",
-					LeaseDuration: 15,
-					RenewDeadline: 10,
-					RetryPeriod:   2,
-				},
+			check: func(t *testing.T, config *Config) {
+				if config.Port != 6443 || !config.EnableARP {
+					t.Fatalf("Port = %d, EnableARP = %t", config.Port, config.EnableARP)
+				}
 			},
-			wantErr: false,
 		},
 		{
-			name:     "Valid JSON config",
-			filename: "config.json",
-			content: `{
-  "logging": 3,
-  "enableBGP": true,
-  "enableServices": true,
-  "address": "10.0.0.100",
-  "port": 8443,
-  "interface": "ens192",
-  "namespace": "kube-system",
-  "loadBalancers": [
-    {
-      "name": "control-plane",
-      "ports": [
-        {
-          "type": "TCP",
-          "port": 6443
-        }
-      ],
-      "bindToVip": true,
-      "forwardingMethod": "local"
-    }
-  ]
-}`,
-			expectedConfig: &Config{
-				Logging:        3,
-				EnableBGP:      true,
-				EnableServices: true,
-				Address:        "10.0.0.100",
-				Port:           8443,
-				Interface:      "ens192",
-				Namespace:      "kube-system",
-				LoadBalancers: []LoadBalancer{
-					{
-						Name: "control-plane",
-						Ports: []Port{
-							{
-								Type: "TCP",
-								Port: 6443,
-							},
-						},
-						BindToVip:        true,
-						ForwardingMethod: "local",
-					},
-				},
+			name: "explicit zero false and empty override defaults",
+			ext:  ".yaml",
+			content: `port: 0
+lbClassNameLegacyHandling: false
+prometheusHTTPServer: ""
+`,
+			check: func(t *testing.T, config *Config) {
+				if config.Port != 0 || config.LoadBalancerClassLegacyHandling || config.PrometheusHTTPServer != "" {
+					t.Fatalf("explicit values not retained: %#v", config)
+				}
 			},
-			wantErr: false,
 		},
 		{
-			name:     "Complex BGP config",
-			filename: "bgp-config.yaml",
-			content: `
-enableBGP: true
-bgpConfig:
-  routerID: "192.168.1.1"
-  as: 65000
-  sourceIF: "eth0"
-  holdTime: 60
-  keepaliveInterval: 20
+			name:    "JSON external names",
+			ext:     ".json",
+			content: `{"enableBGP":true,"dnsDualStackMode":"dual","bgpConfig":{"routerID":"192.0.2.1","as":65000}}`,
+			check: func(t *testing.T, config *Config) {
+				if !config.EnableBGP || config.DNSMode != "dual" || config.BGPConfig.RouterID != "192.0.2.1" {
+					t.Fatalf("JSON names not decoded: %#v", config)
+				}
+			},
+		},
+		{
+			name: "standalone BGP peer is consumed by runtime",
+			ext:  ".yaml",
+			content: `bgpPeerConfig:
+  address: 192.0.2.2
+  as: 65001
+  multiHop: true
+`,
+			check: func(t *testing.T, config *Config) {
+				if len(config.BGPConfig.Peers) != 1 || config.BGPConfig.Peers[0].Address != "192.0.2.2" || !config.BGPConfig.Peers[0].MultiHop {
+					t.Fatalf("standalone peer not normalized: %#v", config.BGPConfig)
+				}
+			},
+		},
+		{
+			name: "YAML aliases",
+			ext:  ".yaml",
+			content: `bgpConfig:
   peers:
-    - address: "192.168.1.2"
-      as: 65001
-      port: 179
-      multiHop: false
-    - address: "192.168.1.3"
-      as: 65002
-      port: 179
-      multiHop: true
+    - &peer
+      address: 192.0.2.3
+      as: 65003
+    - *peer
 `,
-			expectedConfig: &Config{
-				EnableBGP: true,
-				BGPConfig: BGPConfig{
-					RouterID:          "192.168.1.1",
-					AS:                65000,
-					SourceIF:          "eth0",
-					HoldTime:          60,
-					KeepaliveInterval: 20,
-					Peers: []BGPPeer{
-						{
-							Address:  "192.168.1.2",
-							AS:       65001,
-							Port:     179,
-							MultiHop: false,
-						},
-						{
-							Address:  "192.168.1.3",
-							AS:       65002,
-							Port:     179,
-							MultiHop: true,
-						},
-					},
-				},
+			check: func(t *testing.T, config *Config) {
+				if len(config.BGPConfig.Peers) != 2 || config.BGPConfig.Peers[1].Address != "192.0.2.3" {
+					t.Fatalf("YAML alias not decoded: %#v", config.BGPConfig.Peers)
+				}
 			},
-			wantErr: false,
-		},
-		{
-			name:        "Invalid JSON",
-			filename:    "invalid.json",
-			content:     `{"logging": 2, "invalid": }`,
-			wantErr:     true,
-			errContains: "failed to parse JSON config file",
-		},
-		{
-			name:        "Invalid YAML",
-			filename:    "invalid.yaml",
-			content:     "logging: 2\ninvalid: [unclosed",
-			wantErr:     true,
-			errContains: "failed to parse YAML config file",
-		},
-		{
-			name:        "Unsupported format",
-			filename:    "config.txt",
-			content:     "logging=2",
-			wantErr:     true,
-			errContains: "unsupported config file format",
-		},
-		{
-			name:        "Empty path",
-			filename:    "",
-			content:     "",
-			wantErr:     true,
-			errContains: "config file path is empty",
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var filePath string
-			if tt.filename != "" {
-				filePath = filepath.Join(tmpDir, tt.filename)
-				if err := os.WriteFile(filePath, []byte(tt.content), 0600); err != nil {
-					t.Fatalf("Failed to write test file: %v", err)
-				}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config"+test.ext)
+			if err := os.WriteFile(path, []byte(test.content), 0600); err != nil {
+				t.Fatal(err)
 			}
-
-			config, err := LoadConfigFromFile(filePath)
-
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("LoadConfigFromFile() expected error, got nil")
-					return
-				}
-				if tt.errContains != "" && !containsString(err.Error(), tt.errContains) {
-					t.Errorf("LoadConfigFromFile() error = %v, expected to contain %v", err, tt.errContains)
-				}
-				return
+			config := &Config{Port: 6443, LoadBalancerClassLegacyHandling: true, PrometheusHTTPServer: ":2112"}
+			if err := MergeConfigFromFile(config, path); err != nil {
+				t.Fatal(err)
 			}
-
-			if err != nil {
-				t.Errorf("LoadConfigFromFile() unexpected error = %v", err)
-				return
+			if config.ConfigFile != path {
+				t.Fatalf("ConfigFile = %q, want %q", config.ConfigFile, path)
 			}
-
-			if config == nil {
-				t.Errorf("LoadConfigFromFile() returned nil config")
-				return
-			}
-
-			// Compare key fields
-			if config.Logging != tt.expectedConfig.Logging {
-				t.Errorf("Logging = %v, expected %v", config.Logging, tt.expectedConfig.Logging)
-			}
-			if config.EnableARP != tt.expectedConfig.EnableARP {
-				t.Errorf("EnableARP = %v, expected %v", config.EnableARP, tt.expectedConfig.EnableARP)
-			}
-			if config.EnableBGP != tt.expectedConfig.EnableBGP {
-				t.Errorf("EnableBGP = %v, expected %v", config.EnableBGP, tt.expectedConfig.EnableBGP)
-			}
-			if config.Address != tt.expectedConfig.Address {
-				t.Errorf("Address = %v, expected %v", config.Address, tt.expectedConfig.Address)
-			}
-			if config.Port != tt.expectedConfig.Port {
-				t.Errorf("Port = %v, expected %v", config.Port, tt.expectedConfig.Port)
-			}
-			if config.Interface != tt.expectedConfig.Interface {
-				t.Errorf("Interface = %v, expected %v", config.Interface, tt.expectedConfig.Interface)
-			}
-			if config.InstanceName != tt.expectedConfig.InstanceName {
-				t.Errorf("InstanceName = %v, expected %v", config.InstanceName, tt.expectedConfig.InstanceName)
-			}
-
-			// Test BGP config if present
-			if tt.expectedConfig.EnableBGP {
-				if config.BGPConfig.RouterID != tt.expectedConfig.BGPConfig.RouterID {
-					t.Errorf("BGPConfig.RouterID = %v, expected %v", config.BGPConfig.RouterID, tt.expectedConfig.BGPConfig.RouterID)
-				}
-				if config.BGPConfig.AS != tt.expectedConfig.BGPConfig.AS {
-					t.Errorf("BGPConfig.AS = %v, expected %v", config.BGPConfig.AS, tt.expectedConfig.BGPConfig.AS)
-				}
-				if len(config.BGPConfig.Peers) != len(tt.expectedConfig.BGPConfig.Peers) {
-					t.Errorf("BGPConfig.Peers length = %v, expected %v", len(config.BGPConfig.Peers), len(tt.expectedConfig.BGPConfig.Peers))
-				}
-			}
-
-			// Test LoadBalancers if present
-			if len(tt.expectedConfig.LoadBalancers) > 0 {
-				if len(config.LoadBalancers) != len(tt.expectedConfig.LoadBalancers) {
-					t.Errorf("LoadBalancers length = %v, expected %v", len(config.LoadBalancers), len(tt.expectedConfig.LoadBalancers))
-				}
-			}
+			test.check(t, config)
 		})
 	}
 }
 
-func TestMergeConfigFromFile(t *testing.T) {
-	// Create temporary directory for test files
-	tmpDir, err := os.MkdirTemp("", "kube-vip-merge-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	// Create test config file
-	configFile := filepath.Join(tmpDir, "test-config.yaml")
-	configContent := `
-logging: 3
-enableARP: true
-enableServices: true
-address: "192.168.1.200"
-port: 6443
-interface: "eth1"
-namespace: "test-namespace"
-leaseName: "file-lease"
-leaseDuration: 20
-prometheusHTTPServer: ":3000"
-`
-	if err := os.WriteFile(configFile, []byte(configContent), 0600); err != nil {
-		t.Fatalf("Failed to write test config file: %v", err)
-	}
-
+func TestMergeConfigFromFileRejectsUnknownAndExcludedFields(t *testing.T) {
 	tests := []struct {
-		name           string
-		baseConfig     *Config
-		configFilePath string
-		expected       *Config
-		wantErr        bool
+		name string
+		key  string
 	}{
-		{
-			name:           "Merge with empty base config",
-			baseConfig:     &Config{},
-			configFilePath: configFile,
-			expected: &Config{
-				Logging:              3,
-				EnableARP:            true,
-				EnableServices:       true,
-				Address:              "192.168.1.200",
-				Port:                 6443,
-				Interface:            "eth1",
-				Namespace:            "test-namespace",
-				PrometheusHTTPServer: ":3000",
-				KubernetesLeaderElection: KubernetesLeaderElection{
-					LeaseName:     "file-lease",
-					LeaseDuration: 20,
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "Merge respects existing values (priority test)",
-			baseConfig: &Config{
-				Logging:   5,      // Should not be overridden
-				Port:      8443,   // Should not be overridden
-				Interface: "eth0", // Should not be overridden
-			},
-			configFilePath: configFile,
-			expected: &Config{
-				Logging:              5,                // From base (higher priority)
-				EnableARP:            true,             // From file
-				EnableServices:       true,             // From file
-				Address:              "192.168.1.200",  // From file
-				Port:                 8443,             // From base (higher priority)
-				Interface:            "eth0",           // From base (higher priority)
-				Namespace:            "test-namespace", // From file
-				PrometheusHTTPServer: ":3000",          // From file
-				KubernetesLeaderElection: KubernetesLeaderElection{
-					LeaseName:     "file-lease", // From file
-					LeaseDuration: 20,           // From file
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "Empty config file path",
-			baseConfig: &Config{
-				Logging: 1,
-			},
-			configFilePath: "",
-			expected: &Config{
-				Logging: 1, // Unchanged
-			},
-			wantErr: false,
-		},
-		{
-			name: "Non-existent config file",
-			baseConfig: &Config{
-				Logging: 1,
-			},
-			configFilePath: "/non/existent/file.yaml",
-			expected: &Config{
-				Logging: 1,
-			},
-			wantErr: true,
-		},
+		{name: "unknown", key: "unknownSetting"},
+		{name: "runtime-derived dual stack", key: "isDualStack"},
+		{name: "bootstrap config path", key: "configFile"},
+		{name: "generator-only load balancers", key: "loadBalancers"},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := MergeConfigFromFile(tt.baseConfig, tt.configFilePath)
-
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("MergeConfigFromFile() expected error, got nil")
-				}
-				return
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(path, []byte(test.key+": true\n"), 0600); err != nil {
+				t.Fatal(err)
 			}
-
-			if err != nil {
-				t.Errorf("MergeConfigFromFile() unexpected error = %v", err)
-				return
-			}
-
-			// Compare key fields
-			if tt.baseConfig.Logging != tt.expected.Logging {
-				t.Errorf("Logging = %v, expected %v", tt.baseConfig.Logging, tt.expected.Logging)
-			}
-			if tt.baseConfig.EnableARP != tt.expected.EnableARP {
-				t.Errorf("EnableARP = %v, expected %v", tt.baseConfig.EnableARP, tt.expected.EnableARP)
-			}
-			if tt.baseConfig.Address != tt.expected.Address {
-				t.Errorf("Address = %v, expected %v", tt.baseConfig.Address, tt.expected.Address)
-			}
-			if tt.baseConfig.Port != tt.expected.Port {
-				t.Errorf("Port = %v, expected %v", tt.baseConfig.Port, tt.expected.Port)
-			}
-			if tt.baseConfig.Interface != tt.expected.Interface {
-				t.Errorf("Interface = %v, expected %v", tt.baseConfig.Interface, tt.expected.Interface)
-			}
-			if tt.baseConfig.Namespace != tt.expected.Namespace {
-				t.Errorf("Namespace = %v, expected %v", tt.baseConfig.Namespace, tt.expected.Namespace)
-			}
-			if tt.baseConfig.PrometheusHTTPServer != tt.expected.PrometheusHTTPServer {
-				t.Errorf("PrometheusHTTPServer = %v, expected %v", tt.baseConfig.PrometheusHTTPServer, tt.expected.PrometheusHTTPServer)
+			err := MergeConfigFromFile(&Config{}, path)
+			if err == nil || !strings.Contains(err.Error(), "field "+test.key+" not found") {
+				t.Fatalf("error = %v, want unknown-field error", err)
 			}
 		})
 	}
 }
 
-func TestMergeConfigValues(t *testing.T) {
+func TestLoadConfigFromFileErrors(t *testing.T) {
 	tests := []struct {
-		name         string
-		baseConfig   *Config
-		fileConfig   *Config
-		expectedBase *Config
+		name string
+		path string
+		want string
 	}{
-		{
-			name: "Merge basic configuration",
-			baseConfig: &Config{
-				Logging: 5, // Should not be overridden
-				Port:    0, // Should be overridden
-			},
-			fileConfig: &Config{
-				Logging:      2,
-				Port:         6443,
-				Interface:    "eth0",
-				Address:      "192.168.1.100",
-				InstanceName: "release_a",
-			},
-			expectedBase: &Config{
-				Logging:      5,               // From base (non-zero)
-				Port:         6443,            // From file (base was zero)
-				Interface:    "eth0",          // From file (base was empty)
-				Address:      "192.168.1.100", // From file (base was empty)
-				InstanceName: "release_a",     // From file (base was empty)
-			},
-		},
-		{
-			name: "Merge boolean flags",
-			baseConfig: &Config{
-				EnableARP: true, // Should not be overridden
-			},
-			fileConfig: &Config{
-				EnableARP:       false, // Should not override true
-				EnableBGP:       true,  // Should be set
-				EnableServices:  true,  // Should be set
-				EnableWireguard: false, // Should not be set (false doesn't override false)
-			},
-			expectedBase: &Config{
-				EnableARP:       true,  // From base (true has priority)
-				EnableBGP:       true,  // From file
-				EnableServices:  true,  // From file
-				EnableWireguard: false, // Remains false
-			},
-		},
-		{
-			name: "Merge BGP configuration",
-			baseConfig: &Config{
-				BGPConfig: BGPConfig{
-					RouterID: "1.1.1.1", // Should not be overridden
-				},
-			},
-			fileConfig: &Config{
-				BGPConfig: BGPConfig{
-					RouterID:          "2.2.2.2", // Should not override
-					AS:                65000,     // Should be set
-					SourceIF:          "eth0",    // Should be set
-					HoldTime:          30,        // Should be set
-					KeepaliveInterval: 10,        // Should be set
-				},
-			},
-			expectedBase: &Config{
-				BGPConfig: BGPConfig{
-					RouterID:          "1.1.1.1", // From base (non-empty)
-					AS:                65000,     // From file (base was zero)
-					SourceIF:          "eth0",    // From file (base was empty)
-					HoldTime:          30,        // From file (base was zero)
-					KeepaliveInterval: 10,        // From file (base was zero)
-				},
-			},
-		},
-		{
-			name: "Merge leader election configuration",
-			baseConfig: &Config{
-				KubernetesLeaderElection: KubernetesLeaderElection{
-					LeaseName: "base-lease", // Should not be overridden
-				},
-			},
-			fileConfig: &Config{
-				KubernetesLeaderElection: KubernetesLeaderElection{
-					LeaseName:     "file-lease", // Should not override
-					LeaseDuration: 15,           // Should be set
-					RenewDeadline: 10,           // Should be set
-					RetryPeriod:   2,            // Should be set
-				},
-			},
-			expectedBase: &Config{
-				KubernetesLeaderElection: KubernetesLeaderElection{
-					LeaseName:     "base-lease", // From base (non-empty)
-					LeaseDuration: 15,           // From file (base was zero)
-					RenewDeadline: 10,           // From file (base was zero)
-					RetryPeriod:   2,            // From file (base was zero)
-				},
-			},
-		},
+		{name: "empty", want: "config file path is empty"},
+		{name: "missing", path: filepath.Join(t.TempDir(), "missing.yaml"), want: "config file does not exist"},
+		{name: "unsupported", path: filepath.Join(t.TempDir(), "config.txt"), want: "unsupported config file format"},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mergeConfigValues(tt.baseConfig, tt.fileConfig)
-
-			// Compare results
-			if tt.baseConfig.Logging != tt.expectedBase.Logging {
-				t.Errorf("Logging = %v, expected %v", tt.baseConfig.Logging, tt.expectedBase.Logging)
-			}
-			if tt.baseConfig.Port != tt.expectedBase.Port {
-				t.Errorf("Port = %v, expected %v", tt.baseConfig.Port, tt.expectedBase.Port)
-			}
-			if tt.baseConfig.Interface != tt.expectedBase.Interface {
-				t.Errorf("Interface = %v, expected %v", tt.baseConfig.Interface, tt.expectedBase.Interface)
-			}
-			if tt.baseConfig.InstanceName != tt.expectedBase.InstanceName {
-				t.Errorf("InstanceName = %v, expected %v", tt.baseConfig.InstanceName, tt.expectedBase.InstanceName)
-			}
-			if tt.baseConfig.EnableARP != tt.expectedBase.EnableARP {
-				t.Errorf("EnableARP = %v, expected %v", tt.baseConfig.EnableARP, tt.expectedBase.EnableARP)
-			}
-			if tt.baseConfig.EnableBGP != tt.expectedBase.EnableBGP {
-				t.Errorf("EnableBGP = %v, expected %v", tt.baseConfig.EnableBGP, tt.expectedBase.EnableBGP)
-			}
-			if tt.baseConfig.BGPConfig.RouterID != tt.expectedBase.BGPConfig.RouterID {
-				t.Errorf("BGPConfig.RouterID = %v, expected %v", tt.baseConfig.BGPConfig.RouterID, tt.expectedBase.BGPConfig.RouterID)
-			}
-			if tt.baseConfig.BGPConfig.AS != tt.expectedBase.BGPConfig.AS {
-				t.Errorf("BGPConfig.AS = %v, expected %v", tt.baseConfig.BGPConfig.AS, tt.expectedBase.BGPConfig.AS)
-			}
-			if tt.baseConfig.KubernetesLeaderElection.LeaseName != tt.expectedBase.KubernetesLeaderElection.LeaseName {
-				t.Errorf("KubernetesLeaderElection.LeaseName = %v, expected %v", tt.baseConfig.KubernetesLeaderElection.LeaseName, tt.expectedBase.KubernetesLeaderElection.LeaseName)
+	if err := os.WriteFile(tests[2].path, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := LoadConfigFromFile(test.path)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want %q", err, test.want)
 			}
 		})
 	}
-}
-
-func TestLoadConfigFromFile_FileNotExists(t *testing.T) {
-	_, err := LoadConfigFromFile("/non/existent/path/config.yaml")
-	if err == nil {
-		t.Error("LoadConfigFromFile() expected error for non-existent file, got nil")
-	}
-	if !containsString(err.Error(), "config file does not exist") {
-		t.Errorf("LoadConfigFromFile() error = %v, expected to contain 'config file does not exist'", err)
-	}
-}
-
-// Helper function to check if a string contains a substring
-func containsString(str, substr string) bool {
-	return len(str) >= len(substr) && (str == substr || len(substr) == 0 ||
-		(len(substr) > 0 && func() bool {
-			for i := 0; i <= len(str)-len(substr); i++ {
-				if str[i:i+len(substr)] == substr {
-					return true
-				}
-			}
-			return false
-		}()))
 }

--- a/pkg/kubevip/config_sources_test.go
+++ b/pkg/kubevip/config_sources_test.go
@@ -1,0 +1,156 @@
+package kubevip
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+type configFieldSource struct {
+	category string
+	reason   string
+}
+
+const (
+	configSourceMergeable = "mergeable"
+	configSourceDerived   = "derived"
+	configSourceBootstrap = "bootstrap"
+	configSourceGenerator = "generator"
+)
+
+var nonMergeableConfigFields = map[string]configFieldSource{
+	"AddPeersAsBackends": {
+		category: configSourceGenerator,
+		reason:   "controls generated control-plane manifests rather than manager startup",
+	},
+	"BGPPeers": {
+		category: configSourceGenerator,
+		reason:   "legacy CLI input is parsed into BGPConfig.Peers before runtime use",
+	},
+	"ConfigFile": {
+		category: configSourceBootstrap,
+		reason:   "selects the file to load and cannot be selected by that same file",
+	},
+	"IsDualStack": {
+		category: configSourceDerived,
+		reason:   "computed from a Service IP family at reconciliation time",
+	},
+	"LoadBalancers": {
+		category: configSourceGenerator,
+		reason:   "describes generated IPVS manifests rather than manager configuration",
+	},
+	"RequireDualStack": {
+		category: configSourceDerived,
+		reason:   "computed from a Service IP family policy at reconciliation time",
+	},
+	"SingleNode": {
+		category: configSourceGenerator,
+		reason:   "controls generated control-plane manifests rather than manager startup",
+	},
+	"StartAsLeader": {
+		category: configSourceGenerator,
+		reason:   "controls generated control-plane manifests rather than manager startup",
+	},
+}
+
+func TestConfigFieldsHaveSourceSemantics(t *testing.T) {
+	typ := reflect.TypeOf(Config{})
+	counts := map[string]int{}
+
+	for name, source := range nonMergeableConfigFields {
+		switch source.category {
+		case configSourceDerived, configSourceBootstrap, configSourceGenerator:
+		default:
+			t.Errorf("Config.%s has invalid source category %q", name, source.category)
+		}
+		if source.reason == "" {
+			t.Errorf("Config.%s classification must include category and reason", name)
+		}
+		if _, ok := typ.FieldByName(name); !ok {
+			t.Errorf("stale Config.%s classification", name)
+		}
+	}
+
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		source := configSourceForField(field.Name)
+		if source.category == "" || source.reason == "" {
+			t.Errorf("Config.%s has incomplete source semantics", field.Name)
+		}
+		counts[source.category]++
+	}
+	for _, category := range []string{configSourceMergeable, configSourceDerived, configSourceBootstrap, configSourceGenerator} {
+		if counts[category] == 0 {
+			t.Errorf("no Config fields classified as %s", category)
+		}
+	}
+}
+
+func configSourceForField(name string) configFieldSource {
+	if source, ok := nonMergeableConfigFields[name]; ok {
+		return source
+	}
+	return configFieldSource{
+		category: configSourceMergeable,
+		reason:   "accepted from file configuration and overlaid by higher-priority sources",
+	}
+}
+
+func TestConfigFileLoaderUsesExternalNames(t *testing.T) {
+	path := writeConfigSourceFile(t, ".json", `{
+  "enableBGP": true,
+  "bgpConfig": {"routerID": "192.0.2.1", "as": 65000}
+}`)
+
+	config, err := LoadConfigFromFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !config.EnableBGP || config.BGPConfig.RouterID != "192.0.2.1" || config.BGPConfig.AS != 65000 {
+		t.Fatalf("decoded config = %#v", config)
+	}
+}
+
+func TestConfigFileMergePopulatesDestination(t *testing.T) {
+	path := writeConfigSourceFile(t, ".yaml", `enableARP: true
+port: 7443
+interface: eth1
+`)
+	config := &Config{}
+
+	if err := MergeConfigFromFile(config, path); err != nil {
+		t.Fatal(err)
+	}
+	if !config.EnableARP || config.Port != 7443 || config.Interface != "eth1" {
+		t.Fatalf("merged config = %#v", config)
+	}
+}
+
+func TestConfigEnvironmentOverridesLoadedFile(t *testing.T) {
+	path := writeConfigSourceFile(t, ".yaml", `enableARP: true
+port: 7443
+`)
+	config := &Config{}
+
+	if err := MergeConfigFromFile(config, path); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(vipArp, "false")
+	t.Setenv(port, "8443")
+	if err := ParseEnvironment(config); err != nil {
+		t.Fatal(err)
+	}
+	if config.EnableARP || config.Port != 8443 {
+		t.Fatalf("environment did not override file values: %#v", config)
+	}
+}
+
+func writeConfigSourceFile(t *testing.T, extension, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config"+extension)
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -64,20 +64,20 @@ type Config struct {
 	LoseLeadershipTimeoutSeconds int `yaml:"loseLeadershipTimeoutSeconds"`
 
 	// Annotations will define if we're going to wait and lookup configuration from Kubernetes node annotations
-	Annotations string
+	Annotations string `yaml:"annotations"`
 
 	// LeaderElectionType defines the backend to run the leader election: kubernetes or etcd. Defaults to kubernetes.
 	// Etcd doesn't support load balancer mode (EnableLoadBalancer=true) or any other feature that depends on the kube-api server.
 	LeaderElectionType string `yaml:"leaderElectionType"`
 
 	// KubernetesLeaderElection defines the settings around Kubernetes KubernetesLeaderElection
-	KubernetesLeaderElection
+	KubernetesLeaderElection `yaml:",inline"`
 
 	// Etcd defines all the settings for the etcd client.
-	Etcd Etcd
+	Etcd Etcd `yaml:"etcd"`
 
 	// AddPeersAsBackends, this will automatically add RAFT peers as backends to a loadbalancer
-	AddPeersAsBackends bool `yaml:"addPeersAsBackends"`
+	AddPeersAsBackends bool `yaml:"-"`
 
 	// VIP is the Virtual IP address exposed for the cluster (TODO: deprecate)
 	VIP string `yaml:"vip"`
@@ -107,10 +107,10 @@ type Config struct {
 	NodeName string `yaml:"leaseNodeName"`
 
 	// SingleNode will start the cluster as a single Node (Raft disabled)
-	SingleNode bool `yaml:"singleNode"`
+	SingleNode bool `yaml:"-"`
 
 	// StartAsLeader, this will start this node as the leader before other nodes connect
-	StartAsLeader bool `yaml:"startAsLeader"`
+	StartAsLeader bool `yaml:"-"`
 
 	// Interface is the network interface to bind to (default: First Adapter)
 	Interface string `yaml:"interface,omitempty"`
@@ -146,16 +146,16 @@ type Config struct {
 	SkipDAD bool `yaml:"skipDAD"`
 
 	// BGP Configuration
-	BGPConfig     BGPConfig
-	BGPPeerConfig BGPPeer
-	BGPPeers      []string
+	BGPConfig     BGPConfig `yaml:"bgpConfig"`
+	BGPPeerConfig BGPPeer   `yaml:"bgpPeerConfig"`
+	BGPPeers      []string  `yaml:"-"`
 
 	// ControlPlaneHealthCheck configures HTTP polling of the control plane when using BGP without
 	// leader election. If the health check fails, the BGP route will be withdrawn.
 	ControlPlaneHealthCheck HealthCheck `yaml:"controlPlaneHealthCheck,omitempty"`
 
 	// LoadBalancers are the various services we can load balance over
-	LoadBalancers []LoadBalancer `yaml:"loadBalancers,omitempty"`
+	LoadBalancers []LoadBalancer `yaml:"-"`
 
 	// The hostport used to expose Prometheus metrics over an HTTP server
 	PrometheusHTTPServer string `yaml:"prometheusHTTPServer,omitempty"`
@@ -163,16 +163,16 @@ type Config struct {
 	// Egress configuration
 
 	// EgressPodCidr, this contains the pod cidr range to ignore Egress
-	EgressPodCidr string
+	EgressPodCidr string `yaml:"egressPodCidr"`
 
 	// EgressServiceCidr, this contains the service cidr range to ignore
-	EgressServiceCidr string
+	EgressServiceCidr string `yaml:"egressServiceCidr"`
 
 	// EnableInternalSNAT, this will enable the internal SNAT rule that kube-vip adds to the egress chain
-	EnableInternalSNAT bool
+	EnableInternalSNAT bool `yaml:"enableInternalSNAT"`
 
 	// EgressWithNftables, this will use the iptables-nftables OVER iptables
-	EgressWithNftables bool
+	EgressWithNftables bool `yaml:"egressWithNftables"`
 
 	// ServicesLeaseName, this will set the lease name for services leader in arp mode
 	ServicesLeaseName string `yaml:"servicesLeaseName"`
@@ -184,10 +184,10 @@ type Config struct {
 	DNSMode string `yaml:"dnsDualStackMode"`
 
 	// IsDualStack reports if service is DualStack.
-	IsDualStack bool
+	IsDualStack bool `yaml:"-"`
 
 	// RequireDualStack defines if DualStack is required for the service. Based on service's Spec.ipFamilyPolicy field.
-	RequireDualStack bool
+	RequireDualStack bool `yaml:"-"`
 
 	// DNSMode, this will set the mode DHCP lookup will be performed for DDNS (ipv4, ipv6, dual). By default will be the same as DNSMode.
 	// If DNSMode is 'first', IPv4 will be used.
@@ -223,7 +223,7 @@ type Config struct {
 	EgressClean bool `yaml:"egressClean"`
 
 	// ConfigFile defines the path to a JSON/YAML configuration file
-	ConfigFile string `yaml:"configFile"`
+	ConfigFile string `yaml:"-"`
 
 	// DHCPBackoffAttempts defines how many times will DHCP client try to obtain address (unlimited when 0)
 	DHCPBackoffAttempts uint `yaml:"dhcpBackoffAttempts"`
@@ -244,24 +244,24 @@ type KubernetesLeaderElection struct {
 	LeaseName string `yaml:"leaseName"`
 
 	// Lease Duration - length of time a lease can be held for
-	LeaseDuration int
+	LeaseDuration int `yaml:"leaseDuration"`
 
 	// RenewDeadline - length of time a host can attempt to renew its lease
-	RenewDeadline int
+	RenewDeadline int `yaml:"renewDeadline"`
 
 	// RetryPeriod - length of time (in seconds) the LeaderElector clients should wait between tries of actions
-	RetryPeriod int
+	RetryPeriod int `yaml:"retryPeriod"`
 
 	// LeaseAnnotations - annotations which will be given to the lease object
-	LeaseAnnotations map[string]string
+	LeaseAnnotations map[string]string `yaml:"leaseAnnotations"`
 }
 
 // Etcd defines all the settings for the etcd client.
 type Etcd struct {
-	CAFile         string
-	ClientCertFile string
-	ClientKeyFile  string
-	Endpoints      []string
+	CAFile         string   `yaml:"caFile"`
+	ClientCertFile string   `yaml:"clientCertFile"`
+	ClientKeyFile  string   `yaml:"clientKeyFile"`
+	Endpoints      []string `yaml:"endpoints"`
 }
 
 // HealthCheck defines HTTP health-check settings for control-plane polling when using BGP
@@ -287,7 +287,7 @@ type LoadBalancer struct {
 	Name string `yaml:"name"`
 
 	// Ports exposed by a LoadBalancer
-	Ports []Port
+	Ports []Port `yaml:"ports"`
 
 	// BindToVip will bind the load balancer port to the VIP itself
 	BindToVip bool `yaml:"bindToVip"`


### PR DESCRIPTION
## Purpose

Make runtime configuration precedence presence-aware across defaults, config files, environment variables, and flags.

## Key changes

- Tracks whether values were explicitly supplied instead of inferring source from zero values.
- Applies config-file values without dropping valid fields, then lets explicitly set environment variables and flags override them.
- Aligns BGP configuration handling and documents the supported precedence behavior.
- Adds source-precedence coverage across command and kubevip configuration paths.

## Validation

Unit, integration, lint, CodeQL, and ARP, routing-table, BGP, and service E2E checks pass.

## Dependency

Base: `main`. No stack dependency.