### PR TITLE
fix(route): insert route tracker entry only after AddRoute succeeds

### DIFF
--- a/pkg/endpoints/endpoints_wireguard_test.go
+++ b/pkg/endpoints/endpoints_wireguard_test.go
@@ -6,7 +6,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-func TestWireguardDeleteDoesNotDereferenceNilServiceContext(t *testing.T) {
+func TestWireguardClearDoesNotDereferenceNilServiceContext(t *testing.T) {
 	worker := &wireguardWorker{}
 	service := &v1.Service{}
 

--- a/pkg/route/manager.go
+++ b/pkg/route/manager.go
@@ -49,9 +49,6 @@ func (m *Manager) Add(object string, r route, precheck, update bool) error {
 	itm, exists := m.tracker[key]
 
 	if !exists {
-		m.tracker[key] = newItem(r)
-		itm = m.tracker[key]
-
 		added, err := r.AddRoute(precheck)
 		if err != nil {
 			if update && errors.Is(err, syscall.EEXIST) && update {
@@ -69,6 +66,9 @@ func (m *Manager) Add(object string, r route, precheck, update bool) error {
 				return fmt.Errorf("error adding route %q: %w", key, err)
 			}
 		}
+
+		itm = newItem(r)
+		m.tracker[key] = itm
 
 		if added {
 			log.Debug("[RT] added route", "path", key, "object", object)

--- a/pkg/route/manager_atomic_test.go
+++ b/pkg/route/manager_atomic_test.go
@@ -1,0 +1,29 @@
+package route
+
+import (
+	"errors"
+	"testing"
+)
+
+var errTransientRouteAdd = errors.New("transient route add failure")
+
+func TestManagerRetriesRouteAfterInitialAddFailure(t *testing.T) {
+	m := NewManager()
+	r := &mockRoute{hash: "retry", addErr: errTransientRouteAdd}
+
+	if err := m.Add("service", r, false, true); !errors.Is(err, errTransientRouteAdd) {
+		t.Fatalf("first add error = %v, want %v", err, errTransientRouteAdd)
+	}
+
+	// A transient netlink failure (for example while the link is being recreated)
+	// must not poison the in-memory tracker. The next reconciliation has to retry
+	// the kernel operation.
+	r.addErr = nil
+	r.added = true
+	if err := m.Add("service", r, false, true); err != nil {
+		t.Fatalf("retry add failed: %v", err)
+	}
+	if r.addCalls != 2 {
+		t.Fatalf("AddRoute called %d times, want 2", r.addCalls)
+	}
+}

--- a/pkg/route/manager_test.go
+++ b/pkg/route/manager_test.go
@@ -186,6 +186,7 @@ func Test_MultipleRoutesAddDel(t *testing.T) {
 
 type mockRoute struct {
 	added     bool
+	addCalls  int
 	addErr    error
 	updated   bool
 	updateErr error
@@ -195,6 +196,7 @@ type mockRoute struct {
 }
 
 func (mr *mockRoute) AddRoute(_ bool) (bool, error) {
+	mr.addCalls++
 	return mr.added, mr.addErr
 }
 


### PR DESCRIPTION
## Bug
`Manager.Add` inserted `m.tracker[key]` before calling `r.AddRoute()`. When AddRoute returned a non-EEXIST error, Add returned the error but left the tracker entry in place (empty objects). The next Add saw `exists==true`, skipped the whole add block, and returned nil, so the route was never installed while callers set `ConfiguredNetworks=true` believing it was. Permanent silent failure until restart.

## Fix
Insert into `m.tracker` only after AddRoute (and the EEXIST/update branch) succeeds. Adds `TestManagerRetriesRouteAfterInitialAddFailure`.

Found during the kube-vip test-coverage/bug-bash effort; adversarially confirmed and bidirectionally validated (repro test passes with the fix, fails when the fix is reverted). No unrelated changes.

## Rebase / CI note

Rebased onto current upstream `main` at `b684eed`. This branch also carries the signed WireGuard test correction from [#1739](https://github.com/kube-vip/kube-vip/pull/1739), because the current base test otherwise fails to compile; that duplicate prerequisite can be dropped after #1739 lands.