### PR TITLE
feat(metrics): BGP, egress/nftables and watcher-restart metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Added
+- Prometheus metrics for build information, service activity, reconciliation,
+  leader election, and watcher-loop liveness, with a metrics reference guide.
 - Configurable control-plane health check for BGP mode without leader election
   - Polls a configurable HTTP(S) endpoint (e.g. `https://localhost:6443/livez`) to verify the exposed service is healthy (usually the local kube-apiserver)
   - Withdraws the BGP route after a configurable number of consecutive failures, removing the unhealthy node from the ECMP set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Added
+- Prometheus counters and gauges for VIP, ARP, NDP, route, and DNS dataplane
+  operations, including restart-safe DNS VIP ownership accounting.
 - Prometheus metrics for build information, service activity, reconciliation,
   leader election, and watcher-loop liveness, with a metrics reference guide.
 - Configurable control-plane health check for BGP mode without leader election

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Added
+- Prometheus metrics for BGP route ownership, egress rules and operations,
+  watcher failures, and successful UPnP mappings.
 - Prometheus counters and gauges for VIP, ARP, NDP, route, and DNS dataplane
   operations, including restart-safe DNS VIP ownership accounting.
 - Prometheus metrics for build information, service activity, reconciliation,

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Kube-Vip was originally created to provide a HA solution for the Kubernetes cont
 - Egress! Kube-vip will utilise a service loadbalancer as both the ingress and **egress** for a pod. 
 - ... manifest generation, vendor API integrations and many more...
 
+## Prometheus metrics
+
+kube-vip exposes a Prometheus endpoint at `/metrics` by default. See the
+[metrics reference](docs/metrics.md) for the complete metric catalog,
+configuration, labels, and example queries.
+
 ## Why?
 
 The purpose of `kube-vip` is to simplify the building of HA Kubernetes clusters, which at this time can involve a few components and configurations that all need to be managed. This was blogged about in detail by [thebsdbox](https://twitter.com/thebsdbox/) here -> [https://thebsdbox.co.uk/2020/01/02/Designing-Building-HA-bare-metal-Kubernetes-cluster/#Networking-load-balancing](https://thebsdbox.co.uk/2020/01/02/Designing-Building-HA-bare-metal-Kubernetes-cluster/#Networking-load-balancing).

--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -474,7 +474,7 @@ var kubeVipManager = &cobra.Command{
 		}
 
 		metrics.RegisterPrometheusMetrics()
-		metrics.BuildInfo.WithLabelValues(Release.Version, Release.Build, initConfig.NodeName)
+		metrics.BuildInfo.WithLabelValues(Release.Version, Release.Build, initConfig.NodeName).Set(1)
 
 		// Start the service manager, this will watch the config Map and construct kube-vip services for it
 		err = mgr.Start(ctx)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,79 @@
+# kube-vip Prometheus metrics
+
+kube-vip exposes Prometheus metrics from every kube-vip process. The metrics
+endpoint is enabled by default at `:2112/metrics` and can be configured with
+the `--prometheusHTTPServer` flag, the `prometheusHTTPServer` configuration
+field, or the `prometheus_server` environment variable. Set the address to an
+empty string to disable the endpoint.
+
+Scrape each kube-vip pod or node-local process separately. Most gauges describe
+the state managed by that process, while counters and histograms describe work
+observed by that process and reset when it restarts. Use `rate()` or `increase()`
+for counters instead of comparing their raw values across restarts.
+
+Metrics that depend on a particular kube-vip mode are only emitted after that
+mode exercises the corresponding code path. Label values listed below are the
+values currently emitted by kube-vip; new values may be added as supported
+backends grow.
+
+## Service and VIP lifecycle
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `kube_vip_active_services` | Gauge | `namespace` | Number of managed LoadBalancer services in the namespace. |
+| `kube_vip_service_reconcile_errors_total` | Counter | `namespace`, `name`, `reason` | Service reconciliation failures. Current reasons include `invalid_config`, `service_context`, `delete_service`, and `new_instance`. |
+| `kube_vip_service_reconcile_duration_seconds` | Histogram | `namespace` | End-to-end duration of service `AddOrModify` reconciliation. |
+
+## Service events and leader election
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `kube_vip_manager_all_services_events_total` | Counter | `type` | Events received by the service watcher. `type` is a Kubernetes watch event such as `ADDED`, `MODIFIED`, `DELETED`, `BOOKMARK`, or `ERROR`. |
+| `kube_vip_leader_election_transitions_total` | Counter | `lease_name` | Number of observed transitions into leadership for a lease. A high rate can indicate instability. |
+| `kube_vip_is_leader` | Gauge | `node`, `lease_name` | `1` when the labeled node currently holds the lease, otherwise `0`. |
+| `kube_vip_watcher_loops` | Gauge | `kind` | Number of live watcher goroutines. Current kinds are `service`, `endpoint`, `lease`, and `node`. Endpoint and lease watchers are per service. |
+| `kube_vip_election_loops` | Gauge | `type` | Number of live leader-election loops. Current types are `kubernetes` and `etcd`. |
+| `kube_vip_service_election_loops` | Gauge | `namespace`, `name` | Live per-service leader-election restart loops on this node. A value greater than `1` indicates leaked loops. |
+| `kube_vip_service_election_attempts_total` | Counter | `namespace`, `name` | Attempts made by a per-service leader-election restart loop. |
+| `kube_vip_service_election_errors_total` | Counter | `namespace`, `name`, `reason` | Per-service election failures. The current failure reason is `no_lease`. |
+
+The loop gauges are balanced at goroutine start and exit. They are useful for
+detecting a leaked watcher or election loop after a service update, leadership
+loss, or watcher restart. For example:
+
+```promql
+max by (namespace, name, instance) (kube_vip_service_election_loops) > 1
+sum by (instance, kind) (kube_vip_watcher_loops)
+rate(kube_vip_leader_election_transitions_total[5m])
+```
+
+## BGP session state
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `kube_vip_manager_bgp_session_info` | Gauge | `state`, `peer` | BGP session state for a peer. For each peer, the current GoBGP state has value `1` and the other state series have value `0`; `peer` is emitted as `address:179`. |
+
+This metric is only useful when BGP is enabled. A session alert should select
+the state that represents an established session in the deployed GoBGP
+version, rather than assuming that an absent series means a failed session.
+
+## Build information
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `kube_vip_build_info` | Gauge | `version`, `build`, `node` | Constant `1`, useful for identifying the kube-vip version and build running on each node. |
+
+## Querying safely
+
+Service labels are intentionally included for troubleshooting, but they can
+create many time series in clusters with many short-lived services. Prefer
+aggregation or recording rules for dashboards, and use `rate()`/`increase()`
+for counters:
+
+```promql
+sum by (namespace) (kube_vip_active_services)
+sum by (result) (rate(kube_vip_service_reconcile_errors_total[5m]))
+histogram_quantile(0.99,
+  sum by (le) (rate(kube_vip_service_reconcile_duration_seconds_bucket[5m])))
+```
+

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -3,8 +3,9 @@
 kube-vip exposes Prometheus metrics from every kube-vip process. The metrics
 endpoint is enabled by default at `:2112/metrics` and can be configured with
 the `--prometheusHTTPServer` flag, the `prometheusHTTPServer` configuration
-field, or the `prometheus_server` environment variable. Set the address to an
-empty string to disable the endpoint.
+field, or the `prometheus_server` environment variable. The flag defaults to
+`:2112`; configuration-file and environment values override it only when they
+are non-empty.
 
 Scrape each kube-vip pod or node-local process separately. Most gauges describe
 the state managed by that process, while counters and histograms describe work
@@ -51,7 +52,7 @@ rate(kube_vip_leader_election_transitions_total[5m])
 
 | Metric | Type | Labels | Meaning |
 | --- | --- | --- | --- |
-| `kube_vip_manager_bgp_session_info` | Gauge | `state`, `peer` | BGP session state for a peer. For each peer, the current GoBGP state has value `1` and the other state series have value `0`; `peer` is emitted as `address:179`. |
+| `kube_vip_manager_bgp_session_info` | Gauge | `state`, `peer` | BGP session state for a peer. For each peer, the current GoBGP state has value `1` and the other state series have value `0`; `peer` contains the address and configured remote port. |
 
 This metric is only useful when BGP is enabled. A session alert should select
 the state that represents an established session in the deployed GoBGP
@@ -76,4 +77,3 @@ sum by (result) (rate(kube_vip_service_reconcile_errors_total[5m]))
 histogram_quantile(0.99,
   sum by (le) (rate(kube_vip_service_reconcile_duration_seconds_bucket[5m])))
 ```
-

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -61,7 +61,7 @@ sum by (result) (rate(kube_vip_ndp_advertisements_total[5m]))
 | `kube_vip_bgp_route_operations_total` | Counter | `op`, `result` | BGP route operations. Current operations are `add` and `delete`; results are `ok` or `error`. |
 | `kube_vip_egress_rules` | Gauge | `table` | Egress SNAT rules currently present in the labeled iptables or nftables table. The value is refreshed from the ruleset after successful changes. |
 | `kube_vip_egress_operations_total` | Counter | `op`, `result` | Egress SNAT operations. Current operations are `add` and `delete`; results are `ok` or `error`. |
-| `kube_vip_upnp_mappings` | Gauge | — | Number of distinct external gateway mappings currently tracked by the service processor. |
+| `kube_vip_upnp_mappings` | Gauge | — | Number of successful VIP/port/gateway mappings currently tracked by the service processor. |
 
 The BGP route gauge tracks the routes kube-vip owns in its host tracker; it is
 not a dump of every route in the BGP server. The egress rule gauge is a
@@ -73,14 +73,14 @@ updates. Table names are backend-specific, so dashboards should group by the
 sum by (instance, family) (kube_vip_bgp_routes_advertised)
 sum by (op, result) (rate(kube_vip_bgp_route_operations_total[5m]))
 sum by (instance, table) (kube_vip_egress_rules)
-sum by (kind, reason) (increase(kube_vip_watcher_restarts_total[15m]))
+sum by (kind, reason) (increase(kube_vip_watcher_failures_total[15m]))
 ```
 
 ## Watcher recovery
 
 | Metric | Type | Labels | Meaning |
 | --- | --- | --- | --- |
-| `kube_vip_watcher_restarts_total` | Counter | `kind`, `reason` | Watcher restarts caused by a watch failure or an unexpected channel/lifecycle event. Current kinds include `service`, `endpoint`, `annotations`, `lease`, and `node`; current reasons include `watch_error`, `channel_closed`, and `leader_election_error`. |
+| `kube_vip_watcher_failures_total` | Counter | `kind`, `reason` | Watcher failures that cause or request recovery. Current kinds include `service`, `endpoint`, `annotations`, `lease`, and `node`; current reasons include `watch_error`, `channel_closed`, and `leader_election_error`. |
 
 Use `kube_vip_watcher_loops` together with this counter: the counter shows
 that recovery was needed, while the gauge verifies that the replacement loop

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -53,6 +53,39 @@ sum by (result) (rate(kube_vip_arp_advertisements_total[5m]))
 sum by (result) (rate(kube_vip_ndp_advertisements_total[5m]))
 ```
 
+## BGP routes and egress
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `kube_vip_bgp_routes_advertised` | Gauge | `family` | BGP host routes currently advertised by address family. `family` is `IPv4` or `IPv6`. |
+| `kube_vip_bgp_route_operations_total` | Counter | `op`, `result` | BGP route operations. Current operations are `add` and `delete`; results are `ok` or `error`. |
+| `kube_vip_egress_rules` | Gauge | `table` | Egress SNAT rules currently present in the labeled iptables or nftables table. The value is refreshed from the ruleset after successful changes. |
+| `kube_vip_egress_operations_total` | Counter | `op`, `result` | Egress SNAT operations. Current operations are `add` and `delete`; results are `ok` or `error`. |
+| `kube_vip_upnp_mappings` | Gauge | — | Number of distinct external gateway mappings currently tracked by the service processor. |
+
+The BGP route gauge tracks the routes kube-vip owns in its host tracker; it is
+not a dump of every route in the BGP server. The egress rule gauge is a
+snapshot, while the egress operation metric records the outcome of individual
+updates. Table names are backend-specific, so dashboards should group by the
+`table` label instead of hard-coding one table name.
+
+```promql
+sum by (instance, family) (kube_vip_bgp_routes_advertised)
+sum by (op, result) (rate(kube_vip_bgp_route_operations_total[5m]))
+sum by (instance, table) (kube_vip_egress_rules)
+sum by (kind, reason) (increase(kube_vip_watcher_restarts_total[15m]))
+```
+
+## Watcher recovery
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `kube_vip_watcher_restarts_total` | Counter | `kind`, `reason` | Watcher restarts caused by a watch failure or an unexpected channel/lifecycle event. Current kinds include `service`, `endpoint`, `annotations`, `lease`, and `node`; current reasons include `watch_error`, `channel_closed`, and `leader_election_error`. |
+
+Use `kube_vip_watcher_loops` together with this counter: the counter shows
+that recovery was needed, while the gauge verifies that the replacement loop
+settled at the expected live-loop count.
+
 ## Service events and leader election
 
 | Metric | Type | Labels | Meaning |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -25,6 +25,31 @@ backends grow.
 | `kube_vip_service_reconcile_errors_total` | Counter | `namespace`, `name`, `reason` | Service reconciliation failures. Current reasons include `invalid_config`, `service_context`, `delete_service`, and `new_instance`. |
 | `kube_vip_service_reconcile_duration_seconds` | Histogram | `namespace` | End-to-end duration of service `AddOrModify` reconciliation. |
 
+## Dataplane operations
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `kube_vip_vip_addresses` | Gauge | `interface`, `family` | VIP addresses currently held by an interface. `family` is `IPv4` or `IPv6`. |
+| `kube_vip_vip_operations_total` | Counter | `op`, `result` | VIP address operations. Current operations are `add` and `delete`; results are `ok` or `error`. |
+| `kube_vip_arp_advertisements_total` | Counter | `result` | Gratuitous ARP advertisements, labeled `ok` or `error`. |
+| `kube_vip_ndp_advertisements_total` | Counter | `result` | Gratuitous NDP advertisements, labeled `ok` or `error`. |
+| `kube_vip_route_operations_total` | Counter | `op`, `result` | Routing-table operations. Current operations are `add`, `delete`, `replace`, and `update`; results are `ok` or `error`. |
+| `kube_vip_dns_resolutions_total` | Counter | `result` | DNS resolutions performed by the DNS-backed VIP updater, labeled `ok` or `error`. |
+| `kube_vip_dns_ip_changes_total` | Counter | — | Number of DNS-backed VIP changes where the resolved address changed. |
+
+The VIP address gauge is state-based: an address is counted once per
+interface/family and is removed when kube-vip releases it. Operation counters
+are attempt/outcome signals and should normally be queried with `rate()`.
+
+Useful examples:
+
+```promql
+sum by (instance, interface, family) (kube_vip_vip_addresses)
+sum by (op, result) (rate(kube_vip_vip_operations_total[5m]))
+sum by (result) (rate(kube_vip_arp_advertisements_total[5m]))
+sum by (result) (rate(kube_vip_ndp_advertisements_total[5m]))
+```
+
 ## Service events and leader election
 
 | Metric | Type | Labels | Meaning |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -38,8 +38,11 @@ backends grow.
 | `kube_vip_dns_ip_changes_total` | Counter | — | Number of DNS-backed VIP changes where the resolved address changed. |
 
 The VIP address gauge is state-based: an address is counted once per
-interface/family and is removed when kube-vip releases it. Operation counters
-are attempt/outcome signals and should normally be queried with `rate()`.
+interface/family, including when kube-vip reclaims an existing address after a
+restart. DNS changes transfer ownership from the old address to the new one,
+and the label series is removed when kube-vip releases the final address for
+that interface/family. Operation counters are attempt/outcome signals and
+should normally be queried with `rate()`.
 
 Useful examples:
 

--- a/pkg/arp/arp.go
+++ b/pkg/arp/arp.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 	"github.com/kube-vip/kube-vip/pkg/vip"
 	"github.com/vishvananda/netlink"
@@ -238,7 +239,10 @@ func ensureIPAndSendGratuitous(instance *Instance) {
 		// Gratuitous ARP, will broadcast to new MAC <-> IPv4 address
 		err := vip.ARPSendGratuitous(ipString, iface)
 		if err != nil {
+			metrics.ARPAdvertisementsTotal.WithLabelValues("error").Inc()
 			log.Warn(err.Error())
+		} else {
+			metrics.ARPAdvertisementsTotal.WithLabelValues("ok").Inc()
 		}
 	}
 }

--- a/pkg/bgp/hosts.go
+++ b/pkg/bgp/hosts.go
@@ -6,6 +6,8 @@ import (
 	log "log/slog"
 	"net"
 
+	"github.com/kube-vip/kube-vip/pkg/metrics"
+	"github.com/kube-vip/kube-vip/pkg/utils"
 	"github.com/osrg/gobgp/v4/pkg/apiutil"
 )
 
@@ -22,24 +24,33 @@ func (b *Server) AddHost(ctx context.Context, addr string, object string) error 
 
 		ip, _, err := net.ParseCIDR(addr)
 		if err != nil {
+			metrics.BGPRouteOperationsTotal.WithLabelValues("add", "error").Inc()
 			return err
 		}
 
 		p := b.getPath(ip)
 		if p == nil {
+			metrics.BGPRouteOperationsTotal.WithLabelValues("add", "error").Inc()
 			return fmt.Errorf("failed to get path for %v", ip)
 		}
 
 		if _, err := b.s.AddPath(apiutil.AddPathRequest{
 			Paths: []*apiutil.Path{p},
 		}); err != nil {
+			metrics.BGPRouteOperationsTotal.WithLabelValues("add", "error").Inc()
 			return err
 		}
+		family := utils.IPv4Family
+		if ip.To4() == nil {
+			family = utils.IPv6Family
+		}
+		metrics.BGPRoutesAdvertised.WithLabelValues(family).Inc()
 		log.Debug("[BGP] added host", "addr", addr, "cnt", len(objects)+1, "object", object)
 	}
 
 	objects[object] = true
 
+	metrics.BGPRouteOperationsTotal.WithLabelValues("add", "ok").Inc()
 	return nil
 }
 
@@ -51,11 +62,13 @@ func (b *Server) DelHost(ctx context.Context, addr string, object string) error 
 	objects, exists := b.tracker[addr]
 	if !exists {
 		log.Debug("[BGP] deleting host - nothing to delete", "addr", addr, "object", object)
+		metrics.BGPRouteOperationsTotal.WithLabelValues("delete", "ok").Inc()
 		return nil
 	}
 
 	ip, _, err := net.ParseCIDR(addr)
 	if err != nil {
+		metrics.BGPRouteOperationsTotal.WithLabelValues("delete", "error").Inc()
 		return err
 	}
 
@@ -64,19 +77,27 @@ func (b *Server) DelHost(ctx context.Context, addr string, object string) error 
 	if len(objects) == 0 {
 		p := b.getPath(ip)
 		if p == nil {
+			metrics.BGPRouteOperationsTotal.WithLabelValues("delete", "ok").Inc()
 			return nil
 		}
 
 		if err := b.s.DeletePath(apiutil.DeletePathRequest{
 			Paths: []*apiutil.Path{p},
 		}); err != nil {
+			metrics.BGPRouteOperationsTotal.WithLabelValues("delete", "error").Inc()
 			return err
 		}
+		family := utils.IPv4Family
+		if ip.To4() == nil {
+			family = utils.IPv6Family
+		}
+		metrics.BGPRoutesAdvertised.WithLabelValues(family).Dec()
 		delete(b.tracker, addr)
 		log.Debug("[BGP] deleted host", "addr", addr, "cnt", len(objects), "object", object)
 	} else {
 		log.Debug("[BGP] deleting from tracker only", "addr", addr, "object", object)
 	}
 
+	metrics.BGPRouteOperationsTotal.WithLabelValues("delete", "ok").Inc()
 	return nil
 }

--- a/pkg/bgp/hosts.go
+++ b/pkg/bgp/hosts.go
@@ -19,9 +19,6 @@ func (b *Server) AddHost(ctx context.Context, addr string, object string) error 
 	objects, exists := b.tracker[addr]
 
 	if !exists {
-		b.tracker[addr] = make(map[string]bool)
-		objects = b.tracker[addr]
-
 		ip, _, err := net.ParseCIDR(addr)
 		if err != nil {
 			metrics.BGPRouteOperationsTotal.WithLabelValues("add", "error").Inc()
@@ -40,6 +37,8 @@ func (b *Server) AddHost(ctx context.Context, addr string, object string) error 
 			metrics.BGPRouteOperationsTotal.WithLabelValues("add", "error").Inc()
 			return err
 		}
+		objects = make(map[string]bool)
+		b.tracker[addr] = objects
 		family := utils.IPv4Family
 		if ip.To4() == nil {
 			family = utils.IPv6Family
@@ -93,6 +92,17 @@ func (b *Server) DelHost(ctx context.Context, addr string, object string) error 
 		}
 		metrics.BGPRoutesAdvertised.WithLabelValues(family).Dec()
 		delete(b.tracker, addr)
+		familyStillAdvertised := false
+		for trackedAddress := range b.tracker {
+			trackedIP, _, err := net.ParseCIDR(trackedAddress)
+			if err == nil && (trackedIP.To4() == nil) == (ip.To4() == nil) {
+				familyStillAdvertised = true
+				break
+			}
+		}
+		if !familyStillAdvertised {
+			metrics.BGPRoutesAdvertised.DeleteLabelValues(family)
+		}
 		log.Debug("[BGP] deleted host", "addr", addr, "cnt", len(objects), "object", object)
 	} else {
 		log.Debug("[BGP] deleting from tracker only", "addr", addr, "object", object)

--- a/pkg/bgp/hosts_test.go
+++ b/pkg/bgp/hosts_test.go
@@ -1,0 +1,23 @@
+package bgp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+)
+
+func TestAddHostDoesNotTrackFailedAdvertisement(t *testing.T) {
+	server := newPeerTestServer(t, kubevip.BGPConfig{})
+	const invalidAddress = "not-a-cidr"
+
+	if err := server.AddHost(context.Background(), invalidAddress, "service-a"); err == nil {
+		t.Fatal("AddHost returned no error for an invalid address")
+	}
+	if _, exists := server.tracker[invalidAddress]; exists {
+		t.Fatal("failed advertisement poisoned host tracker")
+	}
+	if err := server.AddHost(context.Background(), invalidAddress, "service-b"); err == nil {
+		t.Fatal("second AddHost bypassed advertisement after prior failure")
+	}
+}

--- a/pkg/election/election.go
+++ b/pkg/election/election.go
@@ -243,6 +243,7 @@ func (em *Manager) NodeWatcher(ctx context.Context, lb *loadbalancer.IPVSLoadBal
 			// Un-used
 		case watch.Error:
 			log.Error("Error attempting to watch Kubernetes Nodes")
+			metrics.WatcherRestartsTotal.WithLabelValues("node", "watch_error").Inc()
 			watchErr = fmt.Errorf("node watcher error: %w", utils.WatchError(event.Object))
 			log.Error("watcher", "err", watchErr)
 		default:
@@ -256,6 +257,7 @@ func (em *Manager) NodeWatcher(ctx context.Context, lb *loadbalancer.IPVSLoadBal
 	if ctx.Err() != nil {
 		return nil
 	}
+	metrics.WatcherRestartsTotal.WithLabelValues("node", "channel_closed").Inc()
 	return utils.NewPanicError("node watcher channel closed unexpectedly")
 }
 

--- a/pkg/election/election.go
+++ b/pkg/election/election.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/loadbalancer"
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	v1 "k8s.io/api/core/v1"
@@ -72,6 +73,10 @@ func RunOrDie(ctx context.Context, run *RunConfig, c *kubevip.Config) error {
 }
 
 func runKubernetesLeaderElectionOrDie(ctx context.Context, run *RunConfig) {
+	loops := metrics.ElectionLoops.WithLabelValues("kubernetes")
+	loops.Inc()
+	defer loops.Dec()
+
 	// we use the Lease lock type since edits to Leases are less common
 	// and fewer objects in the cluster watch "all Leases".
 	lock := &resourcelock.LeaseLock{
@@ -108,6 +113,10 @@ func runKubernetesLeaderElectionOrDie(ctx context.Context, run *RunConfig) {
 }
 
 func runEtcdLeaderElectionOrDie(ctx context.Context, run *RunConfig) error {
+	loops := metrics.ElectionLoops.WithLabelValues("etcd")
+	loops.Inc()
+	defer loops.Dec()
+
 	if err := etcd.RunElectionOrDie(ctx, &etcd.LeaderElectionConfig{
 		EtcdConfig:           etcd.ClientConfig{Client: run.Mgr.EtcdClient},
 		Name:                 run.LeaseID.NamespacedName(),
@@ -147,6 +156,10 @@ type RunConfig struct {
 }
 
 func (em *Manager) NodeWatcher(ctx context.Context, lb *loadbalancer.IPVSLoadBalancer, port uint16) error {
+	loops := metrics.WatcherLoops.WithLabelValues("node")
+	loops.Inc()
+	defer loops.Dec()
+
 	// Use a restartable watcher, as this should help in the event of etcd or timeout issues
 	log.Info("Kube-Vip is watching nodes for control-plane labels")
 

--- a/pkg/election/election.go
+++ b/pkg/election/election.go
@@ -243,7 +243,7 @@ func (em *Manager) NodeWatcher(ctx context.Context, lb *loadbalancer.IPVSLoadBal
 			// Un-used
 		case watch.Error:
 			log.Error("Error attempting to watch Kubernetes Nodes")
-			metrics.WatcherRestartsTotal.WithLabelValues("node", "watch_error").Inc()
+			metrics.WatcherFailuresTotal.WithLabelValues("node", "watch_error").Inc()
 			watchErr = fmt.Errorf("node watcher error: %w", utils.WatchError(event.Object))
 			log.Error("watcher", "err", watchErr)
 		default:
@@ -257,7 +257,7 @@ func (em *Manager) NodeWatcher(ctx context.Context, lb *loadbalancer.IPVSLoadBal
 	if ctx.Err() != nil {
 		return nil
 	}
-	metrics.WatcherRestartsTotal.WithLabelValues("node", "channel_closed").Inc()
+	metrics.WatcherFailuresTotal.WithLabelValues("node", "channel_closed").Inc()
 	return utils.NewPanicError("node watcher channel closed unexpectedly")
 }
 

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -308,6 +308,10 @@ func (p *Processor) startServiceHandlingIfNeeded(svcCtx *servicecontext.Context,
 }
 
 func (p *Processor) startLeaderElection(svcCtx *servicecontext.Context, service *v1.Service, serviceFunc func(*servicecontext.Context, *v1.Service, *sync.WaitGroup, bool) error, wg *sync.WaitGroup) {
+	watcherLoops := metrics.WatcherLoops.WithLabelValues("lease")
+	watcherLoops.Inc()
+	defer watcherLoops.Dec()
+
 	// Track this loop for the lifetime of the goroutine. There has to be at most
 	// one per service, so a value above 1 means loops leaked.
 	loops := metrics.ServiceElectionLoops.WithLabelValues(service.Namespace, service.Name)

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -314,9 +314,7 @@ func (p *Processor) startLeaderElection(svcCtx *servicecontext.Context, service 
 
 	// Track this loop for the lifetime of the goroutine. There has to be at most
 	// one per service, so a value above 1 means loops leaked.
-	loops := metrics.ServiceElectionLoops.WithLabelValues(service.Namespace, service.Name)
-	loops.Inc()
-	defer loops.Dec()
+	defer metrics.TrackServiceElectionLoop(service.Namespace, service.Name)()
 
 	attempts := metrics.ServiceElectionAttemptsTotal.WithLabelValues(service.Namespace, service.Name)
 

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -339,6 +339,7 @@ func (p *Processor) startLeaderElection(svcCtx *servicecontext.Context, service 
 				attempts.Inc()
 				err := serviceFunc(svcCtx, service, wg, true)
 				if err != nil {
+					metrics.WatcherRestartsTotal.WithLabelValues("lease", "leader_election_error").Inc()
 					log.Error(err.Error())
 				}
 			} else {

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -339,7 +339,7 @@ func (p *Processor) startLeaderElection(svcCtx *servicecontext.Context, service 
 				attempts.Inc()
 				err := serviceFunc(svcCtx, service, wg, true)
 				if err != nil {
-					metrics.WatcherRestartsTotal.WithLabelValues("lease", "leader_election_error").Inc()
+					metrics.WatcherFailuresTotal.WithLabelValues("lease", "leader_election_error").Inc()
 					log.Error(err.Error())
 				}
 			} else {

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -52,7 +52,8 @@ type Instance struct {
 	VLANInterface string
 
 	// External Gateway IP the service is forwarded from
-	UPNPGatewayIPs []string
+	UPNPGatewayIPs   []string
+	UPNPMappingCount int
 
 	// Kubernetes service mapping
 	ServiceSnapshot *v1.Service

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/manager/worker"
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/networkinterface"
 	"github.com/kube-vip/kube-vip/pkg/nftables"
 	"github.com/kube-vip/kube-vip/pkg/node"
@@ -417,6 +418,7 @@ func (sm *Manager) startMode(ctx context.Context) error {
 						sm.Kill()
 						return fmt.Errorf("failed to reconcile services, non-recoverable error: %w", err)
 					} else {
+						metrics.WatcherRestartsTotal.WithLabelValues("service", "watch_error").Inc()
 						log.Error("failed to reconcile services, restarting", "error", err)
 					}
 				}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -24,7 +24,6 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/manager/worker"
-	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/networkinterface"
 	"github.com/kube-vip/kube-vip/pkg/nftables"
 	"github.com/kube-vip/kube-vip/pkg/node"
@@ -418,7 +417,6 @@ func (sm *Manager) startMode(ctx context.Context) error {
 						sm.Kill()
 						return fmt.Errorf("failed to reconcile services, non-recoverable error: %w", err)
 					} else {
-						metrics.WatcherRestartsTotal.WithLabelValues("service", "watch_error").Inc()
 						log.Error("failed to reconcile services, restarting", "error", err)
 					}
 				}

--- a/pkg/manager/watch_annotations.go
+++ b/pkg/manager/watch_annotations.go
@@ -11,6 +11,7 @@ import (
 	log "log/slog"
 
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 
 	v1 "k8s.io/api/core/v1"
@@ -110,6 +111,7 @@ func annotationsWatcher(ctx context.Context, clientSet,
 			// Un-used
 		case watch.Error:
 			log.Error("Error attempting to watch Kubernetes Nodes")
+			metrics.WatcherRestartsTotal.WithLabelValues("annotations", "watch_error").Inc()
 			log.Error("annotations watcher failed", "err", utils.WatchError(event.Object))
 		default:
 		}
@@ -118,6 +120,7 @@ func annotationsWatcher(ctx context.Context, clientSet,
 	if ctx.Err() != nil {
 		return nil
 	}
+	metrics.WatcherRestartsTotal.WithLabelValues("annotations", "channel_closed").Inc()
 	return utils.NewPanicError("annotations watcher channel closed unexpectedly")
 }
 

--- a/pkg/manager/watch_annotations.go
+++ b/pkg/manager/watch_annotations.go
@@ -111,7 +111,7 @@ func annotationsWatcher(ctx context.Context, clientSet,
 			// Un-used
 		case watch.Error:
 			log.Error("Error attempting to watch Kubernetes Nodes")
-			metrics.WatcherRestartsTotal.WithLabelValues("annotations", "watch_error").Inc()
+			metrics.WatcherFailuresTotal.WithLabelValues("annotations", "watch_error").Inc()
 			log.Error("annotations watcher failed", "err", utils.WatchError(event.Object))
 		default:
 		}
@@ -120,7 +120,7 @@ func annotationsWatcher(ctx context.Context, clientSet,
 	if ctx.Err() != nil {
 		return nil
 	}
-	metrics.WatcherRestartsTotal.WithLabelValues("annotations", "channel_closed").Inc()
+	metrics.WatcherFailuresTotal.WithLabelValues("annotations", "channel_closed").Inc()
 	return utils.NewPanicError("annotations watcher channel closed unexpectedly")
 }
 

--- a/pkg/manager/worker/bgp.go
+++ b/pkg/manager/worker/bgp.go
@@ -59,28 +59,26 @@ func (b *BGP) Configure(ctx context.Context, _ *sync.WaitGroup) error {
 			return
 		}
 
-		ipaddr := p.Peer.State.NeighborAddress.String()
-
-		port := 179
-		peerDescription := net.JoinHostPort(ipaddr, strconv.Itoa(port))
-
-		for stateName, stateValue := range api.PeerState_SessionState_value {
-			metricValue := 0.0
-			if int(p.Peer.State.SessionState) == int(stateValue)-1 {
-
-				metricValue = 1
-			}
-
-			metrics.BGPSessionInfoGauge.With(prometheus.Labels{
-				"state": stateName,
-				"peer":  peerDescription,
-			}).Set(metricValue)
-		}
+		observeBGPPeerState(p)
 	}); err != nil {
 		return fmt.Errorf("starting BGP server: %w", err)
 	}
 
 	return nil
+}
+
+func observeBGPPeerState(p *apiutil.WatchEventMessage_PeerEvent) {
+	peerDescription := net.JoinHostPort(p.Peer.State.NeighborAddress.String(), strconv.FormatUint(uint64(p.Peer.Transport.RemotePort), 10))
+	for stateName, stateValue := range api.PeerState_SessionState_value {
+		metricValue := 0.0
+		if int(p.Peer.State.SessionState) == int(stateValue)-1 {
+			metricValue = 1
+		}
+		metrics.BGPSessionInfoGauge.With(prometheus.Labels{
+			"state": stateName,
+			"peer":  peerDescription,
+		}).Set(metricValue)
+	}
 }
 
 func (b *BGP) Cleanup() {

--- a/pkg/manager/worker/bgp_test.go
+++ b/pkg/manager/worker/bgp_test.go
@@ -1,0 +1,31 @@
+package worker
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/kube-vip/kube-vip/pkg/metrics"
+	api "github.com/osrg/gobgp/v4/api"
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestObserveBGPPeerStateUsesRemotePort(t *testing.T) {
+	metrics.BGPSessionInfoGauge.Reset()
+	t.Cleanup(metrics.BGPSessionInfoGauge.Reset)
+
+	observeBGPPeerState(&apiutil.WatchEventMessage_PeerEvent{
+		Type: apiutil.PEER_EVENT_STATE,
+		Peer: apiutil.Peer{
+			State: apiutil.PeerState{
+				NeighborAddress: netip.MustParseAddr("192.0.2.10"),
+				SessionState:    5,
+			},
+			Transport: apiutil.Transport{RemotePort: 10179},
+		},
+	})
+
+	if got := testutil.ToFloat64(metrics.BGPSessionInfoGauge.WithLabelValues(api.PeerState_SessionState_name[6], "192.0.2.10:10179")); got != 1 {
+		t.Fatalf("custom-port BGP session metric = %v, want 1", got)
+	}
+}

--- a/pkg/manager/worker/wireguard.go
+++ b/pkg/manager/worker/wireguard.go
@@ -204,6 +204,7 @@ func (w *WireGuard) watchKubernetesEndpoints(ctx context.Context, tunnelConfig *
 				log.Error("failed to update control plane DNAT rules", "err", err)
 			}
 		case watch.Error:
+			metrics.WatcherRestartsTotal.WithLabelValues("endpoint", "watch_error").Inc()
 			log.Warn("kubernetes endpoint watch error", "event", event)
 		}
 	}

--- a/pkg/manager/worker/wireguard.go
+++ b/pkg/manager/worker/wireguard.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/endpoints/providers"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/networkinterface"
 	"github.com/kube-vip/kube-vip/pkg/nftables"
 	"github.com/kube-vip/kube-vip/pkg/node"
@@ -155,6 +156,10 @@ func (w *WireGuard) OnStartedLeading(ctx context.Context) {
 // watchKubernetesEndpoints watches the kubernetes service EndpointSlices for changes
 // and updates the DNAT rules when API server endpoints change (e.g., when an API server goes down)
 func (w *WireGuard) watchKubernetesEndpoints(ctx context.Context, tunnelConfig *wireguard.TunnelConfig) {
+	loops := metrics.WatcherLoops.WithLabelValues("endpoint")
+	loops.Inc()
+	defer loops.Dec()
+
 	log.Info("starting kubernetes endpoint watcher for control plane")
 
 	kubeSvc := &v1.Service{

--- a/pkg/manager/worker/wireguard.go
+++ b/pkg/manager/worker/wireguard.go
@@ -204,7 +204,7 @@ func (w *WireGuard) watchKubernetesEndpoints(ctx context.Context, tunnelConfig *
 				log.Error("failed to update control plane DNAT rules", "err", err)
 			}
 		case watch.Error:
-			metrics.WatcherRestartsTotal.WithLabelValues("endpoint", "watch_error").Inc()
+			metrics.WatcherFailuresTotal.WithLabelValues("endpoint", "watch_error").Inc()
 			log.Warn("kubernetes endpoint watch error", "event", event)
 		}
 	}

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -35,6 +35,14 @@ var (
 		prometheus.GaugeOpts{Name: "kube_vip_is_leader", Help: "1 if this node currently holds the lease"},
 		[]string{"node", "lease_name"},
 	)
+	WatcherLoops = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "kube_vip_watcher_loops", Help: "Live watcher loops by kind"},
+		[]string{"kind"},
+	)
+	ElectionLoops = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "kube_vip_election_loops", Help: "Live leader election loops by type"},
+		[]string{"type"},
+	)
 	ServiceElectionLoops = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{Name: "kube_vip_service_election_loops",
 			Help: "Live per-service leader election restart loops on this node; more than 1 per service means loops leaked"},
@@ -76,6 +84,8 @@ func RegisterPrometheusMetrics() {
 		ServiceReconcileDuration,
 		LeaderTransitionsTotal,
 		IsLeader,
+		WatcherLoops,
+		ElectionLoops,
 		ServiceElectionLoops,
 		ServiceElectionAttemptsTotal,
 		ServiceElectionErrorsTotal,

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -1,6 +1,15 @@
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	serviceElectionLoopsMu   sync.Mutex
+	serviceElectionLoopCount = map[string]int{}
+)
 
 var (
 	// Service / VIP Lifecycle
@@ -93,4 +102,28 @@ func RegisterPrometheusMetrics() {
 		BuildInfo,
 		CountServiceWatchEvent,
 	)
+}
+
+// TrackServiceElectionLoop increments the loop gauge and returns a function
+// that decrements it and removes the series after the final loop exits.
+func TrackServiceElectionLoop(namespace, name string) func() {
+	key := namespace + "\x00" + name
+	serviceElectionLoopsMu.Lock()
+	serviceElectionLoopCount[key]++
+	ServiceElectionLoops.WithLabelValues(namespace, name).Inc()
+	serviceElectionLoopsMu.Unlock()
+
+	return func() {
+		serviceElectionLoopsMu.Lock()
+		defer serviceElectionLoopsMu.Unlock()
+
+		count := serviceElectionLoopCount[key]
+		if count <= 1 {
+			delete(serviceElectionLoopCount, key)
+			ServiceElectionLoops.DeleteLabelValues(namespace, name)
+			return
+		}
+		serviceElectionLoopCount[key] = count - 1
+		ServiceElectionLoops.WithLabelValues(namespace, name).Dec()
+	}
 }

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -9,6 +9,9 @@ import (
 var (
 	serviceElectionLoopsMu   sync.Mutex
 	serviceElectionLoopCount = map[string]int{}
+	vipAddressesMu           sync.Mutex
+	vipAddressReferences     = map[string]int{}
+	vipAddressLabelCounts    = map[string]int{}
 )
 
 var (
@@ -136,6 +139,51 @@ func RegisterPrometheusMetrics() {
 		BuildInfo,
 		CountServiceWatchEvent,
 	)
+}
+
+// TrackVIPAddress adds a reference to an address and increments the aggregate
+// gauge only when that address gains its first owner in this process.
+func TrackVIPAddress(iface, family, address string) {
+	addressKey := iface + "\x00" + family + "\x00" + address
+	labelKey := iface + "\x00" + family
+
+	vipAddressesMu.Lock()
+	defer vipAddressesMu.Unlock()
+
+	if vipAddressReferences[addressKey] == 0 {
+		vipAddressLabelCounts[labelKey]++
+		VIPAddresses.WithLabelValues(iface, family).Inc()
+	}
+	vipAddressReferences[addressKey]++
+}
+
+// UntrackVIPAddress removes an address reference and deletes the aggregate
+// series when no tracked addresses remain for its interface and family.
+func UntrackVIPAddress(iface, family, address string) {
+	addressKey := iface + "\x00" + family + "\x00" + address
+	labelKey := iface + "\x00" + family
+
+	vipAddressesMu.Lock()
+	defer vipAddressesMu.Unlock()
+
+	references := vipAddressReferences[addressKey]
+	if references == 0 {
+		return
+	}
+	if references > 1 {
+		vipAddressReferences[addressKey] = references - 1
+		return
+	}
+
+	delete(vipAddressReferences, addressKey)
+	remaining := vipAddressLabelCounts[labelKey] - 1
+	if remaining == 0 {
+		delete(vipAddressLabelCounts, labelKey)
+		VIPAddresses.DeleteLabelValues(iface, family)
+		return
+	}
+	vipAddressLabelCounts[labelKey] = remaining
+	VIPAddresses.WithLabelValues(iface, family).Dec()
 }
 
 // TrackServiceElectionLoop increments the loop gauge and returns a function

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -113,8 +113,8 @@ var (
 			Help: "Per-service leader election failures by reason"},
 		[]string{"namespace", "name", "reason"},
 	)
-	WatcherRestartsTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{Name: "kube_vip_watcher_restarts_total", Help: "Watcher restarts by kind and reason"},
+	WatcherFailuresTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "kube_vip_watcher_failures_total", Help: "Watcher failures by kind and reason"},
 		[]string{"kind", "reason"},
 	)
 
@@ -162,12 +162,21 @@ func RegisterPrometheusMetrics() {
 		ServiceElectionLoops,
 		ServiceElectionAttemptsTotal,
 		ServiceElectionErrorsTotal,
-		WatcherRestartsTotal,
+		WatcherFailuresTotal,
 		BGPSessionInfoGauge,
 		UPNPMappings,
 		BuildInfo,
 		CountServiceWatchEvent,
 	)
+}
+
+// SetEgressRules updates a table snapshot and removes an empty dynamic series.
+func SetEgressRules(table string, count int) {
+	if count == 0 {
+		EgressRules.DeleteLabelValues(table)
+		return
+	}
+	EgressRules.WithLabelValues(table).Set(float64(count))
 }
 
 // TrackVIPAddress adds a reference to an address and increments the aggregate

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -25,6 +25,33 @@ var (
 		prometheus.HistogramOpts{Name: "kube_vip_service_reconcile_duration_seconds", Help: "How long AddOrModify takes end-to-end"},
 		[]string{"namespace"},
 	)
+	VIPAddresses = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "kube_vip_vip_addresses", Help: "VIP addresses currently held by interface and address family"},
+		[]string{"interface", "family"},
+	)
+	VIPOperationsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "kube_vip_vip_operations_total", Help: "VIP address operations by operation and result"},
+		[]string{"op", "result"},
+	)
+	ARPAdvertisementsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "kube_vip_arp_advertisements_total", Help: "Gratuitous ARP advertisements by result"},
+		[]string{"result"},
+	)
+	NDPAdvertisementsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "kube_vip_ndp_advertisements_total", Help: "Gratuitous NDP advertisements by result"},
+		[]string{"result"},
+	)
+	RouteOperationsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "kube_vip_route_operations_total", Help: "Routing table operations by operation and result"},
+		[]string{"op", "result"},
+	)
+	DNSResolutionsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "kube_vip_dns_resolutions_total", Help: "DNS resolutions by result"},
+		[]string{"result"},
+	)
+	DNSIPChangesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{Name: "kube_vip_dns_ip_changes_total", Help: "DNS-driven VIP IP changes"},
+	)
 
 	// This is a prometheus counter used to count the number of events received
 	// from the service watcher
@@ -91,6 +118,13 @@ func RegisterPrometheusMetrics() {
 		ActiveServices,
 		ServiceReconcileErrorsTotal,
 		ServiceReconcileDuration,
+		VIPAddresses,
+		VIPOperationsTotal,
+		ARPAdvertisementsTotal,
+		NDPAdvertisementsTotal,
+		RouteOperationsTotal,
+		DNSResolutionsTotal,
+		DNSIPChangesTotal,
 		LeaderTransitionsTotal,
 		IsLeader,
 		WatcherLoops,

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -55,6 +55,22 @@ var (
 	DNSIPChangesTotal = prometheus.NewCounter(
 		prometheus.CounterOpts{Name: "kube_vip_dns_ip_changes_total", Help: "DNS-driven VIP IP changes"},
 	)
+	BGPRoutesAdvertised = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "kube_vip_bgp_routes_advertised", Help: "BGP routes currently advertised by address family"},
+		[]string{"family"},
+	)
+	BGPRouteOperationsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "kube_vip_bgp_route_operations_total", Help: "BGP route operations by operation and result"},
+		[]string{"op", "result"},
+	)
+	EgressRules = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "kube_vip_egress_rules", Help: "Egress SNAT rules currently configured by table"},
+		[]string{"table"},
+	)
+	EgressOperationsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "kube_vip_egress_operations_total", Help: "Egress SNAT operations by operation and result"},
+		[]string{"op", "result"},
+	)
 
 	// This is a prometheus counter used to count the number of events received
 	// from the service watcher
@@ -97,6 +113,10 @@ var (
 			Help: "Per-service leader election failures by reason"},
 		[]string{"namespace", "name", "reason"},
 	)
+	WatcherRestartsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "kube_vip_watcher_restarts_total", Help: "Watcher restarts by kind and reason"},
+		[]string{"kind", "reason"},
+	)
 
 	// This is a prometheus gauge indicating the state of the sessions.
 	// 1 means "ESTABLISHED", 0 means "NOT ESTABLISHED"
@@ -106,6 +126,9 @@ var (
 		Name:      "bgp_session_info",
 		Help:      "Display state of session by setting metric for label value with current state to 1",
 	}, []string{"state", "peer"},
+	)
+	UPNPMappings = prometheus.NewGauge(
+		prometheus.GaugeOpts{Name: "kube_vip_upnp_mappings", Help: "UPNP mappings currently tracked"},
 	)
 
 	// General Health
@@ -128,6 +151,10 @@ func RegisterPrometheusMetrics() {
 		RouteOperationsTotal,
 		DNSResolutionsTotal,
 		DNSIPChangesTotal,
+		BGPRoutesAdvertised,
+		BGPRouteOperationsTotal,
+		EgressRules,
+		EgressOperationsTotal,
 		LeaderTransitionsTotal,
 		IsLeader,
 		WatcherLoops,
@@ -135,7 +162,9 @@ func RegisterPrometheusMetrics() {
 		ServiceElectionLoops,
 		ServiceElectionAttemptsTotal,
 		ServiceElectionErrorsTotal,
+		WatcherRestartsTotal,
 		BGPSessionInfoGauge,
+		UPNPMappings,
 		BuildInfo,
 		CountServiceWatchEvent,
 	)

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -1,0 +1,55 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestLoopMetricsRegisterAndTrackLiveness(t *testing.T) {
+	WatcherLoops.Reset()
+	ElectionLoops.Reset()
+	t.Cleanup(func() {
+		WatcherLoops.Reset()
+		ElectionLoops.Reset()
+	})
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(WatcherLoops, ElectionLoops)
+
+	watcher := WatcherLoops.WithLabelValues("service")
+	election := ElectionLoops.WithLabelValues("kubernetes")
+
+	watcher.Inc()
+	election.Inc()
+	if got := testutil.ToFloat64(watcher); got != 1 {
+		t.Fatalf("watcher loop gauge is %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(election); got != 1 {
+		t.Fatalf("election loop gauge is %v, want 1", got)
+	}
+
+	watcher.Dec()
+	election.Dec()
+	if got := testutil.ToFloat64(watcher); got != 0 {
+		t.Fatalf("watcher loop gauge is %v after stop, want 0", got)
+	}
+	if got := testutil.ToFloat64(election); got != 0 {
+		t.Fatalf("election loop gauge is %v after stop, want 0", got)
+	}
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gathering loop gauges: %v", err)
+	}
+	seen := make(map[string]bool, len(families))
+	for _, family := range families {
+		seen[family.GetName()] = true
+	}
+	for _, name := range []string{"kube_vip_watcher_loops", "kube_vip_election_loops"} {
+		if !seen[name] {
+			t.Errorf("loop gauge %q was not registered", name)
+		}
+	}
+}

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -1,11 +1,71 @@
 package metrics
 
 import (
+	"io"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
+
+func TestBuildInfoScrape(t *testing.T) {
+	BuildInfo.Reset()
+	t.Cleanup(BuildInfo.Reset)
+
+	BuildInfo.WithLabelValues("v1.2.3", "abc123", "node-a").Set(1)
+	registry := prometheus.NewPedanticRegistry()
+	registry.MustRegister(BuildInfo)
+
+	request := httptest.NewRequest("GET", "/metrics", nil)
+	response := httptest.NewRecorder()
+	promhttp.HandlerFor(registry, promhttp.HandlerOpts{}).ServeHTTP(response, request)
+	if response.Code != 200 {
+		t.Fatalf("scrape status = %d, want 200", response.Code)
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("reading scrape: %v", err)
+	}
+	if err := testutil.GatherAndCompare(registry, strings.NewReader(`# HELP kube_vip_build_info Constant 1; track version skew across nodes
+# TYPE kube_vip_build_info gauge
+kube_vip_build_info{build="abc123",node="node-a",version="v1.2.3"} 1
+`), "kube_vip_build_info"); err != nil {
+		t.Fatalf("scraping build info: %v", err)
+	}
+	if !strings.Contains(string(body), `kube_vip_build_info{build="abc123",node="node-a",version="v1.2.3"} 1`) {
+		t.Fatalf("scrape does not contain build info: %s", body)
+	}
+}
+
+func TestTrackServiceElectionLoopDeletesOnlyAfterFinalExit(t *testing.T) {
+	ServiceElectionLoops.Reset()
+	t.Cleanup(ServiceElectionLoops.Reset)
+
+	doneFirst := TrackServiceElectionLoop("default", "api")
+	doneSecond := TrackServiceElectionLoop("default", "api")
+	if got := testutil.ToFloat64(ServiceElectionLoops.WithLabelValues("default", "api")); got != 2 {
+		t.Fatalf("loop gauge = %v, want 2", got)
+	}
+
+	doneFirst()
+	if got := testutil.ToFloat64(ServiceElectionLoops.WithLabelValues("default", "api")); got != 1 {
+		t.Fatalf("loop gauge after first exit = %v, want 1", got)
+	}
+	doneSecond()
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(ServiceElectionLoops)
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gathering loop gauge: %v", err)
+	}
+	if len(families) != 0 {
+		t.Fatalf("loop series remains after final exit: %v", families)
+	}
+}
 
 func TestLoopMetricsRegisterAndTrackLiveness(t *testing.T) {
 	WatcherLoops.Reset()

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -113,3 +113,61 @@ func TestLoopMetricsRegisterAndTrackLiveness(t *testing.T) {
 		}
 	}
 }
+
+func TestDataplaneMetricsRegister(t *testing.T) {
+	VIPAddresses.Reset()
+	VIPOperationsTotal.Reset()
+	ARPAdvertisementsTotal.Reset()
+	NDPAdvertisementsTotal.Reset()
+	RouteOperationsTotal.Reset()
+	DNSResolutionsTotal.Reset()
+	t.Cleanup(func() {
+		VIPAddresses.Reset()
+		VIPOperationsTotal.Reset()
+		ARPAdvertisementsTotal.Reset()
+		NDPAdvertisementsTotal.Reset()
+		RouteOperationsTotal.Reset()
+		DNSResolutionsTotal.Reset()
+	})
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(
+		VIPAddresses,
+		VIPOperationsTotal,
+		ARPAdvertisementsTotal,
+		NDPAdvertisementsTotal,
+		RouteOperationsTotal,
+		DNSResolutionsTotal,
+		DNSIPChangesTotal,
+	)
+
+	VIPAddresses.WithLabelValues("eth0", "IPv4").Inc()
+	VIPOperationsTotal.WithLabelValues("add", "ok").Inc()
+	ARPAdvertisementsTotal.WithLabelValues("ok").Inc()
+	NDPAdvertisementsTotal.WithLabelValues("error").Inc()
+	RouteOperationsTotal.WithLabelValues("replace", "ok").Inc()
+	DNSResolutionsTotal.WithLabelValues("error").Inc()
+	DNSIPChangesTotal.Inc()
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gathering dataplane metrics: %v", err)
+	}
+	seen := make(map[string]bool, len(families))
+	for _, family := range families {
+		seen[family.GetName()] = true
+	}
+	for _, name := range []string{
+		"kube_vip_vip_addresses",
+		"kube_vip_vip_operations_total",
+		"kube_vip_arp_advertisements_total",
+		"kube_vip_ndp_advertisements_total",
+		"kube_vip_route_operations_total",
+		"kube_vip_dns_resolutions_total",
+		"kube_vip_dns_ip_changes_total",
+	} {
+		if !seen[name] {
+			t.Errorf("dataplane metric %q was not registered", name)
+		}
+	}
+}

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -171,3 +171,73 @@ func TestDataplaneMetricsRegister(t *testing.T) {
 		}
 	}
 }
+
+func TestPR14CMetricsRegisterAndTrack(t *testing.T) {
+	BGPRoutesAdvertised.Reset()
+	BGPRouteOperationsTotal.Reset()
+	EgressRules.Reset()
+	EgressOperationsTotal.Reset()
+	WatcherRestartsTotal.Reset()
+	BGPSessionInfoGauge.Reset()
+	UPNPMappings.Set(0)
+	t.Cleanup(func() {
+		BGPRoutesAdvertised.Reset()
+		BGPRouteOperationsTotal.Reset()
+		EgressRules.Reset()
+		EgressOperationsTotal.Reset()
+		WatcherRestartsTotal.Reset()
+		BGPSessionInfoGauge.Reset()
+		UPNPMappings.Set(0)
+	})
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(
+		BGPRoutesAdvertised,
+		BGPRouteOperationsTotal,
+		EgressRules,
+		EgressOperationsTotal,
+		WatcherRestartsTotal,
+		BGPSessionInfoGauge,
+		UPNPMappings,
+	)
+
+	BGPRoutesAdvertised.WithLabelValues("IPv4").Set(1)
+	BGPRouteOperationsTotal.WithLabelValues("add", "ok").Inc()
+	EgressRules.WithLabelValues("kube_vip_v4").Set(2)
+	EgressOperationsTotal.WithLabelValues("delete", "error").Inc()
+	WatcherRestartsTotal.WithLabelValues("service", "watch_error").Inc()
+	BGPSessionInfoGauge.WithLabelValues("ESTABLISHED", "127.0.0.1:179").Set(1)
+	UPNPMappings.Set(3)
+
+	if got := testutil.ToFloat64(BGPRoutesAdvertised.WithLabelValues("IPv4")); got != 1 {
+		t.Fatalf("BGP advertised route gauge is %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(EgressRules.WithLabelValues("kube_vip_v4")); got != 2 {
+		t.Fatalf("egress rule gauge is %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(UPNPMappings); got != 3 {
+		t.Fatalf("UPNP mapping gauge is %v, want 3", got)
+	}
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gathering PR-14c metrics: %v", err)
+	}
+	seen := make(map[string]bool, len(families))
+	for _, family := range families {
+		seen[family.GetName()] = true
+	}
+	for _, name := range []string{
+		"kube_vip_bgp_routes_advertised",
+		"kube_vip_bgp_route_operations_total",
+		"kube_vip_egress_rules",
+		"kube_vip_egress_operations_total",
+		"kube_vip_watcher_restarts_total",
+		"kube_vip_manager_bgp_session_info",
+		"kube_vip_upnp_mappings",
+	} {
+		if !seen[name] {
+			t.Errorf("PR-14c metric %q was not registered", name)
+		}
+	}
+}

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -177,7 +177,7 @@ func TestPR14CMetricsRegisterAndTrack(t *testing.T) {
 	BGPRouteOperationsTotal.Reset()
 	EgressRules.Reset()
 	EgressOperationsTotal.Reset()
-	WatcherRestartsTotal.Reset()
+	WatcherFailuresTotal.Reset()
 	BGPSessionInfoGauge.Reset()
 	UPNPMappings.Set(0)
 	t.Cleanup(func() {
@@ -185,7 +185,7 @@ func TestPR14CMetricsRegisterAndTrack(t *testing.T) {
 		BGPRouteOperationsTotal.Reset()
 		EgressRules.Reset()
 		EgressOperationsTotal.Reset()
-		WatcherRestartsTotal.Reset()
+		WatcherFailuresTotal.Reset()
 		BGPSessionInfoGauge.Reset()
 		UPNPMappings.Set(0)
 	})
@@ -196,7 +196,7 @@ func TestPR14CMetricsRegisterAndTrack(t *testing.T) {
 		BGPRouteOperationsTotal,
 		EgressRules,
 		EgressOperationsTotal,
-		WatcherRestartsTotal,
+		WatcherFailuresTotal,
 		BGPSessionInfoGauge,
 		UPNPMappings,
 	)
@@ -205,7 +205,7 @@ func TestPR14CMetricsRegisterAndTrack(t *testing.T) {
 	BGPRouteOperationsTotal.WithLabelValues("add", "ok").Inc()
 	EgressRules.WithLabelValues("kube_vip_v4").Set(2)
 	EgressOperationsTotal.WithLabelValues("delete", "error").Inc()
-	WatcherRestartsTotal.WithLabelValues("service", "watch_error").Inc()
+	WatcherFailuresTotal.WithLabelValues("service", "watch_error").Inc()
 	BGPSessionInfoGauge.WithLabelValues("ESTABLISHED", "127.0.0.1:179").Set(1)
 	UPNPMappings.Set(3)
 
@@ -232,12 +232,33 @@ func TestPR14CMetricsRegisterAndTrack(t *testing.T) {
 		"kube_vip_bgp_route_operations_total",
 		"kube_vip_egress_rules",
 		"kube_vip_egress_operations_total",
-		"kube_vip_watcher_restarts_total",
+		"kube_vip_watcher_failures_total",
 		"kube_vip_manager_bgp_session_info",
 		"kube_vip_upnp_mappings",
 	} {
 		if !seen[name] {
 			t.Errorf("PR-14c metric %q was not registered", name)
 		}
+	}
+}
+
+func TestSetEgressRulesDeletesEmptyTableSeries(t *testing.T) {
+	EgressRules.Reset()
+	t.Cleanup(EgressRules.Reset)
+
+	SetEgressRules("kube_vip_v4", 2)
+	if got := testutil.ToFloat64(EgressRules.WithLabelValues("kube_vip_v4")); got != 2 {
+		t.Fatalf("egress rules = %v, want 2", got)
+	}
+	SetEgressRules("kube_vip_v4", 0)
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(EgressRules)
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gathering egress rules: %v", err)
+	}
+	if len(families) != 0 {
+		t.Fatalf("empty egress table series remains: %v", families)
 	}
 }

--- a/pkg/nftables/nftables.go
+++ b/pkg/nftables/nftables.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/nftables"
 	"github.com/google/nftables/binaryutil"
 	"github.com/google/nftables/expr"
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -59,13 +60,23 @@ func ApplySNAT(podIP, vipIP, service, destinationPorts string, ignoreCIDR []stri
 }
 
 // ApplySNATWithTable applies an egress SNAT rule in the configured table.
-func ApplySNATWithTable(podIP, vipIP, service, destinationPorts string, ignoreCIDR []string, allowCIDR []string, IPv6 bool, tableName string) error {
+func ApplySNATWithTable(podIP, vipIP, service, destinationPorts string, ignoreCIDR []string, allowCIDR []string, IPv6 bool, tableName string) (err error) {
+	resolvedTableName := egressTableName(tableName, IPv6)
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+		} else {
+			metrics.EgressRules.WithLabelValues(resolvedTableName).Inc()
+		}
+		metrics.EgressOperationsTotal.WithLabelValues("add", result).Inc()
+	}()
+
 	conn, err := nftables.New()
 	if err != nil {
 		return err
 	}
 
-	resolvedTableName := egressTableName(tableName, IPv6)
 	// Look up the table
 	if t, err := FilterTable(conn, resolvedTableName, IPv6); err != nil {
 		if t == nil {
@@ -308,7 +319,19 @@ func DeleteSNAT(IPv6 bool, service string) error {
 }
 
 // DeleteSNATFromTable deletes an egress SNAT chain from the configured table.
-func DeleteSNATFromTable(IPv6 bool, service, tableName string) error {
+func DeleteSNATFromTable(IPv6 bool, service, tableName string) (err error) {
+	resolvedTableName := egressTableName(tableName, IPv6)
+	deleted := false
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+		} else if deleted {
+			metrics.EgressRules.WithLabelValues(resolvedTableName).Dec()
+		}
+		metrics.EgressOperationsTotal.WithLabelValues("delete", result).Inc()
+	}()
+
 	conn, err := nftables.New()
 	if err != nil {
 		return err
@@ -324,7 +347,11 @@ func DeleteSNATFromTable(IPv6 bool, service, tableName string) error {
 	if chain != nil {
 		slog.Info("[egress]", "Deleting chain", chainName)
 		conn.DelChain(chain)
-		return conn.Flush()
+		err = conn.Flush()
+		if err == nil {
+			deleted = true
+		}
+		return err
 
 	}
 
@@ -333,7 +360,19 @@ func DeleteSNATFromTable(IPv6 bool, service, tableName string) error {
 
 // DeleteSNATFromTableIfExists deletes a Service's egress SNAT chain when it is
 // present. It is used while migrating a Service between instance-owned tables.
-func DeleteSNATFromTableIfExists(IPv6 bool, service, tableName string) error {
+func DeleteSNATFromTableIfExists(IPv6 bool, service, tableName string) (err error) {
+	resolvedTableName := egressTableName(tableName, IPv6)
+	deleted := false
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+		} else if deleted {
+			metrics.EgressRules.WithLabelValues(resolvedTableName).Dec()
+		}
+		metrics.EgressOperationsTotal.WithLabelValues("delete", result).Inc()
+	}()
+
 	conn, err := nftables.New()
 	if err != nil {
 		return err
@@ -350,7 +389,11 @@ func DeleteSNATFromTableIfExists(IPv6 bool, service, tableName string) error {
 		if chain.Table != nil && chain.Table.Name == table.Name && chain.Name == chainName {
 			slog.Info("[egress] deleting service chain", "table", table.Name, "chain", chainName)
 			conn.DelChain(chain)
-			return conn.Flush()
+			err = conn.Flush()
+			if err == nil {
+				deleted = true
+			}
+			return err
 		}
 	}
 
@@ -375,7 +418,20 @@ func DeleteSNATFromAllTables(service string) error {
 	)
 }
 
-func deleteSNATFromTables(IPv6 bool, service, keepTableName string) error {
+func deleteSNATFromTables(IPv6 bool, service, keepTableName string) (err error) {
+	deletedTables := make([]string, 0)
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+		} else {
+			for _, tableName := range deletedTables {
+				metrics.EgressRules.WithLabelValues(tableName).Dec()
+			}
+		}
+		metrics.EgressOperationsTotal.WithLabelValues("delete", result).Inc()
+	}()
+
 	conn, err := nftables.New()
 	if err != nil {
 		return err
@@ -402,6 +458,7 @@ func deleteSNATFromTables(IPv6 bool, service, keepTableName string) error {
 		}
 		slog.Info("[egress] deleting stale service chain", "table", chain.Table.Name, "chain", chainName)
 		conn.DelChain(chain)
+		deletedTables = append(deletedTables, chain.Table.Name)
 		deleted = true
 	}
 	if deleted {

--- a/pkg/nftables/nftables.go
+++ b/pkg/nftables/nftables.go
@@ -22,6 +22,7 @@ import (
 const (
 	NatTable               = "kube_vip_%s"
 	SNatChain              = "kube_vip_snat_%s"
+	egressSNATChainPrefix  = "kube_vip_snat_"
 	DefaultEgressTableName = "kube_vip"
 )
 
@@ -67,7 +68,7 @@ func ApplySNATWithTable(podIP, vipIP, service, destinationPorts string, ignoreCI
 		if err != nil {
 			result = "error"
 		} else {
-			metrics.EgressRules.WithLabelValues(resolvedTableName).Inc()
+			setEgressRulesGauge(resolvedTableName, IPv6)
 		}
 		metrics.EgressOperationsTotal.WithLabelValues("add", result).Inc()
 	}()
@@ -321,13 +322,12 @@ func DeleteSNAT(IPv6 bool, service string) error {
 // DeleteSNATFromTable deletes an egress SNAT chain from the configured table.
 func DeleteSNATFromTable(IPv6 bool, service, tableName string) (err error) {
 	resolvedTableName := egressTableName(tableName, IPv6)
-	deleted := false
 	defer func() {
 		result := "ok"
 		if err != nil {
 			result = "error"
-		} else if deleted {
-			metrics.EgressRules.WithLabelValues(resolvedTableName).Dec()
+		} else {
+			setEgressRulesGauge(resolvedTableName, IPv6)
 		}
 		metrics.EgressOperationsTotal.WithLabelValues("delete", result).Inc()
 	}()
@@ -348,9 +348,6 @@ func DeleteSNATFromTable(IPv6 bool, service, tableName string) (err error) {
 		slog.Info("[egress]", "Deleting chain", chainName)
 		conn.DelChain(chain)
 		err = conn.Flush()
-		if err == nil {
-			deleted = true
-		}
 		return err
 
 	}
@@ -362,13 +359,12 @@ func DeleteSNATFromTable(IPv6 bool, service, tableName string) (err error) {
 // present. It is used while migrating a Service between instance-owned tables.
 func DeleteSNATFromTableIfExists(IPv6 bool, service, tableName string) (err error) {
 	resolvedTableName := egressTableName(tableName, IPv6)
-	deleted := false
 	defer func() {
 		result := "ok"
 		if err != nil {
 			result = "error"
-		} else if deleted {
-			metrics.EgressRules.WithLabelValues(resolvedTableName).Dec()
+		} else {
+			setEgressRulesGauge(resolvedTableName, IPv6)
 		}
 		metrics.EgressOperationsTotal.WithLabelValues("delete", result).Inc()
 	}()
@@ -390,9 +386,6 @@ func DeleteSNATFromTableIfExists(IPv6 bool, service, tableName string) (err erro
 			slog.Info("[egress] deleting service chain", "table", table.Name, "chain", chainName)
 			conn.DelChain(chain)
 			err = conn.Flush()
-			if err == nil {
-				deleted = true
-			}
 			return err
 		}
 	}
@@ -426,7 +419,7 @@ func deleteSNATFromTables(IPv6 bool, service, keepTableName string) (err error) 
 			result = "error"
 		} else {
 			for _, tableName := range deletedTables {
-				metrics.EgressRules.WithLabelValues(tableName).Dec()
+				setEgressRulesGauge(tableName, IPv6)
 			}
 		}
 		metrics.EgressOperationsTotal.WithLabelValues("delete", result).Inc()
@@ -469,6 +462,40 @@ func deleteSNATFromTables(IPv6 bool, service, keepTableName string) (err error) 
 
 func shouldDeleteSNATChain(chain *nftables.Chain, chainName, keepTable string) bool {
 	return chain.Table != nil && chain.Name == chainName && chain.Table.Name != keepTable
+}
+
+func setEgressRulesGauge(tableName string, IPv6 bool) {
+	conn, err := nftables.New()
+	if err != nil {
+		slog.Debug("[egress] unable to count nftables SNAT rules", "table", tableName, "err", err)
+		return
+	}
+	defer func() { _ = conn.CloseLasting() }()
+
+	family := nftables.TableFamilyIPv4
+	if IPv6 {
+		family = nftables.TableFamilyIPv6
+	}
+	chains, err := conn.ListChainsOfTableFamily(family)
+	if err != nil {
+		slog.Debug("[egress] unable to list nftables SNAT chains", "table", tableName, "err", err)
+		return
+	}
+
+	count := 0
+	for _, chain := range chains {
+		if chain.Table == nil || chain.Table.Name != tableName || !strings.HasPrefix(chain.Name, egressSNATChainPrefix) {
+			continue
+		}
+		rules, err := conn.GetRules(chain.Table, chain)
+		if err != nil {
+			slog.Debug("[egress] unable to list nftables SNAT rules", "table", tableName, "chain", chain.Name, "err", err)
+			return
+		}
+		count += len(rules)
+	}
+
+	metrics.EgressRules.WithLabelValues(tableName).Set(float64(count))
 }
 
 func GetTable(IPv6 bool) *nftables.Table {

--- a/pkg/nftables/nftables.go
+++ b/pkg/nftables/nftables.go
@@ -495,7 +495,7 @@ func setEgressRulesGauge(tableName string, IPv6 bool) {
 		count += len(rules)
 	}
 
-	metrics.EgressRules.WithLabelValues(tableName).Set(float64(count))
+	metrics.SetEgressRules(tableName, count)
 }
 
 func GetTable(IPv6 bool) *nftables.Table {

--- a/pkg/route/manager.go
+++ b/pkg/route/manager.go
@@ -112,6 +112,9 @@ func (m *Manager) Delete(object string, r route) error {
 }
 
 func (m *Manager) Clear() {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
 	for _, itm := range m.tracker {
 		if err := itm.route.DeleteRoute(); err != nil {
 			log.Warn("[RT] failed to delete route", "err", err.Error())
@@ -121,6 +124,9 @@ func (m *Manager) Clear() {
 }
 
 func (m *Manager) Check(key string) bool {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
 	_, exists := m.tracker[key]
 	return exists
 }

--- a/pkg/route/manager.go
+++ b/pkg/route/manager.go
@@ -6,6 +6,8 @@ import (
 	log "log/slog"
 	"sync"
 	"syscall"
+
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 )
 
 type Manager struct {
@@ -56,6 +58,7 @@ func (m *Manager) Add(object string, r route, precheck, update bool) error {
 				// of kube-vip) try to update it if necessary
 				isUpdated, err := r.UpdateRoutes()
 				if err != nil {
+					metrics.RouteOperationsTotal.WithLabelValues("add", "error").Inc()
 					return fmt.Errorf("error updating existing route: %w", err)
 				}
 				if isUpdated {
@@ -63,6 +66,7 @@ func (m *Manager) Add(object string, r route, precheck, update bool) error {
 				}
 			} else {
 				// If other error occurs, return error
+				metrics.RouteOperationsTotal.WithLabelValues("add", "error").Inc()
 				return fmt.Errorf("error adding route %q: %w", key, err)
 			}
 		}
@@ -79,6 +83,7 @@ func (m *Manager) Add(object string, r route, precheck, update bool) error {
 
 	log.Debug("[RT] incremented route", "path", key, "object", object, "cnt", len(itm.objects))
 
+	metrics.RouteOperationsTotal.WithLabelValues("add", "ok").Inc()
 	return nil
 }
 
@@ -92,6 +97,7 @@ func (m *Manager) Delete(object string, r route) error {
 	itm, exists := m.tracker[key]
 	if !exists {
 		log.Debug("[RT] deleting route - nothing to delete", "path", key, "object", object)
+		metrics.RouteOperationsTotal.WithLabelValues("delete", "ok").Inc()
 		return nil
 	}
 
@@ -102,12 +108,14 @@ func (m *Manager) Delete(object string, r route) error {
 	if len(itm.objects) == 0 {
 		if err := r.DeleteRoute(); err != nil {
 			itm.objects[object] = true
+			metrics.RouteOperationsTotal.WithLabelValues("delete", "error").Inc()
 			return fmt.Errorf("failed to delete route: %w", err)
 		}
 		delete(m.tracker, key)
 		log.Debug("[RT] deleted route", "path", key, "object", object)
 	}
 
+	metrics.RouteOperationsTotal.WithLabelValues("delete", "ok").Inc()
 	return nil
 }
 
@@ -117,7 +125,10 @@ func (m *Manager) Clear() {
 
 	for _, itm := range m.tracker {
 		if err := itm.route.DeleteRoute(); err != nil {
+			metrics.RouteOperationsTotal.WithLabelValues("delete", "error").Inc()
 			log.Warn("[RT] failed to delete route", "err", err.Error())
+		} else {
+			metrics.RouteOperationsTotal.WithLabelValues("delete", "ok").Inc()
 		}
 	}
 	m.tracker = make(map[string]*item)

--- a/pkg/route/manager_atomic_test.go
+++ b/pkg/route/manager_atomic_test.go
@@ -2,6 +2,8 @@ package route
 
 import (
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
 )
 
@@ -27,3 +29,35 @@ func TestManagerRetriesRouteAfterInitialAddFailure(t *testing.T) {
 		t.Fatalf("AddRoute called %d times, want 2", r.addCalls)
 	}
 }
+
+func TestManagerConcurrentLifecycle(t *testing.T) {
+	m := NewManager()
+	var wg sync.WaitGroup
+	for i := range 20 {
+		r := concurrentRoute{hash: fmt.Sprintf("route-%d", i)}
+		wg.Go(func() {
+			for j := range 100 {
+				object := fmt.Sprintf("service-%d", j)
+				if err := m.Add(object, r, false, false); err != nil {
+					t.Errorf("adding route: %v", err)
+				}
+				m.Check(r.RouteHash())
+				if err := m.Delete(object, r); err != nil {
+					t.Errorf("deleting route: %v", err)
+				}
+				if j%10 == 0 {
+					m.Clear()
+				}
+			}
+		})
+	}
+	wg.Wait()
+}
+
+type concurrentRoute struct{ hash string }
+
+func (r concurrentRoute) AddRoute(bool) (bool, error) { return true, nil }
+func (r concurrentRoute) UpdateRoutes() (bool, error) { return false, nil }
+func (r concurrentRoute) DeleteRoute() error          { return nil }
+func (r concurrentRoute) RouteHash() string           { return r.hash }
+func (concurrentRoute) Interface() string             { return "test" }

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -185,7 +185,12 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 }
 
 func (p *Processor) onStartedLeading(svcCtx *servicecontext.Context, service *v1.Service, wg *sync.WaitGroup) error {
-	err := p.SyncServices(svcCtx, service, wg, true)
+	var err error
+	if !p.withActiveService(svcCtx, func() {
+		err = p.SyncServices(svcCtx, service, wg, true)
+	}) {
+		return nil
+	}
 	if err != nil {
 		log.Error("service sync", "uid", service.UID, "err", err)
 		return err

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -341,8 +341,6 @@ func (p *Processor) deleteTrackedService(svc *v1.Service) error {
 		log.Warn("(svcs) The load balancer was deleted, cancelling context", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
 		svcCtx.Cancel()
 		p.svcMap.Delete(svc.UID)
-		// Drop the per-service election series so a recreated service starts clean.
-		metrics.ServiceElectionLoops.DeleteLabelValues(svc.Namespace, svc.Name)
 		p.updateActiveServicesMetric()
 
 		log.Info("(svcs) deleted", "service name", svc.Name, "namespace", svc.Namespace)

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -219,7 +219,9 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 			metrics.ServiceReconcileErrorsTotal.WithLabelValues(svc.Namespace, svc.Name, "new_instance").Inc()
 			return fmt.Errorf("unable to create instance for service %s/%s", svc.Namespace, svc.Name)
 		}
+		p.mutex.Lock()
 		p.ServiceInstances = append(p.ServiceInstances, svcInstance)
+		p.mutex.Unlock()
 		p.updateActiveServicesMetric()
 	}
 

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -40,8 +40,9 @@ type Processor struct {
 	// Keeps track of all running instances
 	ServiceInstances []*instance.Instance
 
-	mutex     sync.Mutex
-	bgpServer *bgp.Server
+	mutex          sync.Mutex
+	lifecycleMutex sync.Mutex
+	bgpServer      *bgp.Server
 
 	clientSet   *kubernetes.Clientset
 	rwClientSet *kubernetes.Clientset
@@ -315,12 +316,20 @@ func (p *Processor) Delete(event watch.Event, forcedOnly bool) error {
 }
 
 func (p *Processor) deleteTrackedService(svc *v1.Service) error {
+	p.lifecycleMutex.Lock()
+	defer p.lifecycleMutex.Unlock()
+
 	svcCtx, err := p.getServiceContext(svc.UID)
 	if err != nil {
 		return fmt.Errorf("(svcs) unable to get context: %w", err)
 	}
 
 	if svcCtx != nil {
+		// Stop every producer before tearing down the tracked instance. Endpoint
+		// reconciliation uses lifecycleMutex too, so no queued event can restore
+		// datapath state after this point.
+		svcCtx.Cancel()
+
 		// If no leader election is enabled, delete routes here
 		if !p.config.EnableLeaderElection && !p.config.EnableServicesElection &&
 			p.config.EnableRoutingTable && svcCtx.HasConfiguredNetworks() {
@@ -329,24 +338,36 @@ func (p *Processor) deleteTrackedService(svc *v1.Service) error {
 			}
 		}
 
-		if !p.config.EnableServicesElection {
-			// If this is an active service then and additional leaderElection will handle stopping
-			err = p.deleteService(svcCtx.Ctx, svc.UID)
-			if err != nil {
-				log.Error(err.Error())
-			}
+		// Delete synchronously even with per-Service election. Waiting for the
+		// election callback leaves a window in which a queued callback can add the
+		// deleted Service again.
+		if err = p.deleteService(context.WithoutCancel(svcCtx.Ctx), svc.UID); err != nil {
+			log.Error(err.Error())
 		}
 
-		// Calls the cancel function of the context
 		log.Warn("(svcs) The load balancer was deleted, cancelling context", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
-		svcCtx.Cancel()
-		p.svcMap.Delete(svc.UID)
+		ns, name := lease.ServiceName(svc)
+		leaseID := lease.NewID(p.config.LeaderElectionType, ns, name)
+		p.leaseMgr.Delete(leaseID, lease.ServiceNamespacedName(svc), nil)
+		p.svcMap.CompareAndDelete(svc.UID, svcCtx)
+		// Drop the per-service election series so a recreated service starts clean.
+		metrics.ServiceElectionLoops.DeleteLabelValues(svc.Namespace, svc.Name)
 		p.updateActiveServicesMetric()
 
 		log.Info("(svcs) deleted", "service name", svc.Name, "namespace", svc.Namespace)
 	}
 
 	return nil
+}
+
+func (p *Processor) withActiveService(svcCtx *servicecontext.Context, reconcile func()) bool {
+	p.lifecycleMutex.Lock()
+	defer p.lifecycleMutex.Unlock()
+	if svcCtx.Ctx.Err() != nil {
+		return false
+	}
+	reconcile()
+	return true
 }
 
 func (p *Processor) Stop() {

--- a/pkg/services/processor_lease_test.go
+++ b/pkg/services/processor_lease_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/kube-vip/kube-vip/pkg/instance"
@@ -13,6 +14,42 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 )
+
+func TestDeletedSharedVIPServiceRejectsRacingEndpointUpdate(t *testing.T) {
+	p := &Processor{}
+	first := servicecontext.New(context.Background())
+	second := servicecontext.New(context.Background())
+	const vip = "192.0.2.10"
+	references := map[string]map[string]bool{
+		vip: {"local-a": true, "local-b": true},
+	}
+
+	// Hold deletion's lifecycle section so the endpoint update is queued in
+	// the same state observed in the E2E failure.
+	p.lifecycleMutex.Lock()
+	var wg sync.WaitGroup
+	updated := make(chan bool, 1)
+	wg.Go(func() {
+		updated <- p.withActiveService(first, func() {
+			references[vip]["local-a"] = true
+		})
+	})
+
+	first.Cancel()
+	delete(references[vip], "local-a")
+	p.lifecycleMutex.Unlock()
+	wg.Wait()
+
+	if <-updated {
+		t.Fatal("endpoint update reconciled after its Service was cancelled")
+	}
+	if references[vip]["local-a"] {
+		t.Fatal("deleted Service restored its shared VIP reference")
+	}
+	if !references[vip]["local-b"] || second.Ctx.Err() != nil {
+		t.Fatal("deleting one Local Service disturbed the other shared VIP owner")
+	}
+}
 
 func TestAddOrModifyStopsTrackedServiceWhenTypeChanges(t *testing.T) {
 	for _, ignored := range []bool{false, true} {

--- a/pkg/services/processor_lease_test.go
+++ b/pkg/services/processor_lease_test.go
@@ -20,8 +20,18 @@ func TestDeletedSharedVIPServiceRejectsRacingEndpointUpdate(t *testing.T) {
 	first := servicecontext.New(context.Background())
 	second := servicecontext.New(context.Background())
 	const vip = "192.0.2.10"
+	localA := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "local-a", UID: "local-a"},
+		Spec: v1.ServiceSpec{
+			LoadBalancerIP:        vip,
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+		},
+	}
+	localB := localA.DeepCopy()
+	localB.Name = "local-b"
+	localB.UID = "local-b"
 	references := map[string]map[string]bool{
-		vip: {"local-a": true, "local-b": true},
+		vip: {string(localA.UID): true, string(localB.UID): true},
 	}
 
 	// Hold deletion's lifecycle section so the endpoint update is queued in
@@ -31,22 +41,22 @@ func TestDeletedSharedVIPServiceRejectsRacingEndpointUpdate(t *testing.T) {
 	updated := make(chan bool, 1)
 	wg.Go(func() {
 		updated <- p.withActiveService(first, func() {
-			references[vip]["local-a"] = true
+			references[vip][string(localA.UID)] = true
 		})
 	})
 
 	first.Cancel()
-	delete(references[vip], "local-a")
+	delete(references[vip], string(localA.UID))
 	p.lifecycleMutex.Unlock()
 	wg.Wait()
 
 	if <-updated {
 		t.Fatal("endpoint update reconciled after its Service was cancelled")
 	}
-	if references[vip]["local-a"] {
+	if references[vip][string(localA.UID)] {
 		t.Fatal("deleted Service restored its shared VIP reference")
 	}
-	if !references[vip]["local-b"] || second.Ctx.Err() != nil {
+	if !references[vip][string(localB.UID)] || second.Ctx.Err() != nil {
 		t.Fatal("deleting one Local Service disturbed the other shared VIP owner")
 	}
 }

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -45,6 +45,9 @@ const (
 )
 
 func (p *Processor) SyncServices(ctx *servicecontext.Context, svc *v1.Service, wg *sync.WaitGroup, usesLeaderElection bool) error {
+	if ctx.Ctx.Err() != nil {
+		return nil
+	}
 	log.Debug("[STARTING] Service Sync", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
 
 	// Iterate through the synchronising services
@@ -170,6 +173,9 @@ func (p *Processor) addService(ctx context.Context, inst *instance.Instance, svc
 	// protect against addService while reading
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
+	if ctx.Err() != nil {
+		return nil
+	}
 
 	startTime := time.Now()
 

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -474,7 +474,8 @@ func (p *Processor) deleteService(ctx context.Context, uid types.UID) error {
 			log.Error("[service] nftables egress teardown", "service", serviceInstance.ServiceSnapshot.Name, "err", err)
 		}
 	}
-	metrics.UPNPMappings.Sub(float64(len(serviceInstance.UPNPGatewayIPs)))
+	metrics.UPNPMappings.Sub(float64(serviceInstance.UPNPMappingCount))
+	serviceInstance.UPNPMappingCount = 0
 
 	if !shared {
 		for x := range serviceInstance.Clusters {
@@ -768,7 +769,8 @@ func (p *Processor) upnpMap(ctx context.Context, s *instance.Instance) {
 	leaseDurationSec := upnpLeaseDurationForServiceSec(s)
 
 	// Reset Gateway IPs to remove stale addresses
-	previousMappings := len(s.UPNPGatewayIPs)
+	previousMappings := s.UPNPMappingCount
+	successfulMappings := 0
 	s.UPNPGatewayIPs = make([]string, 0)
 
 	vips, _ := instance.FetchServiceAddresses(s.ServiceSnapshot)
@@ -810,6 +812,7 @@ func (p *Processor) upnpMap(ctx context.Context, s *instance.Instance) {
 				}
 
 				if forwardSucessful {
+					successfulMappings++
 					ip, err := gw.ConnectionClient.GetExternalIPAddress()
 					if err == nil {
 						s.UPNPGatewayIPs = append(s.UPNPGatewayIPs, ip)
@@ -822,7 +825,12 @@ func (p *Processor) upnpMap(ctx context.Context, s *instance.Instance) {
 	// Remove duplicate IPs
 	slices.Sort(s.UPNPGatewayIPs)
 	s.UPNPGatewayIPs = slices.Compact(s.UPNPGatewayIPs)
-	metrics.UPNPMappings.Add(float64(len(s.UPNPGatewayIPs) - previousMappings))
+	setUPNPMappingSnapshot(s, previousMappings, successfulMappings)
+}
+
+func setUPNPMappingSnapshot(s *instance.Instance, previous, current int) {
+	s.UPNPMappingCount = current
+	metrics.UPNPMappings.Add(float64(current - previous))
 }
 
 func (p *Processor) updateStatus(ctx context.Context, i *instance.Instance) error {
@@ -967,8 +975,10 @@ func (p *Processor) RefreshUPNPForwards(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			p.mutex.Lock()
 			// Skip logging if no service instances
 			if len(p.ServiceInstances) == 0 {
+				p.mutex.Unlock()
 				continue
 			}
 
@@ -979,6 +989,7 @@ func (p *Processor) RefreshUPNPForwards(ctx context.Context) {
 					log.Warn("[UPNP] Error updating service", "ip", p.ServiceInstances[i].ServiceSnapshot.Name, "err", err)
 				}
 			}
+			p.mutex.Unlock()
 		}
 	}
 }

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/instance"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/nftables"
 	"github.com/kube-vip/kube-vip/pkg/servicecontext"
 	"github.com/kube-vip/kube-vip/pkg/upnp"
@@ -473,6 +474,7 @@ func (p *Processor) deleteService(ctx context.Context, uid types.UID) error {
 			log.Error("[service] nftables egress teardown", "service", serviceInstance.ServiceSnapshot.Name, "err", err)
 		}
 	}
+	metrics.UPNPMappings.Sub(float64(len(serviceInstance.UPNPGatewayIPs)))
 
 	if !shared {
 		for x := range serviceInstance.Clusters {
@@ -766,6 +768,7 @@ func (p *Processor) upnpMap(ctx context.Context, s *instance.Instance) {
 	leaseDurationSec := upnpLeaseDurationForServiceSec(s)
 
 	// Reset Gateway IPs to remove stale addresses
+	previousMappings := len(s.UPNPGatewayIPs)
 	s.UPNPGatewayIPs = make([]string, 0)
 
 	vips, _ := instance.FetchServiceAddresses(s.ServiceSnapshot)
@@ -819,6 +822,7 @@ func (p *Processor) upnpMap(ctx context.Context, s *instance.Instance) {
 	// Remove duplicate IPs
 	slices.Sort(s.UPNPGatewayIPs)
 	s.UPNPGatewayIPs = slices.Compact(s.UPNPGatewayIPs)
+	metrics.UPNPMappings.Add(float64(len(s.UPNPGatewayIPs) - previousMappings))
 }
 
 func (p *Processor) updateStatus(ctx context.Context, i *instance.Instance) error {

--- a/pkg/services/services_test.go
+++ b/pkg/services/services_test.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/kube-vip/kube-vip/pkg/instance"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func TestConfigureServiceDoesNotOverwriteActiveEndpoint(t *testing.T) {
@@ -82,6 +84,25 @@ func TestConfigureServiceDoesNotOverwriteActiveEndpoint(t *testing.T) {
 	}
 	if got := currentService.Annotations[kubevip.ActiveEndpoint]; got != selectedEndpoint {
 		t.Fatalf("active endpoint = %q, want %q", got, selectedEndpoint)
+	}
+}
+
+func TestSetUPNPMappingSnapshotCountsMappingsNotGateways(t *testing.T) {
+	metrics.UPNPMappings.Set(0)
+	t.Cleanup(func() { metrics.UPNPMappings.Set(0) })
+
+	serviceInstance := &instance.Instance{UPNPGatewayIPs: []string{"192.0.2.1"}}
+	setUPNPMappingSnapshot(serviceInstance, 0, 3)
+	if got := testutil.ToFloat64(metrics.UPNPMappings); got != 3 {
+		t.Fatalf("UPnP mapping gauge = %v, want 3", got)
+	}
+	if serviceInstance.UPNPMappingCount != 3 {
+		t.Fatalf("tracked UPnP mappings = %d, want 3", serviceInstance.UPNPMappingCount)
+	}
+
+	setUPNPMappingSnapshot(serviceInstance, 3, 1)
+	if got := testutil.ToFloat64(metrics.UPNPMappings); got != 1 {
+		t.Fatalf("UPnP mapping gauge after refresh = %v, want 1", got)
 	}
 }
 

--- a/pkg/services/watch_endpoints.go
+++ b/pkg/services/watch_endpoints.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/debouncer"
 	"github.com/kube-vip/kube-vip/pkg/endpoints"
 	"github.com/kube-vip/kube-vip/pkg/endpoints/providers"
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/servicecontext"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 	v1 "k8s.io/api/core/v1"
@@ -18,6 +19,10 @@ import (
 
 func (p *Processor) watchEndpoint(svcCtx *servicecontext.Context, id string, service *v1.Service,
 	provider providers.Provider, cancelWatcher context.CancelCauseFunc) error {
+	watcherLoops := metrics.WatcherLoops.WithLabelValues("endpoint")
+	watcherLoops.Inc()
+	defer watcherLoops.Dec()
+
 	log.Info("watching", "provider", provider.GetLabel(), "service_name", service.Name, "namespace", service.Namespace)
 	// Use a restartable watcher, as this should help in the event of etcd or timeout issues
 

--- a/pkg/services/watch_endpoints.go
+++ b/pkg/services/watch_endpoints.go
@@ -106,7 +106,7 @@ func (p *Processor) watchEndpoint(svcCtx *servicecontext.Context, id string, ser
 			if svcCtx.Ctx.Err() != nil {
 				return nil
 			}
-			metrics.WatcherRestartsTotal.WithLabelValues("endpoint", "watch_error").Inc()
+			metrics.WatcherFailuresTotal.WithLabelValues("endpoint", "watch_error").Inc()
 			watchErr := utils.WatchError(event.Object)
 			log.Error("watch error", "provider", provider.GetLabel(), "err", watchErr)
 			return utils.WrapPanicError(watchErr, "[%s] endpoint watch failed", provider.GetLabel())
@@ -115,7 +115,7 @@ func (p *Processor) watchEndpoint(svcCtx *servicecontext.Context, id string, ser
 	if svcCtx.Ctx.Err() != nil {
 		return nil
 	}
-	metrics.WatcherRestartsTotal.WithLabelValues("endpoint", "channel_closed").Inc()
+	metrics.WatcherFailuresTotal.WithLabelValues("endpoint", "channel_closed").Inc()
 	log.Info("[endpoint watcher] stopping watching", "provider", provider.GetLabel(), "service name", service.Name, "namespace", service.Namespace)
 	return utils.NewPanicError("[%s] endpoint watch channel closed unexpectedly for service %s/%s", provider.GetLabel(), service.Namespace, service.Name)
 }

--- a/pkg/services/watch_endpoints.go
+++ b/pkg/services/watch_endpoints.go
@@ -106,6 +106,7 @@ func (p *Processor) watchEndpoint(svcCtx *servicecontext.Context, id string, ser
 			if svcCtx.Ctx.Err() != nil {
 				return nil
 			}
+			metrics.WatcherRestartsTotal.WithLabelValues("endpoint", "watch_error").Inc()
 			watchErr := utils.WatchError(event.Object)
 			log.Error("watch error", "provider", provider.GetLabel(), "err", watchErr)
 			return utils.WrapPanicError(watchErr, "[%s] endpoint watch failed", provider.GetLabel())
@@ -114,6 +115,7 @@ func (p *Processor) watchEndpoint(svcCtx *servicecontext.Context, id string, ser
 	if svcCtx.Ctx.Err() != nil {
 		return nil
 	}
+	metrics.WatcherRestartsTotal.WithLabelValues("endpoint", "channel_closed").Inc()
 	log.Info("[endpoint watcher] stopping watching", "provider", provider.GetLabel(), "service name", service.Name, "namespace", service.Namespace)
 	return utils.NewPanicError("[%s] endpoint watch channel closed unexpectedly for service %s/%s", provider.GetLabel(), service.Namespace, service.Name)
 }

--- a/pkg/services/watch_endpoints.go
+++ b/pkg/services/watch_endpoints.go
@@ -88,8 +88,14 @@ func (p *Processor) watchEndpoint(svcCtx *servicecontext.Context, id string, ser
 				log.Info("[endpoint watcher] endpoint object deleted", "provider", provider.GetLabel(), "service name", service.Name, "namespace", service.Namespace)
 			}
 
-			restart, err := epProcessor.Reconcile(svcCtx, event, &lastKnownGoodEndpoint, service, id,
-				p.StartServicesLeaderElection, &wg, p.clientSet, p.updateEgressConfiguration)
+			var restart bool
+			var err error
+			if !p.withActiveService(svcCtx, func() {
+				restart, err = epProcessor.Reconcile(svcCtx, event, &lastKnownGoodEndpoint, service, id,
+					p.StartServicesLeaderElection, &wg, p.clientSet, p.updateEgressConfiguration)
+			}) {
+				return nil
+			}
 			if restart {
 				continue
 			} else if err != nil {

--- a/pkg/services/watch_services.go
+++ b/pkg/services/watch_services.go
@@ -120,6 +120,7 @@ func (p *Processor) ServicesWatcher(ctx context.Context, serviceFunc *Callback, 
 			// Un-used
 		case watch.Error:
 			log.Error("Error attempting to watch Kubernetes services")
+			metrics.WatcherRestartsTotal.WithLabelValues("service", "watch_error").Inc()
 			watchErr := utils.WatchError(event.Object)
 			log.Error("services", "err", watchErr)
 			return utils.WrapPanicError(watchErr, "service watch failed")
@@ -133,6 +134,7 @@ func (p *Processor) ServicesWatcher(ctx context.Context, serviceFunc *Callback, 
 	if watcherErr := context.Cause(watcherCtx); watcherErr != nil {
 		return watcherErr
 	}
+	metrics.WatcherRestartsTotal.WithLabelValues("service", "channel_closed").Inc()
 	log.Warn("Stopping watching services for type: LoadBalancer in all namespaces")
 	return utils.NewPanicError("service watch channel closed unexpectedly")
 }

--- a/pkg/services/watch_services.go
+++ b/pkg/services/watch_services.go
@@ -22,6 +22,10 @@ import (
 
 // This function handles the watching of a services endpoints and updates a load balancers endpoint configurations accordingly
 func (p *Processor) ServicesWatcher(ctx context.Context, serviceFunc *Callback, forcedOnly bool) error {
+	loops := metrics.WatcherLoops.WithLabelValues("service")
+	loops.Inc()
+	defer loops.Dec()
+
 	// first start port mirroring if enabled
 	if err := p.startTrafficMirroringIfEnabled(); err != nil {
 		return err

--- a/pkg/services/watch_services.go
+++ b/pkg/services/watch_services.go
@@ -120,7 +120,7 @@ func (p *Processor) ServicesWatcher(ctx context.Context, serviceFunc *Callback, 
 			// Un-used
 		case watch.Error:
 			log.Error("Error attempting to watch Kubernetes services")
-			metrics.WatcherRestartsTotal.WithLabelValues("service", "watch_error").Inc()
+			metrics.WatcherFailuresTotal.WithLabelValues("service", "watch_error").Inc()
 			watchErr := utils.WatchError(event.Object)
 			log.Error("services", "err", watchErr)
 			return utils.WrapPanicError(watchErr, "service watch failed")
@@ -134,7 +134,7 @@ func (p *Processor) ServicesWatcher(ctx context.Context, serviceFunc *Callback, 
 	if watcherErr := context.Cause(watcherCtx); watcherErr != nil {
 		return watcherErr
 	}
-	metrics.WatcherRestartsTotal.WithLabelValues("service", "channel_closed").Inc()
+	metrics.WatcherFailuresTotal.WithLabelValues("service", "channel_closed").Inc()
 	log.Warn("Stopping watching services for type: LoadBalancer in all namespaces")
 	return utils.NewPanicError("service watch channel closed unexpectedly")
 }

--- a/pkg/vip/address.go
+++ b/pkg/vip/address.go
@@ -122,9 +122,9 @@ type network struct {
 	// anycast semantics, e.g. ECMP, must not use DAD
 	dadSkip bool
 
-	// trackedVIPAddresses contains the addresses represented in VIPAddresses.
-	// AddIP and DeleteIP access it while holding link.Lock.
-	trackedVIPAddresses map[string]struct{}
+	// trackedVIPAddress is this network's reference represented in VIPAddresses.
+	// AddIP, DeleteIP, and SetIP access it while holding link.Lock.
+	trackedVIPAddress string
 }
 
 // NewConfig will attempt to provide an interface to the kernel network configuration
@@ -452,43 +452,40 @@ func (configurator *network) shouldSkipDAD(override bool) bool {
 	return override || configurator.dadSkip
 }
 
-func (configurator *network) accountVIPAddressAdd(existing *netlink.Addr) {
-	if existing != nil || configurator.address == nil {
-		return
-	}
-
-	if configurator.trackedVIPAddresses == nil {
-		configurator.trackedVIPAddresses = make(map[string]struct{})
-	}
-	key := configurator.address.String()
-	if _, ok := configurator.trackedVIPAddresses[key]; ok {
-		return
-	}
-
-	family := utils.IPv4Family
-	if utils.IsIPv6(configurator.address.IP.String()) {
-		family = utils.IPv6Family
-	}
-	metrics.VIPAddresses.WithLabelValues(configurator.link.Intf.Attrs().Name, family).Inc()
-	configurator.trackedVIPAddresses[key] = struct{}{}
-}
-
-func (configurator *network) accountVIPAddressDelete() {
+func (configurator *network) accountVIPAddressAdd() {
 	if configurator.address == nil {
 		return
 	}
 
 	key := configurator.address.String()
-	if _, ok := configurator.trackedVIPAddresses[key]; !ok {
+	if configurator.trackedVIPAddress == key {
 		return
 	}
-	delete(configurator.trackedVIPAddresses, key)
-
-	family := utils.IPv4Family
-	if utils.IsIPv6(configurator.address.IP.String()) {
-		family = utils.IPv6Family
+	if configurator.trackedVIPAddress != "" {
+		configurator.accountVIPAddressDelete()
 	}
-	metrics.VIPAddresses.WithLabelValues(configurator.link.Intf.Attrs().Name, family).Dec()
+
+	metrics.TrackVIPAddress(configurator.link.Intf.Attrs().Name, addressFamily(configurator.address), key)
+	configurator.trackedVIPAddress = key
+}
+
+func (configurator *network) accountVIPAddressDelete() {
+	if configurator.trackedVIPAddress == "" {
+		return
+	}
+
+	tracked, err := netlink.ParseAddr(configurator.trackedVIPAddress)
+	if err == nil {
+		metrics.UntrackVIPAddress(configurator.link.Intf.Attrs().Name, addressFamily(tracked), configurator.trackedVIPAddress)
+	}
+	configurator.trackedVIPAddress = ""
+}
+
+func addressFamily(address *netlink.Addr) string {
+	if utils.IsIPv6(address.IP.String()) {
+		return utils.IPv6Family
+	}
+	return utils.IPv4Family
 }
 
 // AddIP - Add an IP address to the interface
@@ -513,6 +510,7 @@ func (configurator *network) AddIP(precheck bool, skipDAD bool, minLifetime ...i
 	}
 
 	if existing != nil && existing.ValidLft > lifetime {
+		configurator.accountVIPAddressAdd()
 		metrics.VIPOperationsTotal.WithLabelValues("add", "ok").Inc()
 		return false, nil
 	}
@@ -538,7 +536,7 @@ func (configurator *network) AddIP(precheck bool, skipDAD bool, minLifetime ...i
 		return false, errors.Wrap(err, fmt.Sprintf("could not add ip to device %q", configurator.link.Intf.Attrs().Name))
 	}
 
-	configurator.accountVIPAddressAdd(existing)
+	configurator.accountVIPAddressAdd()
 
 	if configurator.nftables {
 		if err := configurator.configureNFTables(); err != nil {

--- a/pkg/vip/address.go
+++ b/pkg/vip/address.go
@@ -26,6 +26,7 @@ import (
 
 	iptables "github.com/kube-vip/kube-vip/pkg/iptables"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	nfinternal "github.com/kube-vip/kube-vip/pkg/nftables"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 
@@ -394,7 +395,12 @@ func (configurator *network) ReplaceRoute() error {
 	} else {
 		route.Realm = 2
 	}
-	return netlink.RouteReplace(route)
+	if err := netlink.RouteReplace(route); err != nil {
+		metrics.RouteOperationsTotal.WithLabelValues("replace", "error").Inc()
+		return err
+	}
+	metrics.RouteOperationsTotal.WithLabelValues("replace", "ok").Inc()
+	return nil
 }
 
 // DeleteRoute - Delete an IP address from a route table
@@ -415,6 +421,7 @@ func (configurator *network) getRoutes() (*[]netlink.Route, error) {
 func (configurator *network) UpdateRoutes() (bool, error) {
 	routes, err := configurator.getRoutes()
 	if err != nil {
+		metrics.RouteOperationsTotal.WithLabelValues("update", "error").Inc()
 		return false, fmt.Errorf("error updating routes: %w", err)
 	}
 	isUpdated := false
@@ -424,11 +431,13 @@ func (configurator *network) UpdateRoutes() (bool, error) {
 			(route.Type == r.Type || route.Type == unix.RTN_UNICAST) &&
 			route.LinkIndex == r.LinkIndex && route.Scope == r.Scope {
 			if err = netlink.RouteReplace(r); err != nil {
+				metrics.RouteOperationsTotal.WithLabelValues("update", "error").Inc()
 				return false, fmt.Errorf("error replacing route: %w", err)
 			}
 			isUpdated = true
 		}
 	}
+	metrics.RouteOperationsTotal.WithLabelValues("update", "ok").Inc()
 	return isUpdated, nil
 }
 
@@ -449,6 +458,7 @@ func (configurator *network) AddIP(precheck bool, skipDAD bool, minLifetime ...i
 	var err error
 	if precheck {
 		if existing, err = configurator.IsSet(); err != nil {
+			metrics.VIPOperationsTotal.WithLabelValues("add", "error").Inc()
 			return false, errors.Wrap(err, "could not check if address exists")
 		}
 	}
@@ -460,6 +470,7 @@ func (configurator *network) AddIP(precheck bool, skipDAD bool, minLifetime ...i
 	}
 
 	if existing != nil && existing.ValidLft > lifetime {
+		metrics.VIPOperationsTotal.WithLabelValues("add", "ok").Inc()
 		return false, nil
 	}
 
@@ -480,19 +491,29 @@ func (configurator *network) AddIP(precheck bool, skipDAD bool, minLifetime ...i
 
 	log.Debug("replacing IP", "address", configurator.address)
 	if err := netlink.AddrReplace(configurator.link.Intf, configurator.address); err != nil {
+		metrics.VIPOperationsTotal.WithLabelValues("add", "error").Inc()
 		return false, errors.Wrap(err, fmt.Sprintf("could not add ip to device %q", configurator.link.Intf.Attrs().Name))
 	}
 
+	family := utils.IPv4Family
+	if utils.IsIPv6(configurator.address.IP.String()) {
+		family = utils.IPv6Family
+	}
+	metrics.VIPAddresses.WithLabelValues(configurator.link.Intf.Attrs().Name, family).Inc()
+
 	if configurator.nftables {
 		if err := configurator.configureNFTables(); err != nil {
+			metrics.VIPOperationsTotal.WithLabelValues("add", "error").Inc()
 			return true, errors.Wrap(err, "could not configure NFTables")
 		}
 	} else {
 		if err := configurator.configureIPTables(); err != nil {
+			metrics.VIPOperationsTotal.WithLabelValues("add", "error").Inc()
 			return true, errors.Wrap(err, "could not configure IPTables")
 		}
 	}
 
+	metrics.VIPOperationsTotal.WithLabelValues("add", "ok").Inc()
 	return true, nil
 }
 
@@ -1062,17 +1083,26 @@ func (configurator *network) DeleteIP() (bool, error) {
 
 	result, err := configurator.IsSet()
 	if err != nil {
+		metrics.VIPOperationsTotal.WithLabelValues("delete", "error").Inc()
 		return false, errors.Wrap(err, "ip check in DeleteIP failed")
 	}
 
 	// Nothing to delete
 	if result == nil {
+		metrics.VIPOperationsTotal.WithLabelValues("delete", "ok").Inc()
 		return false, nil
 	}
 
 	if err = netlink.AddrDel(configurator.link.Intf, configurator.address); err != nil {
+		metrics.VIPOperationsTotal.WithLabelValues("delete", "error").Inc()
 		return false, errors.Wrap(err, "could not delete ip")
 	}
+
+	family := utils.IPv4Family
+	if utils.IsIPv6(configurator.address.IP.String()) {
+		family = utils.IPv6Family
+	}
+	metrics.VIPAddresses.WithLabelValues(configurator.link.Intf.Attrs().Name, family).Dec()
 
 	if configurator.nftables {
 		vip := configurator.address.IP.String()
@@ -1083,6 +1113,7 @@ func (configurator *network) DeleteIP() (bool, error) {
 		}
 		c, err := nfinternal.NewClient(opt)
 		if err != nil {
+			metrics.VIPOperationsTotal.WithLabelValues("delete", "error").Inc()
 			return false, fmt.Errorf("unable to create nftables client: %w", err)
 		}
 
@@ -1099,22 +1130,26 @@ func (configurator *network) DeleteIP() (bool, error) {
 		}
 
 		if err := c.Close(); err != nil {
+			metrics.VIPOperationsTotal.WithLabelValues("delete", "error").Inc()
 			return true, errors.Wrap(err, "failed to close nftables client")
 		}
 	} else {
 		if configurator.enableSecurity && !configurator.ignoreSecurity {
 			if err := configurator.removeIptablesRuleToLimitTrafficPorts(); err != nil {
+				metrics.VIPOperationsTotal.WithLabelValues("delete", "error").Inc()
 				return true, errors.Wrap(err, "could not remove iptables rules to limit traffic ports")
 			}
 		}
 
 		if configurator.serviceName == "" && configurator.ipvsEnabled && configurator.forwardMethod == "masquerade" && configurator.address.IP.To4() != nil {
 			if err := configurator.removeIptablesRulesForMasquerade(); err != nil {
+				metrics.VIPOperationsTotal.WithLabelValues("delete", "error").Inc()
 				return true, errors.Wrap(err, "could not remove iptables masquerade rules ")
 			}
 		}
 	}
 
+	metrics.VIPOperationsTotal.WithLabelValues("delete", "ok").Inc()
 	return true, nil
 }
 

--- a/pkg/vip/address.go
+++ b/pkg/vip/address.go
@@ -121,6 +121,10 @@ type network struct {
 	// dadSkip marks the address with IFA_F_NODAD on every add:
 	// anycast semantics, e.g. ECMP, must not use DAD
 	dadSkip bool
+
+	// trackedVIPAddresses contains the addresses represented in VIPAddresses.
+	// AddIP and DeleteIP access it while holding link.Lock.
+	trackedVIPAddresses map[string]struct{}
 }
 
 // NewConfig will attempt to provide an interface to the kernel network configuration
@@ -448,6 +452,45 @@ func (configurator *network) shouldSkipDAD(override bool) bool {
 	return override || configurator.dadSkip
 }
 
+func (configurator *network) accountVIPAddressAdd(existing *netlink.Addr) {
+	if existing != nil || configurator.address == nil {
+		return
+	}
+
+	if configurator.trackedVIPAddresses == nil {
+		configurator.trackedVIPAddresses = make(map[string]struct{})
+	}
+	key := configurator.address.String()
+	if _, ok := configurator.trackedVIPAddresses[key]; ok {
+		return
+	}
+
+	family := utils.IPv4Family
+	if utils.IsIPv6(configurator.address.IP.String()) {
+		family = utils.IPv6Family
+	}
+	metrics.VIPAddresses.WithLabelValues(configurator.link.Intf.Attrs().Name, family).Inc()
+	configurator.trackedVIPAddresses[key] = struct{}{}
+}
+
+func (configurator *network) accountVIPAddressDelete() {
+	if configurator.address == nil {
+		return
+	}
+
+	key := configurator.address.String()
+	if _, ok := configurator.trackedVIPAddresses[key]; !ok {
+		return
+	}
+	delete(configurator.trackedVIPAddresses, key)
+
+	family := utils.IPv4Family
+	if utils.IsIPv6(configurator.address.IP.String()) {
+		family = utils.IPv6Family
+	}
+	metrics.VIPAddresses.WithLabelValues(configurator.link.Intf.Attrs().Name, family).Dec()
+}
+
 // AddIP - Add an IP address to the interface
 // precheck: if true, check if the IP already exists before adding
 // skipDAD: if true, set IFA_F_NODAD flag for IPv6 addresses to skip Duplicate Address Detection
@@ -495,11 +538,7 @@ func (configurator *network) AddIP(precheck bool, skipDAD bool, minLifetime ...i
 		return false, errors.Wrap(err, fmt.Sprintf("could not add ip to device %q", configurator.link.Intf.Attrs().Name))
 	}
 
-	family := utils.IPv4Family
-	if utils.IsIPv6(configurator.address.IP.String()) {
-		family = utils.IPv6Family
-	}
-	metrics.VIPAddresses.WithLabelValues(configurator.link.Intf.Attrs().Name, family).Inc()
+	configurator.accountVIPAddressAdd(existing)
 
 	if configurator.nftables {
 		if err := configurator.configureNFTables(); err != nil {
@@ -1089,6 +1128,7 @@ func (configurator *network) DeleteIP() (bool, error) {
 
 	// Nothing to delete
 	if result == nil {
+		configurator.accountVIPAddressDelete()
 		metrics.VIPOperationsTotal.WithLabelValues("delete", "ok").Inc()
 		return false, nil
 	}
@@ -1098,11 +1138,7 @@ func (configurator *network) DeleteIP() (bool, error) {
 		return false, errors.Wrap(err, "could not delete ip")
 	}
 
-	family := utils.IPv4Family
-	if utils.IsIPv6(configurator.address.IP.String()) {
-		family = utils.IPv6Family
-	}
-	metrics.VIPAddresses.WithLabelValues(configurator.link.Intf.Attrs().Name, family).Dec()
+	configurator.accountVIPAddressDelete()
 
 	if configurator.nftables {
 		vip := configurator.address.IP.String()

--- a/pkg/vip/address_test.go
+++ b/pkg/vip/address_test.go
@@ -2,6 +2,12 @@ package vip
 
 import (
 	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/vishvananda/netlink"
+
+	"github.com/kube-vip/kube-vip/pkg/metrics"
+	"github.com/kube-vip/kube-vip/pkg/networkinterface"
 )
 
 func TestShouldSkipDAD(t *testing.T) {
@@ -24,5 +30,36 @@ func TestShouldSkipDAD(t *testing.T) {
 				t.Fatalf("shouldSkipDAD(%v) with dadSkip=%v = %v, want %v", tc.override, tc.dadSkip, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestVIPAddressGaugeRenewalDoesNotDrift(t *testing.T) {
+	metrics.VIPAddresses.Reset()
+	t.Cleanup(metrics.VIPAddresses.Reset)
+
+	address, err := netlink.ParseAddr("192.0.2.10/32")
+	if err != nil {
+		t.Fatalf("parsing test address: %v", err)
+	}
+	n := &network{
+		address: address,
+		link: &networkinterface.Link{
+			Intf: &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "eth0"}},
+		},
+	}
+	gauge := metrics.VIPAddresses.WithLabelValues("eth0", "IPv4")
+
+	// The first add creates the address; subsequent adds represent DNS renewals.
+	n.accountVIPAddressAdd(nil)
+	n.accountVIPAddressAdd(&netlink.Addr{})
+	n.accountVIPAddressAdd(&netlink.Addr{})
+	if got := testutil.ToFloat64(gauge); got != 1 {
+		t.Fatalf("VIP address gauge after renewals is %v, want 1", got)
+	}
+
+	n.accountVIPAddressDelete()
+	n.accountVIPAddressDelete()
+	if got := testutil.ToFloat64(gauge); got != 0 {
+		t.Fatalf("VIP address gauge after repeated deletion reconciliation is %v, want 0", got)
 	}
 }

--- a/pkg/vip/address_test.go
+++ b/pkg/vip/address_test.go
@@ -3,6 +3,7 @@ package vip
 import (
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/vishvananda/netlink"
 
@@ -50,16 +51,87 @@ func TestVIPAddressGaugeRenewalDoesNotDrift(t *testing.T) {
 	gauge := metrics.VIPAddresses.WithLabelValues("eth0", "IPv4")
 
 	// The first add creates the address; subsequent adds represent DNS renewals.
-	n.accountVIPAddressAdd(nil)
-	n.accountVIPAddressAdd(&netlink.Addr{})
-	n.accountVIPAddressAdd(&netlink.Addr{})
+	n.accountVIPAddressAdd()
+	n.accountVIPAddressAdd()
+	n.accountVIPAddressAdd()
 	if got := testutil.ToFloat64(gauge); got != 1 {
 		t.Fatalf("VIP address gauge after renewals is %v, want 1", got)
 	}
 
 	n.accountVIPAddressDelete()
 	n.accountVIPAddressDelete()
-	if got := testutil.ToFloat64(gauge); got != 0 {
-		t.Fatalf("VIP address gauge after repeated deletion reconciliation is %v, want 0", got)
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(metrics.VIPAddresses)
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gathering VIP address gauge: %v", err)
 	}
+	if len(families) != 0 {
+		t.Fatalf("VIP address series remains after repeated deletion: %v", families)
+	}
+}
+
+func TestVIPAddressGaugeTransfersAcrossDNSChanges(t *testing.T) {
+	metrics.VIPAddresses.Reset()
+	t.Cleanup(metrics.VIPAddresses.Reset)
+
+	address, err := netlink.ParseAddr("192.0.2.10/32")
+	if err != nil {
+		t.Fatalf("parsing test address: %v", err)
+	}
+	n := &network{
+		address:         address,
+		possibleSubnets: "32",
+		dnsName:         "vip.example.com",
+		link: &networkinterface.Link{
+			Intf: &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "dns0"}},
+		},
+	}
+	gauge := metrics.VIPAddresses.WithLabelValues("dns0", "IPv4")
+
+	n.accountVIPAddressAdd()
+	if err := n.SetIP("192.0.2.11"); err != nil {
+		t.Fatalf("changing DNS VIP: %v", err)
+	}
+	n.accountVIPAddressAdd()
+	if got := testutil.ToFloat64(gauge); got != 1 {
+		t.Fatalf("VIP address gauge after transfer is %v, want 1", got)
+	}
+	if n.trackedVIPAddress != "192.0.2.11/32" {
+		t.Fatalf("tracked VIP = %q, want 192.0.2.11/32", n.trackedVIPAddress)
+	}
+
+	n.accountVIPAddressDelete()
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(metrics.VIPAddresses)
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gathering VIP address gauge: %v", err)
+	}
+	if len(families) != 0 {
+		t.Fatalf("VIP address series remains after deletion: %v", families)
+	}
+}
+
+func TestVIPAddressGaugeCountsExistingAddressOnReclaim(t *testing.T) {
+	metrics.VIPAddresses.Reset()
+	t.Cleanup(metrics.VIPAddresses.Reset)
+
+	address, err := netlink.ParseAddr("198.51.100.20/32")
+	if err != nil {
+		t.Fatalf("parsing test address: %v", err)
+	}
+	n := &network{
+		address: address,
+		link: &networkinterface.Link{
+			Intf: &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "reclaim0"}},
+		},
+	}
+
+	n.accountVIPAddressAdd()
+	n.accountVIPAddressAdd()
+	if got := testutil.ToFloat64(metrics.VIPAddresses.WithLabelValues("reclaim0", "IPv4")); got != 1 {
+		t.Fatalf("reclaimed VIP address gauge = %v, want 1", got)
+	}
+	n.accountVIPAddressDelete()
 }

--- a/pkg/vip/dns.go
+++ b/pkg/vip/dns.go
@@ -6,6 +6,7 @@ import (
 
 	log "log/slog"
 
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 )
 
@@ -47,15 +48,22 @@ func (d *ipUpdater) Run(ctx context.Context) {
 			log.Info("stop ipUpdater")
 			return
 		case <-t.C:
+			previousIP := d.vip.IP()
 			ip, err := utils.LookupHost(dnsName, mode, true)
 			if err != nil {
+				metrics.DNSResolutionsTotal.WithLabelValues("error").Inc()
 				log.Warn("cannot lookup", "name", dnsName, "err", err)
 				// fallback to renewing the existing IP
 				ip = []string{d.vip.IP()}
+			} else {
+				metrics.DNSResolutionsTotal.WithLabelValues("ok").Inc()
 			}
 
-			if err := d.vip.SetIP(ip[0]); err != nil {
-				log.Error("setting IP", "address", ip, "err", err)
+			setIPErr := d.vip.SetIP(ip[0])
+			if setIPErr != nil {
+				log.Error("setting IP", "address", ip, "err", setIPErr)
+			} else if previousIP != ip[0] {
+				metrics.DNSIPChangesTotal.Inc()
 			}
 
 			// Normal VIP addition for DNS, use skipDAD=false for normal DAD process

--- a/pkg/vip/egress.go
+++ b/pkg/vip/egress.go
@@ -35,6 +35,7 @@ const Comment = "a3ViZS12aXAK=kube-vip"
 type Egress struct {
 	ipTablesClient *iptables.IPTables
 	comment        string
+	useNftables    bool
 }
 
 func CreateIptablesClient(nftables bool, namespace string, protocol iptables.Protocol) (*Egress, error) {
@@ -55,6 +56,7 @@ func CreateIptablesClient(nftables bool, namespace string, protocol iptables.Pro
 
 	e.ipTablesClient, err = iptables.New(options...)
 	e.comment = Comment + "-" + namespace
+	e.useNftables = nftables
 	return e, err
 }
 
@@ -98,7 +100,7 @@ func (e *Egress) DeleteMangleMarkingForNetwork(podIP, name, network string) erro
 }
 
 func (e *Egress) DeleteSourceNat(podIP, vip string) (err error) {
-	defer func() { observeSNATOperation("delete", err, -1) }()
+	defer func() { e.observeSNATOperation("delete", err) }()
 
 	log.Info("[egress] Removing source nat", "podIP", podIP, "vip", vip)
 
@@ -111,7 +113,7 @@ func (e *Egress) DeleteSourceNat(podIP, vip string) (err error) {
 }
 
 func (e *Egress) DeleteSourceNatForDestinationPort(podIP, vip, port, proto string) (err error) {
-	defer func() { observeSNATOperation("delete", err, -1) }()
+	defer func() { e.observeSNATOperation("delete", err) }()
 
 	log.Info("[egress] Removing source nat", "podIP", podIP, "vip", vip, "destination port", port)
 
@@ -171,7 +173,7 @@ func (e *Egress) InsertMangeTableIntoPrerouting(name string) error {
 }
 
 func (e *Egress) InsertSourceNat(vip, podIP string) (err error) {
-	defer func() { observeSNATOperation("add", err, 1) }()
+	defer func() { e.observeSNATOperation("add", err) }()
 
 	log.Info("[egress] Adding source nat", "original source", podIP, "new source", vip)
 	if exists, err := e.ipTablesClient.Exists("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-m", "comment", "--comment", e.comment); err != nil {
@@ -186,7 +188,7 @@ func (e *Egress) InsertSourceNat(vip, podIP string) (err error) {
 }
 
 func (e *Egress) InsertSourceNatForDestinationPort(vip, podIP, port, proto string) (err error) {
-	defer func() { observeSNATOperation("add", err, 1) }()
+	defer func() { e.observeSNATOperation("add", err) }()
 
 	log.Info("[egress] Adding source nat", "from", podIP, "to", vip, "port", port)
 	natRules, err := e.ipTablesClient.List("nat", "POSTROUTING")
@@ -213,14 +215,77 @@ func (e *Egress) InsertSourceNatForDestinationPort(vip, podIP, port, proto strin
 	return e.ipTablesClient.Insert("nat", "POSTROUTING", 1, "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-p", proto, "--dport", port, "-m", "comment", "--comment", e.comment)
 }
 
-func observeSNATOperation(op string, err error, rulesDelta float64) {
+func (e *Egress) observeSNATOperation(op string, err error) {
 	result := "ok"
 	if err != nil {
 		result = "error"
 	} else {
-		metrics.EgressRules.WithLabelValues(iptables.TableNat).Add(rulesDelta)
+		e.setSNATRuleCount()
 	}
 	metrics.EgressOperationsTotal.WithLabelValues(op, result).Inc()
+}
+
+func (e *Egress) setSNATRuleCount() {
+	if e.ipTablesClient == nil {
+		return
+	}
+
+	rules, err := e.ipTablesClient.List(iptables.TableNat, iptables.ChainPOSTROUTING)
+	if err != nil {
+		log.Debug("[egress] unable to count iptables SNAT rules", "err", err)
+		return
+	}
+	count := countEgressSNATRules(rules)
+
+	// The iptables metric label is shared by both address families, so include
+	// rules from the other family in the same gauge when it is available.
+	otherProtocol := iptables.ProtocolIPv6
+	if e.ipTablesClient.Proto() == iptables.ProtocolIPv6 {
+		otherProtocol = iptables.ProtocolIPv4
+	}
+	options := []iptables.Option{
+		iptables.EnableNFTables(e.useNftables),
+		iptables.IPFamily(otherProtocol),
+	}
+	if otherProtocol == iptables.ProtocolIPv6 {
+		options = append(options, iptables.Timeout(5))
+	}
+	otherClient, err := iptables.New(options...)
+	if err == nil {
+		otherRules, listErr := otherClient.List(iptables.TableNat, iptables.ChainPOSTROUTING)
+		if listErr != nil {
+			log.Debug("[egress] unable to count ip6tables SNAT rules", "err", listErr)
+			return
+		}
+		count += countEgressSNATRules(otherRules)
+	}
+
+	metrics.EgressRules.WithLabelValues(iptables.TableNat).Set(float64(count))
+}
+
+func countEgressSNATRules(rules []string) int {
+	count := 0
+	for _, rule := range rules {
+		fields := strings.Fields(rule)
+		hasEgressComment := false
+		hasSNATTarget := false
+		for i := 0; i < len(fields); i++ {
+			switch fields[i] {
+			case "--comment":
+				if i+1 < len(fields) {
+					hasEgressComment = strings.HasPrefix(strings.Trim(fields[i+1], `"`), Comment+"-")
+				}
+			case "-j", "--jump":
+				if i+1 < len(fields) && fields[i+1] == "SNAT" {
+					hasSNATTarget = true
+				}
+			}
+		}
+		if hasEgressComment && hasSNATTarget {
+			count++
+		}
+	}
+	return count
 }
 
 func DeleteExistingSessions(sessionIP string, destination bool, destinationPorts, srcPorts string) error {
@@ -390,6 +455,7 @@ func (e *Egress) CleanIPtables() error {
 	} else {
 		log.Warn("No existing mangle chain exists", "chain name", MangleChainName)
 	}
+	e.setSNATRuleCount()
 	return nil
 }
 

--- a/pkg/vip/egress.go
+++ b/pkg/vip/egress.go
@@ -8,6 +8,7 @@ import (
 	log "log/slog"
 
 	iptables "github.com/kube-vip/kube-vip/pkg/iptables"
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 
 	ct "github.com/florianl/go-conntrack"
@@ -96,7 +97,9 @@ func (e *Egress) DeleteMangleMarkingForNetwork(podIP, name, network string) erro
 	return e.ipTablesClient.Delete("mangle", name, "-s", podIP, "-d", network, "-j", "MARK", "--set-mark", "64/64", "-m", "comment", "--comment", e.comment)
 }
 
-func (e *Egress) DeleteSourceNat(podIP, vip string) error {
+func (e *Egress) DeleteSourceNat(podIP, vip string) (err error) {
+	defer func() { observeSNATOperation("delete", err, -1) }()
+
 	log.Info("[egress] Removing source nat", "podIP", podIP, "vip", vip)
 
 	exists, _ := e.ipTablesClient.Exists("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-m", "comment", "--comment", e.comment)
@@ -107,7 +110,9 @@ func (e *Egress) DeleteSourceNat(podIP, vip string) error {
 	return e.ipTablesClient.Delete("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-m", "comment", "--comment", e.comment)
 }
 
-func (e *Egress) DeleteSourceNatForDestinationPort(podIP, vip, port, proto string) error {
+func (e *Egress) DeleteSourceNatForDestinationPort(podIP, vip, port, proto string) (err error) {
+	defer func() { observeSNATOperation("delete", err, -1) }()
+
 	log.Info("[egress] Removing source nat", "podIP", podIP, "vip", vip, "destination port", port)
 
 	exists, _ := e.ipTablesClient.Exists("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-p", proto, "--dport", port, "-m", "comment", "--comment", e.comment)
@@ -165,7 +170,9 @@ func (e *Egress) InsertMangeTableIntoPrerouting(name string) error {
 	return e.ipTablesClient.Insert("mangle", "PREROUTING", 1, "-j", name, "-m", "comment", "--comment", e.comment)
 }
 
-func (e *Egress) InsertSourceNat(vip, podIP string) error {
+func (e *Egress) InsertSourceNat(vip, podIP string) (err error) {
+	defer func() { observeSNATOperation("add", err, 1) }()
+
 	log.Info("[egress] Adding source nat", "original source", podIP, "new source", vip)
 	if exists, err := e.ipTablesClient.Exists("nat", "POSTROUTING", "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-m", "comment", "--comment", e.comment); err != nil {
 		return err
@@ -178,7 +185,9 @@ func (e *Egress) InsertSourceNat(vip, podIP string) error {
 	return e.ipTablesClient.Insert("nat", "POSTROUTING", 1, "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-m", "comment", "--comment", e.comment)
 }
 
-func (e *Egress) InsertSourceNatForDestinationPort(vip, podIP, port, proto string) error {
+func (e *Egress) InsertSourceNatForDestinationPort(vip, podIP, port, proto string) (err error) {
+	defer func() { observeSNATOperation("add", err, 1) }()
+
 	log.Info("[egress] Adding source nat", "from", podIP, "to", vip, "port", port)
 	natRules, err := e.ipTablesClient.List("nat", "POSTROUTING")
 	if err != nil {
@@ -202,6 +211,16 @@ func (e *Egress) InsertSourceNatForDestinationPort(vip, podIP, port, proto strin
 	}
 
 	return e.ipTablesClient.Insert("nat", "POSTROUTING", 1, "-s", podIP+"/32", "-m", "mark", "--mark", "64/64", "-j", "SNAT", "--to-source", vip, "-p", proto, "--dport", port, "-m", "comment", "--comment", e.comment)
+}
+
+func observeSNATOperation(op string, err error, rulesDelta float64) {
+	result := "ok"
+	if err != nil {
+		result = "error"
+	} else {
+		metrics.EgressRules.WithLabelValues(iptables.TableNat).Add(rulesDelta)
+	}
+	metrics.EgressOperationsTotal.WithLabelValues(op, result).Inc()
 }
 
 func DeleteExistingSessions(sessionIP string, destination bool, destinationPorts, srcPorts string) error {

--- a/pkg/vip/egress.go
+++ b/pkg/vip/egress.go
@@ -260,7 +260,7 @@ func (e *Egress) setSNATRuleCount() {
 		count += countEgressSNATRules(otherRules)
 	}
 
-	metrics.EgressRules.WithLabelValues(iptables.TableNat).Set(float64(count))
+	metrics.SetEgressRules(iptables.TableNat, count)
 }
 
 func countEgressSNATRules(rules []string) int {

--- a/pkg/vip/egress_test.go
+++ b/pkg/vip/egress_test.go
@@ -34,3 +34,15 @@ func Test_findRules(t *testing.T) {
 		})
 	}
 }
+
+func TestCountEgressSNATRules(t *testing.T) {
+	rules := []string{
+		fmt.Sprintf("-A POSTROUTING -s 10.0.0.2/32 -j SNAT --to-source 10.0.0.1 -m comment --comment \"%s-default\"", Comment),
+		fmt.Sprintf("-A POSTROUTING -s 10.0.0.3/32 -j RETURN -m comment --comment \"%s-default\"", Comment),
+		"-A POSTROUTING -s 10.0.0.4/32 -j SNAT --to-source 10.0.0.1 -m comment --comment \"other\"",
+	}
+
+	if got := countEgressSNATRules(rules); got != 1 {
+		t.Fatalf("countEgressSNATRules() = %d, want 1", got)
+	}
+}

--- a/pkg/vip/ndp.go
+++ b/pkg/vip/ndp.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/mdlayher/ndp"
 
+	"github.com/kube-vip/kube-vip/pkg/metrics"
+
 	log "log/slog"
 )
 
@@ -47,11 +49,18 @@ func (n *NdpResponder) Close() error {
 func (n *NdpResponder) SendGratuitous(address string) error {
 	ip, err := netip.ParseAddr(address)
 	if err != nil {
+		metrics.NDPAdvertisementsTotal.WithLabelValues("error").Inc()
 		return fmt.Errorf("failed to parse address %s", ip)
 	}
 
 	log.Info("Broadcasting NDP update", "ip", address, "hwaddr", n.hardwareAddr, "interface", n.intf)
-	return n.advertise(netip.IPv6LinkLocalAllNodes(), ip, true)
+	err = n.advertise(netip.IPv6LinkLocalAllNodes(), ip, true)
+	if err != nil {
+		metrics.NDPAdvertisementsTotal.WithLabelValues("error").Inc()
+	} else {
+		metrics.NDPAdvertisementsTotal.WithLabelValues("ok").Inc()
+	}
+	return err
 }
 
 func (n *NdpResponder) advertise(dst, target netip.Addr, gratuitous bool) error {


### PR DESCRIPTION
## Purpose

Complete the metrics stack with BGP, egress, nftables, and watcher-recovery observability.

## Key changes

- Adds BGP route and session, egress/nftables rule, and watcher-restart metrics.
- Derives egress rule gauges from actual counted rules instead of reconcile frequency.
- Adds generic egress SNAT rule-count coverage and documents recovery and query guidance.
- Includes the loop-liveness and dataplane metrics from #1740 and #1741.

## Validation

Unit, integration, lint, CodeQL, and ARP, routing-table, BGP, and service E2E checks pass.

## Stack

Stacked on #1741, which is stacked on #1740. Merge order: #1740, #1741, #1742.