### PR TITLE
Panic when global leader is lost

### DIFF
--- a/pkg/kubevip/config_manager.go
+++ b/pkg/kubevip/config_manager.go
@@ -74,3 +74,9 @@ func isValidInterface(iface string) error {
 
 	return nil
 }
+
+// IsOnGlobalLeaderElection returns true if kube-vip is relying on a single global leader election lock
+// rather than per-service leader election.
+func (c *Config) IsOnGlobalLeaderElection() bool {
+	return !c.EnableServicesElection && !c.PerServiceElectionOnDemand
+}

--- a/pkg/manager/worker/common.go
+++ b/pkg/manager/worker/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	log "log/slog"
+	"os"
 	"sync"
 	"sync/atomic"
 
@@ -140,6 +141,13 @@ func (c *Common) OnStoppedLeading() {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	log.Info("leader lost", "former leader", c.config.NodeName)
+
+	// Fail-fast for global leader election: exit immediately to let kubelet restart the pod
+	if c.config.IsOnGlobalLeaderElection() {
+		log.Error("lost global services leadership, exiting process immediately for pod restart")
+		os.Exit(1)
+	}
+
 	c.svcProcessor.Stop()
 
 	log.Error("lost services leadership, restarting kube-vip")


### PR DESCRIPTION
Fix issue https://github.com/kube-vip/kube-vip/issues/1747

With the similar operation like https://github.com/harvester/harvester/issues/11584, the kube-vip POD terminates immediately.

Manually trigger the leader lost:
```
kubectl patch lease plndr-svcs-lock -n harvester-system \
  --type='json' \
  -p='[{"op": "replace", "path": "/spec/holderIdentity", "value": "stolen-by-test"}]'
```

```
kubectl logs -n harvester-system kube-vip-mgf8q --follow
2026/09/04 10:43:51 INFO kube-vip.io version=v1.2.4-RC1 build=0667b343a8c6a7def5588efa31bd22af07acd57e
2026/09/04 10:43:51 INFO starting namespace=kube-system Mode=ARP "Control Plane"=false Services=true
2026/09/04 10:43:51 INFO No interface is specified for VIP in config, auto-detecting default Interface
2026/09/04 10:43:51 INFO prometheus HTTP server started
2026/09/04 10:43:51 INFO kube-vip bind interface=mgmt-br
2026/09/04 10:43:51 WARN Node name is missing from the config, fall back to hostname
2026/09/04 10:43:51 INFO using node name name=harv31
2026/09/04 10:43:51 INFO starting Kube-vip Manager mode=ARP
2026/09/04 10:43:51 INFO Start ARP/NDP advertisement Global
2026/09/04 10:43:51 INFO [ARP manager] starting ARP/NDP advertisement
I0904 10:43:51.866032       1 leaderelection.go:258] "Attempting to acquire leader lease..." lock="harvester-system/plndr-svcs-lock"
2026/09/04 10:43:51 INFO new leader elected "new leader"=stolen-by-test
I0904 10:44:08.855556       1 leaderelection.go:272] "Successfully acquired lease" lock="harvester-system/plndr-svcs-lock"
2026/09/04 10:44:08 INFO (svcs) starting services watcher for all namespaces
2026/09/04 10:44:08 INFO new instance namespace=default service=lb1 addresses=[0.0.0.0] hostnames=[]
2026/09/04 10:44:08 INFO Using existing macvlan interface for DHCP interface=vip-7c8311ee
2026/09/04 10:44:08 ERROR [DHCP] unable to write rp_filter value=0 err="failed to open file: open /proc/sys/net/ipv4/conf/vip-7c8311ee/rp_filter: read-only file system"
2026/09/04 10:44:08 INFO (svcs) adding VIP ip=192.168.122.127 interface=vip-7c8311ee namespace=default name=lb1
2026/09/04 10:44:08 INFO watching provider=endpointslices service_name=lb1 namespace=default
2026/09/04 10:44:08 INFO (svcs) service function starting uid=7c8311ee-2d84-4bff-a89f-46fcee4b013e
2026/09/04 10:44:08 INFO new instance namespace=kube-system service=rke2-traefik addresses=[192.168.122.131] hostnames=[]
2026/09/04 10:44:08 INFO (svcs) adding VIP ip=192.168.122.131 interface=mgmt-br namespace=kube-system name=rke2-traefik
2026/09/04 10:44:08 INFO (svcs) service function starting uid=fd887b83-c1c9-44e2-b9b8-6d52fc0138a2
2026/09/04 10:44:08 INFO watching provider=endpointslices service_name=rke2-traefik namespace=kube-system
2026/09/04 10:44:08 INFO successful add IP address=192.168.122.131
2026/09/04 10:44:08 INFO layer 2 broadcaster starting IP=192.168.122.131 device=mgmt-br
2026/09/04 10:44:08 INFO [ARP manager] inserting ARP/NDP instance name=192.168.122.131/32-mgmt-br
2026/09/04 10:44:08 INFO [service] service=rke2-traefik namespace=kube-system "synchronised in"=2ms
2026/09/04 10:44:08 INFO (svcs) service function done uid=fd887b83-c1c9-44e2-b9b8-6d52fc0138a2
2026/09/04 10:44:08 INFO successful add IP address=192.168.122.127
2026/09/04 10:44:08 INFO layer 2 broadcaster starting IP=192.168.122.127 device=vip-7c8311ee
2026/09/04 10:44:08 INFO [ARP manager] inserting ARP/NDP instance name=192.168.122.127/32-vip-7c8311ee
2026/09/04 10:44:08 INFO [service] service=lb1 namespace=default "synchronised in"=2ms
2026/09/04 10:44:08 INFO (svcs) service function done uid=7c8311ee-2d84-4bff-a89f-46fcee4b013e
2026/09/04 10:45:25 INFO new leader elected "new leader"=stolen-by-test
I0904 10:45:25.119608       1 leaderelection.go:304] "Failed to renew lease" lock="harvester-system/plndr-svcs-lock" err="context deadline exceeded"
2026/09/04 10:45:25 INFO leader lost "former leader"=harv31
2026/09/04 10:45:25 ERROR lost global services leadership, exiting process immediately for pod restart

harv31:/home/rancher # kubectl describe pod -n harvester-system kube-vip-mgf8q
Name:             kube-vip-mgf8q
Namespace:        harvester-system
Priority:         0
Service Account:  kube-vip
Node:             harv31/192.168.122.153
Start Time:       Fri, 04 Sep 2026 10:42:58 +0000
Labels:           app.kubernetes.io/instance=harvester
                  app.kubernetes.io/name=kube-vip
                  controller-revision-hash=5f4556585
                  pod-template-generation=5
Annotations:      <none>
Status:           Running
IP:               192.168.122.153
IPs:
  IP:           192.168.122.153
Controlled By:  DaemonSet/kube-vip
Containers:
  kube-vip:
    Container ID:  containerd://e64dfadfc53b068e7ed3fb800058152809412b81d021060bc46664e62825213c
    Image:         ttl.sh/kube-vip:1h
    Image ID:      ttl.sh/kube-vip@sha256:d8394282fba81a203b27bd7f4f0ce3a983d2c6da7a1fdab84f8fe277f952a72c
    Port:          <none>
    Host Port:     <none>
    Args:
      manager
    State:          Running
      Started:      Fri, 04 Sep 2026 10:45:37 +0000
    Last State:     Terminated
      Reason:       Error
      Exit Code:    1
      Started:      Fri, 04 Sep 2026 10:43:51 +0000
      Finished:     Fri, 04 Sep 2026 10:45:25 +0000
    Ready:          True
    Restart Count:  2                      // quickly rebooted if leader is lost
    Environment:
      cp_enable:                false
      enable_service_security:  true
      lb_enable:                true
      lb_port:                  6443


```

Also: https://github.com/harvester/harvester/issues/11584