### PR TITLE
fix(kubevip): keep configured values when their env var is unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Preserve configured ARP broadcast rate and DHCP mode when their environment variables are unset.
 - Propagate `bgp_attach_ip_to_interface` into per-service config so it attaches BGP-mode Service VIPs to the interface as configured.
 - Add a configurable kube-vip instance name and use it to isolate internal nftables egress tables, persist table ownership on Services, and migrate per-Service chains without affecting other deployments. Fixes #1634.
 - Retry on 403 Forbidden and 401 Unauthorized in `ServicesWatcher` at startup with exponential backoff. Fixes #1464.

--- a/pkg/kubevip/config_env_precedence_test.go
+++ b/pkg/kubevip/config_env_precedence_test.go
@@ -1,0 +1,152 @@
+package kubevip
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+func TestParseEnvironmentPreservesConfiguredARPAndDHCPValues(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		set  func(*Config) string
+		want string
+	}{
+		{
+			name: "ARP broadcast rate",
+			cfg:  Config{ArpBroadcastRate: 1234},
+			set: func(c *Config) string {
+				return strconv.FormatInt(c.ArpBroadcastRate, 10)
+			},
+			want: "1234",
+		},
+		{
+			name: "DHCP mode",
+			cfg:  Config{DNSMode: "first", DHCPMode: "ipv6"},
+			set: func(c *Config) string {
+				return c.DHCPMode
+			},
+			want: "ipv6",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(vipArpRate, "")
+			t.Setenv(dhcpMode, "")
+			t.Setenv(dnsMode, "")
+
+			config := tt.cfg
+			if err := ParseEnvironment(&config); err != nil {
+				t.Fatalf("ParseEnvironment() error = %v", err)
+			}
+
+			if got := tt.set(&config); got != tt.want {
+				t.Fatalf("configured value was overwritten: got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseEnvironmentDefaultsARPAndDHCPValues(t *testing.T) {
+	t.Setenv(vipArpRate, "")
+	t.Setenv(dhcpMode, "")
+	t.Setenv(dnsMode, "")
+
+	config := Config{DNSMode: "first"}
+	if err := ParseEnvironment(&config); err != nil {
+		t.Fatalf("ParseEnvironment() error = %v", err)
+	}
+
+	if config.ArpBroadcastRate != 3000 {
+		t.Fatalf("ArpBroadcastRate = %d, want 3000", config.ArpBroadcastRate)
+	}
+	if config.DHCPMode != "ipv4" {
+		t.Fatalf("DHCPMode = %q, want %q", config.DHCPMode, "ipv4")
+	}
+}
+
+func TestParseEnvironmentOverridesConfiguredARPAndDHCPValues(t *testing.T) {
+	t.Setenv(vipArpRate, "5678")
+	t.Setenv(dhcpMode, "dual")
+
+	config := Config{ArpBroadcastRate: 1234, DHCPMode: "ipv6"}
+	if err := ParseEnvironment(&config); err != nil {
+		t.Fatalf("ParseEnvironment() error = %v", err)
+	}
+
+	if config.ArpBroadcastRate != 5678 {
+		t.Fatalf("ArpBroadcastRate = %d, want 5678", config.ArpBroadcastRate)
+	}
+	if config.DHCPMode != "dual" {
+		t.Fatalf("DHCPMode = %q, want %q", config.DHCPMode, "dual")
+	}
+}
+
+func TestParseEnvironmentPreservesConfigFileARPRate(t *testing.T) {
+	t.Setenv(vipArpRate, "")
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("arpBroadcastRate: 1234\n"), 0o600); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+
+	config := Config{}
+	if err := MergeConfigFromFile(&config, path); err != nil {
+		t.Fatalf("MergeConfigFromFile() error = %v", err)
+	}
+	if err := ParseEnvironment(&config); err != nil {
+		t.Fatalf("ParseEnvironment() error = %v", err)
+	}
+
+	if config.ArpBroadcastRate != 1234 {
+		t.Fatalf("ArpBroadcastRate = %d, want 1234", config.ArpBroadcastRate)
+	}
+}
+
+func TestLoadConfigFromFileDHCPAndDNSModes(t *testing.T) {
+	tests := []struct {
+		name    string
+		ext     string
+		content string
+	}{
+		{
+			name:    "YAML",
+			ext:     ".yaml",
+			content: "dnsDualStackMode: dual\ndhcpDualStackMode: ipv6\n",
+		},
+		{
+			name:    "JSON",
+			ext:     ".json",
+			content: `{"dnsDualStackMode":"dual","dhcpDualStackMode":"ipv6"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(dhcpMode, "")
+			t.Setenv(dnsMode, "")
+
+			path := filepath.Join(t.TempDir(), "config"+tt.ext)
+			if err := os.WriteFile(path, []byte(tt.content), 0o600); err != nil {
+				t.Fatalf("write config file: %v", err)
+			}
+
+			config, err := LoadConfigFromFile(path)
+			if err != nil {
+				t.Fatalf("LoadConfigFromFile() error = %v", err)
+			}
+			if err := ParseEnvironment(config); err != nil {
+				t.Fatalf("ParseEnvironment() error = %v", err)
+			}
+			if config.DNSMode != "dual" {
+				t.Fatalf("DNSMode = %q, want %q", config.DNSMode, "dual")
+			}
+			if config.DHCPMode != "ipv6" {
+				t.Fatalf("DHCPMode = %q, want %q", config.DHCPMode, "ipv6")
+			}
+		})
+	}
+}

--- a/pkg/kubevip/config_environment.go
+++ b/pkg/kubevip/config_environment.go
@@ -322,7 +322,7 @@ func ParseEnvironment(c *Config) error {
 			return err
 		}
 		c.ArpBroadcastRate = i64
-	} else {
+	} else if c.ArpBroadcastRate == 0 {
 		// default to three seconds
 		c.ArpBroadcastRate = 3000
 	}
@@ -426,7 +426,7 @@ func ParseEnvironment(c *Config) error {
 	env = os.Getenv(dhcpMode)
 	if env != "" {
 		c.DHCPMode = env
-	} else {
+	} else if c.DHCPMode == "" {
 		if c.DNSMode != "first" {
 			c.DHCPMode = c.DNSMode
 		} else {

--- a/pkg/kubevip/config_types.go
+++ b/pkg/kubevip/config_types.go
@@ -181,7 +181,7 @@ type Config struct {
 	K8sConfigFile string `yaml:"k8sConfigFile"`
 
 	// DNSMode, this will set the mode DSN lookup will be performed (first, ipv4, ipv6, dual)
-	DNSMode string `yaml:"dnsDualStackMode"`
+	DNSMode string `json:"dnsDualStackMode" yaml:"dnsDualStackMode"`
 
 	// IsDualStack reports if service is DualStack.
 	IsDualStack bool
@@ -191,7 +191,7 @@ type Config struct {
 
 	// DNSMode, this will set the mode DHCP lookup will be performed for DDNS (ipv4, ipv6, dual). By default will be the same as DNSMode.
 	// If DNSMode is 'first', IPv4 will be used.
-	DHCPMode string `yaml:"dhcpDualStackMode"`
+	DHCPMode string `json:"dhcpDualStackMode" yaml:"dhcpDualStackMode"`
 
 	// DisableServiceUpdates, if true, kube-vip will only advertise service, but it will not update service's Status.LoadBalancer.Ingress slice
 	DisableServiceUpdates bool `yaml:"disableServiceUpdates"`


### PR DESCRIPTION
## Purpose

Preserve configured ARP and DHCP values when their environment variables are unset.

## Key changes

- Defaults `ArpBroadcastRate` only when no value is already configured.
- Derives `DHCPMode` from DNS mode only when DHCP mode is still unset.
- Restores the documented `flags > environment > file` behavior for this scope.

## Validation

Adds `TestParseEnvironmentPreservesConfiguredARPAndDHCPValues`. Unit, integration, lint, CodeQL, and E2E checks pass.

## Dependency

Base: `main`. No stack dependency.