### PR TITLE
Crash when default interface changes

### DIFF
--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -450,7 +450,7 @@ var kubeVipManager = &cobra.Command{
 				wg.Go(func() {
 					if err := vip.MonitorDefaultInterface(ctx, defaultIF); err != nil {
 						log.Error("interface monitor", "err", err)
-						os.Exit(1)
+						cancel()
 					}
 				})
 			}

--- a/cmd/kube-vip.go
+++ b/cmd/kube-vip.go
@@ -449,9 +449,8 @@ var kubeVipManager = &cobra.Command{
 
 				wg.Go(func() {
 					if err := vip.MonitorDefaultInterface(ctx, defaultIF); err != nil {
-
 						log.Error("interface monitor", "err", err)
-						return
+						os.Exit(1)
 					}
 				})
 			}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -353,7 +353,7 @@ func (sm *Manager) startMode(ctx context.Context) error {
 	wg := sync.WaitGroup{}
 	modeCtx, cancel := context.WithCancel(ctx)
 	defer func() {
-
+		sm.Kill()
 		wg.Wait()
 		w.Cleanup()
 		cancel()


### PR DESCRIPTION
According to [this PR](https://github.com/kube-vip/kube-vip/pull/339) the purpose of the monitoring of the default interface was to hard crash if it changed to force the pod to restart.
This behavior seems to have changed during [this change](https://github.com/kube-vip/kube-vip/pull/1043) and now it just seems to print the error and stop monitoring the interface.

This PR aims to revert to this behavior.