### PR TITLE
fix(cluster): withdraw control-plane route on leadership loss in routing-table mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Run routing-table control-plane mode under leader election when configured, and withdraw its routes on leadership loss or shutdown even when VIP preservation is enabled.
 - Propagate `bgp_attach_ip_to_interface` into per-service config so it attaches BGP-mode Service VIPs to the interface as configured.
 - Add a configurable kube-vip instance name and use it to isolate internal nftables egress tables, persist table ownership on Services, and migrate per-Service chains without affecting other deployments. Fixes #1634.
 - Retry on 403 Forbidden and 401 Unauthorized in `ServicesWatcher` at startup with exponential backoff. Fixes #1464.

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -278,6 +278,12 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 				}
 			}
 		})
+
+		for i := range cluster.Network {
+			if err := cluster.routeMgr.Delete(c.NodeName, cluster.Network[i]); err != nil {
+				log.Warn("deleting route", "err", err)
+			}
+		}
 	}
 
 	if c.EnableBGP {

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -279,10 +279,14 @@ func (cluster *Cluster) StartVipService(ctx context.Context, c *kubevip.Config, 
 			}
 		})
 
+		var deleteErrors []error
 		for i := range cluster.Network {
-			if err := cluster.routeMgr.Delete(c.NodeName, cluster.Network[i]); err != nil {
-				log.Warn("deleting route", "err", err)
+			if deleteErr := cluster.routeMgr.Delete(c.NodeName, cluster.Network[i]); deleteErr != nil {
+				deleteErrors = append(deleteErrors, fmt.Errorf("deleting route for %s: %w", cluster.Network[i].IP(), deleteErr))
 			}
+		}
+		if err := errors.Join(deleteErrors...); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/cluster/service_rtwithdraw_test.go
+++ b/pkg/cluster/service_rtwithdraw_test.go
@@ -1,0 +1,33 @@
+package cluster_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestRoutingTableHealthCheck_WithdrawsRouteWhenServiceStops(t *testing.T) {
+	t.Parallel()
+	healthcheck := newTestHealthServer(t, http.StatusOK)
+	t.Cleanup(healthcheck.server.Close)
+
+	network := &mockNetwork{ip: "10.0.0.1", cidr: testCIDR}
+	cfg := newRoutingTableConfig(healthcheck.server.URL, healthcheck.caPath)
+	cfg.PreserveVIPOnLeadershipLoss = true
+	cancel, done := startRoutingTableVipService(t, cfg, network)
+
+	expectEventually(t, network.isRoutePresent,
+		"RT route should be installed while the control-plane health check is healthy")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("routing-table VIP service did not stop after context cancellation")
+	}
+
+	if network.isRoutePresent() || network.routeDeleteCalls() == 0 {
+		t.Fatalf("RT route remained after service stop: present=%v deleteCalls=%d",
+			network.isRoutePresent(), network.routeDeleteCalls())
+	}
+}

--- a/pkg/cluster/service_rtwithdraw_test.go
+++ b/pkg/cluster/service_rtwithdraw_test.go
@@ -1,33 +1,116 @@
 package cluster_test
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/kube-vip/kube-vip/pkg/cluster"
+	"github.com/kube-vip/kube-vip/pkg/election"
+	"github.com/kube-vip/kube-vip/pkg/lease"
+	"github.com/kube-vip/kube-vip/pkg/node"
+	"github.com/kube-vip/kube-vip/pkg/route"
+	"github.com/kube-vip/kube-vip/pkg/vip"
 )
 
 func TestRoutingTableHealthCheck_WithdrawsRouteWhenServiceStops(t *testing.T) {
+	for _, preserve := range []bool{false, true} {
+		t.Run(fmt.Sprintf("preserve=%t", preserve), func(t *testing.T) {
+			t.Parallel()
+			healthcheck := newTestHealthServer(t, http.StatusOK)
+			t.Cleanup(healthcheck.server.Close)
+
+			network := &mockNetwork{ip: "10.0.0.1", cidr: testCIDR}
+			cfg := newRoutingTableConfig(healthcheck.server.URL, healthcheck.caPath)
+			cfg.PreserveVIPOnLeadershipLoss = preserve
+			cancel, done := startRoutingTableVipService(t, cfg, network)
+
+			expectEventually(t, network.isRoutePresent,
+				"RT route should be installed while the control-plane health check is healthy")
+
+			cancel()
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatal("routing-table VIP service did not stop after context cancellation")
+			}
+
+			if network.isRoutePresent() || network.routeDeleteCalls() == 0 {
+				t.Fatalf("RT route remained after service stop: present=%v deleteCalls=%d",
+					network.isRoutePresent(), network.routeDeleteCalls())
+			}
+		})
+	}
+}
+
+func TestRoutingTableHealthCheck_ReturnsRouteDeletionFailure(t *testing.T) {
 	t.Parallel()
 	healthcheck := newTestHealthServer(t, http.StatusOK)
 	t.Cleanup(healthcheck.server.Close)
 
-	network := &mockNetwork{ip: "10.0.0.1", cidr: testCIDR}
+	deleteErr := errors.New("route deletion failed")
+	network := &mockNetwork{ip: "10.0.0.1", cidr: testCIDR, deleteRouteErr: deleteErr}
 	cfg := newRoutingTableConfig(healthcheck.server.URL, healthcheck.caPath)
-	cfg.PreserveVIPOnLeadershipLoss = true
-	cancel, done := startRoutingTableVipService(t, cfg, network)
+	c, err := cluster.InitCluster(cfg, true, nil, nil, route.NewManager(), nil)
+	if err != nil {
+		t.Fatalf("InitCluster: %v", err)
+	}
+	c.Network = []vip.Network{network}
 
-	expectEventually(t, network.isRoutePresent,
-		"RT route should be installed while the control-plane health check is healthy")
-
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- c.StartVipService(ctx, cfg, nil, nil, func() {})
+	}()
+	expectEventually(t, network.isRoutePresent, "RT route should be installed")
 	cancel()
+
 	select {
-	case <-done:
+	case err := <-done:
+		if !errors.Is(err, deleteErr) {
+			t.Fatalf("StartVipService error = %v, want deletion error", err)
+		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("routing-table VIP service did not stop after context cancellation")
 	}
+}
 
-	if network.isRoutePresent() || network.routeDeleteCalls() == 0 {
-		t.Fatalf("RT route remained after service stop: present=%v deleteCalls=%d",
-			network.isRoutePresent(), network.routeDeleteCalls())
+func TestRoutingTableLeaderContext_WithdrawsRouteOnLeadershipLoss(t *testing.T) {
+	t.Parallel()
+
+	cfg := newRoutingTableConfig("", "")
+	cfg.PreserveVIPOnLeadershipLoss = true
+	network := &mockNetwork{ip: "10.0.0.1", cidr: testCIDR}
+	routeMgr := route.NewManager()
+	if err := routeMgr.Add(cfg.NodeName, network, true, false); err != nil {
+		t.Fatalf("add route: %v", err)
+	}
+	c, err := cluster.InitCluster(cfg, true, nil, nil, routeMgr, node.NewManager(cfg, nil))
+	if err != nil {
+		t.Fatalf("InitCluster: %v", err)
+	}
+	c.Network = []vip.Network{network}
+
+	leaseMgr := lease.NewManager()
+	objLease := leaseMgr.Add(context.Background(), lease.NewID("kubernetes", "default", "control-plane"))
+	objLease.Lock()
+	done := make(chan struct{})
+	go func() {
+		c.OnStartedLeading(cfg, objLease, &election.Manager{}, nil, func() {}, false)
+		close(done)
+	}()
+
+	expectEventually(t, func() bool { return objLease.Elected.Load() }, "leader service should start")
+	c.OnStoppedLeading(cfg, objLease, nil)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("leader service did not stop after leadership loss")
+	}
+	if network.isRoutePresent() {
+		t.Fatal("RT route remained after leadership loss")
 	}
 }

--- a/pkg/cluster/service_test.go
+++ b/pkg/cluster/service_test.go
@@ -223,7 +223,7 @@ func startVipService(t *testing.T, cfg *kubevip.Config, bgpManager *mockBGPRoute
 // startRoutingTableVipService launches vipService in routing-table mode with a
 // mock network and a real route.Manager (which only drives the mock network's
 // route methods, so no netlink calls happen). Registers cleanup to stop it.
-func startRoutingTableVipService(t *testing.T, cfg *kubevip.Config, network *mockNetwork) {
+func startRoutingTableVipService(t *testing.T, cfg *kubevip.Config, network *mockNetwork) (context.CancelFunc, <-chan struct{}) {
 	t.Helper()
 
 	c, err := cluster.InitCluster(cfg, true, nil, nil, route.NewManager(), nil)
@@ -244,6 +244,8 @@ func startRoutingTableVipService(t *testing.T, cfg *kubevip.Config, network *moc
 		cancel()
 		<-done
 	})
+
+	return cancel, done
 }
 
 func newRoutingTableConfig(url, caPath string) *kubevip.Config {
@@ -318,13 +320,15 @@ func (m *mockBGPRouteManager) setDelErr(err error) {
 	m.mu.Unlock()
 }
 
-// mockNetwork implements vip.Network with no-op operations.
+// mockNetwork implements vip.Network with in-memory VIP and route state.
 type mockNetwork struct {
 	ip   string
 	cidr string
 
-	mu      sync.Mutex
-	present bool
+	mu               sync.Mutex
+	present          bool
+	routePresent     bool
+	deleteRouteCalls int
 }
 
 func (m *mockNetwork) AddIP(bool, bool, ...int) (bool, error) {
@@ -344,9 +348,35 @@ func (m *mockNetwork) isPresent() bool {
 	defer m.mu.Unlock()
 	return m.present
 }
-func (m *mockNetwork) AddRoute(bool) (bool, error)     { return false, nil }
-func (m *mockNetwork) ReplaceRoute() error             { return nil }
-func (m *mockNetwork) DeleteRoute() error              { return nil }
+func (m *mockNetwork) AddRoute(bool) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.routePresent = true
+	return true, nil
+}
+func (m *mockNetwork) ReplaceRoute() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.routePresent = true
+	return nil
+}
+func (m *mockNetwork) DeleteRoute() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.deleteRouteCalls++
+	m.routePresent = false
+	return nil
+}
+func (m *mockNetwork) isRoutePresent() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.routePresent
+}
+func (m *mockNetwork) routeDeleteCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.deleteRouteCalls
+}
 func (m *mockNetwork) UpdateRoutes() (bool, error)     { return false, nil }
 func (m *mockNetwork) IsSet() (*netlink.Addr, error)   { return nil, nil }
 func (m *mockNetwork) IP() string                      { return m.ip }

--- a/pkg/cluster/service_test.go
+++ b/pkg/cluster/service_test.go
@@ -329,6 +329,7 @@ type mockNetwork struct {
 	present          bool
 	routePresent     bool
 	deleteRouteCalls int
+	deleteRouteErr   error
 }
 
 func (m *mockNetwork) AddIP(bool, bool, ...int) (bool, error) {
@@ -364,6 +365,9 @@ func (m *mockNetwork) DeleteRoute() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.deleteRouteCalls++
+	if m.deleteRouteErr != nil {
+		return m.deleteRouteErr
+	}
 	m.routePresent = false
 	return nil
 }

--- a/pkg/manager/worker/common.go
+++ b/pkg/manager/worker/common.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 
 	"github.com/kube-vip/kube-vip/pkg/arp"
+	"github.com/kube-vip/kube-vip/pkg/bgp"
 	"github.com/kube-vip/kube-vip/pkg/cluster"
 	"github.com/kube-vip/kube-vip/pkg/election"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
@@ -20,9 +21,14 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+type controlPlaneCluster interface {
+	StartCluster(context.Context, *kubevip.Config, *election.Manager, *bgp.Server, *lease.Manager, func()) error
+	StartVipService(context.Context, *kubevip.Config, *election.Manager, cluster.BGPRouteManager, func()) error
+}
+
 type Common struct {
 	arpMgr       *arp.Manager
-	cpCluster    *cluster.Cluster
+	cpCluster    controlPlaneCluster
 	intfMgr      *networkinterface.Manager
 	config       *kubevip.Config
 	closing      *atomic.Bool

--- a/pkg/manager/worker/table.go
+++ b/pkg/manager/worker/table.go
@@ -57,12 +57,16 @@ func (t *Table) Configure(ctx context.Context, wg *sync.WaitGroup) error {
 }
 
 func (t *Table) StartControlPlane(ctx context.Context, electionManager *election.Manager) {
-	if err := t.cpCluster.StartVipService(ctx, t.config, electionManager, nil, t.killFunc); err != nil {
+	var err error
+	if t.config.EnableLeaderElection {
+		err = t.cpCluster.StartCluster(ctx, t.config, electionManager, nil, t.leaseMgr, t.killFunc)
+	} else {
+		err = t.cpCluster.StartVipService(ctx, t.config, electionManager, nil, t.killFunc)
+	}
+	if err != nil {
 		log.Error("Control Plane", "err", err)
 		// Trigger the shutdown of this manager instance
 		t.killFunc()
-	} else {
-		log.Debug("start VipServer for cluster manager successful")
 	}
 }
 

--- a/pkg/manager/worker/table_controlplane_test.go
+++ b/pkg/manager/worker/table_controlplane_test.go
@@ -1,0 +1,72 @@
+package worker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kube-vip/kube-vip/pkg/bgp"
+	"github.com/kube-vip/kube-vip/pkg/cluster"
+	"github.com/kube-vip/kube-vip/pkg/election"
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/lease"
+)
+
+type controlPlaneClusterSpy struct {
+	startClusterCalls    int
+	startVipServiceCalls int
+}
+
+func (s *controlPlaneClusterSpy) StartCluster(context.Context, *kubevip.Config, *election.Manager, *bgp.Server, *lease.Manager, func()) error {
+	s.startClusterCalls++
+	return nil
+}
+
+func (s *controlPlaneClusterSpy) StartVipService(context.Context, *kubevip.Config, *election.Manager, cluster.BGPRouteManager, func()) error {
+	s.startVipServiceCalls++
+	return nil
+}
+
+func TestTableStartControlPlane(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		enableLeaderElection bool
+		wantStartCluster     int
+		wantStartVIPService  int
+	}{
+		{
+			name:                 "leader election",
+			enableLeaderElection: true,
+			wantStartCluster:     1,
+		},
+		{
+			name:                "without leader election",
+			wantStartVIPService: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			spy := &controlPlaneClusterSpy{}
+			table := &Table{Common: Common{
+				config: &kubevip.Config{KubernetesLeaderElection: kubevip.KubernetesLeaderElection{
+					EnableLeaderElection: tt.enableLeaderElection,
+				}},
+				cpCluster: spy,
+				leaseMgr:  lease.NewManager(),
+				killFunc:  func() {},
+			}}
+
+			table.StartControlPlane(context.Background(), &election.Manager{})
+
+			if spy.startClusterCalls != tt.wantStartCluster {
+				t.Errorf("StartCluster calls = %d, want %d", spy.startClusterCalls, tt.wantStartCluster)
+			}
+			if spy.startVipServiceCalls != tt.wantStartVIPService {
+				t.Errorf("StartVipService calls = %d, want %d", spy.startVipServiceCalls, tt.wantStartVIPService)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Purpose

Make routing-table control-plane leadership install and withdraw routes through the intended election lifecycle.

## Key changes

- Dispatches routing-table control-plane startup to the actual leader-election path instead of bypassing election.
- Withdraws control-plane routes when leadership context is canceled.
- Adds coverage for election dispatch and route cleanup on service stop.

## Validation

Unit, integration, lint, CodeQL, and ARP, routing-table, BGP, and service E2E checks pass.

## Dependency

Base: `main`. No stack dependency.