### PR TITLE
fix(bgp): keep host tracker in sync with GoBGP to prevent silent route loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Retry BGP Service route advertisement after a failed withdrawal without corrupting route reference tracking.
 - Propagate `bgp_attach_ip_to_interface` into per-service config so it attaches BGP-mode Service VIPs to the interface as configured.
 - Add a configurable kube-vip instance name and use it to isolate internal nftables egress tables, persist table ownership on Services, and migrate per-Service chains without affecting other deployments. Fixes #1634.
 - Retry on 403 Forbidden and 401 Unauthorized in `ServicesWatcher` at startup with exponential backoff. Fixes #1464.

--- a/pkg/bgp/hosts.go
+++ b/pkg/bgp/hosts.go
@@ -16,29 +16,32 @@ func (b *Server) AddHost(ctx context.Context, addr string, object string) error 
 
 	objects, exists := b.tracker[addr]
 
+	ip, _, err := net.ParseCIDR(addr)
+	if err != nil {
+		return err
+	}
+
+	p := b.getPath(ip)
+	if p == nil {
+		return fmt.Errorf("failed to get path for %v", ip)
+	}
+
+	// The tracker can outlive the GoBGP server or retain a route after a
+	// failed withdrawal. Re-adding the path keeps the daemon and tracker in
+	// sync; GoBGP treats an identical path as an idempotent operation.
+	if _, err := b.s.AddPath(apiutil.AddPathRequest{
+		Paths: []*apiutil.Path{p},
+	}); err != nil {
+		return err
+	}
+
 	if !exists {
-		b.tracker[addr] = make(map[string]bool)
-		objects = b.tracker[addr]
-
-		ip, _, err := net.ParseCIDR(addr)
-		if err != nil {
-			return err
-		}
-
-		p := b.getPath(ip)
-		if p == nil {
-			return fmt.Errorf("failed to get path for %v", ip)
-		}
-
-		if _, err := b.s.AddPath(apiutil.AddPathRequest{
-			Paths: []*apiutil.Path{p},
-		}); err != nil {
-			return err
-		}
-		log.Debug("[BGP] added host", "addr", addr, "cnt", len(objects)+1, "object", object)
+		objects = make(map[string]bool)
+		b.tracker[addr] = objects
 	}
 
 	objects[object] = true
+	log.Debug("[BGP] added host", "addr", addr, "cnt", len(objects), "object", object)
 
 	return nil
 }
@@ -59,9 +62,12 @@ func (b *Server) DelHost(ctx context.Context, addr string, object string) error 
 		return err
 	}
 
-	delete(objects, object)
+	remaining := len(objects)
+	if _, ok := objects[object]; ok {
+		remaining--
+	}
 
-	if len(objects) == 0 {
+	if remaining == 0 {
 		p := b.getPath(ip)
 		if p == nil {
 			return nil
@@ -73,8 +79,9 @@ func (b *Server) DelHost(ctx context.Context, addr string, object string) error 
 			return err
 		}
 		delete(b.tracker, addr)
-		log.Debug("[BGP] deleted host", "addr", addr, "cnt", len(objects), "object", object)
+		log.Debug("[BGP] deleted host", "addr", addr, "cnt", remaining, "object", object)
 	} else {
+		delete(objects, object)
 		log.Debug("[BGP] deleting from tracker only", "addr", addr, "object", object)
 	}
 

--- a/pkg/bgp/hosts.go
+++ b/pkg/bgp/hosts.go
@@ -26,13 +26,14 @@ func (b *Server) AddHost(ctx context.Context, addr string, object string) error 
 		return fmt.Errorf("failed to get path for %v", ip)
 	}
 
-	// The tracker can outlive the GoBGP server or retain a route after a
-	// failed withdrawal. Re-adding the path keeps the daemon and tracker in
-	// sync; GoBGP treats an identical path as an idempotent operation.
-	if _, err := b.s.AddPath(apiutil.AddPathRequest{
-		Paths: []*apiutil.Path{p},
-	}); err != nil {
-		return err
+	if !exists || objects[object] {
+		// Without Add-Path, GoBGP replaces an identical path. Re-add an existing
+		// reference so reconciliation can recover after a failed withdrawal.
+		if _, err := b.s.AddPath(apiutil.AddPathRequest{
+			Paths: []*apiutil.Path{p},
+		}); err != nil {
+			return err
+		}
 	}
 
 	if !exists {

--- a/pkg/bgp/hosts_atomic_test.go
+++ b/pkg/bgp/hosts_atomic_test.go
@@ -1,0 +1,111 @@
+package bgp
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	api "github.com/osrg/gobgp/v4/api"
+	gobgp "github.com/osrg/gobgp/v4/pkg/server"
+)
+
+func TestAddHostRetriesAfterGoBGPFailure(t *testing.T) {
+	b, first := newEmbeddedHostTestServer(t)
+	const addr = "10.0.0.34/32"
+	const object = "default/service"
+
+	// Stop the embedded daemon to make the first AddPath fail. This is the
+	// failure mode seen during a BGP/API restart, not a malformed service VIP.
+	if err := first.StopBgp(context.Background(), &api.StopBgpRequest{}); err != nil {
+		t.Fatalf("stopping first embedded BGP server: %v", err)
+	}
+	if err := b.AddHost(context.Background(), addr, object); err == nil {
+		t.Fatal("AddHost unexpectedly succeeded while GoBGP was stopped")
+	}
+
+	// The kube-vip Server object survives the daemon recovery. A retry must add
+	// the path to the replacement daemon instead of trusting the failed tracker
+	// entry.
+	b.s = startEmbeddedRawBGP(t)
+	if err := b.AddHost(context.Background(), addr, object); err != nil {
+		t.Fatalf("AddHost retry: %v", err)
+	}
+
+	routes, err := b.ListAdvertisedRoutes(context.Background(), false)
+	if err != nil {
+		t.Fatalf("ListAdvertisedRoutes: %v", err)
+	}
+	if len(routes) != 1 || routes[0].Prefix != addr {
+		t.Fatalf("recovered BGP server routes = %#v, want %q", routes, addr)
+	}
+}
+
+func TestAddHostReAddsAfterFailedDeleteOnBGPRecovery(t *testing.T) {
+	b, first := newEmbeddedHostTestServer(t)
+	const addr = "10.0.0.35/32"
+	const object = "default/service"
+
+	if err := b.AddHost(context.Background(), addr, object); err != nil {
+		t.Fatalf("initial AddHost: %v", err)
+	}
+	if err := first.StopBgp(context.Background(), &api.StopBgpRequest{}); err != nil {
+		t.Fatalf("stopping first embedded BGP server: %v", err)
+	}
+	if err := b.DelHost(context.Background(), addr, object); err == nil {
+		t.Fatal("DelHost unexpectedly succeeded while GoBGP was stopped")
+	}
+
+	// A service can be deleted and recreated while the BGP API is unavailable.
+	// The replacement must not trust the empty tracker entry left by the failed
+	// delete; it still needs to install the route in the recovered daemon.
+	b.s = startEmbeddedRawBGP(t)
+	if err := b.AddHost(context.Background(), addr, object); err != nil {
+		t.Fatalf("recreated service AddHost: %v", err)
+	}
+
+	routes, err := b.ListAdvertisedRoutes(context.Background(), false)
+	if err != nil {
+		t.Fatalf("ListAdvertisedRoutes: %v", err)
+	}
+	if len(routes) != 1 || routes[0].Prefix != addr {
+		t.Fatalf("recreated service routes = %#v, want %q", routes, addr)
+	}
+}
+
+func newEmbeddedHostTestServer(t *testing.T) (*Server, *gobgp.BgpServer) {
+	t.Helper()
+	raw := startEmbeddedRawBGP(t)
+	return &Server{
+		s: raw,
+		c: &kubevip.BGPConfig{
+			AS:       65000,
+			RouterID: "192.0.2.1",
+		},
+		tracker: make(map[string]map[string]bool),
+	}, raw
+}
+
+func startEmbeddedRawBGP(t *testing.T) *gobgp.BgpServer {
+	t.Helper()
+	raw := gobgp.NewBgpServer()
+	go raw.Serve()
+	if err := raw.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        65000,
+			RouterId:   "192.0.2.1",
+			ListenPort: -1,
+		},
+	}); err != nil {
+		t.Fatalf("starting embedded BGP server: %v", err)
+	}
+	var stopOnce sync.Once
+	t.Cleanup(func() {
+		stopOnce.Do(func() {
+			if err := raw.StopBgp(context.Background(), &api.StopBgpRequest{}); err != nil {
+				t.Logf("stopping embedded BGP server: %v", err)
+			}
+		})
+	})
+	return raw
+}

--- a/pkg/bgp/hosts_atomic_test.go
+++ b/pkg/bgp/hosts_atomic_test.go
@@ -2,13 +2,23 @@ package bgp
 
 import (
 	"context"
-	"sync"
 	"testing"
 
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	api "github.com/osrg/gobgp/v4/api"
 	gobgp "github.com/osrg/gobgp/v4/pkg/server"
 )
+
+func TestAddHostDoesNotTrackInvalidCIDR(t *testing.T) {
+	b, _ := newEmbeddedHostTestServer(t)
+
+	if err := b.AddHost(context.Background(), "not-a-cidr", "default/service"); err == nil {
+		t.Fatal("AddHost unexpectedly accepted an invalid CIDR")
+	}
+	if len(b.tracker) != 0 {
+		t.Fatalf("tracker = %#v, want empty after failed add", b.tracker)
+	}
+}
 
 func TestAddHostRetriesAfterGoBGPFailure(t *testing.T) {
 	b, first := newEmbeddedHostTestServer(t)
@@ -22,6 +32,9 @@ func TestAddHostRetriesAfterGoBGPFailure(t *testing.T) {
 	}
 	if err := b.AddHost(context.Background(), addr, object); err == nil {
 		t.Fatal("AddHost unexpectedly succeeded while GoBGP was stopped")
+	}
+	if len(b.tracker) != 0 {
+		t.Fatalf("tracker = %#v, want empty after failed AddPath", b.tracker)
 	}
 
 	// The kube-vip Server object survives the daemon recovery. A retry must add
@@ -73,6 +86,34 @@ func TestAddHostReAddsAfterFailedDeleteOnBGPRecovery(t *testing.T) {
 	}
 }
 
+func TestAddHostDoesNotAddPathForNewReference(t *testing.T) {
+	b, raw := newEmbeddedHostTestServer(t)
+	const addr = "10.0.0.36/32"
+
+	if err := b.AddHost(context.Background(), addr, "default/first"); err != nil {
+		t.Fatalf("initial AddHost: %v", err)
+	}
+	if err := raw.StopBgp(context.Background(), &api.StopBgpRequest{}); err != nil {
+		t.Fatalf("stopping embedded BGP server: %v", err)
+	}
+
+	if err := b.AddHost(context.Background(), addr, "default/second"); err != nil {
+		t.Fatalf("adding a second reference called AddPath: %v", err)
+	}
+	if got := len(b.tracker[addr]); got != 2 {
+		t.Fatalf("tracker reference count = %d, want 2", got)
+	}
+	if err := b.DelHost(context.Background(), addr, "default/first"); err != nil {
+		t.Fatalf("deleting first reference called DeletePath: %v", err)
+	}
+	if got := len(b.tracker[addr]); got != 1 {
+		t.Fatalf("tracker reference count = %d, want 1", got)
+	}
+	if err := b.AddHost(context.Background(), addr, "default/second"); err == nil {
+		t.Fatal("reconciling an existing reference did not call AddPath")
+	}
+}
+
 func newEmbeddedHostTestServer(t *testing.T) (*Server, *gobgp.BgpServer) {
 	t.Helper()
 	raw := startEmbeddedRawBGP(t)
@@ -84,28 +125,4 @@ func newEmbeddedHostTestServer(t *testing.T) (*Server, *gobgp.BgpServer) {
 		},
 		tracker: make(map[string]map[string]bool),
 	}, raw
-}
-
-func startEmbeddedRawBGP(t *testing.T) *gobgp.BgpServer {
-	t.Helper()
-	raw := gobgp.NewBgpServer()
-	go raw.Serve()
-	if err := raw.StartBgp(context.Background(), &api.StartBgpRequest{
-		Global: &api.Global{
-			Asn:        65000,
-			RouterId:   "192.0.2.1",
-			ListenPort: -1,
-		},
-	}); err != nil {
-		t.Fatalf("starting embedded BGP server: %v", err)
-	}
-	var stopOnce sync.Once
-	t.Cleanup(func() {
-		stopOnce.Do(func() {
-			if err := raw.StopBgp(context.Background(), &api.StopBgpRequest{}); err != nil {
-				t.Logf("stopping embedded BGP server: %v", err)
-			}
-		})
-	})
-	return raw
 }

--- a/pkg/bgp/hosts_atomic_test.go
+++ b/pkg/bgp/hosts_atomic_test.go
@@ -2,10 +2,13 @@ package bgp
 
 import (
 	"context"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	api "github.com/osrg/gobgp/v4/api"
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
 	gobgp "github.com/osrg/gobgp/v4/pkg/server"
 )
 
@@ -111,6 +114,179 @@ func TestAddHostDoesNotAddPathForNewReference(t *testing.T) {
 	}
 	if err := b.AddHost(context.Background(), addr, "default/second"); err == nil {
 		t.Fatal("reconciling an existing reference did not call AddPath")
+	}
+}
+
+func TestAddHostOutboundUpdates(t *testing.T) {
+	tests := []struct {
+		name                 string
+		addPath              bool
+		wantSameReferenceMsg bool
+	}{
+		{name: "ordinary peer"},
+		{name: "Add-Path peer", addPath: true, wantSameReferenceMsg: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const addr = "10.0.0.37/32"
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			b, updates := newPeeredHostTestServer(t, ctx, tt.addPath, addr)
+			if err := b.AddHost(ctx, addr, "default/first"); err != nil {
+				t.Fatalf("initial AddHost: %v", err)
+			}
+			waitForHostUpdate(t, ctx, updates, "initial advertisement")
+
+			if err := b.AddHost(ctx, addr, "default/second"); err != nil {
+				t.Fatalf("new-reference AddHost: %v", err)
+			}
+			assertNoHostUpdate(t, updates, "new reference")
+
+			if err := b.AddHost(ctx, addr, "default/first"); err != nil {
+				t.Fatalf("same-reference AddHost: %v", err)
+			}
+			if tt.wantSameReferenceMsg {
+				waitForHostUpdate(t, ctx, updates, "Add-Path same-reference advertisement")
+			} else {
+				assertNoHostUpdate(t, updates, "ordinary same-reference reconciliation")
+			}
+
+		})
+	}
+}
+
+func newPeeredHostTestServer(t *testing.T, ctx context.Context, addPath bool, addr string) (*Server, <-chan struct{}) {
+	t.Helper()
+	receiver, port := startHostReceiver(t, ctx, addPath)
+	updates := make(chan struct{}, 4)
+	if err := receiver.WatchEvent(ctx, gobgp.WatchEventMessageCallbacks{
+		OnPathUpdate: func(paths []*apiutil.Path, _ time.Time) {
+			for _, path := range paths {
+				if !path.Withdrawal && path.Nlri.String() == addr {
+					updates <- struct{}{}
+				}
+			}
+		},
+	}, gobgp.WatchUpdate(false, "", "")); err != nil {
+		t.Fatalf("watching receiver updates: %v", err)
+	}
+
+	sender := startPeeredHostSender(t, ctx, receiver, port, addPath)
+	return &Server{
+		s:       sender,
+		c:       &kubevip.BGPConfig{AS: 65000, RouterID: "192.0.2.1"},
+		tracker: make(map[string]map[string]bool),
+	}, updates
+}
+
+func startHostReceiver(t *testing.T, ctx context.Context, addPath bool) (*gobgp.BgpServer, uint32) {
+	t.Helper()
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserving receiver port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).AddrPort().Port()
+	if err := listener.Close(); err != nil {
+		t.Fatalf("releasing receiver port: %v", err)
+	}
+
+	receiver := gobgp.NewBgpServer()
+	go receiver.Serve()
+	if err := receiver.StartBgp(ctx, &api.StartBgpRequest{Global: &api.Global{
+		Asn:             65000,
+		RouterId:        "192.0.2.2",
+		ListenPort:      int32(port),
+		ListenAddresses: []string{"127.0.0.1"},
+	}}); err != nil {
+		t.Fatalf("starting receiver: %v", err)
+	}
+	if err := receiver.AddPeer(ctx, &api.AddPeerRequest{Peer: hostTestPeer("127.0.0.2", "127.0.0.1", 0, true, addPath, false)}); err != nil {
+		t.Fatalf("adding receiver peer: %v", err)
+	}
+	t.Cleanup(receiver.Stop)
+	return receiver, uint32(port)
+}
+
+func startPeeredHostSender(t *testing.T, ctx context.Context, receiver *gobgp.BgpServer, port uint32, addPath bool) *gobgp.BgpServer {
+	t.Helper()
+	sender := gobgp.NewBgpServer()
+	go sender.Serve()
+	if err := sender.StartBgp(ctx, &api.StartBgpRequest{Global: &api.Global{
+		Asn:        65000,
+		RouterId:   "192.0.2.1",
+		ListenPort: -1,
+	}}); err != nil {
+		t.Fatalf("starting sender: %v", err)
+	}
+	if err := sender.AddPeer(ctx, &api.AddPeerRequest{Peer: hostTestPeer("127.0.0.1", "127.0.0.2", port, false, false, addPath)}); err != nil {
+		t.Fatalf("adding sender peer: %v", err)
+	}
+	waitForEstablishedHostPeers(t, ctx, sender, receiver)
+	t.Cleanup(sender.Stop)
+	return sender
+}
+
+func hostTestPeer(address, localAddress string, port uint32, passive, receiveAddPath, sendAddPath bool) *api.Peer {
+	peer := &api.Peer{
+		Conf: &api.PeerConf{NeighborAddress: address, PeerAsn: 65000},
+		Transport: &api.Transport{
+			LocalAddress: localAddress,
+			RemotePort:   port,
+			PassiveMode:  passive,
+		},
+	}
+	if receiveAddPath || sendAddPath {
+		peer.AfiSafis = []*api.AfiSafi{{
+			Config:   &api.AfiSafiConfig{Family: &api.Family{Afi: api.Family_AFI_IP, Safi: api.Family_SAFI_UNICAST}, Enabled: true},
+			AddPaths: &api.AddPaths{Config: &api.AddPathsConfig{Receive: receiveAddPath, SendMax: map[bool]uint32{true: 2}[sendAddPath]}},
+		}}
+	}
+	return peer
+}
+
+func waitForEstablishedHostPeers(t *testing.T, ctx context.Context, servers ...*gobgp.BgpServer) {
+	t.Helper()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		allEstablished := true
+		for _, server := range servers {
+			established := false
+			if err := server.ListPeer(ctx, &api.ListPeerRequest{}, func(peer *api.Peer) {
+				established = peer.State.SessionState == api.PeerState_SESSION_STATE_ESTABLISHED
+			}); err != nil {
+				t.Fatalf("listing peer state: %v", err)
+			}
+			allEstablished = allEstablished && established
+		}
+		if allEstablished {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("waiting for BGP peers: %v", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func waitForHostUpdate(t *testing.T, ctx context.Context, updates <-chan struct{}, description string) {
+	t.Helper()
+	select {
+	case <-updates:
+	case <-ctx.Done():
+		t.Fatalf("waiting for %s: %v", description, ctx.Err())
+	}
+}
+
+func assertNoHostUpdate(t *testing.T, updates <-chan struct{}, description string) {
+	t.Helper()
+	select {
+	case <-updates:
+		t.Fatalf("received unexpected update for %s", description)
+	case <-time.After(200 * time.Millisecond):
 	}
 }
 

--- a/pkg/endpoints/endpoints_bgp.go
+++ b/pkg/endpoints/endpoints_bgp.go
@@ -13,10 +13,15 @@ import (
 
 type BGP struct {
 	generic
-	bgpServer *bgp.Server
+	bgpServer bgpRouteManager
 }
 
-func newBGP(generic generic, bgpServer *bgp.Server) endpointWorker {
+type bgpRouteManager interface {
+	AddHost(context.Context, string, string) error
+	DelHost(context.Context, string, string) error
+}
+
+func newBGP(generic generic, bgpServer bgpRouteManager) endpointWorker {
 	return &BGP{
 		generic:   generic,
 		bgpServer: bgpServer,
@@ -51,12 +56,12 @@ func (b *BGP) clear(svcCtx *servicecontext.Context, lastKnownGoodEndpoint *strin
 			for _, cluster := range instance.Clusters {
 				for i := range cluster.Network {
 					err := b.bgpServer.DelHost(svcCtx.Ctx, cluster.Network[i].CIDR(), lease.ServiceNamespacedName(service))
+					svcCtx.ConfiguredNetworks.Delete(cluster.Network[i].IP())
 					if err != nil {
 						log.Error("deleting BGP host", "provider", b.provider.GetLabel(), "ip", cluster.Network[i].IP(), "err", err)
 					} else {
 						log.Info("deleted BGP host", "provider",
 							b.provider.GetLabel(), "ip", cluster.Network[i].IP(), "service name", service.Name, "namespace", service.Namespace)
-						svcCtx.ConfiguredNetworks.Delete(cluster.Network[i].IP())
 					}
 				}
 			}

--- a/pkg/endpoints/endpoints_bgp_test.go
+++ b/pkg/endpoints/endpoints_bgp_test.go
@@ -1,0 +1,100 @@
+package endpoints
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kube-vip/kube-vip/pkg/cluster"
+	"github.com/kube-vip/kube-vip/pkg/endpoints/providers"
+	"github.com/kube-vip/kube-vip/pkg/instance"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/servicecontext"
+	"github.com/kube-vip/kube-vip/pkg/vip"
+	"github.com/vishvananda/netlink"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBGPWorkerRetriesAddAfterFailedWithdrawal(t *testing.T) {
+	service := &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: "default", UID: "uid"}}
+	network := &bgpTestNetwork{ip: "10.0.0.40", cidr: "10.0.0.40/32"}
+	instances := []*instance.Instance{{
+		ServiceSnapshot: service.DeepCopy(),
+		Clusters:        []*cluster.Cluster{{Network: []vip.Network{network}}},
+	}}
+	manager := &recordingBGPRouteManager{}
+	worker := &BGP{
+		generic: generic{
+			config:    &kubevip.Config{},
+			provider:  providers.NewEndpointslices(),
+			instances: &instances,
+		},
+		bgpServer: manager,
+	}
+	svcCtx := servicecontext.New(context.Background())
+
+	if err := worker.processInstance(svcCtx, service); err != nil {
+		t.Fatalf("initial processInstance: %v", err)
+	}
+	manager.delErr = errors.New("withdrawal failed")
+	lastEndpoint := "10.0.0.2"
+	worker.clear(svcCtx, &lastEndpoint, service)
+	if svcCtx.IsNetworkConfigured(network.ip) {
+		t.Fatal("network remained configured after failed withdrawal")
+	}
+
+	if err := worker.processInstance(svcCtx, service); err != nil {
+		t.Fatalf("recovery processInstance: %v", err)
+	}
+	if manager.addCalls != 2 {
+		t.Fatalf("AddHost calls = %d, want 2", manager.addCalls)
+	}
+}
+
+type recordingBGPRouteManager struct {
+	addCalls int
+	delErr   error
+}
+
+func (m *recordingBGPRouteManager) AddHost(context.Context, string, string) error {
+	m.addCalls++
+	return nil
+}
+
+func (m *recordingBGPRouteManager) DelHost(context.Context, string, string) error {
+	return m.delErr
+}
+
+type bgpTestNetwork struct {
+	ip   string
+	cidr string
+}
+
+func (n *bgpTestNetwork) AddIP(bool, bool, ...int) (bool, error) { return false, nil }
+func (n *bgpTestNetwork) AddRoute(bool) (bool, error)            { return false, nil }
+func (n *bgpTestNetwork) ReplaceRoute() error                    { return nil }
+func (n *bgpTestNetwork) DeleteIP() (bool, error)                { return false, nil }
+func (n *bgpTestNetwork) DeleteRoute() error                     { return nil }
+func (n *bgpTestNetwork) UpdateRoutes() (bool, error)            { return false, nil }
+func (n *bgpTestNetwork) IsSet() (*netlink.Addr, error)          { return nil, nil }
+func (n *bgpTestNetwork) IP() string                             { return n.ip }
+func (n *bgpTestNetwork) CIDR() string                           { return n.cidr }
+func (n *bgpTestNetwork) IPisLinkLocal() bool                    { return false }
+func (n *bgpTestNetwork) PrepareRoute() *netlink.Route           { return nil }
+func (n *bgpTestNetwork) RouteHash() string                      { return "" }
+func (n *bgpTestNetwork) SetIP(string) error                     { return nil }
+func (n *bgpTestNetwork) SetServicePorts(*v1.Service)            {}
+func (n *bgpTestNetwork) Interface() string                      { return "" }
+func (n *bgpTestNetwork) IsDADFAIL() bool                        { return false }
+func (n *bgpTestNetwork) IsDNS() bool                            { return false }
+func (n *bgpTestNetwork) IsDDNS() bool                           { return false }
+func (n *bgpTestNetwork) DDNSHostName() string                   { return "" }
+func (n *bgpTestNetwork) DNSName() string                        { return "" }
+func (n *bgpTestNetwork) SetMask(string) error                   { return nil }
+func (n *bgpTestNetwork) SetHasEndpoints(bool)                   {}
+func (n *bgpTestNetwork) HasEndpoints() bool                     { return false }
+func (n *bgpTestNetwork) ARPName() string                        { return "" }
+func (n *bgpTestNetwork) GetPossibleSubnets() string             { return "" }
+func (n *bgpTestNetwork) DHCPFamily() string                     { return "" }
+func (n *bgpTestNetwork) IPVSMark() uint32                       { return 0 }


### PR DESCRIPTION
## Purpose

Keep the BGP host tracker synchronized with GoBGP across operation failures and daemon recovery.

## Key changes

- Always issues idempotent `AddPath` calls instead of trusting stale tracker presence.
- Updates tracker refcounts only after successful daemon operations.
- Allows advertisements to recover after failed add/delete operations or GoBGP restart.

## Validation

Adds retry and recovery regression tests. Package race tests and current CI checks pass.

## Dependency

Base: `main`. No stack dependency.