### PR TITLE
fix(cluster): make Cluster.Stop concurrency-safe and lock Processor.Stop

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	log "log/slog"
@@ -22,6 +23,7 @@ import (
 // Cluster - The Cluster object manages the state of the cluster for a particular node
 type Cluster struct {
 	stop                  chan bool
+	stopMutex             sync.Mutex
 	Network               []vip.Network
 	arpMgr                *arp.Manager
 	routeMgr              *route.Manager
@@ -93,6 +95,9 @@ func startNetworking(c *kubevip.Config, intfMgr *networkinterface.Manager) ([]vi
 
 // Stop - Will stop the Cluster and release VIP if needed
 func (cluster *Cluster) Stop() {
+	cluster.stopMutex.Lock()
+	defer cluster.stopMutex.Unlock()
+
 	// Close the stop channel, which will shut down the VIP (if needed)
 	if cluster.stop != nil {
 		close(cluster.stop)

--- a/pkg/cluster/cluster_stop_test.go
+++ b/pkg/cluster/cluster_stop_test.go
@@ -1,0 +1,32 @@
+package cluster
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestStopConcurrentDoesNotRaceOrPanic(t *testing.T) {
+	c := &Cluster{stop: make(chan bool)}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	var panics atomic.Int64
+
+	for range 128 {
+		wg.Go(func() {
+			<-start
+			defer func() {
+				if recover() != nil {
+					panics.Add(1)
+				}
+			}()
+			c.Stop()
+		})
+	}
+
+	close(start)
+	wg.Wait()
+	if got := panics.Load(); got != 0 {
+		t.Fatalf("concurrent Stop panicked %d time(s)", got)
+	}
+}

--- a/pkg/endpoints/endpoints_wireguard_test.go
+++ b/pkg/endpoints/endpoints_wireguard_test.go
@@ -6,7 +6,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-func TestWireguardDeleteDoesNotDereferenceNilServiceContext(t *testing.T) {
+func TestWireguardClearDoesNotDereferenceNilServiceContext(t *testing.T) {
 	worker := &wireguardWorker{}
 	service := &v1.Service{}
 

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -352,6 +352,9 @@ func (p *Processor) deleteTrackedService(svc *v1.Service) error {
 }
 
 func (p *Processor) Stop() {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
 	for _, instance := range p.ServiceInstances {
 		for _, cluster := range instance.Clusters {
 			cluster.Stop()


### PR DESCRIPTION
## Bug
`Cluster.Stop()` did `close(cluster.stop); cluster.stop = make(chan bool)` with no synchronization. During shutdown, `Processor.Stop()` iterates `ServiceInstances` calling `cluster.Stop()` without holding `p.mutex`, concurrently with `deleteService()` (from election `onStoppedLeading`) which also calls `cluster.Stop()`. Concurrent Stop on the same cluster double-closes the same channel (panic) and races the `ServiceInstances` slice.

## Fix
Guard `Cluster.Stop()` with a mutex so close+recreate is atomic and idempotent under concurrency; take `p.mutex` in `Processor.Stop()`. Adds `TestStopConcurrentDoesNotRaceOrPanic` (validated under `-race`: DATA RACE + panic without the fix, clean with it).

Found during the kube-vip test-coverage/bug-bash effort; adversarially confirmed and bidirectionally validated (repro test passes with the fix, fails when the fix is reverted). No unrelated changes.

## Rebase / CI note

Rebased onto current upstream `main` at `b684eed`. This branch also carries the signed WireGuard test correction from [#1739](https://github.com/kube-vip/kube-vip/pull/1739), because the current base test otherwise fails to compile; that duplicate prerequisite can be dropped after #1739 lands.