### PR TITLE
fix(endpoints): aggregate endpoints across multiple EndpointSlices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Aggregate and deduplicate backends across EndpointSlices, including correct per-slice named target ports for WireGuard services.
 - Propagate `bgp_attach_ip_to_interface` into per-service config so it attaches BGP-mode Service VIPs to the interface as configured.
 - Add a configurable kube-vip instance name and use it to isolate internal nftables egress tables, persist table ownership on Services, and migrate per-Service chains without affecting other deployments. Fixes #1634.
 - Retry on 403 Forbidden and 401 Unauthorized in `ServicesWatcher` at startup with exponential backoff. Fixes #1464.

--- a/pkg/endpoints/endpoints_wireguard.go
+++ b/pkg/endpoints/endpoints_wireguard.go
@@ -89,17 +89,9 @@ func (w *wireguardWorker) processInstance(svcCtx *servicecontext.Context, servic
 
 	// Update DNAT rules for each port
 	for _, port := range service.Spec.Ports {
-		// Determine target port (resolve named ports if necessary)
-		targetPort := w.provider.ResolvePort(port)
-		log.Info("[wireguard] resolved port", "service", service.Name, "servicePort", port.Port, "targetPort", targetPort, "targetPortName", port.TargetPort.StrVal)
-
-		// Build targets list from all endpoints
-		targets := make([]nftables.DNATTarget, len(endpoints))
-		for i, ep := range endpoints {
-			targets[i] = nftables.DNATTarget{
-				IP:   ep,
-				Port: uint16(targetPort), //nolint:gosec // Port range validated by Kubernetes
-			}
+		targets, err := w.dnatTargets(service, port)
+		if err != nil {
+			return fmt.Errorf("failed to resolve backends for service port %d: %w", port.Port, err)
 		}
 
 		for _, vip := range serviceIPs {
@@ -164,6 +156,21 @@ func (w *wireguardWorker) processInstance(svcCtx *servicecontext.Context, servic
 	}
 
 	return nil
+}
+
+func (w *wireguardWorker) dnatTargets(service *v1.Service, port v1.ServicePort) ([]nftables.DNATTarget, error) {
+	backends, err := w.provider.GetBackends(port, w.config.NodeName, service.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal)
+	if err != nil {
+		return nil, err
+	}
+	targets := make([]nftables.DNATTarget, len(backends))
+	for i, backend := range backends {
+		targets[i] = nftables.DNATTarget{
+			IP:   backend.Address,
+			Port: uint16(backend.Port), //nolint:gosec // Port range validated by Kubernetes
+		}
+	}
+	return targets, nil
 }
 
 // clear removes DNAT rules when no endpoints are available

--- a/pkg/endpoints/endpoints_wireguard_test.go
+++ b/pkg/endpoints/endpoints_wireguard_test.go
@@ -1,9 +1,16 @@
 package endpoints
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/kube-vip/kube-vip/pkg/endpoints/providers"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/nftables"
 	v1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestWireguardClearDoesNotDereferenceNilServiceContext(t *testing.T) {
@@ -11,4 +18,52 @@ func TestWireguardClearDoesNotDereferenceNilServiceContext(t *testing.T) {
 	service := &v1.Service{}
 
 	worker.clear(nil, nil, service)
+}
+
+func TestWireguardDNATTargetsPreservePerSliceNamedPorts(t *testing.T) {
+	provider := providers.NewEndpointslices()
+	name := "web"
+	firstPort, secondPort := int32(8080), int32(9090)
+	for _, slice := range []*discoveryv1.EndpointSlice{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "slice-a"},
+			Ports:      []discoveryv1.EndpointPort{{Name: &name, Port: &firstPort}},
+			Endpoints:  []discoveryv1.Endpoint{{Addresses: []string{"10.0.0.1"}}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "slice-b"},
+			Ports:      []discoveryv1.EndpointPort{{Name: &name, Port: &secondPort}},
+			Endpoints:  []discoveryv1.Endpoint{{Addresses: []string{"10.0.0.1"}}},
+		},
+	} {
+		if err := provider.LoadObject(slice, func() {}); err != nil {
+			t.Fatalf("LoadObject returned error: %v", err)
+		}
+	}
+
+	worker := &wireguardWorker{config: &kubevip.Config{}, provider: provider}
+	port := v1.ServicePort{Port: 80, Protocol: v1.ProtocolTCP, TargetPort: intstr.FromString(name)}
+	got, err := worker.dnatTargets(&v1.Service{}, port)
+	if err != nil {
+		t.Fatalf("dnatTargets returned error: %v", err)
+	}
+	want := []nftables.DNATTarget{{IP: "10.0.0.1", Port: 8080}, {IP: "10.0.0.1", Port: 9090}}
+	if !sameDNATTargets(got, want) {
+		t.Fatalf("dnatTargets = %v, want %v", got, want)
+	}
+}
+
+func sameDNATTargets(got, want []nftables.DNATTarget) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	gotSet := make(map[nftables.DNATTarget]struct{}, len(got))
+	for _, target := range got {
+		gotSet[target] = struct{}{}
+	}
+	wantSet := make(map[nftables.DNATTarget]struct{}, len(want))
+	for _, target := range want {
+		wantSet[target] = struct{}{}
+	}
+	return reflect.DeepEqual(gotSet, wantSet)
 }

--- a/pkg/endpoints/providers/endpoints.go
+++ b/pkg/endpoints/providers/endpoints.go
@@ -156,3 +156,37 @@ func (ep *Endpoints) ResolvePort(servicePort v1.ServicePort) int32 {
 		return 0
 	})
 }
+
+func (ep *Endpoints) GetBackends(servicePort v1.ServicePort, nodeName string, local bool) ([]Backend, error) {
+	seen := map[Backend]struct{}{}
+	backends := []Backend{}
+	for _, subset := range ep.endpoints.Subsets {
+		targetPort := ResolvePortWithLookup(servicePort, func(name string) int32 {
+			for _, port := range subset.Ports {
+				if port.Name == name && port.Protocol == servicePort.Protocol {
+					return port.Port
+				}
+			}
+			return 0
+		})
+		for _, address := range subset.Addresses {
+			if local && !legacyEndpointIsLocal(address, nodeName) {
+				continue
+			}
+			backend := Backend{Address: strings.Split(address.IP, "/")[0], Port: targetPort}
+			if _, ok := seen[backend]; ok {
+				continue
+			}
+			seen[backend] = struct{}{}
+			backends = append(backends, backend)
+		}
+	}
+	return backends, nil
+}
+
+func legacyEndpointIsLocal(address v1.EndpointAddress, nodeName string) bool {
+	if address.NodeName != nil {
+		return *address.NodeName == nodeName
+	}
+	return address.Hostname == nodeName
+}

--- a/pkg/endpoints/providers/endpointslices.go
+++ b/pkg/endpoints/providers/endpointslices.go
@@ -88,12 +88,19 @@ func isServing(conditions discoveryv1.EndpointConditions) bool {
 
 func (ep *Endpointslices) GetAllEndpoints() ([]string, error) {
 	result := []string{}
+	seen := map[string]struct{}{}
 	for _, eps := range ep.slices {
 		for _, e := range eps.Endpoints {
 			if !isServing(e.Conditions) {
 				continue
 			}
-			result = append(result, e.Addresses...)
+			for _, address := range e.Addresses {
+				if _, ok := seen[address]; ok {
+					continue
+				}
+				seen[address] = struct{}{}
+				result = append(result, address)
+			}
 		}
 	}
 	return result, nil
@@ -101,12 +108,16 @@ func (ep *Endpointslices) GetAllEndpoints() ([]string, error) {
 
 func (ep *Endpointslices) GetLocalEndpoints(id string, _ *kubevip.Config) ([]string, error) {
 	var localEndpoints []string
+	seen := map[string]struct{}{}
 	for _, eps := range ep.slices {
 		for _, endpoint := range eps.Endpoints {
 			if !isServing(endpoint.Conditions) {
 				continue
 			}
 			for _, address := range endpoint.Addresses {
+				if _, ok := seen[address]; ok {
+					continue
+				}
 				// 1. Compare the Nodename
 				if endpoint.NodeName != nil && id == *endpoint.NodeName {
 					if endpoint.Hostname != nil {
@@ -115,6 +126,7 @@ func (ep *Endpointslices) GetLocalEndpoints(id string, _ *kubevip.Config) ([]str
 						log.Debug("found endpoint", "provider", ep.label, "ip", address, "nodename", *endpoint.NodeName)
 					}
 					localEndpoints = append(localEndpoints, address)
+					seen[address] = struct{}{}
 					continue
 				}
 
@@ -122,6 +134,7 @@ func (ep *Endpointslices) GetLocalEndpoints(id string, _ *kubevip.Config) ([]str
 				if endpoint.NodeName == nil && endpoint.Hostname != nil && id == *endpoint.Hostname {
 					log.Debug("found endpoint", "provider", ep.label, "ip", address, "hostname", *endpoint.Hostname)
 					localEndpoints = append(localEndpoints, address)
+					seen[address] = struct{}{}
 				}
 			}
 		}
@@ -176,4 +189,47 @@ func (ep *Endpointslices) ResolvePort(servicePort v1.ServicePort) int32 {
 		}
 		return 0
 	})
+}
+
+func (ep *Endpointslices) GetBackends(servicePort v1.ServicePort, nodeName string, local bool) ([]Backend, error) {
+	seen := map[Backend]struct{}{}
+	backends := []Backend{}
+	for _, eps := range ep.slices {
+		targetPort := ResolvePortWithLookup(servicePort, func(name string) int32 {
+			for _, port := range eps.Ports {
+				if port.Name != nil && *port.Name == name && port.Port != nil && endpointPortProtocol(port) == servicePort.Protocol {
+					return *port.Port
+				}
+			}
+			return 0
+		})
+		for _, endpoint := range eps.Endpoints {
+			if !isServing(endpoint.Conditions) || (local && !endpointIsLocal(endpoint, nodeName)) {
+				continue
+			}
+			for _, address := range endpoint.Addresses {
+				backend := Backend{Address: address, Port: targetPort}
+				if _, ok := seen[backend]; ok {
+					continue
+				}
+				seen[backend] = struct{}{}
+				backends = append(backends, backend)
+			}
+		}
+	}
+	return backends, nil
+}
+
+func endpointIsLocal(endpoint discoveryv1.Endpoint, nodeName string) bool {
+	if endpoint.NodeName != nil {
+		return *endpoint.NodeName == nodeName
+	}
+	return endpoint.Hostname != nil && *endpoint.Hostname == nodeName
+}
+
+func endpointPortProtocol(port discoveryv1.EndpointPort) v1.Protocol {
+	if port.Protocol == nil {
+		return v1.ProtocolTCP
+	}
+	return *port.Protocol
 }

--- a/pkg/endpoints/providers/endpointslices_test.go
+++ b/pkg/endpoints/providers/endpointslices_test.go
@@ -75,6 +75,34 @@ func TestEndpointslicesReplacingSliceUpdatesState(t *testing.T) {
 	assertEndpoints(t, provider, []string{"10.0.0.2"})
 }
 
+func TestEndpointslicesDeduplicatesAddressesAcrossSlices(t *testing.T) {
+	provider := NewEndpointslices().(*Endpointslices)
+	nodeName := "node-1"
+	for _, name := range []string{"slice-1", "slice-2"} {
+		if err := provider.LoadObject(&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Endpoints:  []discoveryv1.Endpoint{{Addresses: []string{"10.0.0.1"}, NodeName: &nodeName}},
+		}, func() {}); err != nil {
+			t.Fatalf("LoadObject returned error: %v", err)
+		}
+	}
+
+	got, err := provider.GetAllEndpoints()
+	if err != nil {
+		t.Fatalf("GetAllEndpoints returned error: %v", err)
+	}
+	if len(got) != 1 || got[0] != "10.0.0.1" {
+		t.Fatalf("GetAllEndpoints = %v (length %d), want one deduplicated endpoint", got, len(got))
+	}
+	local, err := provider.GetLocalEndpoints(nodeName, &kubevip.Config{})
+	if err != nil {
+		t.Fatalf("GetLocalEndpoints returned error: %v", err)
+	}
+	if len(local) != 1 || local[0] != "10.0.0.1" {
+		t.Fatalf("GetLocalEndpoints = %v (length %d), want one deduplicated endpoint", local, len(local))
+	}
+}
+
 func TestEndpointslicesEndpointConditions(t *testing.T) {
 	yes, no := true, false
 	nodeName := "node-1"
@@ -134,6 +162,9 @@ func assertLocalEndpoints(t *testing.T, provider *Endpointslices, nodeName strin
 
 func assertStringSet(t *testing.T, got, want []string) {
 	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("endpoint length mismatch: got %v, want %v", got, want)
+	}
 	counts := map[string]int{}
 	for _, value := range got {
 		counts[value]++

--- a/pkg/endpoints/providers/interface.go
+++ b/pkg/endpoints/providers/interface.go
@@ -23,6 +23,13 @@ type Provider interface {
 	// For named ports, it looks up the port number from the endpoint.
 	// For numeric ports, it returns the port as-is.
 	ResolvePort(servicePort v1.ServicePort) int32
+	GetBackends(servicePort v1.ServicePort, nodeName string, local bool) ([]Backend, error)
+}
+
+// Backend identifies an endpoint and the target port exposed by its backing object.
+type Backend struct {
+	Address string
+	Port    int32
 }
 
 // ResolvePortWithLookup is a helper that resolves a service port using a lookup function

--- a/pkg/endpoints/providers/providers_test.go
+++ b/pkg/endpoints/providers/providers_test.go
@@ -213,6 +213,85 @@ func TestResolvePortWithLookup(t *testing.T) {
 	}
 }
 
+func TestEndpointSliceBackendsPreservePerSliceNamedPorts(t *testing.T) {
+	provider := NewEndpointslices()
+	portName := "web"
+	servicePort := v1.ServicePort{Port: 80, Protocol: v1.ProtocolTCP, TargetPort: intstr.FromString(portName)}
+	firstPort, secondPort := int32(8080), int32(9090)
+	first := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "slice-a"},
+		Ports:      []discoveryv1.EndpointPort{{Name: &portName, Port: &firstPort}},
+		Endpoints:  []discoveryv1.Endpoint{{Addresses: []string{"10.0.0.1"}}},
+	}
+	second := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "slice-b"},
+		Ports:      []discoveryv1.EndpointPort{{Name: &portName, Port: &secondPort}},
+		Endpoints:  []discoveryv1.Endpoint{{Addresses: []string{"10.0.0.1"}}},
+	}
+	for _, slice := range []*discoveryv1.EndpointSlice{first, second} {
+		if err := provider.LoadObject(slice, func() {}); err != nil {
+			t.Fatalf("LoadObject returned error: %v", err)
+		}
+	}
+
+	assertBackends(t, provider, servicePort, []Backend{{Address: "10.0.0.1", Port: 8080}, {Address: "10.0.0.1", Port: 9090}})
+
+	if err := provider.DeleteObject(first); err != nil {
+		t.Fatalf("DeleteObject returned error: %v", err)
+	}
+	assertBackends(t, provider, servicePort, []Backend{{Address: "10.0.0.1", Port: 9090}})
+
+	replacement := second.DeepCopy()
+	replacementPort := int32(9091)
+	replacement.Ports[0].Port = &replacementPort
+	replacement.Endpoints[0].Addresses = []string{"10.0.0.3"}
+	if err := provider.LoadObject(replacement, func() {}); err != nil {
+		t.Fatalf("LoadObject replacement returned error: %v", err)
+	}
+	assertBackends(t, provider, servicePort, []Backend{{Address: "10.0.0.3", Port: 9091}})
+}
+
+func TestLegacyEndpointsDeleteClearsNamedPortBackends(t *testing.T) {
+	provider := NewEndpoints()
+	//nolint:staticcheck // legacy Endpoints cleanup is the subject under test
+	object := &v1.Endpoints{Subsets: []v1.EndpointSubset{{
+		Addresses: []v1.EndpointAddress{{IP: "10.0.0.1"}},
+		Ports:     []v1.EndpointPort{{Name: "web", Port: 8080, Protocol: v1.ProtocolTCP}},
+	}}}
+	servicePort := v1.ServicePort{Port: 80, Protocol: v1.ProtocolTCP, TargetPort: intstr.FromString("web")}
+	if err := provider.LoadObject(object, func() {}); err != nil {
+		t.Fatalf("LoadObject returned error: %v", err)
+	}
+	assertBackends(t, provider, servicePort, []Backend{{Address: "10.0.0.1", Port: 8080}})
+	if err := provider.DeleteObject(object); err != nil {
+		t.Fatalf("DeleteObject returned error: %v", err)
+	}
+	assertBackends(t, provider, servicePort, nil)
+	if got := provider.ResolvePort(servicePort); got != servicePort.Port {
+		t.Fatalf("ResolvePort after delete = %d, want service port fallback %d", got, servicePort.Port)
+	}
+}
+
+func assertBackends(t *testing.T, provider Provider, servicePort v1.ServicePort, want []Backend) {
+	t.Helper()
+	got, err := provider.GetBackends(servicePort, "", false)
+	if err != nil {
+		t.Fatalf("GetBackends returned error: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("GetBackends = %v (length %d), want %v (length %d)", got, len(got), want, len(want))
+	}
+	gotSet := make(map[Backend]struct{}, len(got))
+	for _, backend := range got {
+		gotSet[backend] = struct{}{}
+	}
+	for _, backend := range want {
+		if _, ok := gotSet[backend]; !ok {
+			t.Fatalf("GetBackends = %v, missing %v", got, backend)
+		}
+	}
+}
+
 func endpointSet(endpoints []string) map[string]struct{} {
 	result := make(map[string]struct{}, len(endpoints))
 	for _, endpoint := range endpoints {


### PR DESCRIPTION
## Purpose

Keep complete endpoint state when a Service spans multiple EndpointSlices.

## Key changes

- Stores endpoints by slice name and aggregates them by address family.
- Removes only the deleted slice contribution and preserves dual-stack and named-port behavior.
- Adds a shared provider conformance suite for legacy Endpoints and EndpointSlices, including replacement and cleanup.

## Validation

`go test ./pkg/endpoints/providers ./pkg/endpoints ./pkg/services` and the corresponding `-race` run passed in Debian Bookworm ARM64 Linux. Current CI checks pass.

## Dependency

Base: `main`. No stack dependency.