### PR TITLE
feat(metrics): dataplane operation metrics (VIP/ARP/route/DNS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Added
+- Prometheus metrics for build information, service activity, reconciliation,
+  leader election, and watcher-loop liveness, with a metrics reference guide.
 - Configurable control-plane health check for BGP mode without leader election
   - Polls a configurable HTTP(S) endpoint (e.g. `https://localhost:6443/livez`) to verify the exposed service is healthy (usually the local kube-apiserver)
   - Withdraws the BGP route after a configurable number of consecutive failures, removing the unhealthy node from the ECMP set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Added
+- Prometheus counters and gauges for VIP, ARP, NDP, route, and DNS dataplane
+  operations, including restart-safe DNS VIP ownership accounting.
 - Prometheus metrics for build information, service activity, reconciliation,
   leader election, and watcher-loop liveness, with a metrics reference guide.
 - Configurable control-plane health check for BGP mode without leader election

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Kube-Vip was originally created to provide a HA solution for the Kubernetes cont
 - Egress! Kube-vip will utilise a service loadbalancer as both the ingress and **egress** for a pod. 
 - ... manifest generation, vendor API integrations and many more...
 
+## Prometheus metrics
+
+kube-vip exposes a Prometheus endpoint at `/metrics` by default. See the
+[metrics reference](docs/metrics.md) for the complete metric catalog,
+configuration, labels, and example queries.
+
 ## Why?
 
 The purpose of `kube-vip` is to simplify the building of HA Kubernetes clusters, which at this time can involve a few components and configurations that all need to be managed. This was blogged about in detail by [thebsdbox](https://twitter.com/thebsdbox/) here -> [https://thebsdbox.co.uk/2020/01/02/Designing-Building-HA-bare-metal-Kubernetes-cluster/#Networking-load-balancing](https://thebsdbox.co.uk/2020/01/02/Designing-Building-HA-bare-metal-Kubernetes-cluster/#Networking-load-balancing).

--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -474,7 +474,7 @@ var kubeVipManager = &cobra.Command{
 		}
 
 		metrics.RegisterPrometheusMetrics()
-		metrics.BuildInfo.WithLabelValues(Release.Version, Release.Build, initConfig.NodeName)
+		metrics.BuildInfo.WithLabelValues(Release.Version, Release.Build, initConfig.NodeName).Set(1)
 
 		// Start the service manager, this will watch the config Map and construct kube-vip services for it
 		err = mgr.Start(ctx)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,79 @@
+# kube-vip Prometheus metrics
+
+kube-vip exposes Prometheus metrics from every kube-vip process. The metrics
+endpoint is enabled by default at `:2112/metrics` and can be configured with
+the `--prometheusHTTPServer` flag, the `prometheusHTTPServer` configuration
+field, or the `prometheus_server` environment variable. Set the address to an
+empty string to disable the endpoint.
+
+Scrape each kube-vip pod or node-local process separately. Most gauges describe
+the state managed by that process, while counters and histograms describe work
+observed by that process and reset when it restarts. Use `rate()` or `increase()`
+for counters instead of comparing their raw values across restarts.
+
+Metrics that depend on a particular kube-vip mode are only emitted after that
+mode exercises the corresponding code path. Label values listed below are the
+values currently emitted by kube-vip; new values may be added as supported
+backends grow.
+
+## Service and VIP lifecycle
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `kube_vip_active_services` | Gauge | `namespace` | Number of managed LoadBalancer services in the namespace. |
+| `kube_vip_service_reconcile_errors_total` | Counter | `namespace`, `name`, `reason` | Service reconciliation failures. Current reasons include `invalid_config`, `service_context`, `delete_service`, and `new_instance`. |
+| `kube_vip_service_reconcile_duration_seconds` | Histogram | `namespace` | End-to-end duration of service `AddOrModify` reconciliation. |
+
+## Service events and leader election
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `kube_vip_manager_all_services_events_total` | Counter | `type` | Events received by the service watcher. `type` is a Kubernetes watch event such as `ADDED`, `MODIFIED`, `DELETED`, `BOOKMARK`, or `ERROR`. |
+| `kube_vip_leader_election_transitions_total` | Counter | `lease_name` | Number of observed transitions into leadership for a lease. A high rate can indicate instability. |
+| `kube_vip_is_leader` | Gauge | `node`, `lease_name` | `1` when the labeled node currently holds the lease, otherwise `0`. |
+| `kube_vip_watcher_loops` | Gauge | `kind` | Number of live watcher goroutines. Current kinds are `service`, `endpoint`, `lease`, and `node`. Endpoint and lease watchers are per service. |
+| `kube_vip_election_loops` | Gauge | `type` | Number of live leader-election loops. Current types are `kubernetes` and `etcd`. |
+| `kube_vip_service_election_loops` | Gauge | `namespace`, `name` | Live per-service leader-election restart loops on this node. A value greater than `1` indicates leaked loops. |
+| `kube_vip_service_election_attempts_total` | Counter | `namespace`, `name` | Attempts made by a per-service leader-election restart loop. |
+| `kube_vip_service_election_errors_total` | Counter | `namespace`, `name`, `reason` | Per-service election failures. The current failure reason is `no_lease`. |
+
+The loop gauges are balanced at goroutine start and exit. They are useful for
+detecting a leaked watcher or election loop after a service update, leadership
+loss, or watcher restart. For example:
+
+```promql
+max by (namespace, name, instance) (kube_vip_service_election_loops) > 1
+sum by (instance, kind) (kube_vip_watcher_loops)
+rate(kube_vip_leader_election_transitions_total[5m])
+```
+
+## BGP session state
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `kube_vip_manager_bgp_session_info` | Gauge | `state`, `peer` | BGP session state for a peer. For each peer, the current GoBGP state has value `1` and the other state series have value `0`; `peer` is emitted as `address:179`. |
+
+This metric is only useful when BGP is enabled. A session alert should select
+the state that represents an established session in the deployed GoBGP
+version, rather than assuming that an absent series means a failed session.
+
+## Build information
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `kube_vip_build_info` | Gauge | `version`, `build`, `node` | Constant `1`, useful for identifying the kube-vip version and build running on each node. |
+
+## Querying safely
+
+Service labels are intentionally included for troubleshooting, but they can
+create many time series in clusters with many short-lived services. Prefer
+aggregation or recording rules for dashboards, and use `rate()`/`increase()`
+for counters:
+
+```promql
+sum by (namespace) (kube_vip_active_services)
+sum by (result) (rate(kube_vip_service_reconcile_errors_total[5m]))
+histogram_quantile(0.99,
+  sum by (le) (rate(kube_vip_service_reconcile_duration_seconds_bucket[5m])))
+```
+

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -3,8 +3,9 @@
 kube-vip exposes Prometheus metrics from every kube-vip process. The metrics
 endpoint is enabled by default at `:2112/metrics` and can be configured with
 the `--prometheusHTTPServer` flag, the `prometheusHTTPServer` configuration
-field, or the `prometheus_server` environment variable. Set the address to an
-empty string to disable the endpoint.
+field, or the `prometheus_server` environment variable. The flag defaults to
+`:2112`; configuration-file and environment values override it only when they
+are non-empty.
 
 Scrape each kube-vip pod or node-local process separately. Most gauges describe
 the state managed by that process, while counters and histograms describe work
@@ -51,7 +52,7 @@ rate(kube_vip_leader_election_transitions_total[5m])
 
 | Metric | Type | Labels | Meaning |
 | --- | --- | --- | --- |
-| `kube_vip_manager_bgp_session_info` | Gauge | `state`, `peer` | BGP session state for a peer. For each peer, the current GoBGP state has value `1` and the other state series have value `0`; `peer` is emitted as `address:179`. |
+| `kube_vip_manager_bgp_session_info` | Gauge | `state`, `peer` | BGP session state for a peer. For each peer, the current GoBGP state has value `1` and the other state series have value `0`; `peer` contains the address and configured remote port. |
 
 This metric is only useful when BGP is enabled. A session alert should select
 the state that represents an established session in the deployed GoBGP
@@ -76,4 +77,3 @@ sum by (result) (rate(kube_vip_service_reconcile_errors_total[5m]))
 histogram_quantile(0.99,
   sum by (le) (rate(kube_vip_service_reconcile_duration_seconds_bucket[5m])))
 ```
-

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -25,6 +25,31 @@ backends grow.
 | `kube_vip_service_reconcile_errors_total` | Counter | `namespace`, `name`, `reason` | Service reconciliation failures. Current reasons include `invalid_config`, `service_context`, `delete_service`, and `new_instance`. |
 | `kube_vip_service_reconcile_duration_seconds` | Histogram | `namespace` | End-to-end duration of service `AddOrModify` reconciliation. |
 
+## Dataplane operations
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `kube_vip_vip_addresses` | Gauge | `interface`, `family` | VIP addresses currently held by an interface. `family` is `IPv4` or `IPv6`. |
+| `kube_vip_vip_operations_total` | Counter | `op`, `result` | VIP address operations. Current operations are `add` and `delete`; results are `ok` or `error`. |
+| `kube_vip_arp_advertisements_total` | Counter | `result` | Gratuitous ARP advertisements, labeled `ok` or `error`. |
+| `kube_vip_ndp_advertisements_total` | Counter | `result` | Gratuitous NDP advertisements, labeled `ok` or `error`. |
+| `kube_vip_route_operations_total` | Counter | `op`, `result` | Routing-table operations. Current operations are `add`, `delete`, `replace`, and `update`; results are `ok` or `error`. |
+| `kube_vip_dns_resolutions_total` | Counter | `result` | DNS resolutions performed by the DNS-backed VIP updater, labeled `ok` or `error`. |
+| `kube_vip_dns_ip_changes_total` | Counter | — | Number of DNS-backed VIP changes where the resolved address changed. |
+
+The VIP address gauge is state-based: an address is counted once per
+interface/family and is removed when kube-vip releases it. Operation counters
+are attempt/outcome signals and should normally be queried with `rate()`.
+
+Useful examples:
+
+```promql
+sum by (instance, interface, family) (kube_vip_vip_addresses)
+sum by (op, result) (rate(kube_vip_vip_operations_total[5m]))
+sum by (result) (rate(kube_vip_arp_advertisements_total[5m]))
+sum by (result) (rate(kube_vip_ndp_advertisements_total[5m]))
+```
+
 ## Service events and leader election
 
 | Metric | Type | Labels | Meaning |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -38,8 +38,11 @@ backends grow.
 | `kube_vip_dns_ip_changes_total` | Counter | — | Number of DNS-backed VIP changes where the resolved address changed. |
 
 The VIP address gauge is state-based: an address is counted once per
-interface/family and is removed when kube-vip releases it. Operation counters
-are attempt/outcome signals and should normally be queried with `rate()`.
+interface/family, including when kube-vip reclaims an existing address after a
+restart. DNS changes transfer ownership from the old address to the new one,
+and the label series is removed when kube-vip releases the final address for
+that interface/family. Operation counters are attempt/outcome signals and
+should normally be queried with `rate()`.
 
 Useful examples:
 

--- a/pkg/arp/arp.go
+++ b/pkg/arp/arp.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 	"github.com/kube-vip/kube-vip/pkg/vip"
 	"github.com/vishvananda/netlink"
@@ -238,7 +239,10 @@ func ensureIPAndSendGratuitous(instance *Instance) {
 		// Gratuitous ARP, will broadcast to new MAC <-> IPv4 address
 		err := vip.ARPSendGratuitous(ipString, iface)
 		if err != nil {
+			metrics.ARPAdvertisementsTotal.WithLabelValues("error").Inc()
 			log.Warn(err.Error())
+		} else {
+			metrics.ARPAdvertisementsTotal.WithLabelValues("ok").Inc()
 		}
 	}
 }

--- a/pkg/election/election.go
+++ b/pkg/election/election.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/loadbalancer"
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	v1 "k8s.io/api/core/v1"
@@ -72,6 +73,10 @@ func RunOrDie(ctx context.Context, run *RunConfig, c *kubevip.Config) error {
 }
 
 func runKubernetesLeaderElectionOrDie(ctx context.Context, run *RunConfig) {
+	loops := metrics.ElectionLoops.WithLabelValues("kubernetes")
+	loops.Inc()
+	defer loops.Dec()
+
 	// we use the Lease lock type since edits to Leases are less common
 	// and fewer objects in the cluster watch "all Leases".
 	lock := &resourcelock.LeaseLock{
@@ -108,6 +113,10 @@ func runKubernetesLeaderElectionOrDie(ctx context.Context, run *RunConfig) {
 }
 
 func runEtcdLeaderElectionOrDie(ctx context.Context, run *RunConfig) error {
+	loops := metrics.ElectionLoops.WithLabelValues("etcd")
+	loops.Inc()
+	defer loops.Dec()
+
 	if err := etcd.RunElectionOrDie(ctx, &etcd.LeaderElectionConfig{
 		EtcdConfig:           etcd.ClientConfig{Client: run.Mgr.EtcdClient},
 		Name:                 run.LeaseID.NamespacedName(),
@@ -147,6 +156,10 @@ type RunConfig struct {
 }
 
 func (em *Manager) NodeWatcher(ctx context.Context, lb *loadbalancer.IPVSLoadBalancer, port uint16) error {
+	loops := metrics.WatcherLoops.WithLabelValues("node")
+	loops.Inc()
+	defer loops.Dec()
+
 	// Use a restartable watcher, as this should help in the event of etcd or timeout issues
 	log.Info("Kube-Vip is watching nodes for control-plane labels")
 

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -308,6 +308,10 @@ func (p *Processor) startServiceHandlingIfNeeded(svcCtx *servicecontext.Context,
 }
 
 func (p *Processor) startLeaderElection(svcCtx *servicecontext.Context, service *v1.Service, serviceFunc func(*servicecontext.Context, *v1.Service, *sync.WaitGroup, bool) error, wg *sync.WaitGroup) {
+	watcherLoops := metrics.WatcherLoops.WithLabelValues("lease")
+	watcherLoops.Inc()
+	defer watcherLoops.Dec()
+
 	// Track this loop for the lifetime of the goroutine. There has to be at most
 	// one per service, so a value above 1 means loops leaked.
 	loops := metrics.ServiceElectionLoops.WithLabelValues(service.Namespace, service.Name)

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -314,9 +314,7 @@ func (p *Processor) startLeaderElection(svcCtx *servicecontext.Context, service 
 
 	// Track this loop for the lifetime of the goroutine. There has to be at most
 	// one per service, so a value above 1 means loops leaked.
-	loops := metrics.ServiceElectionLoops.WithLabelValues(service.Namespace, service.Name)
-	loops.Inc()
-	defer loops.Dec()
+	defer metrics.TrackServiceElectionLoop(service.Namespace, service.Name)()
 
 	attempts := metrics.ServiceElectionAttemptsTotal.WithLabelValues(service.Namespace, service.Name)
 

--- a/pkg/manager/worker/bgp.go
+++ b/pkg/manager/worker/bgp.go
@@ -59,28 +59,26 @@ func (b *BGP) Configure(ctx context.Context, _ *sync.WaitGroup) error {
 			return
 		}
 
-		ipaddr := p.Peer.State.NeighborAddress.String()
-
-		port := 179
-		peerDescription := net.JoinHostPort(ipaddr, strconv.Itoa(port))
-
-		for stateName, stateValue := range api.PeerState_SessionState_value {
-			metricValue := 0.0
-			if int(p.Peer.State.SessionState) == int(stateValue)-1 {
-
-				metricValue = 1
-			}
-
-			metrics.BGPSessionInfoGauge.With(prometheus.Labels{
-				"state": stateName,
-				"peer":  peerDescription,
-			}).Set(metricValue)
-		}
+		observeBGPPeerState(p)
 	}); err != nil {
 		return fmt.Errorf("starting BGP server: %w", err)
 	}
 
 	return nil
+}
+
+func observeBGPPeerState(p *apiutil.WatchEventMessage_PeerEvent) {
+	peerDescription := net.JoinHostPort(p.Peer.State.NeighborAddress.String(), strconv.FormatUint(uint64(p.Peer.Transport.RemotePort), 10))
+	for stateName, stateValue := range api.PeerState_SessionState_value {
+		metricValue := 0.0
+		if int(p.Peer.State.SessionState) == int(stateValue)-1 {
+			metricValue = 1
+		}
+		metrics.BGPSessionInfoGauge.With(prometheus.Labels{
+			"state": stateName,
+			"peer":  peerDescription,
+		}).Set(metricValue)
+	}
 }
 
 func (b *BGP) Cleanup() {

--- a/pkg/manager/worker/bgp_test.go
+++ b/pkg/manager/worker/bgp_test.go
@@ -1,0 +1,31 @@
+package worker
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/kube-vip/kube-vip/pkg/metrics"
+	api "github.com/osrg/gobgp/v4/api"
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestObserveBGPPeerStateUsesRemotePort(t *testing.T) {
+	metrics.BGPSessionInfoGauge.Reset()
+	t.Cleanup(metrics.BGPSessionInfoGauge.Reset)
+
+	observeBGPPeerState(&apiutil.WatchEventMessage_PeerEvent{
+		Type: apiutil.PEER_EVENT_STATE,
+		Peer: apiutil.Peer{
+			State: apiutil.PeerState{
+				NeighborAddress: netip.MustParseAddr("192.0.2.10"),
+				SessionState:    5,
+			},
+			Transport: apiutil.Transport{RemotePort: 10179},
+		},
+	})
+
+	if got := testutil.ToFloat64(metrics.BGPSessionInfoGauge.WithLabelValues(api.PeerState_SessionState_name[6], "192.0.2.10:10179")); got != 1 {
+		t.Fatalf("custom-port BGP session metric = %v, want 1", got)
+	}
+}

--- a/pkg/manager/worker/wireguard.go
+++ b/pkg/manager/worker/wireguard.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/endpoints/providers"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/networkinterface"
 	"github.com/kube-vip/kube-vip/pkg/nftables"
 	"github.com/kube-vip/kube-vip/pkg/node"
@@ -155,6 +156,10 @@ func (w *WireGuard) OnStartedLeading(ctx context.Context) {
 // watchKubernetesEndpoints watches the kubernetes service EndpointSlices for changes
 // and updates the DNAT rules when API server endpoints change (e.g., when an API server goes down)
 func (w *WireGuard) watchKubernetesEndpoints(ctx context.Context, tunnelConfig *wireguard.TunnelConfig) {
+	loops := metrics.WatcherLoops.WithLabelValues("endpoint")
+	loops.Inc()
+	defer loops.Dec()
+
 	log.Info("starting kubernetes endpoint watcher for control plane")
 
 	kubeSvc := &v1.Service{

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -35,6 +35,14 @@ var (
 		prometheus.GaugeOpts{Name: "kube_vip_is_leader", Help: "1 if this node currently holds the lease"},
 		[]string{"node", "lease_name"},
 	)
+	WatcherLoops = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "kube_vip_watcher_loops", Help: "Live watcher loops by kind"},
+		[]string{"kind"},
+	)
+	ElectionLoops = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "kube_vip_election_loops", Help: "Live leader election loops by type"},
+		[]string{"type"},
+	)
 	ServiceElectionLoops = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{Name: "kube_vip_service_election_loops",
 			Help: "Live per-service leader election restart loops on this node; more than 1 per service means loops leaked"},
@@ -76,6 +84,8 @@ func RegisterPrometheusMetrics() {
 		ServiceReconcileDuration,
 		LeaderTransitionsTotal,
 		IsLeader,
+		WatcherLoops,
+		ElectionLoops,
 		ServiceElectionLoops,
 		ServiceElectionAttemptsTotal,
 		ServiceElectionErrorsTotal,

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -1,6 +1,15 @@
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	serviceElectionLoopsMu   sync.Mutex
+	serviceElectionLoopCount = map[string]int{}
+)
 
 var (
 	// Service / VIP Lifecycle
@@ -93,4 +102,28 @@ func RegisterPrometheusMetrics() {
 		BuildInfo,
 		CountServiceWatchEvent,
 	)
+}
+
+// TrackServiceElectionLoop increments the loop gauge and returns a function
+// that decrements it and removes the series after the final loop exits.
+func TrackServiceElectionLoop(namespace, name string) func() {
+	key := namespace + "\x00" + name
+	serviceElectionLoopsMu.Lock()
+	serviceElectionLoopCount[key]++
+	ServiceElectionLoops.WithLabelValues(namespace, name).Inc()
+	serviceElectionLoopsMu.Unlock()
+
+	return func() {
+		serviceElectionLoopsMu.Lock()
+		defer serviceElectionLoopsMu.Unlock()
+
+		count := serviceElectionLoopCount[key]
+		if count <= 1 {
+			delete(serviceElectionLoopCount, key)
+			ServiceElectionLoops.DeleteLabelValues(namespace, name)
+			return
+		}
+		serviceElectionLoopCount[key] = count - 1
+		ServiceElectionLoops.WithLabelValues(namespace, name).Dec()
+	}
 }

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -9,6 +9,9 @@ import (
 var (
 	serviceElectionLoopsMu   sync.Mutex
 	serviceElectionLoopCount = map[string]int{}
+	vipAddressesMu           sync.Mutex
+	vipAddressReferences     = map[string]int{}
+	vipAddressLabelCounts    = map[string]int{}
 )
 
 var (
@@ -136,6 +139,51 @@ func RegisterPrometheusMetrics() {
 		BuildInfo,
 		CountServiceWatchEvent,
 	)
+}
+
+// TrackVIPAddress adds a reference to an address and increments the aggregate
+// gauge only when that address gains its first owner in this process.
+func TrackVIPAddress(iface, family, address string) {
+	addressKey := iface + "\x00" + family + "\x00" + address
+	labelKey := iface + "\x00" + family
+
+	vipAddressesMu.Lock()
+	defer vipAddressesMu.Unlock()
+
+	if vipAddressReferences[addressKey] == 0 {
+		vipAddressLabelCounts[labelKey]++
+		VIPAddresses.WithLabelValues(iface, family).Inc()
+	}
+	vipAddressReferences[addressKey]++
+}
+
+// UntrackVIPAddress removes an address reference and deletes the aggregate
+// series when no tracked addresses remain for its interface and family.
+func UntrackVIPAddress(iface, family, address string) {
+	addressKey := iface + "\x00" + family + "\x00" + address
+	labelKey := iface + "\x00" + family
+
+	vipAddressesMu.Lock()
+	defer vipAddressesMu.Unlock()
+
+	references := vipAddressReferences[addressKey]
+	if references == 0 {
+		return
+	}
+	if references > 1 {
+		vipAddressReferences[addressKey] = references - 1
+		return
+	}
+
+	delete(vipAddressReferences, addressKey)
+	remaining := vipAddressLabelCounts[labelKey] - 1
+	if remaining == 0 {
+		delete(vipAddressLabelCounts, labelKey)
+		VIPAddresses.DeleteLabelValues(iface, family)
+		return
+	}
+	vipAddressLabelCounts[labelKey] = remaining
+	VIPAddresses.WithLabelValues(iface, family).Dec()
 }
 
 // TrackServiceElectionLoop increments the loop gauge and returns a function

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -25,6 +25,33 @@ var (
 		prometheus.HistogramOpts{Name: "kube_vip_service_reconcile_duration_seconds", Help: "How long AddOrModify takes end-to-end"},
 		[]string{"namespace"},
 	)
+	VIPAddresses = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "kube_vip_vip_addresses", Help: "VIP addresses currently held by interface and address family"},
+		[]string{"interface", "family"},
+	)
+	VIPOperationsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "kube_vip_vip_operations_total", Help: "VIP address operations by operation and result"},
+		[]string{"op", "result"},
+	)
+	ARPAdvertisementsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "kube_vip_arp_advertisements_total", Help: "Gratuitous ARP advertisements by result"},
+		[]string{"result"},
+	)
+	NDPAdvertisementsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "kube_vip_ndp_advertisements_total", Help: "Gratuitous NDP advertisements by result"},
+		[]string{"result"},
+	)
+	RouteOperationsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "kube_vip_route_operations_total", Help: "Routing table operations by operation and result"},
+		[]string{"op", "result"},
+	)
+	DNSResolutionsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "kube_vip_dns_resolutions_total", Help: "DNS resolutions by result"},
+		[]string{"result"},
+	)
+	DNSIPChangesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{Name: "kube_vip_dns_ip_changes_total", Help: "DNS-driven VIP IP changes"},
+	)
 
 	// This is a prometheus counter used to count the number of events received
 	// from the service watcher
@@ -91,6 +118,13 @@ func RegisterPrometheusMetrics() {
 		ActiveServices,
 		ServiceReconcileErrorsTotal,
 		ServiceReconcileDuration,
+		VIPAddresses,
+		VIPOperationsTotal,
+		ARPAdvertisementsTotal,
+		NDPAdvertisementsTotal,
+		RouteOperationsTotal,
+		DNSResolutionsTotal,
+		DNSIPChangesTotal,
 		LeaderTransitionsTotal,
 		IsLeader,
 		WatcherLoops,

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -1,0 +1,55 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestLoopMetricsRegisterAndTrackLiveness(t *testing.T) {
+	WatcherLoops.Reset()
+	ElectionLoops.Reset()
+	t.Cleanup(func() {
+		WatcherLoops.Reset()
+		ElectionLoops.Reset()
+	})
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(WatcherLoops, ElectionLoops)
+
+	watcher := WatcherLoops.WithLabelValues("service")
+	election := ElectionLoops.WithLabelValues("kubernetes")
+
+	watcher.Inc()
+	election.Inc()
+	if got := testutil.ToFloat64(watcher); got != 1 {
+		t.Fatalf("watcher loop gauge is %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(election); got != 1 {
+		t.Fatalf("election loop gauge is %v, want 1", got)
+	}
+
+	watcher.Dec()
+	election.Dec()
+	if got := testutil.ToFloat64(watcher); got != 0 {
+		t.Fatalf("watcher loop gauge is %v after stop, want 0", got)
+	}
+	if got := testutil.ToFloat64(election); got != 0 {
+		t.Fatalf("election loop gauge is %v after stop, want 0", got)
+	}
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gathering loop gauges: %v", err)
+	}
+	seen := make(map[string]bool, len(families))
+	for _, family := range families {
+		seen[family.GetName()] = true
+	}
+	for _, name := range []string{"kube_vip_watcher_loops", "kube_vip_election_loops"} {
+		if !seen[name] {
+			t.Errorf("loop gauge %q was not registered", name)
+		}
+	}
+}

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -1,11 +1,71 @@
 package metrics
 
 import (
+	"io"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
+
+func TestBuildInfoScrape(t *testing.T) {
+	BuildInfo.Reset()
+	t.Cleanup(BuildInfo.Reset)
+
+	BuildInfo.WithLabelValues("v1.2.3", "abc123", "node-a").Set(1)
+	registry := prometheus.NewPedanticRegistry()
+	registry.MustRegister(BuildInfo)
+
+	request := httptest.NewRequest("GET", "/metrics", nil)
+	response := httptest.NewRecorder()
+	promhttp.HandlerFor(registry, promhttp.HandlerOpts{}).ServeHTTP(response, request)
+	if response.Code != 200 {
+		t.Fatalf("scrape status = %d, want 200", response.Code)
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("reading scrape: %v", err)
+	}
+	if err := testutil.GatherAndCompare(registry, strings.NewReader(`# HELP kube_vip_build_info Constant 1; track version skew across nodes
+# TYPE kube_vip_build_info gauge
+kube_vip_build_info{build="abc123",node="node-a",version="v1.2.3"} 1
+`), "kube_vip_build_info"); err != nil {
+		t.Fatalf("scraping build info: %v", err)
+	}
+	if !strings.Contains(string(body), `kube_vip_build_info{build="abc123",node="node-a",version="v1.2.3"} 1`) {
+		t.Fatalf("scrape does not contain build info: %s", body)
+	}
+}
+
+func TestTrackServiceElectionLoopDeletesOnlyAfterFinalExit(t *testing.T) {
+	ServiceElectionLoops.Reset()
+	t.Cleanup(ServiceElectionLoops.Reset)
+
+	doneFirst := TrackServiceElectionLoop("default", "api")
+	doneSecond := TrackServiceElectionLoop("default", "api")
+	if got := testutil.ToFloat64(ServiceElectionLoops.WithLabelValues("default", "api")); got != 2 {
+		t.Fatalf("loop gauge = %v, want 2", got)
+	}
+
+	doneFirst()
+	if got := testutil.ToFloat64(ServiceElectionLoops.WithLabelValues("default", "api")); got != 1 {
+		t.Fatalf("loop gauge after first exit = %v, want 1", got)
+	}
+	doneSecond()
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(ServiceElectionLoops)
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gathering loop gauge: %v", err)
+	}
+	if len(families) != 0 {
+		t.Fatalf("loop series remains after final exit: %v", families)
+	}
+}
 
 func TestLoopMetricsRegisterAndTrackLiveness(t *testing.T) {
 	WatcherLoops.Reset()

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -113,3 +113,61 @@ func TestLoopMetricsRegisterAndTrackLiveness(t *testing.T) {
 		}
 	}
 }
+
+func TestDataplaneMetricsRegister(t *testing.T) {
+	VIPAddresses.Reset()
+	VIPOperationsTotal.Reset()
+	ARPAdvertisementsTotal.Reset()
+	NDPAdvertisementsTotal.Reset()
+	RouteOperationsTotal.Reset()
+	DNSResolutionsTotal.Reset()
+	t.Cleanup(func() {
+		VIPAddresses.Reset()
+		VIPOperationsTotal.Reset()
+		ARPAdvertisementsTotal.Reset()
+		NDPAdvertisementsTotal.Reset()
+		RouteOperationsTotal.Reset()
+		DNSResolutionsTotal.Reset()
+	})
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(
+		VIPAddresses,
+		VIPOperationsTotal,
+		ARPAdvertisementsTotal,
+		NDPAdvertisementsTotal,
+		RouteOperationsTotal,
+		DNSResolutionsTotal,
+		DNSIPChangesTotal,
+	)
+
+	VIPAddresses.WithLabelValues("eth0", "IPv4").Inc()
+	VIPOperationsTotal.WithLabelValues("add", "ok").Inc()
+	ARPAdvertisementsTotal.WithLabelValues("ok").Inc()
+	NDPAdvertisementsTotal.WithLabelValues("error").Inc()
+	RouteOperationsTotal.WithLabelValues("replace", "ok").Inc()
+	DNSResolutionsTotal.WithLabelValues("error").Inc()
+	DNSIPChangesTotal.Inc()
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gathering dataplane metrics: %v", err)
+	}
+	seen := make(map[string]bool, len(families))
+	for _, family := range families {
+		seen[family.GetName()] = true
+	}
+	for _, name := range []string{
+		"kube_vip_vip_addresses",
+		"kube_vip_vip_operations_total",
+		"kube_vip_arp_advertisements_total",
+		"kube_vip_ndp_advertisements_total",
+		"kube_vip_route_operations_total",
+		"kube_vip_dns_resolutions_total",
+		"kube_vip_dns_ip_changes_total",
+	} {
+		if !seen[name] {
+			t.Errorf("dataplane metric %q was not registered", name)
+		}
+	}
+}

--- a/pkg/route/manager.go
+++ b/pkg/route/manager.go
@@ -112,6 +112,9 @@ func (m *Manager) Delete(object string, r route) error {
 }
 
 func (m *Manager) Clear() {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
 	for _, itm := range m.tracker {
 		if err := itm.route.DeleteRoute(); err != nil {
 			log.Warn("[RT] failed to delete route", "err", err.Error())
@@ -121,6 +124,9 @@ func (m *Manager) Clear() {
 }
 
 func (m *Manager) Check(key string) bool {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
 	_, exists := m.tracker[key]
 	return exists
 }

--- a/pkg/route/manager.go
+++ b/pkg/route/manager.go
@@ -6,6 +6,8 @@ import (
 	log "log/slog"
 	"sync"
 	"syscall"
+
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 )
 
 type Manager struct {
@@ -56,6 +58,7 @@ func (m *Manager) Add(object string, r route, precheck, update bool) error {
 				// of kube-vip) try to update it if necessary
 				isUpdated, err := r.UpdateRoutes()
 				if err != nil {
+					metrics.RouteOperationsTotal.WithLabelValues("add", "error").Inc()
 					return fmt.Errorf("error updating existing route: %w", err)
 				}
 				if isUpdated {
@@ -63,6 +66,7 @@ func (m *Manager) Add(object string, r route, precheck, update bool) error {
 				}
 			} else {
 				// If other error occurs, return error
+				metrics.RouteOperationsTotal.WithLabelValues("add", "error").Inc()
 				return fmt.Errorf("error adding route %q: %w", key, err)
 			}
 		}
@@ -79,6 +83,7 @@ func (m *Manager) Add(object string, r route, precheck, update bool) error {
 
 	log.Debug("[RT] incremented route", "path", key, "object", object, "cnt", len(itm.objects))
 
+	metrics.RouteOperationsTotal.WithLabelValues("add", "ok").Inc()
 	return nil
 }
 
@@ -92,6 +97,7 @@ func (m *Manager) Delete(object string, r route) error {
 	itm, exists := m.tracker[key]
 	if !exists {
 		log.Debug("[RT] deleting route - nothing to delete", "path", key, "object", object)
+		metrics.RouteOperationsTotal.WithLabelValues("delete", "ok").Inc()
 		return nil
 	}
 
@@ -102,12 +108,14 @@ func (m *Manager) Delete(object string, r route) error {
 	if len(itm.objects) == 0 {
 		if err := r.DeleteRoute(); err != nil {
 			itm.objects[object] = true
+			metrics.RouteOperationsTotal.WithLabelValues("delete", "error").Inc()
 			return fmt.Errorf("failed to delete route: %w", err)
 		}
 		delete(m.tracker, key)
 		log.Debug("[RT] deleted route", "path", key, "object", object)
 	}
 
+	metrics.RouteOperationsTotal.WithLabelValues("delete", "ok").Inc()
 	return nil
 }
 
@@ -117,7 +125,10 @@ func (m *Manager) Clear() {
 
 	for _, itm := range m.tracker {
 		if err := itm.route.DeleteRoute(); err != nil {
+			metrics.RouteOperationsTotal.WithLabelValues("delete", "error").Inc()
 			log.Warn("[RT] failed to delete route", "err", err.Error())
+		} else {
+			metrics.RouteOperationsTotal.WithLabelValues("delete", "ok").Inc()
 		}
 	}
 	m.tracker = make(map[string]*item)

--- a/pkg/route/manager_atomic_test.go
+++ b/pkg/route/manager_atomic_test.go
@@ -2,6 +2,8 @@ package route
 
 import (
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
 )
 
@@ -27,3 +29,35 @@ func TestManagerRetriesRouteAfterInitialAddFailure(t *testing.T) {
 		t.Fatalf("AddRoute called %d times, want 2", r.addCalls)
 	}
 }
+
+func TestManagerConcurrentLifecycle(t *testing.T) {
+	m := NewManager()
+	var wg sync.WaitGroup
+	for i := range 20 {
+		r := concurrentRoute{hash: fmt.Sprintf("route-%d", i)}
+		wg.Go(func() {
+			for j := range 100 {
+				object := fmt.Sprintf("service-%d", j)
+				if err := m.Add(object, r, false, false); err != nil {
+					t.Errorf("adding route: %v", err)
+				}
+				m.Check(r.RouteHash())
+				if err := m.Delete(object, r); err != nil {
+					t.Errorf("deleting route: %v", err)
+				}
+				if j%10 == 0 {
+					m.Clear()
+				}
+			}
+		})
+	}
+	wg.Wait()
+}
+
+type concurrentRoute struct{ hash string }
+
+func (r concurrentRoute) AddRoute(bool) (bool, error) { return true, nil }
+func (r concurrentRoute) UpdateRoutes() (bool, error) { return false, nil }
+func (r concurrentRoute) DeleteRoute() error          { return nil }
+func (r concurrentRoute) RouteHash() string           { return r.hash }
+func (concurrentRoute) Interface() string             { return "test" }

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -185,7 +185,12 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 }
 
 func (p *Processor) onStartedLeading(svcCtx *servicecontext.Context, service *v1.Service, wg *sync.WaitGroup) error {
-	err := p.SyncServices(svcCtx, service, wg, true)
+	var err error
+	if !p.withActiveService(svcCtx, func() {
+		err = p.SyncServices(svcCtx, service, wg, true)
+	}) {
+		return nil
+	}
 	if err != nil {
 		log.Error("service sync", "uid", service.UID, "err", err)
 		return err

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -341,8 +341,6 @@ func (p *Processor) deleteTrackedService(svc *v1.Service) error {
 		log.Warn("(svcs) The load balancer was deleted, cancelling context", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
 		svcCtx.Cancel()
 		p.svcMap.Delete(svc.UID)
-		// Drop the per-service election series so a recreated service starts clean.
-		metrics.ServiceElectionLoops.DeleteLabelValues(svc.Namespace, svc.Name)
 		p.updateActiveServicesMetric()
 
 		log.Info("(svcs) deleted", "service name", svc.Name, "namespace", svc.Namespace)

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -40,8 +40,9 @@ type Processor struct {
 	// Keeps track of all running instances
 	ServiceInstances []*instance.Instance
 
-	mutex     sync.Mutex
-	bgpServer *bgp.Server
+	mutex          sync.Mutex
+	lifecycleMutex sync.Mutex
+	bgpServer      *bgp.Server
 
 	clientSet   *kubernetes.Clientset
 	rwClientSet *kubernetes.Clientset
@@ -315,12 +316,20 @@ func (p *Processor) Delete(event watch.Event, forcedOnly bool) error {
 }
 
 func (p *Processor) deleteTrackedService(svc *v1.Service) error {
+	p.lifecycleMutex.Lock()
+	defer p.lifecycleMutex.Unlock()
+
 	svcCtx, err := p.getServiceContext(svc.UID)
 	if err != nil {
 		return fmt.Errorf("(svcs) unable to get context: %w", err)
 	}
 
 	if svcCtx != nil {
+		// Stop every producer before tearing down the tracked instance. Endpoint
+		// reconciliation uses lifecycleMutex too, so no queued event can restore
+		// datapath state after this point.
+		svcCtx.Cancel()
+
 		// If no leader election is enabled, delete routes here
 		if !p.config.EnableLeaderElection && !p.config.EnableServicesElection &&
 			p.config.EnableRoutingTable && svcCtx.HasConfiguredNetworks() {
@@ -329,24 +338,36 @@ func (p *Processor) deleteTrackedService(svc *v1.Service) error {
 			}
 		}
 
-		if !p.config.EnableServicesElection {
-			// If this is an active service then and additional leaderElection will handle stopping
-			err = p.deleteService(svcCtx.Ctx, svc.UID)
-			if err != nil {
-				log.Error(err.Error())
-			}
+		// Delete synchronously even with per-Service election. Waiting for the
+		// election callback leaves a window in which a queued callback can add the
+		// deleted Service again.
+		if err = p.deleteService(context.WithoutCancel(svcCtx.Ctx), svc.UID); err != nil {
+			log.Error(err.Error())
 		}
 
-		// Calls the cancel function of the context
 		log.Warn("(svcs) The load balancer was deleted, cancelling context", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
-		svcCtx.Cancel()
-		p.svcMap.Delete(svc.UID)
+		ns, name := lease.ServiceName(svc)
+		leaseID := lease.NewID(p.config.LeaderElectionType, ns, name)
+		p.leaseMgr.Delete(leaseID, lease.ServiceNamespacedName(svc), nil)
+		p.svcMap.CompareAndDelete(svc.UID, svcCtx)
+		// Drop the per-service election series so a recreated service starts clean.
+		metrics.ServiceElectionLoops.DeleteLabelValues(svc.Namespace, svc.Name)
 		p.updateActiveServicesMetric()
 
 		log.Info("(svcs) deleted", "service name", svc.Name, "namespace", svc.Namespace)
 	}
 
 	return nil
+}
+
+func (p *Processor) withActiveService(svcCtx *servicecontext.Context, reconcile func()) bool {
+	p.lifecycleMutex.Lock()
+	defer p.lifecycleMutex.Unlock()
+	if svcCtx.Ctx.Err() != nil {
+		return false
+	}
+	reconcile()
+	return true
 }
 
 func (p *Processor) Stop() {

--- a/pkg/services/processor_lease_test.go
+++ b/pkg/services/processor_lease_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/kube-vip/kube-vip/pkg/instance"
@@ -13,6 +14,42 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 )
+
+func TestDeletedSharedVIPServiceRejectsRacingEndpointUpdate(t *testing.T) {
+	p := &Processor{}
+	first := servicecontext.New(context.Background())
+	second := servicecontext.New(context.Background())
+	const vip = "192.0.2.10"
+	references := map[string]map[string]bool{
+		vip: {"local-a": true, "local-b": true},
+	}
+
+	// Hold deletion's lifecycle section so the endpoint update is queued in
+	// the same state observed in the E2E failure.
+	p.lifecycleMutex.Lock()
+	var wg sync.WaitGroup
+	updated := make(chan bool, 1)
+	wg.Go(func() {
+		updated <- p.withActiveService(first, func() {
+			references[vip]["local-a"] = true
+		})
+	})
+
+	first.Cancel()
+	delete(references[vip], "local-a")
+	p.lifecycleMutex.Unlock()
+	wg.Wait()
+
+	if <-updated {
+		t.Fatal("endpoint update reconciled after its Service was cancelled")
+	}
+	if references[vip]["local-a"] {
+		t.Fatal("deleted Service restored its shared VIP reference")
+	}
+	if !references[vip]["local-b"] || second.Ctx.Err() != nil {
+		t.Fatal("deleting one Local Service disturbed the other shared VIP owner")
+	}
+}
 
 func TestAddOrModifyStopsTrackedServiceWhenTypeChanges(t *testing.T) {
 	for _, ignored := range []bool{false, true} {

--- a/pkg/services/processor_lease_test.go
+++ b/pkg/services/processor_lease_test.go
@@ -20,8 +20,18 @@ func TestDeletedSharedVIPServiceRejectsRacingEndpointUpdate(t *testing.T) {
 	first := servicecontext.New(context.Background())
 	second := servicecontext.New(context.Background())
 	const vip = "192.0.2.10"
+	localA := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "local-a", UID: "local-a"},
+		Spec: v1.ServiceSpec{
+			LoadBalancerIP:        vip,
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+		},
+	}
+	localB := localA.DeepCopy()
+	localB.Name = "local-b"
+	localB.UID = "local-b"
 	references := map[string]map[string]bool{
-		vip: {"local-a": true, "local-b": true},
+		vip: {string(localA.UID): true, string(localB.UID): true},
 	}
 
 	// Hold deletion's lifecycle section so the endpoint update is queued in
@@ -31,22 +41,22 @@ func TestDeletedSharedVIPServiceRejectsRacingEndpointUpdate(t *testing.T) {
 	updated := make(chan bool, 1)
 	wg.Go(func() {
 		updated <- p.withActiveService(first, func() {
-			references[vip]["local-a"] = true
+			references[vip][string(localA.UID)] = true
 		})
 	})
 
 	first.Cancel()
-	delete(references[vip], "local-a")
+	delete(references[vip], string(localA.UID))
 	p.lifecycleMutex.Unlock()
 	wg.Wait()
 
 	if <-updated {
 		t.Fatal("endpoint update reconciled after its Service was cancelled")
 	}
-	if references[vip]["local-a"] {
+	if references[vip][string(localA.UID)] {
 		t.Fatal("deleted Service restored its shared VIP reference")
 	}
-	if !references[vip]["local-b"] || second.Ctx.Err() != nil {
+	if !references[vip][string(localB.UID)] || second.Ctx.Err() != nil {
 		t.Fatal("deleting one Local Service disturbed the other shared VIP owner")
 	}
 }

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -45,6 +45,9 @@ const (
 )
 
 func (p *Processor) SyncServices(ctx *servicecontext.Context, svc *v1.Service, wg *sync.WaitGroup, usesLeaderElection bool) error {
+	if ctx.Ctx.Err() != nil {
+		return nil
+	}
 	log.Debug("[STARTING] Service Sync", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
 
 	// Iterate through the synchronising services
@@ -170,6 +173,9 @@ func (p *Processor) addService(ctx context.Context, inst *instance.Instance, svc
 	// protect against addService while reading
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
+	if ctx.Err() != nil {
+		return nil
+	}
 
 	startTime := time.Now()
 

--- a/pkg/services/watch_endpoints.go
+++ b/pkg/services/watch_endpoints.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/debouncer"
 	"github.com/kube-vip/kube-vip/pkg/endpoints"
 	"github.com/kube-vip/kube-vip/pkg/endpoints/providers"
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/servicecontext"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 	v1 "k8s.io/api/core/v1"
@@ -18,6 +19,10 @@ import (
 
 func (p *Processor) watchEndpoint(svcCtx *servicecontext.Context, id string, service *v1.Service,
 	provider providers.Provider, cancelWatcher context.CancelCauseFunc) error {
+	watcherLoops := metrics.WatcherLoops.WithLabelValues("endpoint")
+	watcherLoops.Inc()
+	defer watcherLoops.Dec()
+
 	log.Info("watching", "provider", provider.GetLabel(), "service_name", service.Name, "namespace", service.Namespace)
 	// Use a restartable watcher, as this should help in the event of etcd or timeout issues
 

--- a/pkg/services/watch_endpoints.go
+++ b/pkg/services/watch_endpoints.go
@@ -88,8 +88,14 @@ func (p *Processor) watchEndpoint(svcCtx *servicecontext.Context, id string, ser
 				log.Info("[endpoint watcher] endpoint object deleted", "provider", provider.GetLabel(), "service name", service.Name, "namespace", service.Namespace)
 			}
 
-			restart, err := epProcessor.Reconcile(svcCtx, event, &lastKnownGoodEndpoint, service, id,
-				p.StartServicesLeaderElection, &wg, p.clientSet, p.updateEgressConfiguration)
+			var restart bool
+			var err error
+			if !p.withActiveService(svcCtx, func() {
+				restart, err = epProcessor.Reconcile(svcCtx, event, &lastKnownGoodEndpoint, service, id,
+					p.StartServicesLeaderElection, &wg, p.clientSet, p.updateEgressConfiguration)
+			}) {
+				return nil
+			}
 			if restart {
 				continue
 			} else if err != nil {

--- a/pkg/services/watch_services.go
+++ b/pkg/services/watch_services.go
@@ -22,6 +22,10 @@ import (
 
 // This function handles the watching of a services endpoints and updates a load balancers endpoint configurations accordingly
 func (p *Processor) ServicesWatcher(ctx context.Context, serviceFunc *Callback, forcedOnly bool) error {
+	loops := metrics.WatcherLoops.WithLabelValues("service")
+	loops.Inc()
+	defer loops.Dec()
+
 	// first start port mirroring if enabled
 	if err := p.startTrafficMirroringIfEnabled(); err != nil {
 		return err

--- a/pkg/vip/address.go
+++ b/pkg/vip/address.go
@@ -122,9 +122,9 @@ type network struct {
 	// anycast semantics, e.g. ECMP, must not use DAD
 	dadSkip bool
 
-	// trackedVIPAddresses contains the addresses represented in VIPAddresses.
-	// AddIP and DeleteIP access it while holding link.Lock.
-	trackedVIPAddresses map[string]struct{}
+	// trackedVIPAddress is this network's reference represented in VIPAddresses.
+	// AddIP, DeleteIP, and SetIP access it while holding link.Lock.
+	trackedVIPAddress string
 }
 
 // NewConfig will attempt to provide an interface to the kernel network configuration
@@ -452,43 +452,40 @@ func (configurator *network) shouldSkipDAD(override bool) bool {
 	return override || configurator.dadSkip
 }
 
-func (configurator *network) accountVIPAddressAdd(existing *netlink.Addr) {
-	if existing != nil || configurator.address == nil {
-		return
-	}
-
-	if configurator.trackedVIPAddresses == nil {
-		configurator.trackedVIPAddresses = make(map[string]struct{})
-	}
-	key := configurator.address.String()
-	if _, ok := configurator.trackedVIPAddresses[key]; ok {
-		return
-	}
-
-	family := utils.IPv4Family
-	if utils.IsIPv6(configurator.address.IP.String()) {
-		family = utils.IPv6Family
-	}
-	metrics.VIPAddresses.WithLabelValues(configurator.link.Intf.Attrs().Name, family).Inc()
-	configurator.trackedVIPAddresses[key] = struct{}{}
-}
-
-func (configurator *network) accountVIPAddressDelete() {
+func (configurator *network) accountVIPAddressAdd() {
 	if configurator.address == nil {
 		return
 	}
 
 	key := configurator.address.String()
-	if _, ok := configurator.trackedVIPAddresses[key]; !ok {
+	if configurator.trackedVIPAddress == key {
 		return
 	}
-	delete(configurator.trackedVIPAddresses, key)
-
-	family := utils.IPv4Family
-	if utils.IsIPv6(configurator.address.IP.String()) {
-		family = utils.IPv6Family
+	if configurator.trackedVIPAddress != "" {
+		configurator.accountVIPAddressDelete()
 	}
-	metrics.VIPAddresses.WithLabelValues(configurator.link.Intf.Attrs().Name, family).Dec()
+
+	metrics.TrackVIPAddress(configurator.link.Intf.Attrs().Name, addressFamily(configurator.address), key)
+	configurator.trackedVIPAddress = key
+}
+
+func (configurator *network) accountVIPAddressDelete() {
+	if configurator.trackedVIPAddress == "" {
+		return
+	}
+
+	tracked, err := netlink.ParseAddr(configurator.trackedVIPAddress)
+	if err == nil {
+		metrics.UntrackVIPAddress(configurator.link.Intf.Attrs().Name, addressFamily(tracked), configurator.trackedVIPAddress)
+	}
+	configurator.trackedVIPAddress = ""
+}
+
+func addressFamily(address *netlink.Addr) string {
+	if utils.IsIPv6(address.IP.String()) {
+		return utils.IPv6Family
+	}
+	return utils.IPv4Family
 }
 
 // AddIP - Add an IP address to the interface
@@ -513,6 +510,7 @@ func (configurator *network) AddIP(precheck bool, skipDAD bool, minLifetime ...i
 	}
 
 	if existing != nil && existing.ValidLft > lifetime {
+		configurator.accountVIPAddressAdd()
 		metrics.VIPOperationsTotal.WithLabelValues("add", "ok").Inc()
 		return false, nil
 	}
@@ -538,7 +536,7 @@ func (configurator *network) AddIP(precheck bool, skipDAD bool, minLifetime ...i
 		return false, errors.Wrap(err, fmt.Sprintf("could not add ip to device %q", configurator.link.Intf.Attrs().Name))
 	}
 
-	configurator.accountVIPAddressAdd(existing)
+	configurator.accountVIPAddressAdd()
 
 	if configurator.nftables {
 		if err := configurator.configureNFTables(); err != nil {

--- a/pkg/vip/address.go
+++ b/pkg/vip/address.go
@@ -26,6 +26,7 @@ import (
 
 	iptables "github.com/kube-vip/kube-vip/pkg/iptables"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	nfinternal "github.com/kube-vip/kube-vip/pkg/nftables"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 
@@ -394,7 +395,12 @@ func (configurator *network) ReplaceRoute() error {
 	} else {
 		route.Realm = 2
 	}
-	return netlink.RouteReplace(route)
+	if err := netlink.RouteReplace(route); err != nil {
+		metrics.RouteOperationsTotal.WithLabelValues("replace", "error").Inc()
+		return err
+	}
+	metrics.RouteOperationsTotal.WithLabelValues("replace", "ok").Inc()
+	return nil
 }
 
 // DeleteRoute - Delete an IP address from a route table
@@ -415,6 +421,7 @@ func (configurator *network) getRoutes() (*[]netlink.Route, error) {
 func (configurator *network) UpdateRoutes() (bool, error) {
 	routes, err := configurator.getRoutes()
 	if err != nil {
+		metrics.RouteOperationsTotal.WithLabelValues("update", "error").Inc()
 		return false, fmt.Errorf("error updating routes: %w", err)
 	}
 	isUpdated := false
@@ -424,11 +431,13 @@ func (configurator *network) UpdateRoutes() (bool, error) {
 			(route.Type == r.Type || route.Type == unix.RTN_UNICAST) &&
 			route.LinkIndex == r.LinkIndex && route.Scope == r.Scope {
 			if err = netlink.RouteReplace(r); err != nil {
+				metrics.RouteOperationsTotal.WithLabelValues("update", "error").Inc()
 				return false, fmt.Errorf("error replacing route: %w", err)
 			}
 			isUpdated = true
 		}
 	}
+	metrics.RouteOperationsTotal.WithLabelValues("update", "ok").Inc()
 	return isUpdated, nil
 }
 
@@ -449,6 +458,7 @@ func (configurator *network) AddIP(precheck bool, skipDAD bool, minLifetime ...i
 	var err error
 	if precheck {
 		if existing, err = configurator.IsSet(); err != nil {
+			metrics.VIPOperationsTotal.WithLabelValues("add", "error").Inc()
 			return false, errors.Wrap(err, "could not check if address exists")
 		}
 	}
@@ -460,6 +470,7 @@ func (configurator *network) AddIP(precheck bool, skipDAD bool, minLifetime ...i
 	}
 
 	if existing != nil && existing.ValidLft > lifetime {
+		metrics.VIPOperationsTotal.WithLabelValues("add", "ok").Inc()
 		return false, nil
 	}
 
@@ -480,19 +491,29 @@ func (configurator *network) AddIP(precheck bool, skipDAD bool, minLifetime ...i
 
 	log.Debug("replacing IP", "address", configurator.address)
 	if err := netlink.AddrReplace(configurator.link.Intf, configurator.address); err != nil {
+		metrics.VIPOperationsTotal.WithLabelValues("add", "error").Inc()
 		return false, errors.Wrap(err, fmt.Sprintf("could not add ip to device %q", configurator.link.Intf.Attrs().Name))
 	}
 
+	family := utils.IPv4Family
+	if utils.IsIPv6(configurator.address.IP.String()) {
+		family = utils.IPv6Family
+	}
+	metrics.VIPAddresses.WithLabelValues(configurator.link.Intf.Attrs().Name, family).Inc()
+
 	if configurator.nftables {
 		if err := configurator.configureNFTables(); err != nil {
+			metrics.VIPOperationsTotal.WithLabelValues("add", "error").Inc()
 			return true, errors.Wrap(err, "could not configure NFTables")
 		}
 	} else {
 		if err := configurator.configureIPTables(); err != nil {
+			metrics.VIPOperationsTotal.WithLabelValues("add", "error").Inc()
 			return true, errors.Wrap(err, "could not configure IPTables")
 		}
 	}
 
+	metrics.VIPOperationsTotal.WithLabelValues("add", "ok").Inc()
 	return true, nil
 }
 
@@ -1062,17 +1083,26 @@ func (configurator *network) DeleteIP() (bool, error) {
 
 	result, err := configurator.IsSet()
 	if err != nil {
+		metrics.VIPOperationsTotal.WithLabelValues("delete", "error").Inc()
 		return false, errors.Wrap(err, "ip check in DeleteIP failed")
 	}
 
 	// Nothing to delete
 	if result == nil {
+		metrics.VIPOperationsTotal.WithLabelValues("delete", "ok").Inc()
 		return false, nil
 	}
 
 	if err = netlink.AddrDel(configurator.link.Intf, configurator.address); err != nil {
+		metrics.VIPOperationsTotal.WithLabelValues("delete", "error").Inc()
 		return false, errors.Wrap(err, "could not delete ip")
 	}
+
+	family := utils.IPv4Family
+	if utils.IsIPv6(configurator.address.IP.String()) {
+		family = utils.IPv6Family
+	}
+	metrics.VIPAddresses.WithLabelValues(configurator.link.Intf.Attrs().Name, family).Dec()
 
 	if configurator.nftables {
 		vip := configurator.address.IP.String()
@@ -1083,6 +1113,7 @@ func (configurator *network) DeleteIP() (bool, error) {
 		}
 		c, err := nfinternal.NewClient(opt)
 		if err != nil {
+			metrics.VIPOperationsTotal.WithLabelValues("delete", "error").Inc()
 			return false, fmt.Errorf("unable to create nftables client: %w", err)
 		}
 
@@ -1099,22 +1130,26 @@ func (configurator *network) DeleteIP() (bool, error) {
 		}
 
 		if err := c.Close(); err != nil {
+			metrics.VIPOperationsTotal.WithLabelValues("delete", "error").Inc()
 			return true, errors.Wrap(err, "failed to close nftables client")
 		}
 	} else {
 		if configurator.enableSecurity && !configurator.ignoreSecurity {
 			if err := configurator.removeIptablesRuleToLimitTrafficPorts(); err != nil {
+				metrics.VIPOperationsTotal.WithLabelValues("delete", "error").Inc()
 				return true, errors.Wrap(err, "could not remove iptables rules to limit traffic ports")
 			}
 		}
 
 		if configurator.serviceName == "" && configurator.ipvsEnabled && configurator.forwardMethod == "masquerade" && configurator.address.IP.To4() != nil {
 			if err := configurator.removeIptablesRulesForMasquerade(); err != nil {
+				metrics.VIPOperationsTotal.WithLabelValues("delete", "error").Inc()
 				return true, errors.Wrap(err, "could not remove iptables masquerade rules ")
 			}
 		}
 	}
 
+	metrics.VIPOperationsTotal.WithLabelValues("delete", "ok").Inc()
 	return true, nil
 }
 

--- a/pkg/vip/address.go
+++ b/pkg/vip/address.go
@@ -121,6 +121,10 @@ type network struct {
 	// dadSkip marks the address with IFA_F_NODAD on every add:
 	// anycast semantics, e.g. ECMP, must not use DAD
 	dadSkip bool
+
+	// trackedVIPAddresses contains the addresses represented in VIPAddresses.
+	// AddIP and DeleteIP access it while holding link.Lock.
+	trackedVIPAddresses map[string]struct{}
 }
 
 // NewConfig will attempt to provide an interface to the kernel network configuration
@@ -448,6 +452,45 @@ func (configurator *network) shouldSkipDAD(override bool) bool {
 	return override || configurator.dadSkip
 }
 
+func (configurator *network) accountVIPAddressAdd(existing *netlink.Addr) {
+	if existing != nil || configurator.address == nil {
+		return
+	}
+
+	if configurator.trackedVIPAddresses == nil {
+		configurator.trackedVIPAddresses = make(map[string]struct{})
+	}
+	key := configurator.address.String()
+	if _, ok := configurator.trackedVIPAddresses[key]; ok {
+		return
+	}
+
+	family := utils.IPv4Family
+	if utils.IsIPv6(configurator.address.IP.String()) {
+		family = utils.IPv6Family
+	}
+	metrics.VIPAddresses.WithLabelValues(configurator.link.Intf.Attrs().Name, family).Inc()
+	configurator.trackedVIPAddresses[key] = struct{}{}
+}
+
+func (configurator *network) accountVIPAddressDelete() {
+	if configurator.address == nil {
+		return
+	}
+
+	key := configurator.address.String()
+	if _, ok := configurator.trackedVIPAddresses[key]; !ok {
+		return
+	}
+	delete(configurator.trackedVIPAddresses, key)
+
+	family := utils.IPv4Family
+	if utils.IsIPv6(configurator.address.IP.String()) {
+		family = utils.IPv6Family
+	}
+	metrics.VIPAddresses.WithLabelValues(configurator.link.Intf.Attrs().Name, family).Dec()
+}
+
 // AddIP - Add an IP address to the interface
 // precheck: if true, check if the IP already exists before adding
 // skipDAD: if true, set IFA_F_NODAD flag for IPv6 addresses to skip Duplicate Address Detection
@@ -495,11 +538,7 @@ func (configurator *network) AddIP(precheck bool, skipDAD bool, minLifetime ...i
 		return false, errors.Wrap(err, fmt.Sprintf("could not add ip to device %q", configurator.link.Intf.Attrs().Name))
 	}
 
-	family := utils.IPv4Family
-	if utils.IsIPv6(configurator.address.IP.String()) {
-		family = utils.IPv6Family
-	}
-	metrics.VIPAddresses.WithLabelValues(configurator.link.Intf.Attrs().Name, family).Inc()
+	configurator.accountVIPAddressAdd(existing)
 
 	if configurator.nftables {
 		if err := configurator.configureNFTables(); err != nil {
@@ -1089,6 +1128,7 @@ func (configurator *network) DeleteIP() (bool, error) {
 
 	// Nothing to delete
 	if result == nil {
+		configurator.accountVIPAddressDelete()
 		metrics.VIPOperationsTotal.WithLabelValues("delete", "ok").Inc()
 		return false, nil
 	}
@@ -1098,11 +1138,7 @@ func (configurator *network) DeleteIP() (bool, error) {
 		return false, errors.Wrap(err, "could not delete ip")
 	}
 
-	family := utils.IPv4Family
-	if utils.IsIPv6(configurator.address.IP.String()) {
-		family = utils.IPv6Family
-	}
-	metrics.VIPAddresses.WithLabelValues(configurator.link.Intf.Attrs().Name, family).Dec()
+	configurator.accountVIPAddressDelete()
 
 	if configurator.nftables {
 		vip := configurator.address.IP.String()

--- a/pkg/vip/address_test.go
+++ b/pkg/vip/address_test.go
@@ -2,6 +2,12 @@ package vip
 
 import (
 	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/vishvananda/netlink"
+
+	"github.com/kube-vip/kube-vip/pkg/metrics"
+	"github.com/kube-vip/kube-vip/pkg/networkinterface"
 )
 
 func TestShouldSkipDAD(t *testing.T) {
@@ -24,5 +30,36 @@ func TestShouldSkipDAD(t *testing.T) {
 				t.Fatalf("shouldSkipDAD(%v) with dadSkip=%v = %v, want %v", tc.override, tc.dadSkip, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestVIPAddressGaugeRenewalDoesNotDrift(t *testing.T) {
+	metrics.VIPAddresses.Reset()
+	t.Cleanup(metrics.VIPAddresses.Reset)
+
+	address, err := netlink.ParseAddr("192.0.2.10/32")
+	if err != nil {
+		t.Fatalf("parsing test address: %v", err)
+	}
+	n := &network{
+		address: address,
+		link: &networkinterface.Link{
+			Intf: &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "eth0"}},
+		},
+	}
+	gauge := metrics.VIPAddresses.WithLabelValues("eth0", "IPv4")
+
+	// The first add creates the address; subsequent adds represent DNS renewals.
+	n.accountVIPAddressAdd(nil)
+	n.accountVIPAddressAdd(&netlink.Addr{})
+	n.accountVIPAddressAdd(&netlink.Addr{})
+	if got := testutil.ToFloat64(gauge); got != 1 {
+		t.Fatalf("VIP address gauge after renewals is %v, want 1", got)
+	}
+
+	n.accountVIPAddressDelete()
+	n.accountVIPAddressDelete()
+	if got := testutil.ToFloat64(gauge); got != 0 {
+		t.Fatalf("VIP address gauge after repeated deletion reconciliation is %v, want 0", got)
 	}
 }

--- a/pkg/vip/address_test.go
+++ b/pkg/vip/address_test.go
@@ -3,6 +3,7 @@ package vip
 import (
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/vishvananda/netlink"
 
@@ -50,16 +51,87 @@ func TestVIPAddressGaugeRenewalDoesNotDrift(t *testing.T) {
 	gauge := metrics.VIPAddresses.WithLabelValues("eth0", "IPv4")
 
 	// The first add creates the address; subsequent adds represent DNS renewals.
-	n.accountVIPAddressAdd(nil)
-	n.accountVIPAddressAdd(&netlink.Addr{})
-	n.accountVIPAddressAdd(&netlink.Addr{})
+	n.accountVIPAddressAdd()
+	n.accountVIPAddressAdd()
+	n.accountVIPAddressAdd()
 	if got := testutil.ToFloat64(gauge); got != 1 {
 		t.Fatalf("VIP address gauge after renewals is %v, want 1", got)
 	}
 
 	n.accountVIPAddressDelete()
 	n.accountVIPAddressDelete()
-	if got := testutil.ToFloat64(gauge); got != 0 {
-		t.Fatalf("VIP address gauge after repeated deletion reconciliation is %v, want 0", got)
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(metrics.VIPAddresses)
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gathering VIP address gauge: %v", err)
 	}
+	if len(families) != 0 {
+		t.Fatalf("VIP address series remains after repeated deletion: %v", families)
+	}
+}
+
+func TestVIPAddressGaugeTransfersAcrossDNSChanges(t *testing.T) {
+	metrics.VIPAddresses.Reset()
+	t.Cleanup(metrics.VIPAddresses.Reset)
+
+	address, err := netlink.ParseAddr("192.0.2.10/32")
+	if err != nil {
+		t.Fatalf("parsing test address: %v", err)
+	}
+	n := &network{
+		address:         address,
+		possibleSubnets: "32",
+		dnsName:         "vip.example.com",
+		link: &networkinterface.Link{
+			Intf: &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "dns0"}},
+		},
+	}
+	gauge := metrics.VIPAddresses.WithLabelValues("dns0", "IPv4")
+
+	n.accountVIPAddressAdd()
+	if err := n.SetIP("192.0.2.11"); err != nil {
+		t.Fatalf("changing DNS VIP: %v", err)
+	}
+	n.accountVIPAddressAdd()
+	if got := testutil.ToFloat64(gauge); got != 1 {
+		t.Fatalf("VIP address gauge after transfer is %v, want 1", got)
+	}
+	if n.trackedVIPAddress != "192.0.2.11/32" {
+		t.Fatalf("tracked VIP = %q, want 192.0.2.11/32", n.trackedVIPAddress)
+	}
+
+	n.accountVIPAddressDelete()
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(metrics.VIPAddresses)
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gathering VIP address gauge: %v", err)
+	}
+	if len(families) != 0 {
+		t.Fatalf("VIP address series remains after deletion: %v", families)
+	}
+}
+
+func TestVIPAddressGaugeCountsExistingAddressOnReclaim(t *testing.T) {
+	metrics.VIPAddresses.Reset()
+	t.Cleanup(metrics.VIPAddresses.Reset)
+
+	address, err := netlink.ParseAddr("198.51.100.20/32")
+	if err != nil {
+		t.Fatalf("parsing test address: %v", err)
+	}
+	n := &network{
+		address: address,
+		link: &networkinterface.Link{
+			Intf: &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "reclaim0"}},
+		},
+	}
+
+	n.accountVIPAddressAdd()
+	n.accountVIPAddressAdd()
+	if got := testutil.ToFloat64(metrics.VIPAddresses.WithLabelValues("reclaim0", "IPv4")); got != 1 {
+		t.Fatalf("reclaimed VIP address gauge = %v, want 1", got)
+	}
+	n.accountVIPAddressDelete()
 }

--- a/pkg/vip/dns.go
+++ b/pkg/vip/dns.go
@@ -6,6 +6,7 @@ import (
 
 	log "log/slog"
 
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 )
 
@@ -47,15 +48,22 @@ func (d *ipUpdater) Run(ctx context.Context) {
 			log.Info("stop ipUpdater")
 			return
 		case <-t.C:
+			previousIP := d.vip.IP()
 			ip, err := utils.LookupHost(dnsName, mode, true)
 			if err != nil {
+				metrics.DNSResolutionsTotal.WithLabelValues("error").Inc()
 				log.Warn("cannot lookup", "name", dnsName, "err", err)
 				// fallback to renewing the existing IP
 				ip = []string{d.vip.IP()}
+			} else {
+				metrics.DNSResolutionsTotal.WithLabelValues("ok").Inc()
 			}
 
-			if err := d.vip.SetIP(ip[0]); err != nil {
-				log.Error("setting IP", "address", ip, "err", err)
+			setIPErr := d.vip.SetIP(ip[0])
+			if setIPErr != nil {
+				log.Error("setting IP", "address", ip, "err", setIPErr)
+			} else if previousIP != ip[0] {
+				metrics.DNSIPChangesTotal.Inc()
 			}
 
 			// Normal VIP addition for DNS, use skipDAD=false for normal DAD process

--- a/pkg/vip/ndp.go
+++ b/pkg/vip/ndp.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/mdlayher/ndp"
 
+	"github.com/kube-vip/kube-vip/pkg/metrics"
+
 	log "log/slog"
 )
 
@@ -47,11 +49,18 @@ func (n *NdpResponder) Close() error {
 func (n *NdpResponder) SendGratuitous(address string) error {
 	ip, err := netip.ParseAddr(address)
 	if err != nil {
+		metrics.NDPAdvertisementsTotal.WithLabelValues("error").Inc()
 		return fmt.Errorf("failed to parse address %s", ip)
 	}
 
 	log.Info("Broadcasting NDP update", "ip", address, "hwaddr", n.hardwareAddr, "interface", n.intf)
-	return n.advertise(netip.IPv6LinkLocalAllNodes(), ip, true)
+	err = n.advertise(netip.IPv6LinkLocalAllNodes(), ip, true)
+	if err != nil {
+		metrics.NDPAdvertisementsTotal.WithLabelValues("error").Inc()
+	} else {
+		metrics.NDPAdvertisementsTotal.WithLabelValues("ok").Inc()
+	}
+	return err
 }
 
 func (n *NdpResponder) advertise(dst, target netip.Addr, gratuitous bool) error {


### PR DESCRIPTION
## Purpose

Add dataplane operation metrics that report actual VIP, neighbor, route, and DNS behavior.

## Key changes

- Adds VIP address, ARP/NDP, route, and DNS operation metrics with operation and result labels.
- Keeps the VIP-address gauge idempotent across renewals and preserves DNS ownership accounting.
- Includes and documents the loop-liveness metrics from #1740.

## Validation

Unit, integration, lint, CodeQL, and ARP, routing-table, BGP, and service E2E checks pass.

## Stack

Stacked on #1740. Merge order: #1740, #1741, #1742.