### PR TITLE
fix(manager): handle empty node list in annotations watcher

### DIFF
--- a/pkg/endpoints/endpoints_wireguard_test.go
+++ b/pkg/endpoints/endpoints_wireguard_test.go
@@ -6,7 +6,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-func TestWireguardDeleteDoesNotDereferenceNilServiceContext(t *testing.T) {
+func TestWireguardClearDoesNotDereferenceNilServiceContext(t *testing.T) {
 	worker := &wireguardWorker{}
 	service := &v1.Service{}
 

--- a/pkg/manager/watch_annotations.go
+++ b/pkg/manager/watch_annotations.go
@@ -41,6 +41,9 @@ func annotationsWatcher(ctx context.Context, clientSet,
 	if err != nil {
 		return err
 	}
+	if len(nodeList.Items) == 0 {
+		return fmt.Errorf("no node found with hostname %q", config.NodeName)
+	}
 
 	// We'll assume there's only one node with the hostname annotation. If that's not true,
 	// there's probably bigger problems

--- a/pkg/manager/watch_annotations_test.go
+++ b/pkg/manager/watch_annotations_test.go
@@ -1,0 +1,21 @@
+package manager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestAnnotationsWatcherHandlesEmptyNodeList(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	config := &kubevip.Config{
+		NodeName:    "node-a",
+		Annotations: "kube-vip.io",
+	}
+
+	if err := annotationsWatcher(context.Background(), client, client, config); err == nil {
+		t.Fatal("annotationsWatcher() error = nil, want empty node-list error")
+	}
+}


### PR DESCRIPTION
## Bug
The annotations watcher indexed `nodeList.Items[0]` after listing nodes filtered by `kubernetes.io/hostname=<NodeName>`, with no length check. An empty list (misconfigured NodeName, or the hostname label not yet present) panics with index out of range at startup.

## Fix
Return a descriptive error when the filtered node list is empty instead of indexing. Adds `TestAnnotationsWatcherHandlesEmptyNodeList` (panics without the fix).

Found during the kube-vip test-coverage/bug-bash effort; adversarially confirmed and bidirectionally validated (repro test passes with the fix, fails when the fix is reverted). No unrelated changes.

## Rebase / CI note

Rebased onto current upstream `main` at `b684eed`. This branch also carries the signed WireGuard test correction from [#1739](https://github.com/kube-vip/kube-vip/pull/1739), because the current base test otherwise fails to compile; that duplicate prerequisite can be dropped after #1739 lands.