### PR TITLE
fix(nftables): bounds-check and handle unknown expr types in ruleEqual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Compare nftables rules safely while ignoring transient lookup IDs and counter statistics.
 - Propagate `bgp_attach_ip_to_interface` into per-service config so it attaches BGP-mode Service VIPs to the interface as configured.
 - Add a configurable kube-vip instance name and use it to isolate internal nftables egress tables, persist table ownership on Services, and migrate per-Service chains without affecting other deployments. Fixes #1634.
 - Retry on 403 Forbidden and 401 Unauthorized in `ServicesWatcher` at startup with exponential backoff. Fixes #1464.

--- a/pkg/nftables/client.go
+++ b/pkg/nftables/client.go
@@ -320,6 +320,9 @@ func ruleEqual(a, b *nftables.Rule) bool {
 	if !bytes.Equal(a.UserData, b.UserData) {
 		return false
 	}
+	if len(a.Exprs) != len(b.Exprs) {
+		return false
+	}
 
 	for i := range a.Exprs {
 		switch a.Exprs[i].(type) {
@@ -349,6 +352,10 @@ func ruleEqual(a, b *nftables.Rule) bool {
 			}
 		case *expr.Bitwise:
 			if !exprEqual(&expr.Bitwise{}, a.Exprs[i], b.Exprs[i]) {
+				return false
+			}
+		default:
+			if !reflect.DeepEqual(a.Exprs[i], b.Exprs[i]) {
 				return false
 			}
 		}

--- a/pkg/nftables/client.go
+++ b/pkg/nftables/client.go
@@ -325,13 +325,27 @@ func ruleEqual(a, b *nftables.Rule) bool {
 	}
 
 	for i := range a.Exprs {
-		switch a.Exprs[i].(type) {
+		switch aExpr := a.Exprs[i].(type) {
 		case *expr.Meta:
 			if !exprEqual(&expr.Meta{}, a.Exprs[i], b.Exprs[i]) {
 				return false
 			}
 		case *expr.Lookup:
-			if !exprEqual(&expr.Lookup{}, a.Exprs[i], b.Exprs[i]) {
+			bExpr, ok := b.Exprs[i].(*expr.Lookup)
+			if !ok || (aExpr == nil) != (bExpr == nil) {
+				return false
+			}
+			if aExpr == nil {
+				continue
+			}
+			aLookup, bLookup := *aExpr, *bExpr
+			aLookup.SetID = 0
+			bLookup.SetID = 0
+			if !reflect.DeepEqual(aLookup, bLookup) {
+				return false
+			}
+		case *expr.Counter:
+			if _, ok := b.Exprs[i].(*expr.Counter); !ok {
 				return false
 			}
 		case *expr.Verdict:

--- a/pkg/nftables/client_ruleequal_test.go
+++ b/pkg/nftables/client_ruleequal_test.go
@@ -1,0 +1,57 @@
+package nftables
+
+import (
+	"testing"
+
+	googlenftables "github.com/google/nftables"
+	"github.com/google/nftables/expr"
+)
+
+func TestRuleEqualRejectsRulesThatDiffer(t *testing.T) {
+	// DEFECT: ruleEqual indexes the second expression slice without checking its length and ignores expression types it does not enumerate (pkg/nftables/client.go:324).
+	table := &googlenftables.Table{Name: "kube_vip_v4"}
+	chain := &googlenftables.Chain{Name: "kube_vip_snat_service", Table: table}
+
+	tests := []struct {
+		name string
+		a    *googlenftables.Rule
+		b    *googlenftables.Rule
+	}{
+		{
+			name: "different expression lengths",
+			a: &googlenftables.Rule{
+				Table: table,
+				Chain: chain,
+				Exprs: []expr.Any{&expr.Meta{Key: expr.MetaKeyL4PROTO}},
+			},
+			b: &googlenftables.Rule{Table: table, Chain: chain},
+		},
+		{
+			name: "unsupported expression values",
+			a: &googlenftables.Rule{
+				Table: table,
+				Chain: chain,
+				Exprs: []expr.Any{&expr.NAT{Type: expr.NATTypeSourceNAT}},
+			},
+			b: &googlenftables.Rule{
+				Table: table,
+				Chain: chain,
+				Exprs: []expr.Any{&expr.NAT{Type: expr.NATTypeDestNAT}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					t.Fatalf("ruleEqual panicked for unequal rules: %v", recovered)
+				}
+			}()
+
+			if ruleEqual(tt.a, tt.b) {
+				t.Fatal("ruleEqual reported unequal rules as equal")
+			}
+		})
+	}
+}

--- a/pkg/nftables/client_ruleequal_test.go
+++ b/pkg/nftables/client_ruleequal_test.go
@@ -7,37 +7,66 @@ import (
 	"github.com/google/nftables/expr"
 )
 
-func TestRuleEqualRejectsRulesThatDiffer(t *testing.T) {
-	// DEFECT: ruleEqual indexes the second expression slice without checking its length and ignores expression types it does not enumerate (pkg/nftables/client.go:324).
+func TestRuleEqualExpressions(t *testing.T) {
 	table := &googlenftables.Table{Name: "kube_vip_v4"}
 	chain := &googlenftables.Chain{Name: "kube_vip_snat_service", Table: table}
+	rule := func(expressions ...expr.Any) *googlenftables.Rule {
+		return &googlenftables.Rule{Table: table, Chain: chain, Exprs: expressions}
+	}
 
 	tests := []struct {
-		name string
-		a    *googlenftables.Rule
-		b    *googlenftables.Rule
+		name  string
+		a     *googlenftables.Rule
+		b     *googlenftables.Rule
+		equal bool
 	}{
 		{
-			name: "different expression lengths",
-			a: &googlenftables.Rule{
-				Table: table,
-				Chain: chain,
-				Exprs: []expr.Any{&expr.Meta{Key: expr.MetaKeyL4PROTO}},
-			},
-			b: &googlenftables.Rule{Table: table, Chain: chain},
+			name: "first rule has more expressions",
+			a:    rule(&expr.Meta{Key: expr.MetaKeyL4PROTO}),
+			b:    rule(),
 		},
 		{
-			name: "unsupported expression values",
-			a: &googlenftables.Rule{
-				Table: table,
-				Chain: chain,
-				Exprs: []expr.Any{&expr.NAT{Type: expr.NATTypeSourceNAT}},
-			},
-			b: &googlenftables.Rule{
-				Table: table,
-				Chain: chain,
-				Exprs: []expr.Any{&expr.NAT{Type: expr.NATTypeDestNAT}},
-			},
+			name: "second rule has more expressions",
+			a:    rule(),
+			b:    rule(&expr.Meta{Key: expr.MetaKeyL4PROTO}),
+		},
+		{
+			name:  "counter runtime state is ignored",
+			a:     rule(&expr.Counter{Bytes: 10, Packets: 1}),
+			b:     rule(&expr.Counter{Bytes: 20, Packets: 2}),
+			equal: true,
+		},
+		{
+			name: "counter type mismatch",
+			a:    rule(&expr.Counter{}),
+			b:    rule(&expr.Meta{}),
+		},
+		{
+			name:  "lookup transient set ID is ignored",
+			a:     rule(&expr.Lookup{SourceRegister: 1, DestRegister: 2, IsDestRegSet: true, SetID: 10, SetName: "service-map", Invert: true}),
+			b:     rule(&expr.Lookup{SourceRegister: 1, DestRegister: 2, IsDestRegSet: true, SetID: 20, SetName: "service-map", Invert: true}),
+			equal: true,
+		},
+		{
+			name: "lookup semantic fields differ",
+			a:    rule(&expr.Lookup{SourceRegister: 1, SetID: 10, SetName: "service-set"}),
+			b:    rule(&expr.Lookup{SourceRegister: 2, SetID: 10, SetName: "service-set"}),
+		},
+		{
+			name: "lookup type mismatch",
+			a:    rule(&expr.Lookup{}),
+			b:    rule(&expr.Meta{}),
+		},
+		{
+			name: "unknown expression values differ",
+			a:    rule(&expr.NAT{Type: expr.NATTypeSourceNAT}),
+			b:    rule(&expr.NAT{Type: expr.NATTypeDestNAT}),
+		},
+		{
+			name:  "unknown expression values match",
+			a:     rule(&expr.NAT{Type: expr.NATTypeSourceNAT}),
+			b:     rule(&expr.NAT{Type: expr.NATTypeSourceNAT}),
+			equal: true,
 		},
 	}
 
@@ -49,8 +78,8 @@ func TestRuleEqualRejectsRulesThatDiffer(t *testing.T) {
 				}
 			}()
 
-			if ruleEqual(tt.a, tt.b) {
-				t.Fatal("ruleEqual reported unequal rules as equal")
+			if got := ruleEqual(tt.a, tt.b); got != tt.equal {
+				t.Fatalf("ruleEqual() = %t, want %t", got, tt.equal)
 			}
 		})
 	}


### PR DESCRIPTION
## Purpose

Make nftables rule comparison safe and correct for differing or previously unhandled expressions.

## Key changes

- Rejects rules with different expression counts before indexing.
- Uses deep equality for expression types not covered by specialized comparisons.
- Prevents panics and incorrect equality in unique-rule and existence checks.

## Validation

Adds `TestRuleEqualRejectsRulesThatDiffer`. Unit, integration, lint, CodeQL, and E2E checks pass.

## Dependency

Base: `main`. No stack dependency.