### PR TITLE
fix(vip): apply per-call DAD skip instead of leaking it into persistent state

### DIFF
--- a/pkg/endpoints/endpoints_wireguard_test.go
+++ b/pkg/endpoints/endpoints_wireguard_test.go
@@ -6,7 +6,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-func TestWireguardDeleteDoesNotDereferenceNilServiceContext(t *testing.T) {
+func TestWireguardClearDoesNotDereferenceNilServiceContext(t *testing.T) {
 	worker := &wireguardWorker{}
 	service := &v1.Service{}
 

--- a/pkg/vip/address.go
+++ b/pkg/vip/address.go
@@ -469,9 +469,13 @@ func (configurator *network) AddIP(precheck bool, skipDAD bool, minLifetime ...i
 	// an address that we know should be ours (e.g., after DADFAILED recovery).
 	// We also allow to globally configure NODAD in case user knows they are running in an
 	// environment where multiple nodes may advertise the same VIP (e.g., ECMP routing).
-	if configurator.shouldSkipDAD(skipDAD) && utils.IsIPv6(configurator.address.IP.String()) {
-		configurator.address.Flags |= unix.IFA_F_NODAD
-		log.Debug("Setting IFA_F_NODAD flag for IPv6 address to skip DAD", "ip", configurator.address.IP.String())
+	if utils.IsIPv6(configurator.address.IP.String()) {
+		if configurator.shouldSkipDAD(skipDAD) {
+			configurator.address.Flags |= unix.IFA_F_NODAD
+			log.Debug("Setting IFA_F_NODAD flag for IPv6 address to skip DAD", "ip", configurator.address.IP.String())
+		} else {
+			configurator.address.Flags &^= unix.IFA_F_NODAD
+		}
 	}
 
 	log.Debug("replacing IP", "address", configurator.address)

--- a/pkg/vip/address_dad_linux_test.go
+++ b/pkg/vip/address_dad_linux_test.go
@@ -1,0 +1,37 @@
+//go:build linux
+
+package vip
+
+import (
+	"testing"
+
+	"github.com/kube-vip/kube-vip/pkg/networkinterface"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+func TestAddIPPerCallDADSkipDoesNotPersist(t *testing.T) {
+	address, err := netlink.ParseAddr("2001:db8::10/128")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configurator := &network{
+		address: address,
+		link: &networkinterface.Link{
+			Intf: &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "kube-vip-dad-test"}},
+		},
+	}
+
+	// The netlink operation may fail without CAP_NET_ADMIN, but the address
+	// flags are set before that operation and are what this test exercises.
+	_, _ = configurator.AddIP(false, true)
+	if configurator.address.Flags&unix.IFA_F_NODAD == 0 {
+		t.Fatal("skipDAD=true did not set IFA_F_NODAD")
+	}
+
+	_, _ = configurator.AddIP(false, false)
+	if configurator.address.Flags&unix.IFA_F_NODAD != 0 {
+		t.Fatal("IFA_F_NODAD persisted into a normal AddIP call")
+	}
+}


### PR DESCRIPTION
## Bug
`AddIP` only ever OR-ed `IFA_F_NODAD` onto the long-lived `configurator.address.Flags` when a per-call DAD skip was requested, and never cleared it. A transient DADFAILED-recovery call (`AddIP(_, true)`) therefore permanently disabled DAD for that VIP; a later normal `AddIP(_, false)` kept the stale NODAD flag, silently skipping DAD against the operator's `dadSkip=false` configuration.

## Fix
Set or clear `IFA_F_NODAD` to reflect the current call rather than only OR-ing it. Adds `TestAddIPPerCallDADSkipDoesNotPersist`.

Found during the kube-vip test-coverage/bug-bash effort; adversarially confirmed and bidirectionally validated (repro test passes with the fix, fails when reverted). No unrelated changes.

## Rebase / CI note

Rebased onto current upstream `main` at `b684eed`. This branch also carries the signed WireGuard test correction from [#1739](https://github.com/kube-vip/kube-vip/pull/1739), because the current base test otherwise fails to compile; that duplicate prerequisite can be dropped after #1739 lands.