### PR TITLE
fix(bgp): honour configured peer port and keep source interface on MP-BGP fallback

### DIFF
--- a/pkg/bgp/peers.go
+++ b/pkg/bgp/peers.go
@@ -25,6 +25,11 @@ const defaultBGPPort uint32 = 179
 
 // AddPeer will add peers to the BGP configuration
 func (b *Server) AddPeer(ctx context.Context, peer kubevip.BGPPeer) (err error) {
+	remotePort := defaultBGPPort
+	if peer.Port != 0 {
+		remotePort = uint32(peer.Port)
+	}
+
 	p := &api.Peer{
 		Conf: &api.PeerConf{
 			NeighborAddress:   peer.Address,
@@ -50,7 +55,7 @@ func (b *Server) AddPeer(ctx context.Context, peer kubevip.BGPPeer) (err error) 
 		Transport: &api.Transport{
 			MtuDiscovery:  true,
 			RemoteAddress: peer.Address,
-			RemotePort:    defaultBGPPort,
+			RemotePort:    remotePort,
 		},
 	}
 
@@ -85,6 +90,7 @@ func (b *Server) AddPeer(ctx context.Context, peer kubevip.BGPPeer) (err error) 
 		ipv4Address, ipv6Address, err := peer.FindMpbgpAddresses(p, b.c)
 		if err != nil {
 			log.Error("failed to get MP-BGP addresses, will not us MP-BGP for this host", "error", err)
+			b.setPeerSource(p)
 		} else {
 			p.AfiSafis = []*api.AfiSafi{
 				{
@@ -136,13 +142,7 @@ func (b *Server) AddPeer(ctx context.Context, peer kubevip.BGPPeer) (err error) 
 			}
 		}
 	} else {
-		if b.c.SourceIP != "" {
-			p.Transport.LocalAddress = b.c.SourceIP
-		}
-
-		if b.c.SourceIF != "" {
-			p.Transport.BindInterface = b.c.SourceIF
-		}
+		b.setPeerSource(p)
 	}
 
 	if err := b.s.AddPeer(ctx, &api.AddPeerRequest{Peer: p}); err != nil {
@@ -150,6 +150,16 @@ func (b *Server) AddPeer(ctx context.Context, peer kubevip.BGPPeer) (err error) 
 	}
 	log.Info("[BGP]", "peer", p.Conf.NeighborAddress, "AS", p.Conf.PeerAsn, "BFD", p.Bfd)
 	return nil
+}
+
+func (b *Server) setPeerSource(p *api.Peer) {
+	if b.c.SourceIP != "" {
+		p.Transport.LocalAddress = b.c.SourceIP
+	}
+
+	if b.c.SourceIF != "" {
+		p.Transport.BindInterface = b.c.SourceIF
+	}
 }
 
 func (b *Server) getPath(ip net.IP) *apiutil.Path {

--- a/pkg/bgp/peers_config_test.go
+++ b/pkg/bgp/peers_config_test.go
@@ -1,0 +1,135 @@
+package bgp
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	log "log/slog"
+
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	api "github.com/osrg/gobgp/v4/api"
+	gobgp "github.com/osrg/gobgp/v4/pkg/server"
+)
+
+func TestAddPeerUsesConfiguredRemotePort(t *testing.T) {
+	server := newStartedTestBGPServer(t, kubevip.BGPConfig{
+		AS:       65000,
+		RouterID: "192.0.2.1",
+		Peers:    []kubevip.BGPPeer{{Address: "192.0.2.10", AS: 65001}},
+	})
+
+	if err := server.AddPeer(context.Background(), kubevip.BGPPeer{
+		Address: "192.0.2.10",
+		AS:      65001,
+		Port:    180,
+	}); err != nil {
+		t.Fatalf("AddPeer() error = %v", err)
+	}
+
+	peer := listTestPeer(t, server, "192.0.2.10")
+	if got := peer.GetTransport().GetRemotePort(); got != 180 {
+		t.Fatalf("remote port = %d, want %d", got, 180)
+	}
+}
+
+func TestAddPeerFallsBackToConfiguredSourceInterfaceAfterMPBGPResolutionFailure(t *testing.T) {
+	server := newPeerTestServer(t, kubevip.BGPConfig{
+		AS:           65000,
+		RouterID:     "192.0.2.1",
+		SourceIF:     "lo",
+		MpbgpNexthop: "fixed",
+		Peers:        []kubevip.BGPPeer{{Address: "192.0.2.20", AS: 65001}},
+		MpbgpIPv4:    "",
+		MpbgpIPv6:    "",
+	})
+
+	if err := server.AddPeer(context.Background(), kubevip.BGPPeer{
+		Address: "192.0.2.20",
+		AS:      65001,
+	}); err != nil {
+		t.Fatalf("AddPeer: %v", err)
+	}
+
+	var got *api.Peer
+	if err := server.s.ListPeer(context.Background(), &api.ListPeerRequest{}, func(peer *api.Peer) {
+		got = peer
+	}); err != nil {
+		t.Fatalf("ListPeer: %v", err)
+	}
+	if got == nil || got.Transport == nil {
+		t.Fatal("configured peer was not returned")
+	}
+	if got.Transport.BindInterface != "lo" {
+		t.Fatalf("fallback peer interface = %q, want %q", got.Transport.BindInterface, "lo")
+	}
+}
+
+func newStartedTestBGPServer(t *testing.T, config kubevip.BGPConfig) *Server {
+	t.Helper()
+
+	server, err := NewBGPServer(config, log.LevelError)
+	if err != nil {
+		t.Fatalf("NewBGPServer() error = %v", err)
+	}
+
+	go server.s.Serve()
+	if err := server.s.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        config.AS,
+			RouterId:   config.RouterID,
+			ListenPort: -1,
+		},
+	}); err != nil {
+		server.s.Stop()
+		t.Fatalf("StartBgp() error = %v", err)
+	}
+	t.Cleanup(server.s.Stop)
+
+	return server
+}
+
+func listTestPeer(t *testing.T, server *Server, address string) *api.Peer {
+	t.Helper()
+
+	var got *api.Peer
+	if err := server.s.ListPeer(context.Background(), &api.ListPeerRequest{Address: address}, func(peer *api.Peer) {
+		got = peer
+	}); err != nil {
+		t.Fatalf("ListPeer() error = %v", err)
+	}
+	if got == nil {
+		t.Fatalf("ListPeer() returned no peer for %s", address)
+	}
+	return got
+}
+
+func newPeerTestServer(t *testing.T, cfg kubevip.BGPConfig) *Server {
+	t.Helper()
+	raw := startEmbeddedRawBGP(t)
+	return &Server{s: raw, c: &cfg, tracker: make(map[string]map[string]bool)}
+}
+
+func startEmbeddedRawBGP(t *testing.T) *gobgp.BgpServer {
+	t.Helper()
+	raw := gobgp.NewBgpServer()
+	go raw.Serve()
+	if err := raw.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        65000,
+			RouterId:   "192.0.2.1",
+			ListenPort: -1,
+		},
+	}); err != nil {
+		t.Fatalf("starting embedded BGP server: %v", err)
+	}
+	var stopOnce sync.Once
+	t.Cleanup(func() {
+		stopOnce.Do(func() {
+			if err := raw.StopBgp(context.Background(), &api.StopBgpRequest{}); err != nil {
+				t.Logf("stopping embedded BGP server: %v", err)
+			}
+		})
+	})
+	return raw
+}

--- a/pkg/bgp/peers_config_test.go
+++ b/pkg/bgp/peers_config_test.go
@@ -12,56 +12,67 @@ import (
 	gobgp "github.com/osrg/gobgp/v4/pkg/server"
 )
 
-func TestAddPeerUsesConfiguredRemotePort(t *testing.T) {
-	server := newStartedTestBGPServer(t, kubevip.BGPConfig{
-		AS:       65000,
-		RouterID: "192.0.2.1",
-		Peers:    []kubevip.BGPPeer{{Address: "192.0.2.10", AS: 65001}},
-	})
-
-	if err := server.AddPeer(context.Background(), kubevip.BGPPeer{
-		Address: "192.0.2.10",
-		AS:      65001,
-		Port:    180,
-	}); err != nil {
-		t.Fatalf("AddPeer() error = %v", err)
+func TestAddPeerConfiguresTransportOptions(t *testing.T) {
+	tests := []struct {
+		name          string
+		newServer     func(*testing.T) *Server
+		peer          kubevip.BGPPeer
+		wantPort      uint32
+		wantLocalAddr string
+		wantInterface string
+	}{
+		{
+			name: "configured remote port",
+			newServer: func(t *testing.T) *Server {
+				return newStartedTestBGPServer(t, kubevip.BGPConfig{
+					AS:       65000,
+					RouterID: "192.0.2.1",
+					Peers:    []kubevip.BGPPeer{{Address: "192.0.2.10", AS: 65001}},
+				})
+			},
+			peer:     kubevip.BGPPeer{Address: "192.0.2.10", AS: 65001, Port: 180},
+			wantPort: 180,
+		},
+		{
+			name: "configured source interface after MP-BGP fallback",
+			newServer: func(t *testing.T) *Server {
+				return newPeerTestServer(t, kubevip.BGPConfig{
+					AS:           65000,
+					RouterID:     "192.0.2.1",
+					SourceIF:     "lo",
+					MpbgpNexthop: "fixed",
+					Peers:        []kubevip.BGPPeer{{Address: "192.0.2.20", AS: 65001}},
+					MpbgpIPv4:    "",
+					MpbgpIPv6:    "",
+				})
+			},
+			peer:          kubevip.BGPPeer{Address: "192.0.2.20", AS: 65001},
+			wantInterface: "lo",
+		},
 	}
 
-	peer := listTestPeer(t, server, "192.0.2.10")
-	if got := peer.GetTransport().GetRemotePort(); got != 180 {
-		t.Fatalf("remote port = %d, want %d", got, 180)
-	}
-}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			server := tt.newServer(t)
+			if err := server.AddPeer(context.Background(), tt.peer); err != nil {
+				t.Fatalf("AddPeer() error = %v", err)
+			}
 
-func TestAddPeerFallsBackToConfiguredSourceInterfaceAfterMPBGPResolutionFailure(t *testing.T) {
-	server := newPeerTestServer(t, kubevip.BGPConfig{
-		AS:           65000,
-		RouterID:     "192.0.2.1",
-		SourceIF:     "lo",
-		MpbgpNexthop: "fixed",
-		Peers:        []kubevip.BGPPeer{{Address: "192.0.2.20", AS: 65001}},
-		MpbgpIPv4:    "",
-		MpbgpIPv6:    "",
-	})
-
-	if err := server.AddPeer(context.Background(), kubevip.BGPPeer{
-		Address: "192.0.2.20",
-		AS:      65001,
-	}); err != nil {
-		t.Fatalf("AddPeer: %v", err)
-	}
-
-	var got *api.Peer
-	if err := server.s.ListPeer(context.Background(), &api.ListPeerRequest{}, func(peer *api.Peer) {
-		got = peer
-	}); err != nil {
-		t.Fatalf("ListPeer: %v", err)
-	}
-	if got == nil || got.Transport == nil {
-		t.Fatal("configured peer was not returned")
-	}
-	if got.Transport.BindInterface != "lo" {
-		t.Fatalf("fallback peer interface = %q, want %q", got.Transport.BindInterface, "lo")
+			peer := listTestPeer(t, server, tt.peer.Address)
+			if peer.GetTransport() == nil {
+				t.Fatal("configured peer has no transport")
+			}
+			if tt.wantPort != 0 && peer.GetTransport().GetRemotePort() != tt.wantPort {
+				t.Fatalf("remote port = %d, want %d", peer.GetTransport().GetRemotePort(), tt.wantPort)
+			}
+			if tt.wantLocalAddr != "" && peer.GetTransport().GetLocalAddress() != tt.wantLocalAddr {
+				t.Fatalf("local address = %q, want %q", peer.GetTransport().GetLocalAddress(), tt.wantLocalAddr)
+			}
+			if tt.wantInterface != "" && peer.GetTransport().GetBindInterface() != tt.wantInterface {
+				t.Fatalf("bind interface = %q, want %q", peer.GetTransport().GetBindInterface(), tt.wantInterface)
+			}
+		})
 	}
 }
 

--- a/pkg/endpoints/endpoints_wireguard_test.go
+++ b/pkg/endpoints/endpoints_wireguard_test.go
@@ -6,7 +6,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-func TestWireguardDeleteDoesNotDereferenceNilServiceContext(t *testing.T) {
+func TestWireguardClearDoesNotDereferenceNilServiceContext(t *testing.T) {
 	worker := &wireguardWorker{}
 	service := &v1.Service{}
 


### PR DESCRIPTION
## Bugs (both in pkg/bgp/peers.go)
1. `AddPeer` built the peer Transport with `RemotePort: defaultBGPPort` (179) unconditionally and never read `peer.Port`, so a configured/parsed per-peer port was silently dropped.
2. When `MpbgpNexthop` is set but `FindMpbgpAddresses` fails (the #1683 graceful degrade to regular BGP), AddPeer took the error branch that skips the block applying `SourceIP`/`SourceIF`, dropping the configured source interface (breaks IPv6 link-local / source-routed sessions).

## Fix
Use `peer.Port` when non-zero; apply `SourceIP`/`SourceIF` on the MP-BGP fallback path too.

## Generalized verification
The two narrow tests are consolidated into the table-driven `TestAddPeerConfiguresTransportOptions`, covering both configured remote-port handling and configured source-interface preservation after MP-BGP resolution failure.

## Verification
- `go test ./pkg/bgp`
- `go test -race ./pkg/bgp`

Both commands passed in the Debian Bookworm ARM64 OrbStack Linux VM.

## Rebase note
The head also updates the existing WireGuard nil-context regression test to exercise the current `clear(nil, ...)` API after the endpoint reconciliation refactor. This is test-only compatibility coverage; it does not change WireGuard production behavior.

## Rebase / CI note

Rebased onto current upstream `main` at `b684eed`. This branch also carries the signed WireGuard test correction from [#1739](https://github.com/kube-vip/kube-vip/pull/1739), because the current base test otherwise fails to compile; that duplicate prerequisite can be dropped after #1739 lands.