### PR TITLE
test(e2e): add Prometheus metrics scraping helpers and assertions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,8 @@ require (
 	github.com/osrg/gobgp/v4 v4.9.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.24.1
+	github.com/prometheus/client_model v0.6.2
+	github.com/prometheus/common v0.70.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.12.1
 	github.com/vishvananda/netlink v1.3.1
@@ -107,8 +109,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
 	github.com/segmentio/fasthash v1.0.3 // indirect

--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/election"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 
 	log "log/slog"
@@ -105,11 +106,14 @@ func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config,
 		LeaseAnnotations: c.LeaseAnnotations,
 		Mgr:              em,
 		OnStartedLeading: func(context.Context) { //nolint TODO: potential clean code
+			metrics.LeaderTransitionsTotal.WithLabelValues(leaseID.Name()).Inc()
+			metrics.IsLeader.WithLabelValues(c.NodeName, leaseID.Name()).Set(1)
 			cluster.OnStartedLeading(c, objLease, em, bgpServer, killFunc, false)
 		},
 		OnStoppedLeading: func() {
 			objLease.Elected.Store(false)
 			cluster.OnStoppedLeading(c, objLease, bgpServer)
+			metrics.IsLeader.WithLabelValues(c.NodeName, leaseID.Name()).Set(0)
 		},
 		OnNewLeader: func(identity string) {
 			cluster.OnNewLeader(identity, c)

--- a/pkg/manager/worker/common.go
+++ b/pkg/manager/worker/common.go
@@ -242,9 +242,7 @@ func (c *Common) runGlobalElection(ctx context.Context, a election.Actions, leas
 				objLease.Elected.Store(true)
 				objLease.Unlock()
 				close(objLease.Started)
-				a.OnStartedLeading(ctx)
-				metrics.LeaderTransitionsTotal.WithLabelValues(leaseID.Name()).Inc()
-				metrics.IsLeader.WithLabelValues(config.NodeName, leaseID.Name()).Set(1)
+				onStartedLeading(ctx, a, config.NodeName, leaseID.Name())
 			})
 		},
 		OnStoppedLeading: func() {
@@ -258,4 +256,10 @@ func (c *Common) runGlobalElection(ctx context.Context, a election.Actions, leas
 	if err := election.RunOrDie(ctx, run, config); err != nil {
 		log.Error("leaderelection failed", "err", err, "id", config.NodeName, "name", leaseID.Name())
 	}
+}
+
+func onStartedLeading(ctx context.Context, actions election.Actions, nodeName, leaseName string) {
+	metrics.LeaderTransitionsTotal.WithLabelValues(leaseName).Inc()
+	metrics.IsLeader.WithLabelValues(nodeName, leaseName).Set(1)
+	actions.OnStartedLeading(ctx)
 }

--- a/pkg/manager/worker/common_metrics_test.go
+++ b/pkg/manager/worker/common_metrics_test.go
@@ -1,0 +1,51 @@
+package worker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kube-vip/kube-vip/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+type blockingElectionActions struct {
+	started chan struct{}
+}
+
+func (a *blockingElectionActions) OnStartedLeading(ctx context.Context) {
+	close(a.started)
+	<-ctx.Done()
+}
+
+func (*blockingElectionActions) OnStoppedLeading() {}
+
+func (*blockingElectionActions) OnNewLeader(string) {}
+
+func TestLeaderMetricIsPublishedBeforeActionsRun(t *testing.T) {
+	nodeName := t.Name()
+	leaseName := "test-lease"
+	actions := &blockingElectionActions{started: make(chan struct{})}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		onStartedLeading(ctx, actions, nodeName, leaseName)
+		close(done)
+	}()
+
+	select {
+	case <-actions.started:
+	case <-time.After(time.Second):
+		t.Fatal("leadership actions did not start")
+	}
+	if value := testutil.ToFloat64(metrics.IsLeader.WithLabelValues(nodeName, leaseName)); value != 1 {
+		t.Fatalf("leader metric = %v, want 1 while leadership actions are running", value)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("leadership actions did not stop")
+	}
+}

--- a/testing/e2e/README.md
+++ b/testing/e2e/README.md
@@ -24,3 +24,24 @@ The E2E tests:
     * This causes leader election to occur
 * Attempts to connect to the control plane using the VIP
     * The new leader will need send ndp advertisements before this can succeed within a timeout
+
+## Prometheus metrics helpers
+
+The E2E build also provides helpers for checking the metrics endpoint from
+inside a kind node. `ScrapeMetrics` executes `curl` against
+`http://127.0.0.1:2112/metrics` and parses the result into a label-aware sample
+map. The helpers are compiled only with the `e2e` build tag and do not change
+the normal test suite.
+
+Use `MetricValue` when a label selector should match one series; its second
+return value is the number of matching series. Use `SumMetric` or `MaxMetric`
+when a selector intentionally matches multiple series. `CounterDelta` compares
+two scrapes of one counter, while `EventuallyMetric` and
+`ConsistentlyMetric` provide Gomega polling assertions. `MetricStable` checks
+that a value remains unchanged across samples separated by a caller-selected
+gap, which is useful for detecting leaked loops after a fault.
+
+The metrics-enabled tests require kube-vip to expose port `2112` in the kind
+node and require `curl` in the node image. Keep metric assertions focused on
+stable behavior and use label selectors instead of depending on the ordering
+of Prometheus samples.

--- a/testing/e2e/README.md
+++ b/testing/e2e/README.md
@@ -30,8 +30,9 @@ The E2E tests:
 The E2E build also provides helpers for checking the metrics endpoint from
 inside a kind node. `ScrapeMetrics` executes `curl` against
 `http://127.0.0.1:2112/metrics` and parses the result into a label-aware sample
-map. The helpers are compiled only with the `e2e` build tag and do not change
-the normal test suite.
+map using Prometheus's `expfmt` parser. The helpers accept a context so callers
+can cancel Docker commands and stability waits. They are compiled only with
+the `e2e` build tag and do not change the normal test suite.
 
 Use `MetricValue` when a label selector should match one series; its second
 return value is the number of matching series. Use `SumMetric` or `MaxMetric`
@@ -41,7 +42,8 @@ two scrapes of one counter, while `EventuallyMetric` and
 that a value remains unchanged across samples separated by a caller-selected
 gap, which is useful for detecting leaked loops after a fault.
 
-The metrics-enabled tests require kube-vip to expose port `2112` in the kind
-node and require `curl` in the node image. Keep metric assertions focused on
-stable behavior and use label selectors instead of depending on the ordering
-of Prometheus samples.
+The metrics-enabled tests set `PrometheusHTTPServer` to `:2112` in their
+manifest values. It remains empty in other specs so parallel kube-vip pods do
+not contend for a host-network port. Metrics tests also require `curl` in the
+node image. Keep metric assertions focused on stable behavior and use label
+selectors instead of depending on the ordering of Prometheus samples.

--- a/testing/e2e/e2e_metric_helpers_test.go
+++ b/testing/e2e/e2e_metric_helpers_test.go
@@ -1,0 +1,59 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseMetricsFixture(t *testing.T) {
+	payload, err := os.ReadFile("testdata/metrics.prom")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	metrics, err := parseMetrics(string(payload))
+	if err != nil {
+		t.Fatalf("parseMetrics() error = %v", err)
+	}
+
+	if value, matches := MetricValue(metrics, "kube_vip_is_leader", map[string]string{"node": "control-plane"}); value != 1 || matches != 1 {
+		t.Fatalf("MetricValue() = (%v, %d), want (1, 1)", value, matches)
+	}
+	if value := SumMetric(metrics, "kube_vip_is_leader", map[string]string{"lease_name": "plndr-cp-lock"}); value != 1 {
+		t.Fatalf("SumMetric() = %v, want 1", value)
+	}
+	if value, found := MaxMetric(metrics, "kube_vip_election_errors_total", map[string]string{"reason": "api\nserver"}); value != 3 || !found {
+		t.Fatalf("MaxMetric() = (%v, %t), want (3, true)", value, found)
+	}
+	if value, matches := MetricValue(metrics, "kube_vip_reconcile_seconds_count", nil); value != 4 || matches != 1 {
+		t.Fatalf("histogram count = (%v, %d), want (4, 1)", value, matches)
+	}
+}
+
+func TestMetricHelpersReportMissingAndAmbiguousSeries(t *testing.T) {
+	metrics := map[string]float64{
+		`metric{node="one"}`: 1,
+		`metric{node="two"}`: 2,
+	}
+
+	if _, matches := MetricValue(metrics, "metric", nil); matches != 2 {
+		t.Fatalf("MetricValue() matches = %d, want 2", matches)
+	}
+	if _, matches := MetricValue(metrics, "missing", nil); matches != 0 {
+		t.Fatalf("MetricValue() matches = %d, want 0", matches)
+	}
+	if _, ok := CounterDelta(metrics, map[string]float64{`metric{node="one"}`: 4}, "metric", nil); ok {
+		t.Fatal("CounterDelta() reported an ambiguous selector as available")
+	}
+	if delta, ok := CounterDelta(metrics, map[string]float64{`metric{node="one"}`: 4}, "metric", map[string]string{"node": "one"}); delta != 3 || !ok {
+		t.Fatalf("CounterDelta() = (%v, %t), want (3, true)", delta, ok)
+	}
+}
+
+func TestParseMetricsRejectsInvalidFixture(t *testing.T) {
+	if _, err := parseMetrics("not valid prometheus text"); err == nil {
+		t.Fatal("parseMetrics() succeeded for invalid input")
+	}
+}

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -1241,28 +1241,30 @@ func assertControlPlaneIsRoutable(controlPlaneVIP string, transportTimeout, even
 	assertConnection("https", controlPlaneVIP, "6443", "livez", transportTimeout, eventuallyTimeout)
 }
 
-func assertExactlyOneLeaderMetric(ctx context.Context, clusterName string, client kubernetes.Interface) {
+func assertExactlyOneLeaderMetric(ctx context.Context, clusterName string, client kubernetes.Interface, skipNodes ...string) {
 	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(nodes.Items).NotTo(BeEmpty())
 
 	const leaseName = "plndr-cp-lock"
 	labels := map[string]string{"lease_name": leaseName}
-	leaderName := e2e.GetLeaseHolder(ctx, leaseName, "kube-system", client)
-	e2e.EventuallyMetric(clusterName, leaderName, "kube_vip_is_leader", labels,
-		Equal(float64(1)), 60*time.Second, 2*time.Second)
+	skipped := make(map[string]struct{}, len(skipNodes))
+	for _, node := range skipNodes {
+		skipped[node] = struct{}{}
+	}
 
 	Eventually(func() (float64, error) {
 		var total float64
 		for _, node := range nodes.Items {
+			if _, ok := skipped[node.Name]; ok {
+				continue
+			}
+
 			metrics, err := e2e.ScrapeMetrics(clusterName, node.Name)
 			if err != nil {
 				return 0, err
 			}
-			value, ok := e2e.MetricValue(metrics, "kube_vip_is_leader", labels)
-			if ok {
-				total += value
-			}
+			total += e2e.SumMetric(metrics, "kube_vip_is_leader", labels)
 		}
 		return total, nil
 	}, 60*time.Second, 2*time.Second).Should(Equal(float64(1)))

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -136,6 +136,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 					EnableEndpoints:       "true",
 					EnableNodeLabeling:    "false",
 					EnableServiceSecurity: "true",
+					PrometheusHTTPServer:  ":2112",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -183,6 +184,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 					EnableEndpoints:       "true",
 					EnableNodeLabeling:    "false",
 					EnableServiceSecurity: "true",
+					PrometheusHTTPServer:  ":2112",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -203,7 +205,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 				func(svcName string, currentOffset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv4Family, currentOffset, defaultNetwork)
 					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol}, 1, false, dsNumber, func(node string) {
-						e2e.EventuallyMetric(clusterName, node, "kube_vip_active_services", map[string]string{
+						e2e.EventuallyMetric(ctx, clusterName, node, "kube_vip_active_services", map[string]string{
 							"namespace": dsNamespace,
 						}, BeNumerically(">=", float64(1)), 60*time.Second, 2*time.Second)
 					})
@@ -1260,7 +1262,7 @@ func assertExactlyOneLeaderMetric(ctx context.Context, clusterName string, clien
 				continue
 			}
 
-			metrics, err := e2e.ScrapeMetrics(clusterName, node.Name)
+			metrics, err := e2e.ScrapeMetrics(ctx, clusterName, node.Name)
 			if err != nil {
 				return 0, err
 			}

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -151,7 +151,9 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 			})
 
 			It(clusterName+" provides an IPv4 VIP address for the Kubernetes control plane nodes", func() {
-				testControlPlaneVIPs(ctx, []string{cpVIP}, clusterName, client)
+				testControlPlaneVIPs(ctx, []string{cpVIP}, clusterName, client, func() {
+					assertExactlyOneLeaderMetric(ctx, clusterName, client)
+				})
 			})
 		})
 
@@ -200,7 +202,11 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 			DescribeTable("configures an IPv4 VIP address for service",
 				func(svcName string, currentOffset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv4Family, currentOffset, defaultNetwork)
-					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol}, 1, false, dsNumber)
+					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol}, 1, false, dsNumber, func(node string) {
+						e2e.EventuallyMetric(clusterName, node, "kube_vip_active_services", map[string]string{
+							"namespace": dsNamespace,
+						}, BeNumerically(">=", float64(1)), 60*time.Second, 2*time.Second)
+					})
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -1235,6 +1241,33 @@ func assertControlPlaneIsRoutable(controlPlaneVIP string, transportTimeout, even
 	assertConnection("https", controlPlaneVIP, "6443", "livez", transportTimeout, eventuallyTimeout)
 }
 
+func assertExactlyOneLeaderMetric(ctx context.Context, clusterName string, client kubernetes.Interface) {
+	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(nodes.Items).NotTo(BeEmpty())
+
+	const leaseName = "plndr-cp-lock"
+	labels := map[string]string{"lease_name": leaseName}
+	leaderName := e2e.GetLeaseHolder(ctx, leaseName, "kube-system", client)
+	e2e.EventuallyMetric(clusterName, leaderName, "kube_vip_is_leader", labels,
+		Equal(float64(1)), 60*time.Second, 2*time.Second)
+
+	Eventually(func() (float64, error) {
+		var total float64
+		for _, node := range nodes.Items {
+			metrics, err := e2e.ScrapeMetrics(clusterName, node.Name)
+			if err != nil {
+				return 0, err
+			}
+			value, ok := e2e.MetricValue(metrics, "kube_vip_is_leader", labels)
+			if ok {
+				total += value
+			}
+		}
+		return total, nil
+	}, 60*time.Second, 2*time.Second).Should(Equal(float64(1)))
+}
+
 // Assume connection to the provided address is possible
 func assertConnection(protocol, ip, port, suffix string, transportTimeout, eventuallyTimeout time.Duration) {
 	if strings.Contains(ip, ":") {
@@ -1694,12 +1727,12 @@ func cleanupCluster(clusterName, network string, configMtx *sync.Mutex, logger l
 	}
 }
 
-func testControlPlaneVIPs(ctx context.Context, cpVIPs []string, clusterName string, client kubernetes.Interface) {
-	testControlPlaneVIPsWithTimeout(ctx, cpVIPs, clusterName, client, time.Duration(0), 20*time.Second)
+func testControlPlaneVIPs(ctx context.Context, cpVIPs []string, clusterName string, client kubernetes.Interface, afterVIPConfirmed ...func()) {
+	testControlPlaneVIPsWithTimeout(ctx, cpVIPs, clusterName, client, time.Duration(0), 20*time.Second, afterVIPConfirmed...)
 }
 
 func testControlPlaneVIPsWithTimeout(ctx context.Context, cpVIPs []string, clusterName string, client kubernetes.Interface,
-	transportTimeout, eventuallyTimeout time.Duration) {
+	transportTimeout, eventuallyTimeout time.Duration, afterVIPConfirmed ...func()) {
 	Expect(cpVIPs).ToNot(BeEmpty())
 
 	By(withTimestamp("checking that the Kubernetes control plane nodes are accessible via the assigned VIP"))
@@ -1708,6 +1741,9 @@ func testControlPlaneVIPsWithTimeout(ctx context.Context, cpVIPs []string, clust
 	for _, cpVIP := range cpVIPs {
 		By(withTimestamp(fmt.Sprintf("testing connection to VIP: %s", cpVIP)))
 		assertControlPlaneIsRoutable(cpVIP, transportTimeout, eventuallyTimeout)
+	}
+	if len(afterVIPConfirmed) > 0 && afterVIPConfirmed[0] != nil {
+		afterVIPConfirmed[0]()
 	}
 
 	var leaderName string
@@ -1731,6 +1767,7 @@ func testControlPlaneVIPsWithTimeout(ctx context.Context, cpVIPs []string, clust
 
 func testService(ctx context.Context, svcName, lbAddress, leaseName, leaseNamespace string, trafficPolicy corev1.ServiceExternalTrafficPolicy,
 	client kubernetes.Interface, serviceElection bool, ipFamily []corev1.IPFamily, numberOfServices int, deleteDS bool, dsNumber int,
+	afterVIPConfirmed ...func(string),
 ) {
 	lbAddresses := vip.Split(lbAddress)
 
@@ -1758,6 +1795,9 @@ func testService(ctx context.Context, svcName, lbAddress, leaseName, leaseNamesp
 	}
 
 	container := e2e.GetLeaseHolder(ctx, leases[0], leaseNamespace, client)
+	if len(afterVIPConfirmed) > 0 && afterVIPConfirmed[0] != nil {
+		afterVIPConfirmed[0](container)
+	}
 
 	if deleteDS {
 		removeTestDS(ctx, client, dsNamespace, dsName, dsNumber)

--- a/testing/e2e/kube-vip-bgp-annotations.yaml.tmpl
+++ b/testing/e2e/kube-vip-bgp-annotations.yaml.tmpl
@@ -12,7 +12,7 @@ spec:
     args:
     - manager
     - --prometheusHTTPServer
-    - ""
+    - "{{ .PrometheusHTTPServer }}"
     env:
     - name: vip_loglevel
       value: "-4"

--- a/testing/e2e/kube-vip-hostname.yaml.tmpl
+++ b/testing/e2e/kube-vip-hostname.yaml.tmpl
@@ -12,7 +12,7 @@ spec:
     args:
     - manager
     - --prometheusHTTPServer
-    - ""
+    - "{{ .PrometheusHTTPServer }}"
     env:
     - name: vip_arp
       value: "true"

--- a/testing/e2e/kube-vip-routing-table.yaml.tmpl
+++ b/testing/e2e/kube-vip-routing-table.yaml.tmpl
@@ -12,7 +12,7 @@ spec:
     args:
     - manager
     - --prometheusHTTPServer
-    - ""
+    - "{{ .PrometheusHTTPServer }}"
     env:
     - name: vip_loglevel
       value: "-4"

--- a/testing/e2e/kube-vip.yaml.tmpl
+++ b/testing/e2e/kube-vip.yaml.tmpl
@@ -12,7 +12,7 @@ spec:
     args:
     - manager
     - --prometheusHTTPServer
-    - ""
+    - "{{ .PrometheusHTTPServer }}"
     env:
     - name: vip_loglevel
       value: "-4"
@@ -20,8 +20,6 @@ spec:
     - name: lb_class_legacy_handling
       value: "false"
     - name: lb_class_name
-    - name: prometheus_server
-      value: :2112
     - name: disable_service_updates
       value: "false"
     - name: vip_arp

--- a/testing/e2e/metrics.go
+++ b/testing/e2e/metrics.go
@@ -51,14 +51,53 @@ func ScrapeMetrics(clusterName, nodeName string) (map[string]float64, error) {
 	return metrics, nil
 }
 
-// MetricValue returns a metric whose labels contain all requested labels.
-func MetricValue(metrics map[string]float64, name string, labels map[string]string) (float64, bool) {
+// MetricValue returns a metric whose labels contain all requested labels and
+// the number of matching series. When matches is greater than one, value is
+// the first matching series in sorted key order and must not be used as a
+// single-series value.
+func MetricValue(metrics map[string]float64, name string, labels map[string]string) (float64, int) {
+	values := matchingMetricValues(metrics, name, labels)
+	if len(values) == 0 {
+		return 0, 0
+	}
+	return values[0], len(values)
+}
+
+// SumMetric returns the sum of all series whose labels contain all requested
+// labels. It returns zero when no series matches.
+func SumMetric(metrics map[string]float64, name string, labels map[string]string) float64 {
+	var total float64
+	for _, value := range matchingMetricValues(metrics, name, labels) {
+		total += value
+	}
+	return total
+}
+
+// MaxMetric returns the maximum value among all series whose labels contain
+// all requested labels. The bool is false when no series matches.
+func MaxMetric(metrics map[string]float64, name string, labels map[string]string) (float64, bool) {
+	values := matchingMetricValues(metrics, name, labels)
+	if len(values) == 0 {
+		return 0, false
+	}
+
+	maximum := values[0]
+	for _, value := range values[1:] {
+		if value > maximum {
+			maximum = value
+		}
+	}
+	return maximum, true
+}
+
+func matchingMetricValues(metrics map[string]float64, name string, labels map[string]string) []float64 {
 	keys := make([]string, 0, len(metrics))
 	for key := range metrics {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 
+	values := make([]float64, 0)
 	for _, key := range keys {
 		metricName, metricLabels, ok := parseMetricKey(key)
 		if !ok || metricName != name {
@@ -67,28 +106,29 @@ func MetricValue(metrics map[string]float64, name string, labels map[string]stri
 
 		matches := true
 		for labelName, labelValue := range labels {
-			if metricLabels[labelName] != labelValue {
+			metricLabelValue, exists := metricLabels[labelName]
+			if !exists || metricLabelValue != labelValue {
 				matches = false
 				break
 			}
 		}
 		if matches {
-			return metrics[key], true
+			values = append(values, metrics[key])
 		}
 	}
 
-	return 0, false
+	return values
 }
 
 // CounterDelta returns the difference between two counter samples. Missing
 // samples are treated as unavailable rather than as a counter reset.
-func CounterDelta(before, after map[string]float64, name string, labels map[string]string) float64 {
-	beforeValue, beforeOK := MetricValue(before, name, labels)
-	afterValue, afterOK := MetricValue(after, name, labels)
-	if !beforeOK || !afterOK {
-		return 0
+func CounterDelta(before, after map[string]float64, name string, labels map[string]string) (float64, bool) {
+	beforeValue, beforeMatches := MetricValue(before, name, labels)
+	afterValue, afterMatches := MetricValue(after, name, labels)
+	if beforeMatches != 1 || afterMatches != 1 {
+		return 0, false
 	}
-	return afterValue - beforeValue
+	return afterValue - beforeValue, true
 }
 
 // EventuallyMetric retries a metric scrape until its value satisfies matcher.
@@ -99,31 +139,42 @@ func EventuallyMetric(clusterName, node, name string, labels map[string]string, 
 			return 0, err
 		}
 
-		value, ok := MetricValue(metrics, name, labels)
-		if !ok {
-			return 0, fmt.Errorf("metric %s with labels %v was not found", name, labels)
-		}
-		return value, nil
+		return singleMetricValue(metrics, name, labels)
 	}, timeout, interval).Should(matcher)
 }
 
-// MetricStable returns a metric value after confirming that it is unchanged
-// across samples separated by gap.
-func MetricStable(clusterName, node, name string, labels map[string]string, samples int, gap time.Duration) (float64, error) {
-	if samples < 1 {
-		return 0, fmt.Errorf("samples must be at least 1")
-	}
-
-	var stableValue float64
-	for sample := 0; sample < samples; sample++ {
+// ConsistentlyMetric repeatedly scrapes a metric while its value satisfies
+// matcher.
+func ConsistentlyMetric(clusterName, node, name string, labels map[string]string, matcher types.GomegaMatcher, timeout, interval time.Duration) {
+	Consistently(func() (float64, error) {
 		metrics, err := ScrapeMetrics(clusterName, node)
 		if err != nil {
 			return 0, err
 		}
 
-		value, ok := MetricValue(metrics, name, labels)
-		if !ok {
-			return 0, fmt.Errorf("metric %s with labels %v was not found", name, labels)
+		return singleMetricValue(metrics, name, labels)
+	}, timeout, interval).Should(matcher)
+}
+
+// MetricStable returns a metric value after confirming that it is unchanged
+// across samples separated by gap. The observed window is (samples-1)*gap
+// plus scrape latency. A single transient scrape error is retried once for
+// each sample.
+func MetricStable(clusterName, node, name string, labels map[string]string, samples int, gap time.Duration) (float64, error) {
+	if samples < 2 {
+		return 0, fmt.Errorf("samples must be at least 2")
+	}
+
+	var stableValue float64
+	for sample := 0; sample < samples; sample++ {
+		metrics, err := scrapeMetricsRetryOnce(clusterName, node)
+		if err != nil {
+			return 0, err
+		}
+
+		value, err := singleMetricValue(metrics, name, labels)
+		if err != nil {
+			return 0, err
 		}
 		if sample == 0 {
 			stableValue = value
@@ -137,6 +188,31 @@ func MetricStable(clusterName, node, name string, labels map[string]string, samp
 	}
 
 	return stableValue, nil
+}
+
+func singleMetricValue(metrics map[string]float64, name string, labels map[string]string) (float64, error) {
+	value, matches := MetricValue(metrics, name, labels)
+	switch matches {
+	case 0:
+		return 0, fmt.Errorf("metric %s with labels %v was not found", name, labels)
+	case 1:
+		return value, nil
+	default:
+		return 0, fmt.Errorf("metric %s with labels %v matched %d series", name, labels, matches)
+	}
+}
+
+func scrapeMetricsRetryOnce(clusterName, node string) (map[string]float64, error) {
+	metrics, err := ScrapeMetrics(clusterName, node)
+	if err == nil {
+		return metrics, nil
+	}
+
+	retryMetrics, retryErr := ScrapeMetrics(clusterName, node)
+	if retryErr == nil {
+		return retryMetrics, nil
+	}
+	return nil, fmt.Errorf("scrape metrics from %s failed: %v; retry failed: %w", node, err, retryErr)
 }
 
 func parseMetrics(payload string) (map[string]float64, error) {

--- a/testing/e2e/metrics.go
+++ b/testing/e2e/metrics.go
@@ -1,0 +1,393 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+)
+
+// ScrapeMetrics gets and parses the Prometheus metrics exposed by kube-vip in
+// a Kind node. nodeName may be either a Kind node suffix or its full container
+// name.
+func ScrapeMetrics(clusterName, nodeName string) (map[string]float64, error) {
+	if clusterName == "" {
+		return nil, fmt.Errorf("cluster name is empty")
+	}
+	if nodeName == "" {
+		return nil, fmt.Errorf("node name is empty")
+	}
+
+	containerName := nodeName
+	if !strings.HasPrefix(nodeName, clusterName+"-") {
+		containerName = fmt.Sprintf("%s-%s", clusterName, nodeName)
+	}
+
+	cmd := exec.Command("docker", "exec", containerName, "curl", "-fsS", "http://127.0.0.1:2112/metrics")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	payload, err := cmd.Output()
+	if err != nil {
+		if detail := strings.TrimSpace(stderr.String()); detail != "" {
+			return nil, fmt.Errorf("scrape metrics from %s: %w: %s", containerName, err, detail)
+		}
+		return nil, fmt.Errorf("scrape metrics from %s: %w", containerName, err)
+	}
+
+	metrics, err := parseMetrics(string(payload))
+	if err != nil {
+		return nil, fmt.Errorf("parse metrics from %s: %w", containerName, err)
+	}
+	return metrics, nil
+}
+
+// MetricValue returns a metric whose labels contain all requested labels.
+func MetricValue(metrics map[string]float64, name string, labels map[string]string) (float64, bool) {
+	keys := make([]string, 0, len(metrics))
+	for key := range metrics {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		metricName, metricLabels, ok := parseMetricKey(key)
+		if !ok || metricName != name {
+			continue
+		}
+
+		matches := true
+		for labelName, labelValue := range labels {
+			if metricLabels[labelName] != labelValue {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return metrics[key], true
+		}
+	}
+
+	return 0, false
+}
+
+// CounterDelta returns the difference between two counter samples. Missing
+// samples are treated as unavailable rather than as a counter reset.
+func CounterDelta(before, after map[string]float64, name string, labels map[string]string) float64 {
+	beforeValue, beforeOK := MetricValue(before, name, labels)
+	afterValue, afterOK := MetricValue(after, name, labels)
+	if !beforeOK || !afterOK {
+		return 0
+	}
+	return afterValue - beforeValue
+}
+
+// EventuallyMetric retries a metric scrape until its value satisfies matcher.
+func EventuallyMetric(clusterName, node, name string, labels map[string]string, matcher types.GomegaMatcher, timeout, interval time.Duration) {
+	Eventually(func() (float64, error) {
+		metrics, err := ScrapeMetrics(clusterName, node)
+		if err != nil {
+			return 0, err
+		}
+
+		value, ok := MetricValue(metrics, name, labels)
+		if !ok {
+			return 0, fmt.Errorf("metric %s with labels %v was not found", name, labels)
+		}
+		return value, nil
+	}, timeout, interval).Should(matcher)
+}
+
+// MetricStable returns a metric value after confirming that it is unchanged
+// across samples separated by gap.
+func MetricStable(clusterName, node, name string, labels map[string]string, samples int, gap time.Duration) (float64, error) {
+	if samples < 1 {
+		return 0, fmt.Errorf("samples must be at least 1")
+	}
+
+	var stableValue float64
+	for sample := 0; sample < samples; sample++ {
+		metrics, err := ScrapeMetrics(clusterName, node)
+		if err != nil {
+			return 0, err
+		}
+
+		value, ok := MetricValue(metrics, name, labels)
+		if !ok {
+			return 0, fmt.Errorf("metric %s with labels %v was not found", name, labels)
+		}
+		if sample == 0 {
+			stableValue = value
+		} else if value != stableValue {
+			return 0, fmt.Errorf("metric %s with labels %v changed from %v to %v", name, labels, stableValue, value)
+		}
+
+		if sample+1 < samples {
+			time.Sleep(gap)
+		}
+	}
+
+	return stableValue, nil
+}
+
+func parseMetrics(payload string) (map[string]float64, error) {
+	metrics := make(map[string]float64)
+	scanner := bufio.NewScanner(strings.NewReader(payload))
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		name, labels, value, err := parseMetricSample(line)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", lineNumber, err)
+		}
+		key := canonicalMetricKey(name, labels)
+		if _, exists := metrics[key]; exists {
+			return nil, fmt.Errorf("line %d: duplicate sample %s", lineNumber, key)
+		}
+		metrics[key] = value
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan payload: %w", err)
+	}
+
+	return metrics, nil
+}
+
+func parseMetricSample(line string) (string, map[string]string, float64, error) {
+	nameEnd := 0
+	for nameEnd < len(line) && isMetricNameChar(line[nameEnd], nameEnd == 0) {
+		nameEnd++
+	}
+	if nameEnd == 0 {
+		return "", nil, 0, fmt.Errorf("invalid metric name")
+	}
+
+	name := line[:nameEnd]
+	position := nameEnd
+	labels := map[string]string{}
+	if position < len(line) && line[position] == '{' {
+		labelEnd, err := closingBrace(line, position+1)
+		if err != nil {
+			return "", nil, 0, err
+		}
+		labels, err = parseLabelSet(line[position+1 : labelEnd])
+		if err != nil {
+			return "", nil, 0, err
+		}
+		position = labelEnd + 1
+	}
+
+	if position >= len(line) || !isWhitespace(line[position]) {
+		return "", nil, 0, fmt.Errorf("metric %s is missing a value", name)
+	}
+	for position < len(line) && isWhitespace(line[position]) {
+		position++
+	}
+	valueStart := position
+	for position < len(line) && !isWhitespace(line[position]) {
+		position++
+	}
+	if valueStart == position {
+		return "", nil, 0, fmt.Errorf("metric %s is missing a value", name)
+	}
+
+	value, err := strconv.ParseFloat(line[valueStart:position], 64)
+	if err != nil {
+		return "", nil, 0, fmt.Errorf("invalid value for metric %s: %w", name, err)
+	}
+	return name, labels, value, nil
+}
+
+func parseMetricKey(key string) (string, map[string]string, bool) {
+	brace := strings.IndexByte(key, '{')
+	if brace < 0 {
+		if !validMetricName(key) {
+			return "", nil, false
+		}
+		return key, map[string]string{}, true
+	}
+	if !strings.HasSuffix(key, "}") || brace == 0 {
+		return "", nil, false
+	}
+
+	name := key[:brace]
+	if !validMetricName(name) {
+		return "", nil, false
+	}
+	labels, err := parseLabelSet(key[brace+1 : len(key)-1])
+	if err != nil {
+		return "", nil, false
+	}
+	return name, labels, true
+}
+
+func canonicalMetricKey(name string, labels map[string]string) string {
+	if len(labels) == 0 {
+		return name
+	}
+
+	labelNames := make([]string, 0, len(labels))
+	for labelName := range labels {
+		labelNames = append(labelNames, labelName)
+	}
+	sort.Strings(labelNames)
+
+	var builder strings.Builder
+	builder.WriteString(name)
+	builder.WriteByte('{')
+	for index, labelName := range labelNames {
+		if index > 0 {
+			builder.WriteByte(',')
+		}
+		builder.WriteString(labelName)
+		builder.WriteByte('=')
+		builder.WriteString(strconv.Quote(labels[labelName]))
+	}
+	builder.WriteByte('}')
+	return builder.String()
+}
+
+func closingBrace(line string, start int) (int, error) {
+	inQuotes := false
+	escaped := false
+	for position := start; position < len(line); position++ {
+		character := line[position]
+		if inQuotes {
+			if escaped {
+				escaped = false
+			} else if character == '\\' {
+				escaped = true
+			} else if character == '"' {
+				inQuotes = false
+			}
+			continue
+		}
+
+		switch character {
+		case '"':
+			inQuotes = true
+		case '}':
+			return position, nil
+		}
+	}
+	return 0, fmt.Errorf("unterminated label set")
+}
+
+func parseLabelSet(labelSet string) (map[string]string, error) {
+	labels := make(map[string]string)
+	position := 0
+	for {
+		for position < len(labelSet) && isWhitespace(labelSet[position]) {
+			position++
+		}
+		if position == len(labelSet) {
+			return labels, nil
+		}
+
+		labelStart := position
+		for position < len(labelSet) && isMetricNameChar(labelSet[position], position == labelStart) {
+			position++
+		}
+		if labelStart == position {
+			return nil, fmt.Errorf("invalid label name")
+		}
+		labelName := labelSet[labelStart:position]
+
+		for position < len(labelSet) && isWhitespace(labelSet[position]) {
+			position++
+		}
+		if position == len(labelSet) || labelSet[position] != '=' {
+			return nil, fmt.Errorf("label %s is missing an equals sign", labelName)
+		}
+		position++
+		for position < len(labelSet) && isWhitespace(labelSet[position]) {
+			position++
+		}
+		if position == len(labelSet) || labelSet[position] != '"' {
+			return nil, fmt.Errorf("label %s is missing a quoted value", labelName)
+		}
+
+		valueStart := position
+		position++
+		escaped := false
+		closed := false
+		for position < len(labelSet) {
+			character := labelSet[position]
+			position++
+			if escaped {
+				escaped = false
+				continue
+			}
+			if character == '\\' {
+				escaped = true
+				continue
+			}
+			if character == '"' {
+				closed = true
+				break
+			}
+		}
+		if !closed {
+			return nil, fmt.Errorf("label %s has an unterminated value", labelName)
+		}
+
+		value, err := strconv.Unquote(labelSet[valueStart:position])
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for label %s: %w", labelName, err)
+		}
+		if _, exists := labels[labelName]; exists {
+			return nil, fmt.Errorf("duplicate label %s", labelName)
+		}
+		labels[labelName] = value
+
+		for position < len(labelSet) && isWhitespace(labelSet[position]) {
+			position++
+		}
+		if position == len(labelSet) {
+			return labels, nil
+		}
+		if labelSet[position] != ',' {
+			return nil, fmt.Errorf("expected comma after label %s", labelName)
+		}
+		position++
+	}
+}
+
+func validMetricName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for position := range name {
+		if !isMetricNameChar(name[position], position == 0) {
+			return false
+		}
+	}
+	return true
+}
+
+func isMetricNameChar(character byte, first bool) bool {
+	if character == '_' || character == ':' || character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' {
+		return true
+	}
+	return !first && character >= '0' && character <= '9'
+}
+
+func isWhitespace(character byte) bool {
+	return character == ' ' || character == '\t'
+}

--- a/testing/e2e/metrics.go
+++ b/testing/e2e/metrics.go
@@ -4,8 +4,8 @@
 package e2e
 
 import (
-	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 	"sort"
@@ -15,12 +15,15 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 )
 
 // ScrapeMetrics gets and parses the Prometheus metrics exposed by kube-vip in
 // a Kind node. nodeName may be either a Kind node suffix or its full container
 // name.
-func ScrapeMetrics(clusterName, nodeName string) (map[string]float64, error) {
+func ScrapeMetrics(ctx context.Context, clusterName, nodeName string) (map[string]float64, error) {
 	if clusterName == "" {
 		return nil, fmt.Errorf("cluster name is empty")
 	}
@@ -33,7 +36,7 @@ func ScrapeMetrics(clusterName, nodeName string) (map[string]float64, error) {
 		containerName = fmt.Sprintf("%s-%s", clusterName, nodeName)
 	}
 
-	cmd := exec.Command("docker", "exec", containerName, "curl", "-fsS", "http://127.0.0.1:2112/metrics")
+	cmd := exec.CommandContext(ctx, "docker", "exec", containerName, "curl", "-fsS", "http://127.0.0.1:2112/metrics")
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	payload, err := cmd.Output()
@@ -132,9 +135,9 @@ func CounterDelta(before, after map[string]float64, name string, labels map[stri
 }
 
 // EventuallyMetric retries a metric scrape until its value satisfies matcher.
-func EventuallyMetric(clusterName, node, name string, labels map[string]string, matcher types.GomegaMatcher, timeout, interval time.Duration) {
+func EventuallyMetric(ctx context.Context, clusterName, node, name string, labels map[string]string, matcher types.GomegaMatcher, timeout, interval time.Duration) {
 	Eventually(func() (float64, error) {
-		metrics, err := ScrapeMetrics(clusterName, node)
+		metrics, err := ScrapeMetrics(ctx, clusterName, node)
 		if err != nil {
 			return 0, err
 		}
@@ -145,9 +148,9 @@ func EventuallyMetric(clusterName, node, name string, labels map[string]string, 
 
 // ConsistentlyMetric repeatedly scrapes a metric while its value satisfies
 // matcher.
-func ConsistentlyMetric(clusterName, node, name string, labels map[string]string, matcher types.GomegaMatcher, timeout, interval time.Duration) {
+func ConsistentlyMetric(ctx context.Context, clusterName, node, name string, labels map[string]string, matcher types.GomegaMatcher, timeout, interval time.Duration) {
 	Consistently(func() (float64, error) {
-		metrics, err := ScrapeMetrics(clusterName, node)
+		metrics, err := ScrapeMetrics(ctx, clusterName, node)
 		if err != nil {
 			return 0, err
 		}
@@ -160,14 +163,14 @@ func ConsistentlyMetric(clusterName, node, name string, labels map[string]string
 // across samples separated by gap. The observed window is (samples-1)*gap
 // plus scrape latency. A single transient scrape error is retried once for
 // each sample.
-func MetricStable(clusterName, node, name string, labels map[string]string, samples int, gap time.Duration) (float64, error) {
+func MetricStable(ctx context.Context, clusterName, node, name string, labels map[string]string, samples int, gap time.Duration) (float64, error) {
 	if samples < 2 {
 		return 0, fmt.Errorf("samples must be at least 2")
 	}
 
 	var stableValue float64
 	for sample := 0; sample < samples; sample++ {
-		metrics, err := scrapeMetricsRetryOnce(clusterName, node)
+		metrics, err := scrapeMetricsRetryOnce(ctx, clusterName, node)
 		if err != nil {
 			return 0, err
 		}
@@ -183,7 +186,11 @@ func MetricStable(clusterName, node, name string, labels map[string]string, samp
 		}
 
 		if sample+1 < samples {
-			time.Sleep(gap)
+			select {
+			case <-ctx.Done():
+				return 0, ctx.Err()
+			case <-time.After(gap):
+			}
 		}
 	}
 
@@ -202,13 +209,13 @@ func singleMetricValue(metrics map[string]float64, name string, labels map[strin
 	}
 }
 
-func scrapeMetricsRetryOnce(clusterName, node string) (map[string]float64, error) {
-	metrics, err := ScrapeMetrics(clusterName, node)
+func scrapeMetricsRetryOnce(ctx context.Context, clusterName, node string) (map[string]float64, error) {
+	metrics, err := ScrapeMetrics(ctx, clusterName, node)
 	if err == nil {
 		return metrics, nil
 	}
 
-	retryMetrics, retryErr := ScrapeMetrics(clusterName, node)
+	retryMetrics, retryErr := ScrapeMetrics(ctx, clusterName, node)
 	if retryErr == nil {
 		return retryMetrics, nil
 	}
@@ -216,78 +223,38 @@ func scrapeMetricsRetryOnce(clusterName, node string) (map[string]float64, error
 }
 
 func parseMetrics(payload string) (map[string]float64, error) {
+	parser := expfmt.NewTextParser(model.LegacyValidation)
+	families, err := parser.TextToMetricFamilies(strings.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("parse Prometheus text: %w", err)
+	}
+
+	familyList := make([]*dto.MetricFamily, 0, len(families))
+	for _, family := range families {
+		familyList = append(familyList, family)
+	}
+	samples, err := expfmt.ExtractSamples(&expfmt.DecodeOptions{}, familyList...)
+	if err != nil {
+		return nil, fmt.Errorf("extract Prometheus samples: %w", err)
+	}
+
 	metrics := make(map[string]float64)
-	scanner := bufio.NewScanner(strings.NewReader(payload))
-	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-
-	lineNumber := 0
-	for scanner.Scan() {
-		lineNumber++
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-
-		name, labels, value, err := parseMetricSample(line)
-		if err != nil {
-			return nil, fmt.Errorf("line %d: %w", lineNumber, err)
+	for _, sample := range samples {
+		name := string(sample.Metric[model.MetricNameLabel])
+		labels := make(map[string]string, len(sample.Metric)-1)
+		for label, value := range sample.Metric {
+			if label != model.MetricNameLabel {
+				labels[string(label)] = string(value)
+			}
 		}
 		key := canonicalMetricKey(name, labels)
 		if _, exists := metrics[key]; exists {
-			return nil, fmt.Errorf("line %d: duplicate sample %s", lineNumber, key)
+			return nil, fmt.Errorf("duplicate sample %s", key)
 		}
-		metrics[key] = value
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scan payload: %w", err)
+		metrics[key] = float64(sample.Value)
 	}
 
 	return metrics, nil
-}
-
-func parseMetricSample(line string) (string, map[string]string, float64, error) {
-	nameEnd := 0
-	for nameEnd < len(line) && isMetricNameChar(line[nameEnd], nameEnd == 0) {
-		nameEnd++
-	}
-	if nameEnd == 0 {
-		return "", nil, 0, fmt.Errorf("invalid metric name")
-	}
-
-	name := line[:nameEnd]
-	position := nameEnd
-	labels := map[string]string{}
-	if position < len(line) && line[position] == '{' {
-		labelEnd, err := closingBrace(line, position+1)
-		if err != nil {
-			return "", nil, 0, err
-		}
-		labels, err = parseLabelSet(line[position+1 : labelEnd])
-		if err != nil {
-			return "", nil, 0, err
-		}
-		position = labelEnd + 1
-	}
-
-	if position >= len(line) || !isWhitespace(line[position]) {
-		return "", nil, 0, fmt.Errorf("metric %s is missing a value", name)
-	}
-	for position < len(line) && isWhitespace(line[position]) {
-		position++
-	}
-	valueStart := position
-	for position < len(line) && !isWhitespace(line[position]) {
-		position++
-	}
-	if valueStart == position {
-		return "", nil, 0, fmt.Errorf("metric %s is missing a value", name)
-	}
-
-	value, err := strconv.ParseFloat(line[valueStart:position], 64)
-	if err != nil {
-		return "", nil, 0, fmt.Errorf("invalid value for metric %s: %w", name, err)
-	}
-	return name, labels, value, nil
 }
 
 func parseMetricKey(key string) (string, map[string]string, bool) {
@@ -337,32 +304,6 @@ func canonicalMetricKey(name string, labels map[string]string) string {
 	}
 	builder.WriteByte('}')
 	return builder.String()
-}
-
-func closingBrace(line string, start int) (int, error) {
-	inQuotes := false
-	escaped := false
-	for position := start; position < len(line); position++ {
-		character := line[position]
-		if inQuotes {
-			if escaped {
-				escaped = false
-			} else if character == '\\' {
-				escaped = true
-			} else if character == '"' {
-				inQuotes = false
-			}
-			continue
-		}
-
-		switch character {
-		case '"':
-			inQuotes = true
-		case '}':
-			return position, nil
-		}
-	}
-	return 0, fmt.Errorf("unterminated label set")
 }
 
 func parseLabelSet(labelSet string) (map[string]string, error) {

--- a/testing/e2e/template.go
+++ b/testing/e2e/template.go
@@ -32,6 +32,7 @@ type KubevipManifestValues struct {
 	ControlPlaneHealthCheckCAPath           string
 	EnableServiceSecurity                   string
 	PerServiceElectionOnDemand              string
+	PrometheusHTTPServer                    string
 }
 
 type BGPPeerValues struct {

--- a/testing/e2e/testdata/metrics.prom
+++ b/testing/e2e/testdata/metrics.prom
@@ -1,0 +1,12 @@
+# HELP kube_vip_is_leader Whether this process holds a lease.
+# TYPE kube_vip_is_leader gauge
+kube_vip_is_leader{lease_name="plndr-cp-lock",node="control-plane"} 1
+kube_vip_is_leader{node="control-plane2",lease_name="plndr-cp-lock"} 0
+# HELP kube_vip_election_errors_total Election errors.
+# TYPE kube_vip_election_errors_total counter
+kube_vip_election_errors_total{reason="api\nserver",node="control-plane"} 3
+# TYPE kube_vip_reconcile_seconds histogram
+kube_vip_reconcile_seconds_bucket{le="0.1"} 2
+kube_vip_reconcile_seconds_bucket{le="+Inf"} 4
+kube_vip_reconcile_seconds_sum 0.5
+kube_vip_reconcile_seconds_count 4


### PR DESCRIPTION
## Purpose

Add Prometheus scraping and assertion helpers for kube-vip E2E tests.

## Key changes

- Adds scrape, label matching, aggregation, counter delta, eventual, consistent, and stability helpers.
- Uses the helpers in ARP leader-election and service assertions.
- Documents helper behavior and test patterns.

## Validation

Helper tests, E2E-tagged compilation, formatting, vet, and current CI checks pass.

## Stack/Merge order

This is the root of the metrics and fault-suite chain. Merge this PR before `test/pr8-fault-primitives`, then `test/pr9-faults-cp`; merge the service, matrix, and scale descendants after that, and merge `ci/pr12-nightly-wiring` last.

This PR intentionally targets `main`. It currently has no parent stack commits; descendant PRs target `main` too and their parent stack commits will disappear as parents merge into `main`.