### PR TITLE
fix(bgp): validate MP-BGP fixed-address family

### DIFF
--- a/pkg/endpoints/endpoints_wireguard_test.go
+++ b/pkg/endpoints/endpoints_wireguard_test.go
@@ -6,7 +6,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-func TestWireguardDeleteDoesNotDereferenceNilServiceContext(t *testing.T) {
+func TestWireguardClearDoesNotDereferenceNilServiceContext(t *testing.T) {
 	worker := &wireguardWorker{}
 	service := &v1.Service{}
 

--- a/pkg/kubevip/config_bgp.go
+++ b/pkg/kubevip/config_bgp.go
@@ -2,7 +2,6 @@ package kubevip
 
 import (
 	"fmt"
-	"net"
 	"strconv"
 	"strings"
 
@@ -260,12 +259,12 @@ func (p *BGPPeer) FindMpbgpAddresses(ap *api.Peer, server *BGPConfig) (string, s
 		}
 
 		if ipv4 != "" {
-			if net.ParseIP(ipv4) == nil {
+			if !utils.IsIPv4(ipv4) {
 				return "", "", fmt.Errorf("provided address '%s' is not a valid IPv4 address", ipv4)
 			}
 		}
 		if ipv6 != "" {
-			if net.ParseIP(ipv6) == nil {
+			if !utils.IsIPv6(ipv6) {
 				return "", "", fmt.Errorf("provided address '%s' is not a valid IPv6 address", ipv6)
 			}
 		}

--- a/pkg/kubevip/config_bgp_family_test.go
+++ b/pkg/kubevip/config_bgp_family_test.go
@@ -1,0 +1,38 @@
+package kubevip
+
+import (
+	"testing"
+
+	api "github.com/osrg/gobgp/v4/api"
+)
+
+func TestFindMpbgpAddressesRejectsFixedAddressFamilyMismatches(t *testing.T) {
+	tests := []struct {
+		name string
+		peer BGPPeer
+	}{
+		{
+			name: "IPv6 value in IPv4 field",
+			peer: BGPPeer{
+				MpbgpNexthop: "fixed",
+				MpbgpIPv4:    "2001:db8::20",
+			},
+		},
+		{
+			name: "IPv4 value in IPv6 field",
+			peer: BGPPeer{
+				MpbgpNexthop: "fixed",
+				MpbgpIPv6:    "192.0.2.20",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := tt.peer.FindMpbgpAddresses(&api.Peer{Transport: &api.Transport{}}, &BGPConfig{})
+			if err == nil {
+				t.Fatal("FindMpbgpAddresses() error = nil, want address-family error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Bug
The fixed MP-BGP addresses were validated with `net.ParseIP(...) == nil`, which accepts either family, so an IPv6 literal in `MpbgpIPv4` (or vice versa) passed despite the error strings promising family validation. The mis-family address was then used as the family-specific MP-BGP nexthop.

## Fix
Validate with the existing family-specific helpers (`utils.IsIPv4`/`utils.IsIPv6`). Adds `TestFindMpbgpAddressesRejectsFixedAddressFamilyMismatches`.

Found during the kube-vip test-coverage/bug-bash effort; adversarially confirmed and bidirectionally validated (repro test passes with the fix, fails when the fix is reverted). No unrelated changes.

## Rebase / CI note

Rebased onto current upstream `main` at `b684eed`. This branch also carries the signed WireGuard test correction from [#1739](https://github.com/kube-vip/kube-vip/pull/1739), because the current base test otherwise fails to compile; that duplicate prerequisite can be dropped after #1739 lands.