### PR TITLE
fix(worker): honor context cancellation in cleanRoutingTable worker

### DIFF
--- a/pkg/manager/worker/table.go
+++ b/pkg/manager/worker/table.go
@@ -43,7 +43,11 @@ func (t *Table) Configure(ctx context.Context, wg *sync.WaitGroup) error {
 	if t.config.CleanRoutingTable {
 		wg.Go(func() {
 			// we assume that after 10s all services should be configured so we can delete redundant routes
-			time.Sleep(time.Second * 10)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(10 * time.Second):
+			}
 			if err := t.cleanRoutes(); err != nil {
 				log.Error("error checking for old routes", "err", err)
 			}

--- a/pkg/manager/worker/table_ctx_test.go
+++ b/pkg/manager/worker/table_ctx_test.go
@@ -1,0 +1,47 @@
+package worker
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+)
+
+func TestConfigureCleanRoutingTableStopsWithContext(t *testing.T) {
+	t.Parallel()
+
+	var wg sync.WaitGroup
+	table := &Table{Common: Common{
+		config: &kubevip.Config{
+			CleanRoutingTable:  true,
+			EnableControlPlane: true,
+			Address:            "10.254.254.254",
+			RoutingTableID:     0x7fffffff,
+			RoutingProtocol:    255,
+		},
+		mutex: &sync.Mutex{},
+	}}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if err := table.Configure(ctx, &wg); err != nil {
+		t.Fatalf("Configure returned an error: %v", err)
+	}
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		// DEFECT: pkg/manager/worker/table.go:43-48 uses an unconditional
+		// 10-second sleep for cleanRoutingTable and ignores the canceled RT
+		// worker context, delaying shutdown/recovery.
+		t.Fatal("cleanRoutingTable worker did not stop after context cancellation")
+	}
+}


### PR DESCRIPTION
## Bug
`Table.Configure` (pkg/manager/worker/table.go) received a context but the spawned `CleanRoutingTable` goroutine did an unconditional `time.Sleep(10s)` then `cleanRoutes()`, never referencing `ctx`. `wg.Wait()` blocked up to 10s after shutdown and `cleanRoutes()` (netlink route deletion) could fire during teardown. The `ctx` parameter was entirely unused.

## Fix
Make the sleep ctx-aware (`select` on `ctx.Done()`) and return promptly on cancellation. Adds `TestConfigureCleanRoutingTableStopsWithContext`.

Found during the kube-vip test-coverage/bug-bash effort; adversarially confirmed and bidirectionally validated. No unrelated changes.