### PR TITLE
fix(wireguard): guard nil service context in endpoint clear

### DIFF
--- a/pkg/endpoints/endpoints_wireguard.go
+++ b/pkg/endpoints/endpoints_wireguard.go
@@ -212,7 +212,7 @@ func (w *wireguardWorker) clear(svcCtx *servicecontext.Context, lastKnownGoodEnd
 		}
 	}
 
-	if svcCtx.LeaderCancel != nil {
+	if svcCtx != nil && svcCtx.LeaderCancel != nil {
 		svcCtx.LeaderCancel()
 	}
 }

--- a/pkg/endpoints/endpoints_wireguard_test.go
+++ b/pkg/endpoints/endpoints_wireguard_test.go
@@ -1,0 +1,17 @@
+package endpoints
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestWireguardDeleteDoesNotDereferenceNilServiceContext(t *testing.T) {
+	worker := &wireguardWorker{}
+	service := &v1.Service{}
+
+	if err := worker.delete(context.Background(), service, "node-a"); err != nil {
+		t.Fatalf("delete() error = %v", err)
+	}
+}


### PR DESCRIPTION
## Bug
In WireGuard mode the endpoint worker`s `delete()` path calls `clear(nil, nil, service)`, but `clear()` dereferenced `svcCtx.LeaderCancel` without a nil check (`pkg/endpoints/endpoints_wireguard.go:215`). This panics on **every** service or endpoint deletion in WireGuard mode. It is reached in normal operation via the endpoint watcher on a `watch.Deleted` event (`pkg/services/watch_endpoints.go`).

## Fix
Guard the dereference with a nil check on `svcCtx` itself. Behavior is unchanged for the non-nil path.

## Test
Adds `TestWireguardDeleteDoesNotDereferenceNilServiceContext`. Bidirectionally validated: it passes with the fix and panics with a nil pointer dereference when the fix is reverted.

Found during the test-coverage/bug-bash effort (mode resiliency sweep).