### PR TITLE
fix(cluster): close BGP health-check bodies and withdraw CP route on cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Drain control-plane health-check responses for HTTP connection reuse and reliably withdraw BGP routes during shutdown.
 - Propagate `bgp_attach_ip_to_interface` into per-service config so it attaches BGP-mode Service VIPs to the interface as configured.
 - Add a configurable kube-vip instance name and use it to isolate internal nftables egress tables, persist table ownership on Services, and migrate per-Service chains without affecting other deployments. Fixes #1634.
 - Retry on 403 Forbidden and 401 Unauthorized in `ServicesWatcher` at startup with exponential backoff. Fixes #1464.

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"net/http"
 	"net/url"
@@ -209,6 +210,7 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 						} else if resp, doErr := cluster.healthCheckHTTPClient.Do(req); doErr != nil {
 							log.Error("health check request failed", "url", c.ControlPlaneHealthCheck.Address, "err", doErr)
 						} else {
+							_, _ = io.Copy(io.Discard, resp.Body)
 							resp.Body.Close()
 							healthy = resp.StatusCode == http.StatusOK
 							if !healthy {
@@ -282,6 +284,16 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 
 	if c.EnableBGP {
 		<-ctx.Done()
+		if c.ControlPlaneHealthCheck.Address == "" {
+			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+			defer cancel()
+			for i := range cluster.Network {
+				network := cluster.Network[i]
+				if err := bgpServer.DelHost(cleanupCtx, network.CIDR(), c.NodeName); err != nil {
+					log.Error("failed to withdraw route", "address", network.CIDR(), "error", err)
+				}
+			}
+		}
 	}
 
 	return nil
@@ -294,6 +306,16 @@ func (cluster *Cluster) bgpHealthCheckLoop(ctx context.Context, c *kubevip.Confi
 	routeAnnounced := false
 	ticker := time.NewTicker(period)
 	defer ticker.Stop()
+	withdrawOnCancel := func() {
+		if !routeAnnounced {
+			return
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		if err := bgpServer.DelHost(cleanupCtx, vipCIDR, c.NodeName); err != nil {
+			log.Error("BGP health check: failed to withdraw route", "cidr", vipCIDR, "err", err)
+		}
+	}
 
 	log.Info("Starting BGP health check",
 		"address", c.ControlPlaneHealthCheck.Address,
@@ -315,9 +337,14 @@ func (cluster *Cluster) bgpHealthCheckLoop(ctx context.Context, c *kubevip.Confi
 			if err != nil {
 				healthErr = err
 			} else {
-				defer resp.Body.Close()
 				statusCode = resp.StatusCode
+				_, _ = io.Copy(io.Discard, resp.Body)
+				resp.Body.Close()
 			}
+		}
+		if ctx.Err() != nil {
+			withdrawOnCancel()
+			return
 		}
 
 		healthy := healthErr == nil && statusCode == http.StatusOK
@@ -352,11 +379,7 @@ func (cluster *Cluster) bgpHealthCheckLoop(ctx context.Context, c *kubevip.Confi
 
 		select {
 		case <-ctx.Done():
-			if routeAnnounced {
-				if err := bgpServer.DelHost(ctx, vipCIDR, c.NodeName); err != nil {
-					log.Error("BGP health check: failed to withdraw route", "cidr", vipCIDR, "err", err)
-				}
-			}
+			withdrawOnCancel()
 			return
 		case <-ticker.C:
 		}

--- a/pkg/cluster/service_bodyleak_internal_test.go
+++ b/pkg/cluster/service_bodyleak_internal_test.go
@@ -1,0 +1,132 @@
+package cluster
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+)
+
+type testRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f testRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type trackedResponseBody struct {
+	reader  *bytes.Reader
+	readEOF bool
+	closed  chan<- bool
+}
+
+func (b *trackedResponseBody) Read(p []byte) (int, error) {
+	n, err := b.reader.Read(p)
+	if err == io.EOF {
+		b.readEOF = true
+	}
+	return n, err
+}
+
+func (b *trackedResponseBody) Close() error {
+	b.closed <- b.readEOF
+	return nil
+}
+
+type testHealthRouteManager struct{}
+
+func (testHealthRouteManager) AddHost(context.Context, string, string) error { return nil }
+
+func (testHealthRouteManager) DelHost(context.Context, string, string) error { return nil }
+
+func TestBGPHealthCheckLoopDrainsAndClosesResponseBodyPerPoll(t *testing.T) {
+	closed := make(chan bool, 1)
+	client := &http.Client{
+		Transport: testRoundTripper(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body: &trackedResponseBody{
+					reader: bytes.NewReader([]byte("health response")),
+					closed: closed,
+				},
+				Header:  make(http.Header),
+				Request: req,
+			}, nil
+		}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		(&Cluster{healthCheckHTTPClient: client}).bgpHealthCheckLoop(ctx, testHealthConfig("http://health.test/readyz"), testHealthRouteManager{}, "10.0.0.34/32")
+		close(done)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+
+	select {
+	case drained := <-closed:
+		if !drained {
+			t.Fatal("health-check response body was closed before reaching EOF")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("health-check response body was not closed")
+	}
+}
+
+func TestBGPHealthCheckLoopReusesConnection(t *testing.T) {
+	requests := make(chan struct{}, 2)
+	var connections atomic.Int64
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "health response")
+		requests <- struct{}{}
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			connections.Add(1)
+		}
+	}
+	server.Start()
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		(&Cluster{healthCheckHTTPClient: server.Client()}).bgpHealthCheckLoop(ctx, testHealthConfig(server.URL), testHealthRouteManager{}, "10.0.0.34/32")
+		close(done)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+
+	for range 2 {
+		select {
+		case <-requests:
+		case <-time.After(2 * time.Second):
+			t.Fatal("health check did not complete two requests")
+		}
+	}
+	if got := connections.Load(); got != 1 {
+		t.Fatalf("health checks used %d connections, want 1", got)
+	}
+}
+
+func testHealthConfig(address string) *kubevip.Config {
+	return &kubevip.Config{
+		NodeName: "cp-node-1",
+		ControlPlaneHealthCheck: kubevip.HealthCheck{
+			Address:          address,
+			PeriodSeconds:    1,
+			FailureThreshold: 1,
+		},
+	}
+}

--- a/pkg/cluster/service_cpwithdraw_test.go
+++ b/pkg/cluster/service_cpwithdraw_test.go
@@ -1,0 +1,27 @@
+package cluster_test
+
+import (
+	"testing"
+
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+)
+
+func TestStartVipService_WithdrawsStaticRouteOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	bgpManager := newMockBGPRouteManager()
+	cfg := &kubevip.Config{
+		EnableBGP: true,
+		NodeName:  "cp-node-1",
+	}
+	cancelContext, _ := startVipService(t, cfg, bgpManager)
+
+	expectEventually(t, bgpManager.isAnnounced, "route should be announced")
+	cancelContext()
+
+	withdrawal := bgpManager.waitForWithdrawal(t)
+	assertCleanupContext(t, withdrawal)
+	if bgpManager.isAnnounced() {
+		t.Fatal("static BGP route remained announced after service context cancellation")
+	}
+}

--- a/pkg/cluster/service_cpwithdraw_test.go
+++ b/pkg/cluster/service_cpwithdraw_test.go
@@ -14,7 +14,7 @@ func TestStartVipService_WithdrawsStaticRouteOnContextCancel(t *testing.T) {
 		EnableBGP: true,
 		NodeName:  "cp-node-1",
 	}
-	cancelContext, _ := startVipService(t, cfg, bgpManager)
+	cancelContext := startVipService(t, cfg, bgpManager)
 
 	expectEventually(t, bgpManager.isAnnounced, "route should be announced")
 	cancelContext()

--- a/pkg/cluster/service_test.go
+++ b/pkg/cluster/service_test.go
@@ -100,7 +100,7 @@ func TestBGPHealthCheckLoop_StopsOnContextCancel(t *testing.T) {
 	t.Cleanup(healthcheck.server.Close)
 
 	bgpManager := newMockBGPRouteManager()
-	cancelContext, _ := startVipService(t, newTestConfig(healthcheck.server.URL, healthcheck.caPath), bgpManager)
+	cancelContext := startVipService(t, newTestConfig(healthcheck.server.URL, healthcheck.caPath), bgpManager)
 
 	expectEventually(t, func() bool { return bgpManager.isAnnounced() },
 		"route should be announced")
@@ -195,7 +195,7 @@ func (e *testError) Error() string { return e.msg }
 // startVipService launches vipService in a goroutine with a mock network and
 // registers a cleanup to cancel the context and wait for it to finish.
 // Uses InitCluster so the real code parses certs for the BGP health check client.
-func startVipService(t *testing.T, cfg *kubevip.Config, bgpManager *mockBGPRouteManager) (context.CancelFunc, <-chan struct{}) {
+func startVipService(t *testing.T, cfg *kubevip.Config, bgpManager *mockBGPRouteManager) context.CancelFunc {
 	t.Helper()
 
 	c, err := cluster.InitCluster(cfg, true, nil, nil, nil, nil)
@@ -217,7 +217,7 @@ func startVipService(t *testing.T, cfg *kubevip.Config, bgpManager *mockBGPRoute
 		<-done
 	})
 
-	return cancel, done
+	return cancel
 }
 
 // startRoutingTableVipService launches vipService in routing-table mode with a

--- a/pkg/cluster/service_test.go
+++ b/pkg/cluster/service_test.go
@@ -100,17 +100,17 @@ func TestBGPHealthCheckLoop_StopsOnContextCancel(t *testing.T) {
 	t.Cleanup(healthcheck.server.Close)
 
 	bgpManager := newMockBGPRouteManager()
-	cancelContext, vipServiceDone := startVipService(t, newTestConfig(healthcheck.server.URL, healthcheck.caPath), bgpManager)
+	cancelContext, _ := startVipService(t, newTestConfig(healthcheck.server.URL, healthcheck.caPath), bgpManager)
 
 	expectEventually(t, func() bool { return bgpManager.isAnnounced() },
 		"route should be announced")
 
 	cancelContext()
 
-	select {
-	case <-vipServiceDone:
-	case <-time.After(5 * time.Second):
-		t.Fatal("vipService did not stop after context cancellation")
+	withdrawal := bgpManager.waitForWithdrawal(t)
+	assertCleanupContext(t, withdrawal)
+	if bgpManager.isAnnounced() {
+		t.Fatal("health-checked BGP route remained announced after context cancellation")
 	}
 }
 
@@ -274,10 +274,19 @@ type mockBGPRouteManager struct {
 	announced map[string]bool
 	addErr    error
 	delErr    error
+	withdrawn chan withdrawalCall
+}
+
+type withdrawalCall struct {
+	contextErr  error
+	hasDeadline bool
 }
 
 func newMockBGPRouteManager() *mockBGPRouteManager {
-	return &mockBGPRouteManager{announced: make(map[string]bool)}
+	return &mockBGPRouteManager{
+		announced: make(map[string]bool),
+		withdrawn: make(chan withdrawalCall, 10),
+	}
 }
 
 func (m *mockBGPRouteManager) AddHost(_ context.Context, addr string, _ string) error {
@@ -290,14 +299,39 @@ func (m *mockBGPRouteManager) AddHost(_ context.Context, addr string, _ string) 
 	return nil
 }
 
-func (m *mockBGPRouteManager) DelHost(_ context.Context, addr string, _ string) error {
+func (m *mockBGPRouteManager) DelHost(ctx context.Context, addr string, _ string) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.delErr != nil {
-		return m.delErr
+	delErr := m.delErr
+	if delErr != nil {
+		m.mu.Unlock()
+		return delErr
 	}
 	delete(m.announced, addr)
+	m.mu.Unlock()
+	_, hasDeadline := ctx.Deadline()
+	m.withdrawn <- withdrawalCall{contextErr: ctx.Err(), hasDeadline: hasDeadline}
 	return nil
+}
+
+func (m *mockBGPRouteManager) waitForWithdrawal(t *testing.T) withdrawalCall {
+	t.Helper()
+	select {
+	case call := <-m.withdrawn:
+		return call
+	case <-time.After(5 * time.Second):
+		t.Fatal("route was not withdrawn")
+		return withdrawalCall{}
+	}
+}
+
+func assertCleanupContext(t *testing.T, call withdrawalCall) {
+	t.Helper()
+	if call.contextErr != nil {
+		t.Fatalf("withdrawal received canceled context: %v", call.contextErr)
+	}
+	if !call.hasDeadline {
+		t.Fatal("withdrawal context has no cleanup deadline")
+	}
 }
 
 func (m *mockBGPRouteManager) isAnnounced() bool {


### PR DESCRIPTION
## Purpose

Prevent BGP health-check connection leaks and stale control-plane advertisements after leadership loss.

## Key changes

- Closes each health-check response body within its polling iteration.
- Withdraws statically announced control-plane CIDRs when the service context is canceled.
- Covers per-poll body closure and static-route withdrawal.

## Validation

Regression tests pass, together with unit, integration, lint, CodeQL, and E2E checks.

## Dependency

Base: `main`. No stack dependency.