### PR TITLE
test(e2e): add control-plane election and VIP failover fault suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,10 @@ K8S_VERSION ?= v1.35.0
 GINKGO_ARGS ?=
 GINKGO_PROCS ?=
 GINKGO_PARALLEL := $(if $(GINKGO_PROCS),--procs=$(GINKGO_PROCS),-p)
+TEST_MODE ?= arp
 BUILDX_CACHE_FLAGS ?=
 
-.PHONY: all build clean install uninstall simplify check run e2e-tests unit-tests integration-tests unit-tests-docker integration-tests-docker e2e-tests-etcd
+.PHONY: all build clean install uninstall simplify check run e2e-tests e2e-tests-faults unit-tests integration-tests unit-tests-docker integration-tests-docker e2e-tests-etcd
 
 all: check install
 
@@ -142,13 +143,16 @@ integration-tests:
 	go test -tags=integration,e2e -v ./pkg/etcd
 
 e2e-tests-arp: get-whoami
-	GOMAXPROCS=4 TEST_MODE=arp K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) ./testing/e2e
+	GOMAXPROCS=4 TEST_MODE=arp K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) --label-filter='!faults && !scale' ./testing/e2e
 
 e2e-tests-rt: get-whoami
-	GOMAXPROCS=4 TEST_MODE=rt K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) ./testing/e2e
+	GOMAXPROCS=4 TEST_MODE=rt K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) --label-filter='!faults && !scale' ./testing/e2e
 
 e2e-tests-bgp: get-whoami get-gobgp
-	GOMAXPROCS=4 TEST_MODE=bgp K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) ./testing/e2e
+	GOMAXPROCS=4 TEST_MODE=bgp K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) --label-filter='!faults && !scale' ./testing/e2e
+
+e2e-tests-faults: get-whoami
+	GOMAXPROCS=4 TEST_MODE=$(TEST_MODE) K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) --label-filter=faults ./testing/e2e
 
 e2e-tests-etcd: get-whoami
 	GOMAXPROCS=4 K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) ./testing/e2e/etcd

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,7 @@ e2e-tests-bgp: get-whoami get-gobgp
 	GOMAXPROCS=4 TEST_MODE=bgp K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) --label-filter='!faults && !scale' ./testing/e2e
 
 e2e-tests-faults: get-whoami
+	@test "$(TEST_MODE)" = "arp" -o "$(TEST_MODE)" = "rt" || (echo "fault tests support TEST_MODE=arp or TEST_MODE=rt; BGP is not implemented" >&2; exit 1)
 	GOMAXPROCS=4 TEST_MODE=$(TEST_MODE) K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) --label-filter=faults ./testing/e2e
 
 e2e-tests-etcd: get-whoami

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	k8s.io/apimachinery v0.36.4
 	k8s.io/client-go v0.36.4
 	k8s.io/klog/v2 v2.140.0
+	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/kind v0.33.0
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -147,7 +148,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,8 @@ require (
 	github.com/osrg/gobgp/v4 v4.9.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.24.1
+	github.com/prometheus/client_model v0.6.2
+	github.com/prometheus/common v0.70.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.12.1
 	github.com/vishvananda/netlink v1.3.1
@@ -107,8 +109,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
 	github.com/segmentio/fasthash v1.0.3 // indirect

--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/election"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 
 	log "log/slog"
@@ -105,11 +106,14 @@ func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config,
 		LeaseAnnotations: c.LeaseAnnotations,
 		Mgr:              em,
 		OnStartedLeading: func(context.Context) { //nolint TODO: potential clean code
+			metrics.LeaderTransitionsTotal.WithLabelValues(leaseID.Name()).Inc()
+			metrics.IsLeader.WithLabelValues(c.NodeName, leaseID.Name()).Set(1)
 			cluster.OnStartedLeading(c, objLease, em, bgpServer, killFunc, false)
 		},
 		OnStoppedLeading: func() {
 			objLease.Elected.Store(false)
 			cluster.OnStoppedLeading(c, objLease, bgpServer)
+			metrics.IsLeader.WithLabelValues(c.NodeName, leaseID.Name()).Set(0)
 		},
 		OnNewLeader: func(identity string) {
 			cluster.OnNewLeader(identity, c)

--- a/pkg/lease/lease.go
+++ b/pkg/lease/lease.go
@@ -136,6 +136,12 @@ func (l *Lease) Add(name string) bool {
 	return false
 }
 
+// Has reports whether an object is a member of the lease.
+func (l *Lease) Has(name string) bool {
+	_, exists := l.services.Load(name)
+	return exists
+}
+
 // delete removes the service from the lease and decrements the counter
 func (l *Lease) delete(service string) {
 	if _, exists := l.services.Load(service); exists {

--- a/pkg/manager/worker/common.go
+++ b/pkg/manager/worker/common.go
@@ -242,9 +242,7 @@ func (c *Common) runGlobalElection(ctx context.Context, a election.Actions, leas
 				objLease.Elected.Store(true)
 				objLease.Unlock()
 				close(objLease.Started)
-				a.OnStartedLeading(ctx)
-				metrics.LeaderTransitionsTotal.WithLabelValues(leaseID.Name()).Inc()
-				metrics.IsLeader.WithLabelValues(config.NodeName, leaseID.Name()).Set(1)
+				onStartedLeading(ctx, a, config.NodeName, leaseID.Name())
 			})
 		},
 		OnStoppedLeading: func() {
@@ -258,4 +256,10 @@ func (c *Common) runGlobalElection(ctx context.Context, a election.Actions, leas
 	if err := election.RunOrDie(ctx, run, config); err != nil {
 		log.Error("leaderelection failed", "err", err, "id", config.NodeName, "name", leaseID.Name())
 	}
+}
+
+func onStartedLeading(ctx context.Context, actions election.Actions, nodeName, leaseName string) {
+	metrics.LeaderTransitionsTotal.WithLabelValues(leaseName).Inc()
+	metrics.IsLeader.WithLabelValues(nodeName, leaseName).Set(1)
+	actions.OnStartedLeading(ctx)
 }

--- a/pkg/manager/worker/common_metrics_test.go
+++ b/pkg/manager/worker/common_metrics_test.go
@@ -1,0 +1,51 @@
+package worker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kube-vip/kube-vip/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+type blockingElectionActions struct {
+	started chan struct{}
+}
+
+func (a *blockingElectionActions) OnStartedLeading(ctx context.Context) {
+	close(a.started)
+	<-ctx.Done()
+}
+
+func (*blockingElectionActions) OnStoppedLeading() {}
+
+func (*blockingElectionActions) OnNewLeader(string) {}
+
+func TestLeaderMetricIsPublishedBeforeActionsRun(t *testing.T) {
+	nodeName := t.Name()
+	leaseName := "test-lease"
+	actions := &blockingElectionActions{started: make(chan struct{})}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		onStartedLeading(ctx, actions, nodeName, leaseName)
+		close(done)
+	}()
+
+	select {
+	case <-actions.started:
+	case <-time.After(time.Second):
+		t.Fatal("leadership actions did not start")
+	}
+	if value := testutil.ToFloat64(metrics.IsLeader.WithLabelValues(nodeName, leaseName)); value != 1 {
+		t.Fatalf("leader metric = %v, want 1 while leadership actions are running", value)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("leadership actions did not stop")
+	}
+}

--- a/pkg/servicecontext/servicecontext.go
+++ b/pkg/servicecontext/servicecontext.go
@@ -10,6 +10,7 @@ type Context struct {
 	Ctx                context.Context
 	Cancel             context.CancelFunc
 	IsWatched          bool
+	watchingStopped    chan struct{}
 	ConfiguredNetworks sync.Map
 	EndpointsReady     chan any
 	mu                 sync.Mutex
@@ -100,7 +101,28 @@ func (ctx *Context) SetWatched(watched bool) {
 	ctx.mu.Lock()
 	defer ctx.mu.Unlock()
 
+	if watched && !ctx.IsWatched {
+		ctx.watchingStopped = make(chan struct{})
+	}
+	if !watched && ctx.IsWatched {
+		close(ctx.watchingStopped)
+	}
 	ctx.IsWatched = watched
+}
+
+func (ctx *Context) StartWatching() bool {
+	ctx.mu.Lock()
+	defer ctx.mu.Unlock()
+	if ctx.Ctx.Err() != nil || ctx.IsWatched {
+		return false
+	}
+	ctx.IsWatched = true
+	ctx.watchingStopped = make(chan struct{})
+	return true
+}
+
+func (ctx *Context) StopWatching() {
+	ctx.SetWatched(false)
 }
 
 func (ctx *Context) IsWatchedLocked() bool {
@@ -108,4 +130,21 @@ func (ctx *Context) IsWatchedLocked() bool {
 	defer ctx.mu.Unlock()
 
 	return ctx.IsWatched
+}
+
+func (ctx *Context) WaitForWatchingStopped(waitCtx context.Context) error {
+	ctx.mu.Lock()
+	if !ctx.IsWatched {
+		ctx.mu.Unlock()
+		return nil
+	}
+	stopped := ctx.watchingStopped
+	ctx.mu.Unlock()
+
+	select {
+	case <-waitCtx.Done():
+		return waitCtx.Err()
+	case <-stopped:
+		return nil
+	}
 }

--- a/pkg/services/callback.go
+++ b/pkg/services/callback.go
@@ -20,5 +20,8 @@ func NewCallback(f func(*servicecontext.Context, *v1.Service, *sync.WaitGroup, b
 }
 
 func (c *Callback) Run(svcCtx *servicecontext.Context, svc *v1.Service, wg *sync.WaitGroup) error {
+	if svcCtx.Ctx.Err() != nil {
+		return nil
+	}
 	return c.Function(svcCtx, svc, wg, c.UsesLeaderElection)
 }

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -126,9 +126,6 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 			log.Error("error on stopped leading", "error", err)
 		}
 
-		// wait for leaderelection to be finished
-		<-svcLease.Ctx.Done()
-
 		return nil
 	}
 

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -185,12 +185,10 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 }
 
 func (p *Processor) onStartedLeading(svcCtx *servicecontext.Context, service *v1.Service, wg *sync.WaitGroup) error {
-	var err error
-	if !p.withActiveService(service.UID, svcCtx, func() {
-		err = p.SyncServices(svcCtx, service, wg, true)
-	}) {
+	if !p.serviceContextCurrent(service.UID, svcCtx) {
 		return nil
 	}
+	err := p.SyncServices(svcCtx, service, wg, true)
 	if err != nil {
 		log.Error("service sync", "uid", service.UID, "err", err)
 		return err
@@ -199,11 +197,14 @@ func (p *Processor) onStartedLeading(svcCtx *servicecontext.Context, service *v1
 }
 
 func (p *Processor) onStoppedLeading(svcCtx *servicecontext.Context, svcLease *lease.Lease, service *v1.Service) error {
+	unlockService := p.lockService(service.UID)
+	defer unlockService()
+
 	currentSvcCtx, err := p.getServiceContext(service.UID)
 	if err != nil {
 		return err
 	}
-	if currentSvcCtx != nil && currentSvcCtx != svcCtx {
+	if currentSvcCtx != svcCtx {
 		log.Debug("skipping cleanup from superseded service context", "service", service.Name, "uid", service.UID)
 		return nil
 	}

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -185,7 +185,12 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 }
 
 func (p *Processor) onStartedLeading(svcCtx *servicecontext.Context, service *v1.Service, wg *sync.WaitGroup) error {
-	err := p.SyncServices(svcCtx, service, wg, true)
+	var err error
+	if !p.withActiveService(svcCtx, func() {
+		err = p.SyncServices(svcCtx, service, wg, true)
+	}) {
+		return nil
+	}
 	if err != nil {
 		log.Error("service sync", "uid", service.UID, "err", err)
 		return err

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -186,7 +186,7 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 
 func (p *Processor) onStartedLeading(svcCtx *servicecontext.Context, service *v1.Service, wg *sync.WaitGroup) error {
 	var err error
-	if !p.withActiveService(svcCtx, func() {
+	if !p.withActiveService(service.UID, svcCtx, func() {
 		err = p.SyncServices(svcCtx, service, wg, true)
 	}) {
 		return nil

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -123,15 +123,21 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 		// A follower must return when the current leader loses the lease so the
 		// restart loop can campaign for the same shared lease. Waiting only for
 		// the service context leaves the follower blocked forever after takeover.
+	wait:
 		for svcLease.Elected.Load() {
+			timer := time.NewTimer(200 * time.Millisecond)
 			select {
 			case <-svcCtx.Ctx.Done():
-				if err := p.onStoppedLeading(svcCtx, svcLease, service); err != nil {
-					log.Error("error on stopped leading", "error", err)
-				}
-				return nil
-			case <-time.After(200 * time.Millisecond):
+				timer.Stop()
+				break wait
+			case <-svcLease.Ctx.Done():
+				timer.Stop()
+				break wait
+			case <-timer.C:
 			}
+		}
+		if err := p.onStoppedLeading(svcCtx, svcLease, service); err != nil {
+			log.Error("error on stopped leading", "error", err)
 		}
 
 		return nil

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	log "log/slog"
 
@@ -119,11 +120,18 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 			log.Error("error on started leading", "error", err)
 		}
 
-		// Block until service context is cancelled
-		<-svcCtx.Ctx.Done()
-
-		if err := p.onStoppedLeading(svcCtx, svcLease, service); err != nil {
-			log.Error("error on stopped leading", "error", err)
+		// A follower must return when the current leader loses the lease so the
+		// restart loop can campaign for the same shared lease. Waiting only for
+		// the service context leaves the follower blocked forever after takeover.
+		for svcLease.Elected.Load() {
+			select {
+			case <-svcCtx.Ctx.Done():
+				if err := p.onStoppedLeading(svcCtx, svcLease, service); err != nil {
+					log.Error("error on stopped leading", "error", err)
+				}
+				return nil
+			case <-time.After(200 * time.Millisecond):
+			}
 		}
 
 		return nil

--- a/pkg/services/leader_test.go
+++ b/pkg/services/leader_test.go
@@ -5,12 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kube-vip/kube-vip/pkg/instance"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/servicecontext"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 )
 
 // TestStartServicesLeaderElection_ReturnsOnLeaseLossWithoutServiceDeletion is a regression test for
@@ -68,4 +70,139 @@ func TestStartServicesLeaderElection_ReturnsOnLeaseLossWithoutServiceDeletion(t 
 	// The lease-cleanup goroutine should still be running, waiting for the service to be
 	// deleted; confirm it is not left dangling forever by cancelling the service context now.
 	svcCtx.Cancel()
+}
+
+func TestSharedLeaseMemberCancellationDoesNotWaitForLeaseRetirement(t *testing.T) {
+	p := &Processor{
+		config:   &kubevip.Config{},
+		leaseMgr: lease.NewManager(),
+	}
+	newService := func(name string) *v1.Service {
+		return &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				UID:       types.UID(name + "-uid"),
+				Annotations: map[string]string{
+					kubevip.ServiceLease: "shared",
+				},
+			},
+		}
+	}
+
+	leader := newService("leader")
+	follower := newService("follower")
+	leaderCtx := servicecontext.New(context.Background())
+	followerCtx := servicecontext.New(context.Background())
+	p.svcMap.Store(leader.UID, leaderCtx)
+	p.svcMap.Store(follower.UID, followerCtx)
+	p.ServiceInstances = []*instance.Instance{
+		{ServiceSnapshot: leader.DeepCopy(), AddCalled: true},
+		{ServiceSnapshot: follower.DeepCopy(), AddCalled: true},
+	}
+
+	namespace, name := lease.ServiceName(leader)
+	id := lease.NewID(p.config.LeaderElectionType, namespace, name)
+	svcLease := p.leaseMgr.Add(context.Background(), id)
+	svcLease.Add(lease.ServiceNamespacedName(leader))
+	svcLease.Elected.Store(true)
+	close(svcLease.Started)
+
+	if !followerCtx.StartWatching() {
+		t.Fatal("failed to start follower watcher")
+	}
+	followerCtx.SignalReadiness()
+	electionDone := make(chan error, 1)
+	go func() {
+		defer followerCtx.StopWatching()
+		electionDone <- p.StartServicesLeaderElection(followerCtx, follower, nil, true)
+	}()
+
+	deadline := time.After(time.Second)
+	for {
+		if svcLease.Has(lease.ServiceNamespacedName(follower)) {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("follower did not join the shared lease")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	joined := make(chan struct{})
+	go func() {
+		svcLease.Lock()
+		svcLease.Unlock()
+		close(joined)
+	}()
+	select {
+	case <-joined:
+	case <-time.After(time.Second):
+		t.Fatal("follower did not finish joining the active campaign")
+	}
+
+	deleteDone := make(chan error, 1)
+	go func() {
+		deleteDone <- p.Delete(watch.Event{Type: watch.Deleted, Object: follower}, false)
+	}()
+
+	select {
+	case err := <-electionDone:
+		if err != nil {
+			t.Fatalf("StartServicesLeaderElection returned an error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("follower election routine waited for the shared lease to retire")
+	}
+	select {
+	case err := <-deleteDone:
+		if err != nil {
+			t.Fatalf("deleting follower returned an error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("follower watcher did not return")
+	}
+
+	if got := p.leaseMgr.Get(id); got != svcLease {
+		t.Fatal("shared lease was retired while its leader remained")
+	}
+	if svcLease.Ctx.Err() != nil {
+		t.Fatal("shared lease context was cancelled while its leader remained")
+	}
+	if _, ok := p.svcMap.Load(follower.UID); ok {
+		t.Fatal("follower context remained registered")
+	}
+	if len(p.ServiceInstances) != 1 || p.ServiceInstances[0].ServiceSnapshot.UID != leader.UID {
+		t.Fatal("follower instance was not removed without disturbing its sibling")
+	}
+
+	processed := make(chan bool, 1)
+	go func() {
+		processed <- p.withActiveService(leader.UID, leaderCtx, func() {})
+	}()
+	select {
+	case active := <-processed:
+		if !active {
+			t.Fatal("remaining service event was rejected")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("remaining service event processing was blocked")
+	}
+
+	if err := p.Delete(watch.Event{Type: watch.Deleted, Object: leader}, false); err != nil {
+		t.Fatalf("deleting final member returned an error: %v", err)
+	}
+	if p.leaseMgr.Get(id) != nil {
+		t.Fatal("shared lease remained after deleting its final member")
+	}
+	if svcLease.Ctx.Err() == nil {
+		t.Fatal("shared lease context remained live after deleting its final member")
+	}
+	if len(p.ServiceInstances) != 0 {
+		t.Fatalf("service instances remained after final cleanup: %d", len(p.ServiceInstances))
+	}
+	if _, ok := p.svcMap.Load(leader.UID); ok {
+		t.Fatal("final service context remained registered")
+	}
 }

--- a/pkg/services/leader_test.go
+++ b/pkg/services/leader_test.go
@@ -119,10 +119,7 @@ func TestSharedLeaseMemberCancellationDoesNotWaitForLeaseRetirement(t *testing.T
 	}()
 
 	deadline := time.After(time.Second)
-	for {
-		if svcLease.Has(lease.ServiceNamespacedName(follower)) {
-			break
-		}
+	for !svcLease.Has(lease.ServiceNamespacedName(follower)) {
 		select {
 		case <-deadline:
 			t.Fatal("follower did not join the shared lease")
@@ -130,14 +127,18 @@ func TestSharedLeaseMemberCancellationDoesNotWaitForLeaseRetirement(t *testing.T
 			time.Sleep(time.Millisecond)
 		}
 	}
-	joined := make(chan struct{})
+	joined := make(chan bool, 1)
 	go func() {
 		svcLease.Lock()
+		isMember := svcLease.Has(lease.ServiceNamespacedName(follower))
 		svcLease.Unlock()
-		close(joined)
+		joined <- isMember
 	}()
 	select {
-	case <-joined:
+	case isMember := <-joined:
+		if !isMember {
+			t.Fatal("follower membership disappeared during campaign setup")
+		}
 	case <-time.After(time.Second):
 		t.Fatal("follower did not finish joining the active campaign")
 	}

--- a/pkg/services/leader_test.go
+++ b/pkg/services/leader_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/instance"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
+	"github.com/kube-vip/kube-vip/pkg/node/noop"
 	"github.com/kube-vip/kube-vip/pkg/servicecontext"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -205,5 +206,77 @@ func TestSharedLeaseMemberCancellationDoesNotWaitForLeaseRetirement(t *testing.T
 	}
 	if _, ok := p.svcMap.Load(leader.UID); ok {
 		t.Fatal("final service context remained registered")
+	}
+}
+
+func TestSharedLeaseFollowerWithdrawsBeforeTakeover(t *testing.T) {
+	p := &Processor{
+		config:           &kubevip.Config{DisableServiceUpdates: true},
+		leaseMgr:         lease.NewManager(),
+		nodeLabelManager: noop.NewManager(),
+	}
+	newService := func(name string) *v1.Service {
+		return &v1.Service{ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: "default", UID: types.UID(name + "-uid"),
+			Annotations: map[string]string{kubevip.ServiceLease: "shared"},
+		}}
+	}
+	leader := newService("leader")
+	follower := newService("follower")
+	followerCtx := servicecontext.New(context.Background())
+	t.Cleanup(followerCtx.Cancel)
+	p.svcMap.Store(follower.UID, followerCtx)
+	followerInstance := &instance.Instance{ServiceSnapshot: follower.DeepCopy()}
+	p.ServiceInstances = []*instance.Instance{
+		{ServiceSnapshot: leader.DeepCopy(), AddCalled: true},
+		followerInstance,
+	}
+
+	namespace, name := lease.ServiceName(follower)
+	id := lease.NewID(p.config.LeaderElectionType, namespace, name)
+	svcLease := p.leaseMgr.Add(context.Background(), id)
+	svcLease.Add(lease.ServiceNamespacedName(leader))
+	svcLease.Elected.Store(true)
+	close(svcLease.Started)
+	followerCtx.SignalReadiness()
+
+	done := make(chan error, 1)
+	go func() { done <- p.StartServicesLeaderElection(followerCtx, follower, nil, true) }()
+
+	deadline := time.After(time.Second)
+	for {
+		unlock := p.lockService(follower.UID)
+		started := followerInstance.AddCalled
+		unlock()
+		if started {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("follower did not enter the active shared lease campaign")
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	// Local leadership loss must withdraw the follower before the restart loop
+	// campaigns again; the old implementation waited for service deletion.
+	svcLease.Elected.Store(false)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("follower did not return after leader loss: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("follower remained blocked after shared lease leadership was lost")
+	}
+
+	if len(p.ServiceInstances) != 1 || p.ServiceInstances[0].ServiceSnapshot.UID != leader.UID {
+		t.Fatal("follower cleanup removed the sibling service")
+	}
+	if !svcLease.Has(lease.ServiceNamespacedName(leader)) || !svcLease.Has(lease.ServiceNamespacedName(follower)) {
+		t.Fatal("follower cleanup changed shared lease membership")
+	}
+	if svcLease.Ctx.Err() != nil {
+		t.Fatal("follower cleanup retired the shared lease while sibling remained")
 	}
 }

--- a/pkg/services/leader_test.go
+++ b/pkg/services/leader_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -278,5 +279,145 @@ func TestSharedLeaseFollowerWithdrawsBeforeTakeover(t *testing.T) {
 	}
 	if svcLease.Ctx.Err() != nil {
 		t.Fatal("follower cleanup retired the shared lease while sibling remained")
+	}
+}
+
+func TestSharedLeaseOwnerCancellationStopsCampaignBeforeWatcherWait(t *testing.T) {
+	p := &Processor{
+		config:   &kubevip.Config{},
+		leaseMgr: lease.NewManager(),
+	}
+	newService := func(name string) *v1.Service {
+		return &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				UID:       types.UID(name + "-uid"),
+				Annotations: map[string]string{
+					kubevip.ServiceLease: "shared",
+				},
+			},
+		}
+	}
+
+	owner := newService("owner")
+	sibling := newService("sibling")
+	ownerCtx := servicecontext.New(context.Background())
+	siblingCtx := servicecontext.New(context.Background())
+	p.svcMap.Store(owner.UID, ownerCtx)
+	p.svcMap.Store(sibling.UID, siblingCtx)
+	p.ServiceInstances = []*instance.Instance{
+		{ServiceSnapshot: owner.DeepCopy(), AddCalled: true},
+		{ServiceSnapshot: sibling.DeepCopy(), AddCalled: true},
+	}
+
+	namespace, name := lease.ServiceName(owner)
+	id := lease.NewID(p.config.LeaderElectionType, namespace, name)
+	svcLease := p.leaseMgr.Add(context.Background(), id)
+	ownerName := lease.ServiceNamespacedName(owner)
+	siblingName := lease.ServiceNamespacedName(sibling)
+	svcLease.Add(ownerName)
+	svcLease.Add(siblingName)
+	svcLease.Elected.Store(true)
+	close(svcLease.Started)
+
+	if !ownerCtx.StartWatching() {
+		t.Fatal("failed to start owner watcher")
+	}
+	campaignStopped := make(chan struct{})
+	var stopCampaign sync.Once
+	ownerCtx.SetLeaderCancel(func() {
+		stopCampaign.Do(func() {
+			svcLease.Elected.Store(false)
+			svcLease.Started = make(chan any)
+			close(campaignStopped)
+		})
+	})
+	watcherDone := make(chan struct{})
+	go func() {
+		defer close(watcherDone)
+		<-ownerCtx.Ctx.Done()
+		<-campaignStopped
+		ownerCtx.StopWatching()
+	}()
+
+	deleteDone := make(chan error, 1)
+	go func() {
+		deleteDone <- p.Delete(watch.Event{Type: watch.Deleted, Object: owner}, false)
+	}()
+	select {
+	case err := <-deleteDone:
+		if err != nil {
+			t.Fatalf("deleting campaign owner returned an error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("deleting campaign owner waited for its watcher")
+	}
+	<-watcherDone
+	select {
+	case <-campaignStopped:
+	default:
+		t.Fatal("owner campaign was not cancelled before the watcher wait completed")
+	}
+
+	if got := p.leaseMgr.Get(id); got != svcLease {
+		t.Fatal("shared lease was replaced while its sibling remained")
+	}
+	if svcLease.Ctx.Err() != nil {
+		t.Fatal("shared lease was cancelled while its sibling remained")
+	}
+	if svcLease.Has(ownerName) {
+		t.Fatal("campaign owner remained a lease member")
+	}
+	if !svcLease.Has(siblingName) {
+		t.Fatal("sibling membership disappeared with the campaign owner")
+	}
+	if _, ok := p.svcMap.Load(owner.UID); ok {
+		t.Fatal("campaign owner context remained registered")
+	}
+	if len(p.ServiceInstances) != 1 || p.ServiceInstances[0].ServiceSnapshot.UID != sibling.UID {
+		t.Fatal("campaign owner cleanup disturbed its sibling instance")
+	}
+
+	campaigned := make(chan struct{})
+	go func() {
+		svcLease.Lock()
+		if !svcLease.Elected.Load() && svcLease.Has(siblingName) {
+			svcLease.Elected.Store(true)
+			close(svcLease.Started)
+		}
+		svcLease.Unlock()
+		close(campaigned)
+	}()
+	select {
+	case <-campaigned:
+	case <-time.After(time.Second):
+		t.Fatal("sibling could not campaign on the shared lease")
+	}
+	if !svcLease.Elected.Load() {
+		t.Fatal("sibling did not take over the shared lease")
+	}
+
+	if err := p.Delete(watch.Event{Type: watch.Deleted, Object: sibling}, false); err != nil {
+		t.Fatalf("deleting final member returned an error: %v", err)
+	}
+	if p.leaseMgr.Get(id) != nil || svcLease.Ctx.Err() == nil {
+		t.Fatal("final member did not retire the shared lease")
+	}
+	if len(p.ServiceInstances) != 0 {
+		t.Fatalf("service instances remained after final cleanup: %d", len(p.ServiceInstances))
+	}
+	if _, ok := p.svcMap.Load(sibling.UID); ok {
+		t.Fatal("final service context remained registered")
+	}
+
+	replacement := p.leaseMgr.Add(context.Background(), id)
+	replacement.Add(siblingName)
+	if err := p.Delete(watch.Event{Type: watch.Deleted, Object: sibling}, false); err != nil {
+		t.Fatalf("repeating final member deletion returned an error: %v", err)
+	}
+	p.leaseMgr.Delete(id, siblingName, svcLease)
+	if p.leaseMgr.Get(id) != replacement || replacement.Ctx.Err() != nil {
+		t.Fatal("stale final cleanup retired the replacement lease")
 	}
 }

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -40,8 +40,9 @@ type Processor struct {
 	// Keeps track of all running instances
 	ServiceInstances []*instance.Instance
 
-	mutex     sync.Mutex
-	bgpServer *bgp.Server
+	mutex          sync.Mutex
+	lifecycleMutex sync.Mutex
+	bgpServer      *bgp.Server
 
 	clientSet   *kubernetes.Clientset
 	rwClientSet *kubernetes.Clientset
@@ -315,12 +316,20 @@ func (p *Processor) Delete(event watch.Event, forcedOnly bool) error {
 }
 
 func (p *Processor) deleteTrackedService(svc *v1.Service) error {
+	p.lifecycleMutex.Lock()
+	defer p.lifecycleMutex.Unlock()
+
 	svcCtx, err := p.getServiceContext(svc.UID)
 	if err != nil {
 		return fmt.Errorf("(svcs) unable to get context: %w", err)
 	}
 
 	if svcCtx != nil {
+		// Stop every producer before tearing down the tracked instance. Endpoint
+		// reconciliation uses lifecycleMutex too, so no queued event can restore
+		// datapath state after this point.
+		svcCtx.Cancel()
+
 		// If no leader election is enabled, delete routes here
 		if !p.config.EnableLeaderElection && !p.config.EnableServicesElection &&
 			p.config.EnableRoutingTable && svcCtx.HasConfiguredNetworks() {
@@ -329,18 +338,18 @@ func (p *Processor) deleteTrackedService(svc *v1.Service) error {
 			}
 		}
 
-		if !p.config.EnableServicesElection {
-			// If this is an active service then and additional leaderElection will handle stopping
-			err = p.deleteService(svcCtx.Ctx, svc.UID)
-			if err != nil {
-				log.Error(err.Error())
-			}
+		// Delete synchronously even with per-Service election. Waiting for the
+		// election callback leaves a window in which a queued callback can add the
+		// deleted Service again.
+		if err = p.deleteService(context.WithoutCancel(svcCtx.Ctx), svc.UID); err != nil {
+			log.Error(err.Error())
 		}
 
-		// Calls the cancel function of the context
 		log.Warn("(svcs) The load balancer was deleted, cancelling context", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
-		svcCtx.Cancel()
-		p.svcMap.Delete(svc.UID)
+		ns, name := lease.ServiceName(svc)
+		leaseID := lease.NewID(p.config.LeaderElectionType, ns, name)
+		p.leaseMgr.Delete(leaseID, lease.ServiceNamespacedName(svc), nil)
+		p.svcMap.CompareAndDelete(svc.UID, svcCtx)
 		// Drop the per-service election series so a recreated service starts clean.
 		metrics.ServiceElectionLoops.DeleteLabelValues(svc.Namespace, svc.Name)
 		p.updateActiveServicesMetric()
@@ -349,6 +358,16 @@ func (p *Processor) deleteTrackedService(svc *v1.Service) error {
 	}
 
 	return nil
+}
+
+func (p *Processor) withActiveService(svcCtx *servicecontext.Context, reconcile func()) bool {
+	p.lifecycleMutex.Lock()
+	defer p.lifecycleMutex.Unlock()
+	if svcCtx.Ctx.Err() != nil {
+		return false
+	}
+	reconcile()
+	return true
 }
 
 func (p *Processor) Stop() {

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -30,7 +30,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/keymutex"
 )
+
+const concurrentServiceLocks = 128
 
 type Processor struct {
 	config        *kubevip.Config
@@ -40,9 +43,10 @@ type Processor struct {
 	// Keeps track of all running instances
 	ServiceInstances []*instance.Instance
 
-	mutex          sync.Mutex
-	lifecycleMutex sync.Mutex
-	bgpServer      *bgp.Server
+	mutex            sync.Mutex
+	serviceLocks     keymutex.KeyMutex
+	serviceLocksOnce sync.Once
+	bgpServer        *bgp.Server
 
 	clientSet   *kubernetes.Clientset
 	rwClientSet *kubernetes.Clientset
@@ -78,6 +82,7 @@ func NewServicesProcessor(config *kubevip.Config, bgpServer *bgp.Server,
 		config:           config,
 		lbClassFilter:    lbClassFilterFunc,
 		ServiceInstances: []*instance.Instance{},
+		serviceLocks:     keymutex.NewHashed(concurrentServiceLocks),
 		bgpServer:        bgpServer,
 		clientSet:        clientSet,
 		rwClientSet:      rwClientSet,
@@ -142,8 +147,8 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 		svc = s
 	}
 
-	p.lifecycleMutex.Lock()
-	defer p.lifecycleMutex.Unlock()
+	unlockService := p.lockService(svc.UID)
+	defer unlockService()
 
 	svcInstance := instance.FindServiceInstance(svc, p.ServiceInstances)
 
@@ -240,13 +245,7 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 				// start if service is not already watched/handled
 				// signal endpoints goroutine we are ready to start and run service handling function
 				log.Info("(svcs) service function starting", "uid", svc.UID)
-				if serviceFunc.UsesLeaderElection {
-					err = serviceFunc.Run(svcCtx, svc, wg)
-				} else {
-					p.withActiveService(svc.UID, svcCtx, func() {
-						err = serviceFunc.Run(svcCtx, svc, wg)
-					})
-				}
+				err = serviceFunc.Run(svcCtx, svc, wg)
 				if err != nil {
 					log.Error(err.Error())
 					if utils.IsPanicError(err) {
@@ -336,18 +335,18 @@ func (p *Processor) deleteTrackedService(svc *v1.Service) error {
 			}
 		}
 
-		p.lifecycleMutex.Lock()
+		unlockService := p.lockService(svc.UID)
 		currentCtx, err := p.getServiceContext(svc.UID)
 		if err != nil {
-			p.lifecycleMutex.Unlock()
+			unlockService()
 			return fmt.Errorf("(svcs) unable to get context: %w", err)
 		}
 		if currentCtx == svcCtx {
+			defer unlockService()
 			break
 		}
-		p.lifecycleMutex.Unlock()
+		unlockService()
 	}
-	defer p.lifecycleMutex.Unlock()
 
 	if svcCtx != nil {
 		// If no leader election is enabled, delete routes here
@@ -381,8 +380,8 @@ func (p *Processor) deleteTrackedService(svc *v1.Service) error {
 }
 
 func (p *Processor) withActiveService(uid types.UID, svcCtx *servicecontext.Context, reconcile func()) bool {
-	p.lifecycleMutex.Lock()
-	defer p.lifecycleMutex.Unlock()
+	unlockService := p.lockService(uid)
+	defer unlockService()
 	if svcCtx.Ctx.Err() != nil {
 		return false
 	}
@@ -392,6 +391,31 @@ func (p *Processor) withActiveService(uid types.UID, svcCtx *servicecontext.Cont
 	}
 	reconcile()
 	return true
+}
+
+func (p *Processor) serviceContextCurrent(uid types.UID, svcCtx *servicecontext.Context) bool {
+	unlockService := p.lockService(uid)
+	defer unlockService()
+	if svcCtx == nil || svcCtx.Ctx.Err() != nil {
+		return false
+	}
+	current, err := p.getServiceContext(uid)
+	return err == nil && current == svcCtx
+}
+
+func (p *Processor) lockService(uid types.UID) func() {
+	p.serviceLocksOnce.Do(func() {
+		if p.serviceLocks == nil {
+			p.serviceLocks = keymutex.NewHashed(concurrentServiceLocks)
+		}
+	})
+	key := string(uid)
+	p.serviceLocks.LockKey(key)
+	return func() {
+		if err := p.serviceLocks.UnlockKey(key); err != nil {
+			log.Error("failed to unlock service lifecycle", "uid", uid, "err", err)
+		}
+	}
 }
 
 func (p *Processor) Stop() {

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -142,6 +142,9 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 		svc = s
 	}
 
+	p.lifecycleMutex.Lock()
+	defer p.lifecycleMutex.Unlock()
+
 	svcInstance := instance.FindServiceInstance(svc, p.ServiceInstances)
 
 	_, usesCommonLease := svc.Annotations[kubevip.ServiceLease]
@@ -224,20 +227,26 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 	}
 
 	// this goroutine starts service handling function (with or without leaderelection)
-	if !svcCtx.IsWatchedLocked() {
+	if svcCtx.StartWatching() {
 		wg.Go(func() {
 			watchWg := sync.WaitGroup{}
 			defer func() {
 				// wait for the sub-goroutines and tag service as not watched
 				watchWg.Wait()
-				svcCtx.SetWatched(false)
+				svcCtx.StopWatching()
 			}()
 
 			watchWg.Go(func() {
 				// start if service is not already watched/handled
 				// signal endpoints goroutine we are ready to start and run service handling function
 				log.Info("(svcs) service function starting", "uid", svc.UID)
-				err = serviceFunc.Run(svcCtx, svc, wg)
+				if serviceFunc.UsesLeaderElection {
+					err = serviceFunc.Run(svcCtx, svc, wg)
+				} else {
+					p.withActiveService(svc.UID, svcCtx, func() {
+						err = serviceFunc.Run(svcCtx, svc, wg)
+					})
+				}
 				if err != nil {
 					log.Error(err.Error())
 					if utils.IsPanicError(err) {
@@ -267,9 +276,6 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 			})
 
 		})
-
-		// tag service as watched
-		svcCtx.SetWatched(true)
 	}
 
 	if !p.config.EnableServicesElection {
@@ -316,20 +322,34 @@ func (p *Processor) Delete(event watch.Event, forcedOnly bool) error {
 }
 
 func (p *Processor) deleteTrackedService(svc *v1.Service) error {
-	p.lifecycleMutex.Lock()
+	var svcCtx *servicecontext.Context
+	for {
+		var err error
+		svcCtx, err = p.getServiceContext(svc.UID)
+		if err != nil {
+			return fmt.Errorf("(svcs) unable to get context: %w", err)
+		}
+		if svcCtx != nil {
+			svcCtx.Cancel()
+			if err := svcCtx.WaitForWatchingStopped(context.Background()); err != nil {
+				return fmt.Errorf("wait for service watcher: %w", err)
+			}
+		}
+
+		p.lifecycleMutex.Lock()
+		currentCtx, err := p.getServiceContext(svc.UID)
+		if err != nil {
+			p.lifecycleMutex.Unlock()
+			return fmt.Errorf("(svcs) unable to get context: %w", err)
+		}
+		if currentCtx == svcCtx {
+			break
+		}
+		p.lifecycleMutex.Unlock()
+	}
 	defer p.lifecycleMutex.Unlock()
 
-	svcCtx, err := p.getServiceContext(svc.UID)
-	if err != nil {
-		return fmt.Errorf("(svcs) unable to get context: %w", err)
-	}
-
 	if svcCtx != nil {
-		// Stop every producer before tearing down the tracked instance. Endpoint
-		// reconciliation uses lifecycleMutex too, so no queued event can restore
-		// datapath state after this point.
-		svcCtx.Cancel()
-
 		// If no leader election is enabled, delete routes here
 		if !p.config.EnableLeaderElection && !p.config.EnableServicesElection &&
 			p.config.EnableRoutingTable && svcCtx.HasConfiguredNetworks() {
@@ -341,7 +361,7 @@ func (p *Processor) deleteTrackedService(svc *v1.Service) error {
 		// Delete synchronously even with per-Service election. Waiting for the
 		// election callback leaves a window in which a queued callback can add the
 		// deleted Service again.
-		if err = p.deleteService(context.WithoutCancel(svcCtx.Ctx), svc.UID); err != nil {
+		if err := p.deleteService(context.WithoutCancel(svcCtx.Ctx), svc.UID); err != nil {
 			log.Error(err.Error())
 		}
 
@@ -360,10 +380,14 @@ func (p *Processor) deleteTrackedService(svc *v1.Service) error {
 	return nil
 }
 
-func (p *Processor) withActiveService(svcCtx *servicecontext.Context, reconcile func()) bool {
+func (p *Processor) withActiveService(uid types.UID, svcCtx *servicecontext.Context, reconcile func()) bool {
 	p.lifecycleMutex.Lock()
 	defer p.lifecycleMutex.Unlock()
 	if svcCtx.Ctx.Err() != nil {
+		return false
+	}
+	current, err := p.getServiceContext(uid)
+	if err != nil || current != svcCtx {
 		return false
 	}
 	reconcile()

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -330,6 +330,7 @@ func (p *Processor) deleteTrackedService(svc *v1.Service) error {
 		}
 		if svcCtx != nil {
 			svcCtx.Cancel()
+			svcCtx.CallLeaderCancel()
 			if err := svcCtx.WaitForWatchingStopped(context.Background()); err != nil {
 				return fmt.Errorf("wait for service watcher: %w", err)
 			}

--- a/pkg/services/processor_lease_test.go
+++ b/pkg/services/processor_lease_test.go
@@ -5,6 +5,7 @@ import (
 	log "log/slog"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/kube-vip/kube-vip/pkg/bgp"
 	"github.com/kube-vip/kube-vip/pkg/instance"
@@ -16,6 +17,66 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 )
+
+func TestNonElectionSyncDoesNotBlockEndpointReadiness(t *testing.T) {
+	p := &Processor{config: &kubevip.Config{}}
+	service := &v1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name: "first", Namespace: "default", UID: types.UID("first"),
+	}}
+	svcCtx := servicecontext.New(context.Background())
+	p.svcMap.Store(service.UID, svcCtx)
+	p.ServiceInstances = []*instance.Instance{{ServiceSnapshot: service.DeepCopy(), AddCalled: true}}
+
+	callback := NewCallback(p.SyncServices, false)
+	done := make(chan error, 1)
+	go func() {
+		done <- callback.Run(svcCtx, service, &sync.WaitGroup{})
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("SyncServices returned before endpoint readiness: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	if !p.withActiveService(service.UID, svcCtx, svcCtx.SignalReadiness) {
+		t.Fatal("endpoint reconciliation rejected the current Service context")
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("SyncServices returned an error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SyncServices deadlocked waiting for endpoint readiness")
+	}
+}
+
+func TestServiceLifecycleLocksAreIndependent(t *testing.T) {
+	p := &Processor{}
+	firstUID := types.UID("first")
+	secondUID := types.UID("second")
+	first := servicecontext.New(context.Background())
+	second := servicecontext.New(context.Background())
+	p.svcMap.Store(firstUID, first)
+	p.svcMap.Store(secondUID, second)
+
+	unlockFirst := p.lockService(firstUID)
+	defer unlockFirst()
+	processed := make(chan bool, 1)
+	go func() {
+		processed <- p.withActiveService(secondUID, second, func() {})
+	}()
+
+	select {
+	case active := <-processed:
+		if !active {
+			t.Fatal("second Service was not current")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first Service lifecycle blocked an unrelated Service")
+	}
+}
 
 func TestDeletedSharedVIPServiceRejectsRacingEndpointUpdate(t *testing.T) {
 	p := &Processor{}
@@ -44,7 +105,7 @@ func TestDeletedSharedVIPServiceRejectsRacingEndpointUpdate(t *testing.T) {
 		t.Fatalf("initial AddHost() error = %v", err)
 	}
 
-	p.lifecycleMutex.Lock()
+	unlockService := p.lockService(uid)
 	var wg sync.WaitGroup
 	updated := make(chan bool, 1)
 	wg.Go(func() {
@@ -59,7 +120,7 @@ func TestDeletedSharedVIPServiceRejectsRacingEndpointUpdate(t *testing.T) {
 	if err := server.DelHost(context.WithoutCancel(first.Ctx), route, owner); err != nil {
 		t.Fatalf("DelHost() error = %v", err)
 	}
-	p.lifecycleMutex.Unlock()
+	unlockService()
 	wg.Wait()
 
 	if <-updated {
@@ -265,5 +326,50 @@ func TestOnStoppedLeadingDoesNotDeleteReplacementContext(t *testing.T) {
 	}
 	if len(p.ServiceInstances) != 1 || p.ServiceInstances[0] != replacementInstance {
 		t.Fatal("replacement service instance was removed by superseded cleanup")
+	}
+}
+
+func TestOnStoppedLeadingReplacementDuringLockWaitSurvives(t *testing.T) {
+	p := &Processor{
+		config:   &kubevip.Config{},
+		leaseMgr: lease.NewManager(),
+	}
+	service := &v1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name: "example", Namespace: "default", UID: types.UID("service-uid"),
+	}}
+	oldCtx := servicecontext.New(context.Background())
+	replacementCtx := servicecontext.New(context.Background())
+	oldInstance := &instance.Instance{ServiceSnapshot: service.DeepCopy()}
+	replacementInstance := &instance.Instance{ServiceSnapshot: service.DeepCopy()}
+	p.svcMap.Store(service.UID, oldCtx)
+	p.ServiceInstances = []*instance.Instance{oldInstance}
+
+	leaseNamespace, serviceLease := lease.ServiceName(service)
+	svcLease := p.leaseMgr.Add(context.Background(), lease.NewID(p.config.LeaderElectionType, leaseNamespace, serviceLease))
+	unlockService := p.lockService(service.UID)
+	done := make(chan error, 1)
+	go func() {
+		done <- p.onStoppedLeading(oldCtx, svcLease, service)
+	}()
+
+	p.svcMap.Store(service.UID, replacementCtx)
+	p.mutex.Lock()
+	p.ServiceInstances = []*instance.Instance{replacementInstance}
+	p.mutex.Unlock()
+	unlockService()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("onStoppedLeading returned an error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("leadership-loss cleanup did not finish")
+	}
+	if got, err := p.getServiceContext(service.UID); err != nil || got != replacementCtx {
+		t.Fatalf("replacement context was changed: got %v, err %v", got, err)
+	}
+	if len(p.ServiceInstances) != 1 || p.ServiceInstances[0] != replacementInstance {
+		t.Fatal("replacement service instance was removed")
 	}
 }

--- a/pkg/services/processor_lease_test.go
+++ b/pkg/services/processor_lease_test.go
@@ -2,9 +2,11 @@ package services
 
 import (
 	"context"
+	log "log/slog"
 	"sync"
 	"testing"
 
+	"github.com/kube-vip/kube-vip/pkg/bgp"
 	"github.com/kube-vip/kube-vip/pkg/instance"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
@@ -18,36 +20,57 @@ import (
 func TestDeletedSharedVIPServiceRejectsRacingEndpointUpdate(t *testing.T) {
 	p := &Processor{}
 	first := servicecontext.New(context.Background())
-	second := servicecontext.New(context.Background())
-	const vip = "192.0.2.10"
-	references := map[string]map[string]bool{
-		vip: {"local-a": true, "local-b": true},
+	uid := types.UID("service-uid")
+	p.svcMap.Store(uid, first)
+	server, err := bgp.NewBGPServer(kubevip.BGPConfig{
+		AS:       64512,
+		RouterID: "192.0.2.1",
+		Peers: []kubevip.BGPPeer{{
+			Address: "192.0.2.2",
+			AS:      64513,
+		}},
+	}, log.LevelError)
+	if err != nil {
+		t.Fatalf("NewBGPServer() error = %v", err)
+	}
+	if err := server.Start(context.Background(), nil); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+
+	const route = "2001:db8::10/128"
+	const owner = "default/example"
+	if err := server.AddHost(context.Background(), route, owner); err != nil {
+		t.Fatalf("initial AddHost() error = %v", err)
 	}
 
-	// Hold deletion's lifecycle section so the endpoint update is queued in
-	// the same state observed in the E2E failure.
 	p.lifecycleMutex.Lock()
 	var wg sync.WaitGroup
 	updated := make(chan bool, 1)
 	wg.Go(func() {
-		updated <- p.withActiveService(first, func() {
-			references[vip]["local-a"] = true
+		updated <- p.withActiveService(uid, first, func() {
+			if err := server.AddHost(first.Ctx, route, owner); err != nil {
+				t.Errorf("stale AddHost() error = %v", err)
+			}
 		})
 	})
 
 	first.Cancel()
-	delete(references[vip], "local-a")
+	if err := server.DelHost(context.WithoutCancel(first.Ctx), route, owner); err != nil {
+		t.Fatalf("DelHost() error = %v", err)
+	}
 	p.lifecycleMutex.Unlock()
 	wg.Wait()
 
 	if <-updated {
 		t.Fatal("endpoint update reconciled after its Service was cancelled")
 	}
-	if references[vip]["local-a"] {
-		t.Fatal("deleted Service restored its shared VIP reference")
+	routes, err := server.ListAdvertisedRoutes(context.Background(), true)
+	if err != nil {
+		t.Fatalf("ListAdvertisedRoutes() error = %v", err)
 	}
-	if !references[vip]["local-b"] || second.Ctx.Err() != nil {
-		t.Fatal("deleting one Local Service disturbed the other shared VIP owner")
+	if len(routes) != 0 {
+		t.Fatalf("stale endpoint reconciliation re-advertised %s", route)
 	}
 }
 

--- a/pkg/services/processor_lease_test.go
+++ b/pkg/services/processor_lease_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/kube-vip/kube-vip/pkg/instance"
@@ -13,6 +14,42 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 )
+
+func TestDeletedSharedVIPServiceRejectsRacingEndpointUpdate(t *testing.T) {
+	p := &Processor{}
+	first := servicecontext.New(context.Background())
+	second := servicecontext.New(context.Background())
+	const vip = "192.0.2.10"
+	references := map[string]map[string]bool{
+		vip: {"local-a": true, "local-b": true},
+	}
+
+	// Hold deletion's lifecycle section so the endpoint update is queued in
+	// the same state observed in the E2E failure.
+	p.lifecycleMutex.Lock()
+	var wg sync.WaitGroup
+	updated := make(chan bool, 1)
+	wg.Go(func() {
+		updated <- p.withActiveService(first, func() {
+			references[vip]["local-a"] = true
+		})
+	})
+
+	first.Cancel()
+	delete(references[vip], "local-a")
+	p.lifecycleMutex.Unlock()
+	wg.Wait()
+
+	if <-updated {
+		t.Fatal("endpoint update reconciled after its Service was cancelled")
+	}
+	if references[vip]["local-a"] {
+		t.Fatal("deleted Service restored its shared VIP reference")
+	}
+	if !references[vip]["local-b"] || second.Ctx.Err() != nil {
+		t.Fatal("deleting one Local Service disturbed the other shared VIP owner")
+	}
+}
 
 func TestAddOrModifyStopsTrackedServiceWhenTypeChanges(t *testing.T) {
 	for _, ignored := range []bool{false, true} {

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -45,6 +45,9 @@ const (
 )
 
 func (p *Processor) SyncServices(ctx *servicecontext.Context, svc *v1.Service, wg *sync.WaitGroup, usesLeaderElection bool) error {
+	if ctx.Ctx.Err() != nil {
+		return nil
+	}
 	log.Debug("[STARTING] Service Sync", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
 
 	// Iterate through the synchronising services
@@ -170,6 +173,9 @@ func (p *Processor) addService(ctx context.Context, inst *instance.Instance, svc
 	// protect against addService while reading
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
+	if ctx.Err() != nil {
+		return nil
+	}
 
 	startTime := time.Now()
 

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -48,6 +48,23 @@ func (p *Processor) SyncServices(ctx *servicecontext.Context, svc *v1.Service, w
 	if ctx.Ctx.Err() != nil {
 		return nil
 	}
+	if !usesLeaderElection {
+		select {
+		case <-ctx.Ctx.Done():
+			return nil
+		case <-ctx.GetEndpointsReady():
+		}
+	}
+
+	unlockService := p.lockService(svc.UID)
+	defer unlockService()
+	current, err := p.getServiceContext(svc.UID)
+	if err != nil {
+		return err
+	}
+	if current != ctx || ctx.Ctx.Err() != nil {
+		return nil
+	}
 	log.Debug("[STARTING] Service Sync", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
 
 	// Iterate through the synchronising services
@@ -62,14 +79,6 @@ func (p *Processor) SyncServices(ctx *servicecontext.Context, svc *v1.Service, w
 		log.Debug("[service] add", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
 		if instance != nil {
 			instance.AddCalled = true
-		}
-
-		if !usesLeaderElection {
-			select {
-			case <-ctx.Ctx.Done():
-				return nil
-			case <-ctx.GetEndpointsReady():
-			}
 		}
 
 		if err := p.addService(ctx.Ctx, instance, svc, wg); err != nil {

--- a/pkg/services/watch_endpoints.go
+++ b/pkg/services/watch_endpoints.go
@@ -83,8 +83,14 @@ func (p *Processor) watchEndpoint(svcCtx *servicecontext.Context, id string, ser
 				log.Info("[endpoint watcher] endpoint object deleted", "provider", provider.GetLabel(), "service name", service.Name, "namespace", service.Namespace)
 			}
 
-			restart, err := epProcessor.Reconcile(svcCtx, event, &lastKnownGoodEndpoint, service, id,
-				p.StartServicesLeaderElection, &wg, p.clientSet, p.updateEgressConfiguration)
+			var restart bool
+			var err error
+			if !p.withActiveService(svcCtx, func() {
+				restart, err = epProcessor.Reconcile(svcCtx, event, &lastKnownGoodEndpoint, service, id,
+					p.StartServicesLeaderElection, &wg, p.clientSet, p.updateEgressConfiguration)
+			}) {
+				return nil
+			}
 			if restart {
 				continue
 			} else if err != nil {

--- a/pkg/services/watch_endpoints.go
+++ b/pkg/services/watch_endpoints.go
@@ -85,7 +85,7 @@ func (p *Processor) watchEndpoint(svcCtx *servicecontext.Context, id string, ser
 
 			var restart bool
 			var err error
-			if !p.withActiveService(svcCtx, func() {
+			if !p.withActiveService(service.UID, svcCtx, func() {
 				restart, err = epProcessor.Reconcile(svcCtx, event, &lastKnownGoodEndpoint, service, id,
 					p.StartServicesLeaderElection, &wg, p.clientSet, p.updateEgressConfiguration)
 			}) {

--- a/testing/e2e/README.md
+++ b/testing/e2e/README.md
@@ -24,3 +24,24 @@ The E2E tests:
     * This causes leader election to occur
 * Attempts to connect to the control plane using the VIP
     * The new leader will need send ndp advertisements before this can succeed within a timeout
+
+## Prometheus metrics helpers
+
+The E2E build also provides helpers for checking the metrics endpoint from
+inside a kind node. `ScrapeMetrics` executes `curl` against
+`http://127.0.0.1:2112/metrics` and parses the result into a label-aware sample
+map. The helpers are compiled only with the `e2e` build tag and do not change
+the normal test suite.
+
+Use `MetricValue` when a label selector should match one series; its second
+return value is the number of matching series. Use `SumMetric` or `MaxMetric`
+when a selector intentionally matches multiple series. `CounterDelta` compares
+two scrapes of one counter, while `EventuallyMetric` and
+`ConsistentlyMetric` provide Gomega polling assertions. `MetricStable` checks
+that a value remains unchanged across samples separated by a caller-selected
+gap, which is useful for detecting leaked loops after a fault.
+
+The metrics-enabled tests require kube-vip to expose port `2112` in the kind
+node and require `curl` in the node image. Keep metric assertions focused on
+stable behavior and use label selectors instead of depending on the ordering
+of Prometheus samples.

--- a/testing/e2e/README.md
+++ b/testing/e2e/README.md
@@ -30,8 +30,9 @@ The E2E tests:
 The E2E build also provides helpers for checking the metrics endpoint from
 inside a kind node. `ScrapeMetrics` executes `curl` against
 `http://127.0.0.1:2112/metrics` and parses the result into a label-aware sample
-map. The helpers are compiled only with the `e2e` build tag and do not change
-the normal test suite.
+map using Prometheus's `expfmt` parser. The helpers accept a context so callers
+can cancel Docker commands and stability waits. They are compiled only with
+the `e2e` build tag and do not change the normal test suite.
 
 Use `MetricValue` when a label selector should match one series; its second
 return value is the number of matching series. Use `SumMetric` or `MaxMetric`
@@ -41,7 +42,8 @@ two scrapes of one counter, while `EventuallyMetric` and
 that a value remains unchanged across samples separated by a caller-selected
 gap, which is useful for detecting leaked loops after a fault.
 
-The metrics-enabled tests require kube-vip to expose port `2112` in the kind
-node and require `curl` in the node image. Keep metric assertions focused on
-stable behavior and use label selectors instead of depending on the ordering
-of Prometheus samples.
+The metrics-enabled tests set `PrometheusHTTPServer` to `:2112` in their
+manifest values. It remains empty in other specs so parallel kube-vip pods do
+not contend for a host-network port. Metrics tests also require `curl` in the
+node image. Keep metric assertions focused on stable behavior and use label
+selectors instead of depending on the ordering of Prometheus samples.

--- a/testing/e2e/README.md
+++ b/testing/e2e/README.md
@@ -25,6 +25,10 @@ The E2E tests:
 * Attempts to connect to the control plane using the VIP
     * The new leader will need send ndp advertisements before this can succeed within a timeout
 
+Fault recovery helpers are idempotent so they can be registered with `DeferCleanup`
+before a fault is injected. This ensures partial setup failures still reconnect
+nodes, remove API-server firewall rules, and restore static-pod manifests.
+
 ## Prometheus metrics helpers
 
 The E2E build also provides helpers for checking the metrics endpoint from

--- a/testing/e2e/common_lease.go
+++ b/testing/e2e/common_lease.go
@@ -1,6 +1,11 @@
 package e2e
 
-import "fmt"
+import (
+	"fmt"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
 
 // CheckCommonLeaseOwnership verifies a stable lease holder and its exclusive datapath ownership.
 func CheckCommonLeaseOwnership(getHolder func() (string, error), nodes, addresses []string, hasAddress func(string, string) bool) (string, error) {
@@ -30,4 +35,19 @@ func CheckCommonLeaseOwnership(getHolder func() (string, error), nodes, addresse
 	}
 
 	return holder, nil
+}
+
+// CheckCommonLeaseRetired accepts a deleted lease or one without a holder.
+func CheckCommonLeaseRetired(lease *coordinationv1.Lease, err error) error {
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get common lease: %w", err)
+	}
+	if lease.Spec.HolderIdentity != nil && *lease.Spec.HolderIdentity != "" {
+		return fmt.Errorf("common lease is still held by %q", *lease.Spec.HolderIdentity)
+	}
+
+	return nil
 }

--- a/testing/e2e/common_lease.go
+++ b/testing/e2e/common_lease.go
@@ -1,0 +1,33 @@
+package e2e
+
+import "fmt"
+
+// CheckCommonLeaseOwnership verifies a stable lease holder and its exclusive datapath ownership.
+func CheckCommonLeaseOwnership(getHolder func() (string, error), nodes, addresses []string, hasAddress func(string, string) bool) (string, error) {
+	holder, err := getHolder()
+	if err != nil {
+		return "", err
+	}
+	if holder == "" {
+		return "", fmt.Errorf("common lease has no holder")
+	}
+
+	for _, node := range nodes {
+		for _, address := range addresses {
+			expected := node == holder
+			if hasAddress(address, node) != expected {
+				return "", fmt.Errorf("address %q presence on node %q does not match lease holder %q", address, node, holder)
+			}
+		}
+	}
+
+	currentHolder, err := getHolder()
+	if err != nil {
+		return "", err
+	}
+	if currentHolder != holder {
+		return "", fmt.Errorf("common lease holder changed from %q to %q while checking ownership", holder, currentHolder)
+	}
+
+	return holder, nil
+}

--- a/testing/e2e/common_lease_test.go
+++ b/testing/e2e/common_lease_test.go
@@ -1,0 +1,71 @@
+package e2e
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCheckCommonLeaseOwnershipStableHolder(t *testing.T) {
+	present := map[string]string{"192.0.2.10": "node-a", "2001:db8::10": "node-a"}
+	holder, err := CheckCommonLeaseOwnership(
+		func() (string, error) { return "node-a", nil },
+		[]string{"node-a", "node-b"},
+		[]string{"192.0.2.10", "2001:db8::10"},
+		func(address, node string) bool { return present[address] == node },
+	)
+	if err != nil {
+		t.Fatalf("checkCommonLeaseOwnership() error = %v", err)
+	}
+	if holder != "node-a" {
+		t.Fatalf("checkCommonLeaseOwnership() holder = %q, want node-a", holder)
+	}
+}
+
+func TestCheckCommonLeaseOwnershipHolderMigration(t *testing.T) {
+	holderReads := 0
+	getHolder := func() (string, error) {
+		holderReads++
+		if holderReads == 1 {
+			return "node-a", nil
+		}
+		return "node-b", nil
+	}
+	present := map[string]string{"192.0.2.10": "node-a"}
+	hasAddress := func(address, node string) bool { return present[address] == node }
+
+	if _, err := CheckCommonLeaseOwnership(getHolder, []string{"node-a", "node-b"}, []string{"192.0.2.10"}, hasAddress); err == nil {
+		t.Fatal("checkCommonLeaseOwnership() accepted an ownership snapshot while the holder changed")
+	}
+
+	present["192.0.2.10"] = "node-b"
+	holder, err := CheckCommonLeaseOwnership(getHolder, []string{"node-a", "node-b"}, []string{"192.0.2.10"}, hasAddress)
+	if err != nil {
+		t.Fatalf("checkCommonLeaseOwnership() after migration error = %v", err)
+	}
+	if holder != "node-b" {
+		t.Fatalf("checkCommonLeaseOwnership() holder = %q, want node-b", holder)
+	}
+}
+
+func TestCheckCommonLeaseOwnershipRejectsMissingHolder(t *testing.T) {
+	_, err := CheckCommonLeaseOwnership(
+		func() (string, error) { return "", nil },
+		nil,
+		nil,
+		func(string, string) bool { return false },
+	)
+	if err == nil {
+		t.Fatal("checkCommonLeaseOwnership() accepted an empty holder")
+	}
+
+	want := errors.New("get lease")
+	_, err = CheckCommonLeaseOwnership(
+		func() (string, error) { return "", want },
+		nil,
+		nil,
+		func(string, string) bool { return false },
+	)
+	if !errors.Is(err, want) {
+		t.Fatalf("checkCommonLeaseOwnership() error = %v, want %v", err, want)
+	}
+}

--- a/testing/e2e/common_lease_test.go
+++ b/testing/e2e/common_lease_test.go
@@ -3,6 +3,10 @@ package e2e
 import (
 	"errors"
 	"testing"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/ptr"
 )
 
 func TestCheckCommonLeaseOwnershipStableHolder(t *testing.T) {
@@ -67,5 +71,33 @@ func TestCheckCommonLeaseOwnershipRejectsMissingHolder(t *testing.T) {
 	)
 	if !errors.Is(err, want) {
 		t.Fatalf("checkCommonLeaseOwnership() error = %v, want %v", err, want)
+	}
+}
+
+func TestCheckCommonLeaseRetired(t *testing.T) {
+	getError := errors.New("get lease")
+	tests := []struct {
+		name    string
+		lease   *coordinationv1.Lease
+		err     error
+		wantErr bool
+	}{
+		{name: "absent", err: apierrors.NewNotFound(coordinationv1.Resource("leases"), "common-lease")},
+		{name: "nil holder", lease: &coordinationv1.Lease{}},
+		{name: "empty holder", lease: &coordinationv1.Lease{Spec: coordinationv1.LeaseSpec{HolderIdentity: ptr.To("")}}},
+		{name: "nonempty holder", lease: &coordinationv1.Lease{Spec: coordinationv1.LeaseSpec{HolderIdentity: ptr.To("node-a")}}, wantErr: true},
+		{name: "error", err: getError, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckCommonLeaseRetired(tt.lease, tt.err)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("CheckCommonLeaseRetired() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.name == "error" && !errors.Is(err, getError) {
+				t.Fatalf("CheckCommonLeaseRetired() error = %v, want wrapped %v", err, getError)
+			}
+		})
 	}
 }

--- a/testing/e2e/e2e_bgp_healthcheck_test.go
+++ b/testing/e2e/e2e_bgp_healthcheck_test.go
@@ -99,17 +99,13 @@ var _ = Describe("kube-vip BGP ControlPlane health-check", Ordered, func() {
 				node := kindCluster.Nodes[rand.IntN(len(kindCluster.Nodes))]
 
 				By(fmt.Sprintf("stopping the apiserver on node %s", node.String()))
-				e2e.RunInNode(node, "mv",
-					"/etc/kubernetes/manifests/kube-apiserver.yaml",
-					"/tmp/kube-apiserver.yaml")
+				Expect(e2e.StashPodManifest(kindCluster.Name, node.String(), "kube-apiserver.yaml")).To(Succeed())
 
 				bgp.CheckPathCount(ctx, server.Client, cpVIP, len(kindCluster.Nodes)-1, 30*time.Second)
 				assertVIPReachable(ctx, server, cpVIP, httpClient)
 
 				By(fmt.Sprintf("restoring the apiserver on node %s", node.String()))
-				e2e.RunInNode(node, "mv",
-					"/tmp/kube-apiserver.yaml",
-					"/etc/kubernetes/manifests/kube-apiserver.yaml")
+				Expect(e2e.RestorePodManifest(kindCluster.Name, node.String(), "kube-apiserver.yaml")).To(Succeed())
 
 				bgp.CheckPathCount(ctx, server.Client, cpVIP, len(kindCluster.Nodes), 120*time.Second)
 				assertVIPReachable(ctx, server, cpVIP, httpClient)

--- a/testing/e2e/e2e_faults_cp_helpers_test.go
+++ b/testing/e2e/e2e_faults_cp_helpers_test.go
@@ -1,0 +1,48 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestControlPlaneElectionMode(t *testing.T) {
+	arp := controlPlaneElectionMode(ModeARP)
+	if !arp.enabled || arp.leaseName != faultLeaseName {
+		t.Fatalf("ARP election = %+v, want enabled lease %q", arp, faultLeaseName)
+	}
+
+	rt := controlPlaneElectionMode(ModeRT)
+	if rt.enabled || rt.leaseName != "" {
+		t.Fatalf("RT election = %+v, want disabled", rt)
+	}
+}
+
+func TestValidateARPFailover(t *testing.T) {
+	tests := []struct {
+		name      string
+		oldLeader string
+		newLeader string
+		owners    []string
+		wantError string
+	}{
+		{name: "complete", oldLeader: "node-a", newLeader: "node-b", owners: []string{"node-b"}},
+		{name: "same leader recovered", oldLeader: "node-a", newLeader: "node-a", owners: []string{"node-a"}},
+		{name: "stale old owner", oldLeader: "node-a", newLeader: "node-b", owners: []string{"node-a", "node-b"}, wantError: "stale VIP ownership"},
+		{name: "VIP missing", oldLeader: "node-a", newLeader: "node-b", wantError: "has no owner"},
+		{name: "wrong owner", oldLeader: "node-a", newLeader: "node-b", owners: []string{"node-c"}, wantError: "does not own VIP"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateARPFailover(test.oldLeader, test.newLeader, test.owners)
+			if test.wantError == "" && err != nil {
+				t.Fatalf("validateARPFailover() error = %v", err)
+			}
+			if test.wantError != "" && (err == nil || !strings.Contains(err.Error(), test.wantError)) {
+				t.Fatalf("validateARPFailover() error = %v, want substring %q", err, test.wantError)
+			}
+		})
+	}
+}

--- a/testing/e2e/e2e_faults_cp_helpers_test.go
+++ b/testing/e2e/e2e_faults_cp_helpers_test.go
@@ -46,3 +46,29 @@ func TestValidateARPFailover(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateARPTransfer(t *testing.T) {
+	tests := []struct {
+		name      string
+		newLeader string
+		owners    []string
+		wantError string
+	}{
+		{name: "sole replacement owner", newLeader: "node-b", owners: []string{"node-b"}},
+		{name: "stale former owner allowed while kubelet stopped", newLeader: "node-b", owners: []string{"node-a", "node-b"}},
+		{name: "replacement missing", newLeader: "node-b", owners: []string{"node-a"}, wantError: "does not own VIP"},
+		{name: "VIP missing", newLeader: "node-b", wantError: "does not own VIP"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateARPTransfer(test.newLeader, test.owners)
+			if test.wantError == "" && err != nil {
+				t.Fatalf("validateARPTransfer() error = %v", err)
+			}
+			if test.wantError != "" && (err == nil || !strings.Contains(err.Error(), test.wantError)) {
+				t.Fatalf("validateARPTransfer() error = %v, want substring %q", err, test.wantError)
+			}
+		})
+	}
+}

--- a/testing/e2e/e2e_faults_cp_test.go
+++ b/testing/e2e/e2e_faults_cp_test.go
@@ -1,0 +1,477 @@
+//go:build e2e
+// +build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	kindconfigv1alpha4 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kube-vip/kube-vip/pkg/utils"
+	"github.com/kube-vip/kube-vip/testing/e2e"
+)
+
+const (
+	faultClusterNodeCount      = 3
+	faultLeaseNamespace        = "kube-system"
+	faultLeaseName             = "plndr-cp-lock"
+	faultTransitionMetric      = "kube_vip_leader_election_transitions_total"
+	faultPollInterval          = time.Second
+	faultMetricGap             = time.Second
+	faultConvergenceTimeout    = 120 * time.Second
+	faultLeaseObservationLimit = 15 * time.Second
+	faultSteadyStateWindow     = 5 * time.Second
+	faultTransitionDeltaLimit  = 4.0
+)
+
+type controlPlaneFaultSuite struct {
+	ctx     context.Context
+	cancel  context.CancelFunc
+	cluster *e2e.Cluster
+	client  kubernetes.Interface
+	vip     string
+	nodes   []string
+	tempDir string
+}
+
+type faultMetricSnapshot map[string]map[string]float64
+
+var _ = Describe("kube-vip control-plane election and VIP failover faults", Label("faults"), Serial, Ordered, func() {
+	if Mode != ModeARP && Mode != ModeRT {
+		return
+	}
+
+	suite := &controlPlaneFaultSuite{}
+
+	BeforeAll(func() {
+		suite.ctx, suite.cancel = context.WithCancel(context.Background())
+		var err error
+		suite.tempDir, err = os.MkdirTemp("", fmt.Sprintf("kube-vip-faults-%s-", Mode))
+		Expect(err).NotTo(HaveOccurred())
+
+		offset := SOffset.Get()
+		suite.vip = e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
+
+		templateName := "kube-vip.yaml.tmpl"
+		manifestValues := e2e.KubevipManifestValues{
+			ControlPlaneVIP:       suite.vip,
+			ImagePath:             os.Getenv("E2E_IMAGE_PATH"),
+			ConfigPath:            os.Getenv("CONFIG_PATH"),
+			ControlPlaneEnable:    "true",
+			SvcEnable:             "false",
+			SvcElectionEnable:     "false",
+			EnableEndpoints:       "true",
+			EnableNodeLabeling:    "false",
+			EnableServiceSecurity: "true",
+		}
+		networking := kindconfigv1alpha4.Networking{
+			IPFamily: kindconfigv1alpha4.IPv4Family,
+		}
+		if Mode == ModeRT {
+			templateName = "kube-vip-routing-table.yaml.tmpl"
+			manifestValues.VipElectionEnable = "true"
+		}
+
+		suite.cluster = e2e.CreateCluster(suite.ctx, &e2e.ClusterSpec{
+			Name:         fmt.Sprintf("kube-vip-faults-%s-%d", Mode, offset),
+			Nodes:        faultClusterNodeCount,
+			Networking:   networking,
+			KubeVip:      manifestValues,
+			Logger:       e2e.TestLogger{},
+			ConfigMtx:    ConfigMtx,
+			TemplateName: templateName,
+		})
+		suite.client = buildFaultClient(suite.cluster.RestCfg)
+		suite.cluster.Client = suite.client
+
+		for _, node := range suite.cluster.Nodes {
+			suite.nodes = append(suite.nodes, node.String())
+		}
+		Expect(suite.nodes).To(HaveLen(faultClusterNodeCount))
+
+		By(withTimestamp("waiting for the control-plane VIP to become routable"))
+		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
+		leader := suite.waitForLeader()
+		suite.waitForLease()
+		suite.assertLeaderMetric(leader)
+		suite.assertOneLeader()
+		suite.assertSteadyLeader(leader)
+	})
+
+	AfterAll(func() {
+		if suite.cluster != nil {
+			suite.cluster.SaveLogs(suite.ctx, suite.tempDir)
+			suite.cluster.Delete()
+		}
+		if suite.cancel != nil {
+			suite.cancel()
+		}
+		if suite.tempDir != "" && os.Getenv("E2E_KEEP_LOGS") != "true" {
+			Expect(os.RemoveAll(suite.tempDir)).To(Succeed())
+		}
+	})
+
+	It("keeps the VIP available while the leader loses API access and recovers", func() {
+		before := suite.transitionSnapshot()
+		oldLeader := suite.waitForLeader()
+
+		By(withTimestamp(fmt.Sprintf("blackholing the API server from leader %q", oldLeader)))
+		Expect(e2e.BlackholeAPIServer(suite.cluster.Name, oldLeader)).To(Succeed())
+		blackholeActive := true
+		defer func() {
+			if blackholeActive {
+				Expect(e2e.RestoreAPIServer(suite.cluster.Name, oldLeader)).To(Succeed())
+			}
+		}()
+
+		newLeader := suite.waitForDifferentLeader(oldLeader)
+		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
+		lease := suite.waitForLease(oldLeader)
+		By(withTimestamp(fmt.Sprintf("lease %s/%s is held by remaining node %q while %q is blackholed", faultLeaseNamespace, faultLeaseName, *lease.Spec.HolderIdentity, oldLeader)))
+		suite.assertLeaderMetric(newLeader)
+		suite.assertOneLeader(oldLeader)
+
+		By(withTimestamp(fmt.Sprintf("restoring the API server connection on %q", oldLeader)))
+		Expect(e2e.RestoreAPIServer(suite.cluster.Name, oldLeader)).To(Succeed())
+		blackholeActive = false
+
+		suite.waitForLease()
+		recoveredLeader := suite.waitForLeader()
+		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
+		suite.assertLeaderMetric(recoveredLeader)
+		suite.assertOneLeader()
+		suite.assertSteadyLeader(recoveredLeader)
+		suite.assertTransitionCounterStable(before, "API server blackhole and recovery")
+	})
+
+	It("recovers after SIGKILL of the kube-vip leader", func() {
+		before := suite.transitionSnapshot()
+		oldLeader := suite.waitForLeader()
+
+		By(withTimestamp(fmt.Sprintf("sending SIGKILL to kube-vip on leader %q", oldLeader)))
+		Expect(e2e.KillKubeVip(suite.cluster.Name, oldLeader, false)).To(Succeed())
+
+		newLeader := suite.waitForDifferentLeader(oldLeader)
+		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
+		suite.waitForLease(oldLeader)
+		suite.assertLeaderMetric(newLeader)
+
+		By(withTimestamp(fmt.Sprintf("waiting for kube-vip metrics to return on restarted node %q", oldLeader)))
+		suite.waitForMetrics(oldLeader)
+		recoveredLeader := suite.waitForLeader()
+		suite.assertLeaderMetric(recoveredLeader)
+		suite.assertOneLeader()
+		suite.assertSteadyLeader(recoveredLeader)
+		suite.assertTransitionCounterStable(before, "SIGKILL and kube-vip restart")
+	})
+
+	It("reacquires the lease after deletion and lease stealing", func() {
+		beforeDelete := suite.transitionSnapshot()
+		oldLease := suite.getLease()
+		oldUID := string(oldLease.UID)
+
+		By(withTimestamp(fmt.Sprintf("deleting lease %s/%s", faultLeaseNamespace, faultLeaseName)))
+		Expect(e2e.DeleteLease(suite.ctx, suite.client, faultLeaseNamespace, faultLeaseName)).To(Succeed())
+		recreatedLease := suite.waitForLease()
+		Expect(string(recreatedLease.UID)).NotTo(Equal(oldUID))
+		leader := suite.waitForLeader()
+		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
+		suite.assertLeaderMetric(leader)
+		suite.assertOneLeader()
+		suite.assertSteadyLeader(leader)
+		suite.assertTransitionCounterStable(beforeDelete, "lease deletion")
+
+		beforeSteal := suite.transitionSnapshot()
+		const stolenHolder = "fault-injector"
+		By(withTimestamp(fmt.Sprintf("overwriting lease %s/%s with holder %q", faultLeaseNamespace, faultLeaseName, stolenHolder)))
+		Eventually(func() error {
+			return e2e.StealLease(suite.ctx, suite.client, faultLeaseNamespace, faultLeaseName, stolenHolder)
+		}, faultLeaseObservationLimit, faultPollInterval).Should(Succeed())
+		suite.waitForLeaseHolder(stolenHolder)
+		suite.waitForLease(stolenHolder)
+		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
+		suite.assertLeaderMetric(suite.waitForLeader())
+		suite.assertOneLeader()
+		stableLeader := suite.waitForLeader()
+		suite.assertSteadyLeader(stableLeader)
+		suite.assertTransitionCounterStable(beforeSteal, "lease stealing")
+	})
+
+	It("fully recovers after restarting the leader node", func() {
+		before := suite.transitionSnapshot()
+		oldLeader := suite.waitForLeader()
+
+		By(withTimestamp(fmt.Sprintf("restarting leader node %q", oldLeader)))
+		Expect(e2e.RestartNode(suite.cluster.Name, oldLeader)).To(Succeed())
+		suite.waitForNodeReady(oldLeader)
+		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
+
+		By(withTimestamp(fmt.Sprintf("waiting for kube-vip metrics to return on restarted node %q", oldLeader)))
+		suite.waitForMetrics(oldLeader)
+		leader := suite.waitForLeader()
+		suite.waitForLease()
+		suite.assertLeaderMetric(leader)
+		suite.assertOneLeader()
+		suite.assertSteadyLeader(leader)
+		suite.assertTransitionCounterStable(before, "control-plane node restart")
+	})
+})
+
+func buildFaultClient(config *rest.Config) kubernetes.Interface {
+	// Fault polling is deliberately more generous than client-go defaults.
+	config.QPS = 50
+	config.Burst = 100
+	config.Timeout = 10 * time.Second
+
+	client, err := kubernetes.NewForConfig(config)
+	Expect(err).NotTo(HaveOccurred())
+	return client
+}
+
+func (s *controlPlaneFaultSuite) waitForLeader() string {
+	// RT mode keeps the VIP in a route instead of an interface address, so the
+	// existing Docker IP lookup used by ARP mode cannot identify its leader.
+	if Mode == ModeRT {
+		lease := s.waitForLease()
+		return *lease.Spec.HolderIdentity
+	}
+
+	var leader string
+	Eventually(func() (string, error) {
+		leader = findLeader(s.vip, s.cluster.Name)
+		if leader == "" {
+			return "", fmt.Errorf("VIP %s has no leader", s.vip)
+		}
+		return leader, nil
+	}, faultConvergenceTimeout, faultPollInterval).ShouldNot(BeEmpty())
+	return leader
+}
+
+func (s *controlPlaneFaultSuite) waitForDifferentLeader(oldLeader string) string {
+	if Mode == ModeRT {
+		var leader string
+		Eventually(func() (string, error) {
+			lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, faultLeaseName, metav1.GetOptions{})
+			if err != nil {
+				return "", err
+			}
+			if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity == "" {
+				return "", fmt.Errorf("lease %s/%s has no holder", faultLeaseNamespace, faultLeaseName)
+			}
+			if *lease.Spec.HolderIdentity == oldLeader {
+				return "", fmt.Errorf("lease %s/%s is still held by %s", faultLeaseNamespace, faultLeaseName, oldLeader)
+			}
+			leader = *lease.Spec.HolderIdentity
+			return leader, nil
+		}, faultConvergenceTimeout, faultPollInterval).ShouldNot(BeEmpty())
+		return leader
+	}
+
+	var leader string
+	Eventually(func() (string, error) {
+		candidate := findLeader(s.vip, s.cluster.Name)
+		if candidate == "" {
+			return "", fmt.Errorf("VIP %s has no leader", s.vip)
+		}
+		if candidate == oldLeader {
+			return "", fmt.Errorf("VIP %s is still held by %s", s.vip, oldLeader)
+		}
+		leader = candidate
+		return leader, nil
+	}, faultConvergenceTimeout, faultPollInterval).ShouldNot(BeEmpty())
+	return leader
+}
+
+func (s *controlPlaneFaultSuite) getLease() *coordinationv1.Lease {
+	lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, faultLeaseName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	return lease
+}
+
+func (s *controlPlaneFaultSuite) waitForLease(excludedHolders ...string) *coordinationv1.Lease {
+	excluded := make(map[string]struct{}, len(excludedHolders))
+	for _, holder := range excludedHolders {
+		excluded[holder] = struct{}{}
+	}
+
+	var current *coordinationv1.Lease
+	Eventually(func() error {
+		lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, faultLeaseName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity == "" {
+			return fmt.Errorf("lease %s/%s has no holder", faultLeaseNamespace, faultLeaseName)
+		}
+		if _, skip := excluded[*lease.Spec.HolderIdentity]; skip {
+			return fmt.Errorf("lease %s/%s is still held by excluded node %q", faultLeaseNamespace, faultLeaseName, *lease.Spec.HolderIdentity)
+		}
+		current = lease
+		return nil
+	}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
+	return current
+}
+
+func (s *controlPlaneFaultSuite) waitForLeaseHolder(holder string) *coordinationv1.Lease {
+	var current *coordinationv1.Lease
+	Eventually(func() error {
+		lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, faultLeaseName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity != holder {
+			return fmt.Errorf("lease %s/%s is not held by %q", faultLeaseNamespace, faultLeaseName, holder)
+		}
+		current = lease
+		return nil
+	}, faultLeaseObservationLimit, faultPollInterval).Should(Succeed())
+	return current
+}
+
+func (s *controlPlaneFaultSuite) waitForMetrics(node string) {
+	Eventually(func() error {
+		_, err := e2e.ScrapeMetrics(s.cluster.Name, node)
+		return err
+	}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
+}
+
+func (s *controlPlaneFaultSuite) waitForNodeReady(nodeName string) {
+	Eventually(func() error {
+		node, err := s.client.CoreV1().Nodes().Get(s.ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+				return nil
+			}
+		}
+		return fmt.Errorf("node %q is not Ready", nodeName)
+	}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
+}
+
+func (s *controlPlaneFaultSuite) assertLeaderMetric(leader string) {
+	e2e.EventuallyMetric(
+		s.cluster.Name,
+		leader,
+		"kube_vip_is_leader",
+		map[string]string{"node": leader, "lease_name": faultLeaseName},
+		Equal(float64(1)),
+		faultConvergenceTimeout,
+		faultPollInterval,
+	)
+}
+
+func (s *controlPlaneFaultSuite) assertSteadyLeader(leader string) {
+	e2e.ConsistentlyMetric(
+		s.cluster.Name,
+		leader,
+		"kube_vip_is_leader",
+		map[string]string{"node": leader, "lease_name": faultLeaseName},
+		Equal(float64(1)),
+		faultSteadyStateWindow,
+		faultPollInterval,
+	)
+}
+
+func (s *controlPlaneFaultSuite) assertOneLeader(skipNodes ...string) {
+	assertExactlyOneLeaderMetric(s.ctx, s.cluster.Name, s.client, skipNodes...)
+
+	skipped := make(map[string]struct{}, len(skipNodes))
+	for _, node := range skipNodes {
+		skipped[node] = struct{}{}
+	}
+	Eventually(func() (float64, error) {
+		maximum := 0.0
+		found := false
+		for _, node := range s.nodes {
+			if _, skip := skipped[node]; skip {
+				continue
+			}
+			metrics, err := e2e.ScrapeMetrics(s.cluster.Name, node)
+			if err != nil {
+				return 0, err
+			}
+			value, ok := e2e.MaxMetric(metrics, "kube_vip_is_leader", map[string]string{"lease_name": faultLeaseName})
+			if !ok {
+				continue
+			}
+			found = true
+			if value > maximum {
+				maximum = value
+			}
+		}
+		if !found {
+			return 0, fmt.Errorf("no leader metric found")
+		}
+		return maximum, nil
+	}, faultConvergenceTimeout, faultPollInterval).Should(BeNumerically("<=", float64(1)))
+}
+
+func (s *controlPlaneFaultSuite) transitionSnapshot() faultMetricSnapshot {
+	snapshot := make(faultMetricSnapshot, len(s.nodes))
+	for _, node := range s.nodes {
+		var metrics map[string]float64
+		Eventually(func() error {
+			var err error
+			metrics, err = e2e.ScrapeMetrics(s.cluster.Name, node)
+			return err
+		}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
+		snapshot[node] = metrics
+	}
+	return snapshot
+}
+
+func (s *controlPlaneFaultSuite) assertTransitionCounterStable(before faultMetricSnapshot, fault string) {
+	labels := map[string]string{"lease_name": faultLeaseName}
+	stableValues := make(map[string]float64)
+	totalDelta := 0.0
+	observed := 0
+
+	for _, node := range s.nodes {
+		metrics, err := e2e.ScrapeMetrics(s.cluster.Name, node)
+		Expect(err).NotTo(HaveOccurred())
+		if _, matches := e2e.MetricValue(metrics, faultTransitionMetric, labels); matches == 0 {
+			continue
+		}
+
+		var stable float64
+		Eventually(func() error {
+			var stableErr error
+			stable, stableErr = e2e.MetricStable(s.cluster.Name, node, faultTransitionMetric, labels, 2, faultMetricGap)
+			return stableErr
+		}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
+		stableValues[node] = stable
+		observed++
+
+		beforeValue, beforeMatches := e2e.MetricValue(before[node], faultTransitionMetric, labels)
+		stableDelta := stable
+		if beforeMatches == 1 {
+			rawDelta, ok := e2e.CounterDelta(before[node], metrics, faultTransitionMetric, labels)
+			Expect(ok).To(BeTrue())
+			By(withTimestamp(fmt.Sprintf("transition counter on %q changed by %.0f during %s before settling", node, rawDelta, fault)))
+			stableDelta = stable - beforeValue
+			if stableDelta < 0 {
+				stableDelta = stable
+			}
+		}
+		Expect(stableDelta).To(BeNumerically(">=", float64(0)))
+		totalDelta += stableDelta
+	}
+
+	Expect(observed).To(BeNumerically(">=", 1))
+	By(withTimestamp(fmt.Sprintf("stable transition counters after %s: %v; delta %.0f", fault, stableValues, totalDelta)))
+	Expect(totalDelta).To(BeNumerically("<=", faultTransitionDeltaLimit))
+}

--- a/testing/e2e/e2e_faults_cp_test.go
+++ b/testing/e2e/e2e_faults_cp_test.go
@@ -41,15 +41,16 @@ const (
 )
 
 type controlPlaneFaultSuite struct {
-	ctx      context.Context
-	cancel   context.CancelFunc
-	cluster  *e2e.Cluster
-	client   kubernetes.Interface
-	vip      string
-	nodes    []string
-	tempDir  string
-	metrics  bool
-	election faultElectionMode
+	ctx            context.Context
+	cancel         context.CancelFunc
+	cluster        *e2e.Cluster
+	client         kubernetes.Interface
+	vip            string
+	nodes          []string
+	tempDir        string
+	metrics        bool
+	election       faultElectionMode
+	suppressedNode string
 }
 
 type faultElectionMode struct {
@@ -81,6 +82,15 @@ func validateARPFailover(oldLeader, newLeader string, owners []string) error {
 		return fmt.Errorf("elected leader %q does not own VIP; owners are %v", newLeader, owners)
 	}
 	return nil
+}
+
+func validateARPTransfer(newLeader string, owners []string) error {
+	for _, owner := range owners {
+		if owner == newLeader {
+			return nil
+		}
+	}
+	return fmt.Errorf("replacement leader %q does not own VIP; owners are %v (a stale owner is expected until the stopped kubelet restarts)", newLeader, owners)
 }
 
 var _ = Describe("kube-vip control-plane election and VIP failover faults", Label("faults"), Serial, Ordered, func() {
@@ -169,6 +179,15 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 		}
 	})
 
+	AfterEach(func() {
+		if suite.suppressedNode == "" || suite.cluster == nil {
+			return
+		}
+		By(withTimestamp(fmt.Sprintf("restoring kubelet on %q before fault-suite teardown", suite.suppressedNode)))
+		Expect(e2e.RestoreKubeVip(suite.cluster.Name, suite.suppressedNode)).To(Succeed())
+		suite.suppressedNode = ""
+	})
+
 	It("keeps the VIP available while the leader loses API access and recovers", func() {
 		if !suite.election.enabled {
 			node := suite.nodes[0]
@@ -231,21 +250,25 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 		By(withTimestamp(fmt.Sprintf("stopping kubelet and sending SIGKILL to kube-vip on elected leader %q", oldLeader)))
 		oldPID, err := e2e.KillAndSuppressKubeVip(suite.cluster.Name, oldLeader)
 		Expect(err).NotTo(HaveOccurred())
-		DeferCleanup(func() {
-			Expect(e2e.RestoreKubeVip(suite.cluster.Name, oldLeader)).To(Succeed())
-		})
+		suite.suppressedNode = oldLeader
 		By(withTimestamp(fmt.Sprintf("sent SIGKILL to kube-vip PID %s on elected leader %q", oldPID, oldLeader)))
 		suite.assertNodeRunning(oldLeader)
 
 		newLeader := suite.waitForDifferentLeader(oldLeader)
-		suite.waitForARPFailover(oldLeader, newLeader)
+		suite.waitForARPTransfer(newLeader)
 		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
 		suite.assertLeaderMetric(newLeader)
+		owners, err := suite.vipOwners()
+		Expect(err).NotTo(HaveOccurred())
+		By(withTimestamp(fmt.Sprintf("lease and reachability transferred to %q while kubelet is stopped on %q; current VIP owners: %v", newLeader, oldLeader, owners)))
 
 		By(withTimestamp(fmt.Sprintf("restarting kubelet to restore kube-vip on %q", oldLeader)))
 		Expect(e2e.RestoreKubeVip(suite.cluster.Name, oldLeader)).To(Succeed())
+		suite.suppressedNode = ""
+		suite.waitForKubeVipRestart(oldLeader, oldPID)
+		suite.waitForNonLeader(oldLeader, newLeader)
+		suite.waitForARPFailover(oldLeader, newLeader)
 		By(withTimestamp(fmt.Sprintf("waiting for kube-vip metrics to return on restarted node %q", oldLeader)))
-		suite.waitForKubeVip(oldLeader)
 		suite.waitForMetrics(oldLeader)
 		recoveredLeader := suite.waitForLeader()
 		suite.assertLeaderMetric(recoveredLeader)
@@ -359,6 +382,40 @@ func (s *controlPlaneFaultSuite) waitForARPFailover(oldLeader, newLeader string)
 		return validateARPFailover(oldLeader, newLeader, owners)
 	}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
 	By(withTimestamp(fmt.Sprintf("election and sole VIP ownership transferred from %q to %q", oldLeader, newLeader)))
+}
+
+func (s *controlPlaneFaultSuite) waitForARPTransfer(newLeader string) {
+	Eventually(func() error {
+		lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, s.election.leaseName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("observe election transfer while kubelet is stopped: %w", err)
+		}
+		if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity != newLeader {
+			return fmt.Errorf("lease %s/%s is not held by replacement leader %q", faultLeaseNamespace, s.election.leaseName, newLeader)
+		}
+		owners, err := s.vipOwners()
+		if err != nil {
+			return err
+		}
+		return validateARPTransfer(newLeader, owners)
+	}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
+}
+
+func (s *controlPlaneFaultSuite) waitForNonLeader(node, leader string) {
+	Eventually(func() error {
+		lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, s.election.leaseName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if lease.Spec.HolderIdentity == nil {
+			return fmt.Errorf("replacement kube-vip on %q is not confirmed as a nonleader: lease %s/%s has no holder", node, faultLeaseNamespace, s.election.leaseName)
+		}
+		if *lease.Spec.HolderIdentity != leader {
+			return fmt.Errorf("replacement kube-vip on %q is not a nonleader: lease %s/%s holder is %q, want %q", node, faultLeaseNamespace, s.election.leaseName, *lease.Spec.HolderIdentity, leader)
+		}
+		return nil
+	}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
+	By(withTimestamp(fmt.Sprintf("replacement kube-vip on %q started as nonleader behind %q", node, leader)))
 }
 
 func (s *controlPlaneFaultSuite) waitForVIPOwner(want string) {

--- a/testing/e2e/e2e_faults_cp_test.go
+++ b/testing/e2e/e2e_faults_cp_test.go
@@ -38,7 +38,6 @@ const (
 	faultLeaseObservationLimit = 15 * time.Second
 	faultSteadyStateWindow     = 5 * time.Second
 	faultTransitionDeltaLimit  = 4.0
-	faultKubeVipManifest       = "kube-vip.yaml"
 )
 
 type controlPlaneFaultSuite struct {
@@ -229,11 +228,11 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 		oldLeader := *oldLease.Spec.HolderIdentity
 		suite.waitForVIPOwner(oldLeader)
 
-		By(withTimestamp(fmt.Sprintf("removing the static-pod manifest and sending SIGKILL to kube-vip on elected leader %q", oldLeader)))
-		oldPID, err := e2e.KillAndStashKubeVip(suite.cluster.Name, oldLeader, faultKubeVipManifest)
+		By(withTimestamp(fmt.Sprintf("stopping kubelet and sending SIGKILL to kube-vip on elected leader %q", oldLeader)))
+		oldPID, err := e2e.KillAndSuppressKubeVip(suite.cluster.Name, oldLeader)
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
-			Expect(e2e.RestorePodManifest(suite.cluster.Name, oldLeader, faultKubeVipManifest)).To(Succeed())
+			Expect(e2e.RestoreKubeVip(suite.cluster.Name, oldLeader)).To(Succeed())
 		})
 		By(withTimestamp(fmt.Sprintf("sent SIGKILL to kube-vip PID %s on elected leader %q", oldPID, oldLeader)))
 		suite.assertNodeRunning(oldLeader)
@@ -243,8 +242,8 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
 		suite.assertLeaderMetric(newLeader)
 
-		By(withTimestamp(fmt.Sprintf("restoring the kube-vip static-pod manifest on %q", oldLeader)))
-		Expect(e2e.RestorePodManifest(suite.cluster.Name, oldLeader, faultKubeVipManifest)).To(Succeed())
+		By(withTimestamp(fmt.Sprintf("restarting kubelet to restore kube-vip on %q", oldLeader)))
+		Expect(e2e.RestoreKubeVip(suite.cluster.Name, oldLeader)).To(Succeed())
 		By(withTimestamp(fmt.Sprintf("waiting for kube-vip metrics to return on restarted node %q", oldLeader)))
 		suite.waitForKubeVip(oldLeader)
 		suite.waitForMetrics(oldLeader)

--- a/testing/e2e/e2e_faults_cp_test.go
+++ b/testing/e2e/e2e_faults_cp_test.go
@@ -4,13 +4,17 @@
 package e2e_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 	"time"
 
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -34,20 +38,51 @@ const (
 	faultLeaseObservationLimit = 15 * time.Second
 	faultSteadyStateWindow     = 5 * time.Second
 	faultTransitionDeltaLimit  = 4.0
+	faultKubeVipManifest       = "kube-vip.yaml"
 )
 
 type controlPlaneFaultSuite struct {
-	ctx     context.Context
-	cancel  context.CancelFunc
-	cluster *e2e.Cluster
-	client  kubernetes.Interface
-	vip     string
-	nodes   []string
-	tempDir string
-	metrics bool
+	ctx      context.Context
+	cancel   context.CancelFunc
+	cluster  *e2e.Cluster
+	client   kubernetes.Interface
+	vip      string
+	nodes    []string
+	tempDir  string
+	metrics  bool
+	election faultElectionMode
+}
+
+type faultElectionMode struct {
+	enabled   bool
+	leaseName string
 }
 
 type faultMetricSnapshot map[string]map[string]float64
+
+func controlPlaneElectionMode(mode string) faultElectionMode {
+	if mode == ModeARP {
+		return faultElectionMode{enabled: true, leaseName: faultLeaseName}
+	}
+	return faultElectionMode{}
+}
+
+func validateARPFailover(oldLeader, newLeader string, owners []string) error {
+	if len(owners) == 0 {
+		return fmt.Errorf("VIP has no owner while lease is held by %q", newLeader)
+	}
+	if newLeader != oldLeader {
+		for _, owner := range owners {
+			if owner == oldLeader {
+				return fmt.Errorf("stale VIP ownership remains on former leader %q", oldLeader)
+			}
+		}
+	}
+	if len(owners) != 1 || owners[0] != newLeader {
+		return fmt.Errorf("elected leader %q does not own VIP; owners are %v", newLeader, owners)
+	}
+	return nil
+}
 
 var _ = Describe("kube-vip control-plane election and VIP failover faults", Label("faults"), Serial, Ordered, func() {
 	if Mode != ModeARP && Mode != ModeRT {
@@ -59,8 +94,9 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 	BeforeAll(func() {
 		suite.ctx, suite.cancel = context.WithCancel(context.Background())
 		var err error
-		suite.tempDir, err = os.MkdirTemp("", fmt.Sprintf("kube-vip-faults-%s-", Mode))
+		suite.tempDir, err = os.MkdirTemp("", fmt.Sprintf("kube-vip-test-faults-%s-", Mode))
 		Expect(err).NotTo(HaveOccurred())
+		suite.election = controlPlaneElectionMode(Mode)
 
 		offset := SOffset.Get()
 		suite.vip = e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
@@ -106,16 +142,24 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 
 		By(withTimestamp("waiting for the control-plane VIP to become routable"))
 		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
-		leader := suite.waitForLeader()
-		suite.waitForLease()
-		suite.assertLeaderMetric(leader)
-		suite.assertOneLeader()
-		suite.assertSteadyLeader(leader)
+		if suite.election.enabled {
+			leader := suite.waitForLeader()
+			suite.waitForVIPOwner(leader)
+			suite.assertLeaderMetric(leader)
+			suite.assertOneLeader()
+			suite.assertSteadyLeader(leader)
+		} else {
+			suite.assertNoElectionLease()
+			By(withTimestamp(fmt.Sprintf("%s mode is configured without control-plane election; validating process and node recovery only", Mode)))
+		}
 	})
 
 	AfterAll(func() {
 		if suite.cluster != nil {
-			suite.cluster.SaveLogs(suite.ctx, suite.tempDir)
+			By(withTimestamp(fmt.Sprintf("saving fault artifacts to %q", suite.tempDir)))
+			if err := e2e.GetLogs(suite.ctx, suite.client, suite.tempDir, suite.cluster.Name); err != nil {
+				By(withTimestamp(fmt.Sprintf("fault artifact collection failed: %v", err)))
+			}
 			suite.cluster.Delete()
 		}
 		if suite.cancel != nil {
@@ -127,6 +171,16 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 	})
 
 	It("keeps the VIP available while the leader loses API access and recovers", func() {
+		if !suite.election.enabled {
+			node := suite.nodes[0]
+			By(withTimestamp(fmt.Sprintf("blackholing the API server from non-electing %s node %q", Mode, node)))
+			Expect(e2e.BlackholeAPIServer(suite.cluster.Name, node)).To(Succeed())
+			DeferCleanup(func() { Expect(e2e.RestoreAPIServer(suite.cluster.Name, node)).To(Succeed()) })
+			assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
+			Expect(e2e.RestoreAPIServer(suite.cluster.Name, node)).To(Succeed())
+			return
+		}
+
 		before := suite.transitionSnapshot()
 		oldLeader := suite.waitForLeader()
 
@@ -139,7 +193,7 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 		newLeader := suite.waitForDifferentLeader(oldLeader)
 		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
 		lease := suite.waitForLease(oldLeader)
-		By(withTimestamp(fmt.Sprintf("lease %s/%s is held by remaining node %q while %q is blackholed", faultLeaseNamespace, faultLeaseName, *lease.Spec.HolderIdentity, oldLeader)))
+		By(withTimestamp(fmt.Sprintf("lease %s/%s is held by remaining node %q while %q is blackholed", faultLeaseNamespace, suite.election.leaseName, *lease.Spec.HolderIdentity, oldLeader)))
 		suite.assertLeaderMetric(newLeader)
 		suite.assertOneLeader(oldLeader)
 
@@ -156,18 +210,43 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 	})
 
 	It("recovers after SIGKILL of the kube-vip leader", func() {
-		before := suite.transitionSnapshot()
-		oldLeader := suite.waitForLeader()
+		if !suite.election.enabled {
+			node := suite.nodes[0]
+			oldPID, err := e2e.KubeVipPID(suite.cluster.Name, node)
+			Expect(err).NotTo(HaveOccurred())
+			By(withTimestamp(fmt.Sprintf("sending SIGKILL to kube-vip PID %s on non-electing %s node %q", oldPID, Mode, node)))
+			killTime := time.Now()
+			Expect(e2e.KillKubeVip(suite.cluster.Name, node, false)).To(Succeed())
+			suite.waitForKubeVipRestart(node, oldPID)
+			By(withTimestamp(fmt.Sprintf("kube-vip restarted on %q after %s", node, time.Since(killTime))))
+			suite.assertNodeRunning(node)
+			assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
+			return
+		}
 
-		By(withTimestamp(fmt.Sprintf("sending SIGKILL to kube-vip on leader %q", oldLeader)))
-		Expect(e2e.KillKubeVip(suite.cluster.Name, oldLeader, false)).To(Succeed())
+		before := suite.transitionSnapshot()
+		oldLease := suite.waitForLease()
+		oldLeader := *oldLease.Spec.HolderIdentity
+		suite.waitForVIPOwner(oldLeader)
+
+		By(withTimestamp(fmt.Sprintf("removing the static-pod manifest and sending SIGKILL to kube-vip on elected leader %q", oldLeader)))
+		oldPID, err := e2e.KillAndStashKubeVip(suite.cluster.Name, oldLeader, faultKubeVipManifest)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			Expect(e2e.RestorePodManifest(suite.cluster.Name, oldLeader, faultKubeVipManifest)).To(Succeed())
+		})
+		By(withTimestamp(fmt.Sprintf("sent SIGKILL to kube-vip PID %s on elected leader %q", oldPID, oldLeader)))
+		suite.assertNodeRunning(oldLeader)
 
 		newLeader := suite.waitForDifferentLeader(oldLeader)
+		suite.waitForARPFailover(oldLeader, newLeader)
 		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
-		suite.waitForLease(oldLeader)
 		suite.assertLeaderMetric(newLeader)
 
+		By(withTimestamp(fmt.Sprintf("restoring the kube-vip static-pod manifest on %q", oldLeader)))
+		Expect(e2e.RestorePodManifest(suite.cluster.Name, oldLeader, faultKubeVipManifest)).To(Succeed())
 		By(withTimestamp(fmt.Sprintf("waiting for kube-vip metrics to return on restarted node %q", oldLeader)))
+		suite.waitForKubeVip(oldLeader)
 		suite.waitForMetrics(oldLeader)
 		recoveredLeader := suite.waitForLeader()
 		suite.assertLeaderMetric(recoveredLeader)
@@ -177,12 +256,16 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 	})
 
 	It("reacquires the lease after deletion and lease stealing", func() {
+		if !suite.election.enabled {
+			Skip(fmt.Sprintf("%s control-plane mode does not use a Kubernetes election lease", Mode))
+		}
+
 		beforeDelete := suite.transitionSnapshot()
 		oldLease := suite.getLease()
 		oldUID := string(oldLease.UID)
 
-		By(withTimestamp(fmt.Sprintf("deleting lease %s/%s", faultLeaseNamespace, faultLeaseName)))
-		Expect(e2e.DeleteLease(suite.ctx, suite.client, faultLeaseNamespace, faultLeaseName)).To(Succeed())
+		By(withTimestamp(fmt.Sprintf("deleting lease %s/%s", faultLeaseNamespace, suite.election.leaseName)))
+		Expect(e2e.DeleteLease(suite.ctx, suite.client, faultLeaseNamespace, suite.election.leaseName)).To(Succeed())
 		recreatedLease := suite.waitForLease()
 		Expect(string(recreatedLease.UID)).NotTo(Equal(oldUID))
 		leader := suite.waitForLeader()
@@ -194,9 +277,9 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 
 		beforeSteal := suite.transitionSnapshot()
 		const stolenHolder = "fault-injector"
-		By(withTimestamp(fmt.Sprintf("overwriting lease %s/%s with holder %q", faultLeaseNamespace, faultLeaseName, stolenHolder)))
+		By(withTimestamp(fmt.Sprintf("overwriting lease %s/%s with holder %q", faultLeaseNamespace, suite.election.leaseName, stolenHolder)))
 		Eventually(func() error {
-			return e2e.StealLease(suite.ctx, suite.client, faultLeaseNamespace, faultLeaseName, stolenHolder)
+			return e2e.StealLease(suite.ctx, suite.client, faultLeaseNamespace, suite.election.leaseName, stolenHolder)
 		}, faultLeaseObservationLimit, faultPollInterval).Should(Succeed())
 		suite.waitForLeaseHolder(stolenHolder)
 		suite.waitForLease(stolenHolder)
@@ -209,6 +292,16 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 	})
 
 	It("fully recovers after restarting the leader node", func() {
+		if !suite.election.enabled {
+			node := suite.nodes[0]
+			By(withTimestamp(fmt.Sprintf("restarting non-electing %s node %q", Mode, node)))
+			Expect(e2e.RestartNode(suite.cluster.Name, node)).To(Succeed())
+			suite.waitForNodeReady(node)
+			suite.waitForKubeVip(node)
+			assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
+			return
+		}
+
 		before := suite.transitionSnapshot()
 		oldLeader := suite.waitForLeader()
 
@@ -240,61 +333,98 @@ func buildFaultClient(config *rest.Config) kubernetes.Interface {
 }
 
 func (s *controlPlaneFaultSuite) waitForLeader() string {
-	// RT mode keeps the VIP in a route instead of an interface address, so the
-	// existing Docker IP lookup used by ARP mode cannot identify its leader.
-	if Mode == ModeRT {
-		lease := s.waitForLease()
-		return *lease.Spec.HolderIdentity
-	}
-
-	var leader string
-	Eventually(func() (string, error) {
-		leader = findLeader(s.vip, s.cluster.Name)
-		if leader == "" {
-			return "", fmt.Errorf("VIP %s has no leader", s.vip)
-		}
-		return leader, nil
-	}, faultConvergenceTimeout, faultPollInterval).ShouldNot(BeEmpty())
-	return leader
+	Expect(s.election.enabled).To(BeTrue(), "%s mode has no control-plane election leader", Mode)
+	return *s.waitForLease().Spec.HolderIdentity
 }
 
 func (s *controlPlaneFaultSuite) waitForDifferentLeader(oldLeader string) string {
-	if Mode == ModeRT {
-		var leader string
-		Eventually(func() (string, error) {
-			lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, faultLeaseName, metav1.GetOptions{})
-			if err != nil {
-				return "", err
-			}
-			if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity == "" {
-				return "", fmt.Errorf("lease %s/%s has no holder", faultLeaseNamespace, faultLeaseName)
-			}
-			if *lease.Spec.HolderIdentity == oldLeader {
-				return "", fmt.Errorf("lease %s/%s is still held by %s", faultLeaseNamespace, faultLeaseName, oldLeader)
-			}
-			leader = *lease.Spec.HolderIdentity
-			return leader, nil
-		}, faultConvergenceTimeout, faultPollInterval).ShouldNot(BeEmpty())
-		return leader
-	}
+	return *s.waitForLease(oldLeader).Spec.HolderIdentity
+}
 
-	var leader string
+func (s *controlPlaneFaultSuite) waitForARPFailover(oldLeader, newLeader string) {
+	Eventually(func() error {
+		lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, s.election.leaseName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("observe election transfer: %w", err)
+		}
+		if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity == "" {
+			return fmt.Errorf("lease %s/%s has no holder", faultLeaseNamespace, s.election.leaseName)
+		}
+		if *lease.Spec.HolderIdentity != newLeader {
+			return fmt.Errorf("lease %s/%s is held by %q, want %q", faultLeaseNamespace, s.election.leaseName, *lease.Spec.HolderIdentity, newLeader)
+		}
+		owners, err := s.vipOwners()
+		if err != nil {
+			return err
+		}
+		return validateARPFailover(oldLeader, newLeader, owners)
+	}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
+	By(withTimestamp(fmt.Sprintf("election and sole VIP ownership transferred from %q to %q", oldLeader, newLeader)))
+}
+
+func (s *controlPlaneFaultSuite) waitForVIPOwner(want string) {
+	Eventually(func() error {
+		owners, err := s.vipOwners()
+		if err != nil {
+			return err
+		}
+		if len(owners) != 1 || owners[0] != want {
+			return fmt.Errorf("VIP %s owners are %v, want only %q", s.vip, owners, want)
+		}
+		return nil
+	}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
+}
+
+func (s *controlPlaneFaultSuite) vipOwners() ([]string, error) {
+	owners := make([]string, 0, len(s.nodes))
+	for _, node := range s.nodes {
+		var output bytes.Buffer
+		cmd := exec.Command("docker", "exec", node, "ip", "-o", "addr", "show", "to", s.vip+"/32")
+		cmd.Stdout = &output
+		cmd.Stderr = &output
+		if err := cmd.Run(); err != nil {
+			return nil, fmt.Errorf("inspect VIP %s on node %q: %w: %s", s.vip, node, err, strings.TrimSpace(output.String()))
+		}
+		if strings.TrimSpace(output.String()) != "" {
+			owners = append(owners, node)
+		}
+	}
+	return owners, nil
+}
+
+func (s *controlPlaneFaultSuite) waitForKubeVipRestart(node, oldPID string) {
 	Eventually(func() (string, error) {
-		candidate := findLeader(s.vip, s.cluster.Name)
-		if candidate == "" {
-			return "", fmt.Errorf("VIP %s has no leader", s.vip)
+		pid, err := e2e.KubeVipPID(s.cluster.Name, node)
+		if err != nil {
+			return "", err
 		}
-		if candidate == oldLeader {
-			return "", fmt.Errorf("VIP %s is still held by %s", s.vip, oldLeader)
+		if pid == oldPID {
+			return "", fmt.Errorf("kube-vip PID %s is still running on %q", oldPID, node)
 		}
-		leader = candidate
-		return leader, nil
+		return pid, nil
 	}, faultConvergenceTimeout, faultPollInterval).ShouldNot(BeEmpty())
-	return leader
+}
+
+func (s *controlPlaneFaultSuite) waitForKubeVip(node string) {
+	Eventually(func() error {
+		_, err := e2e.KubeVipPID(s.cluster.Name, node)
+		return err
+	}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
+}
+
+func (s *controlPlaneFaultSuite) assertNodeRunning(node string) {
+	running, err := e2e.NodeRunning(s.cluster.Name, node)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(running).To(BeTrue(), "SIGKILL must stop kube-vip, not its node container")
+}
+
+func (s *controlPlaneFaultSuite) assertNoElectionLease() {
+	_, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, faultLeaseName, metav1.GetOptions{})
+	Expect(apierrors.IsNotFound(err)).To(BeTrue(), "non-electing %s mode unexpectedly exposed control-plane lease %s/%s: %v", Mode, faultLeaseNamespace, faultLeaseName, err)
 }
 
 func (s *controlPlaneFaultSuite) getLease() *coordinationv1.Lease {
-	lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, faultLeaseName, metav1.GetOptions{})
+	lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, s.election.leaseName, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	return lease
 }
@@ -307,15 +437,15 @@ func (s *controlPlaneFaultSuite) waitForLease(excludedHolders ...string) *coordi
 
 	var current *coordinationv1.Lease
 	Eventually(func() error {
-		lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, faultLeaseName, metav1.GetOptions{})
+		lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, s.election.leaseName, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
 		if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity == "" {
-			return fmt.Errorf("lease %s/%s has no holder", faultLeaseNamespace, faultLeaseName)
+			return fmt.Errorf("lease %s/%s has no holder", faultLeaseNamespace, s.election.leaseName)
 		}
 		if _, skip := excluded[*lease.Spec.HolderIdentity]; skip {
-			return fmt.Errorf("lease %s/%s is still held by excluded node %q", faultLeaseNamespace, faultLeaseName, *lease.Spec.HolderIdentity)
+			return fmt.Errorf("lease %s/%s is still held by excluded node %q", faultLeaseNamespace, s.election.leaseName, *lease.Spec.HolderIdentity)
 		}
 		current = lease
 		return nil
@@ -326,12 +456,12 @@ func (s *controlPlaneFaultSuite) waitForLease(excludedHolders ...string) *coordi
 func (s *controlPlaneFaultSuite) waitForLeaseHolder(holder string) *coordinationv1.Lease {
 	var current *coordinationv1.Lease
 	Eventually(func() error {
-		lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, faultLeaseName, metav1.GetOptions{})
+		lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, s.election.leaseName, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
 		if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity != holder {
-			return fmt.Errorf("lease %s/%s is not held by %q", faultLeaseNamespace, faultLeaseName, holder)
+			return fmt.Errorf("lease %s/%s is not held by %q", faultLeaseNamespace, s.election.leaseName, holder)
 		}
 		current = lease
 		return nil
@@ -373,7 +503,7 @@ func (s *controlPlaneFaultSuite) assertLeaderMetric(leader string) {
 		s.cluster.Name,
 		leader,
 		"kube_vip_is_leader",
-		map[string]string{"node": leader, "lease_name": faultLeaseName},
+		map[string]string{"node": leader, "lease_name": s.election.leaseName},
 		Equal(float64(1)),
 		faultConvergenceTimeout,
 		faultPollInterval,
@@ -389,7 +519,7 @@ func (s *controlPlaneFaultSuite) assertSteadyLeader(leader string) {
 		s.cluster.Name,
 		leader,
 		"kube_vip_is_leader",
-		map[string]string{"node": leader, "lease_name": faultLeaseName},
+		map[string]string{"node": leader, "lease_name": s.election.leaseName},
 		Equal(float64(1)),
 		faultSteadyStateWindow,
 		faultPollInterval,
@@ -417,7 +547,7 @@ func (s *controlPlaneFaultSuite) assertOneLeader(skipNodes ...string) {
 			if err != nil {
 				return 0, err
 			}
-			value, ok := e2e.MaxMetric(metrics, "kube_vip_is_leader", map[string]string{"lease_name": faultLeaseName})
+			value, ok := e2e.MaxMetric(metrics, "kube_vip_is_leader", map[string]string{"lease_name": s.election.leaseName})
 			if !ok {
 				continue
 			}
@@ -454,7 +584,7 @@ func (s *controlPlaneFaultSuite) assertTransitionCounterStable(before faultMetri
 	if !s.metrics {
 		return
 	}
-	labels := map[string]string{"lease_name": faultLeaseName}
+	labels := map[string]string{"lease_name": s.election.leaseName}
 	stableValues := make(map[string]float64)
 	totalDelta := 0.0
 	observed := 0

--- a/testing/e2e/e2e_faults_cp_test.go
+++ b/testing/e2e/e2e_faults_cp_test.go
@@ -44,6 +44,7 @@ type controlPlaneFaultSuite struct {
 	vip     string
 	nodes   []string
 	tempDir string
+	metrics bool
 }
 
 type faultMetricSnapshot map[string]map[string]float64
@@ -75,6 +76,7 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 			EnableEndpoints:       "true",
 			EnableNodeLabeling:    "false",
 			EnableServiceSecurity: "true",
+			PrometheusHTTPServer:  ":2112",
 		}
 		networking := kindconfigv1alpha4.Networking{
 			IPFamily: kindconfigv1alpha4.IPv4Family,
@@ -100,6 +102,7 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 			suite.nodes = append(suite.nodes, node.String())
 		}
 		Expect(suite.nodes).To(HaveLen(faultClusterNodeCount))
+		suite.metrics = suite.metricsAvailable()
 
 		By(withTimestamp("waiting for the control-plane VIP to become routable"))
 		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
@@ -129,12 +132,9 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 
 		By(withTimestamp(fmt.Sprintf("blackholing the API server from leader %q", oldLeader)))
 		Expect(e2e.BlackholeAPIServer(suite.cluster.Name, oldLeader)).To(Succeed())
-		blackholeActive := true
-		defer func() {
-			if blackholeActive {
-				Expect(e2e.RestoreAPIServer(suite.cluster.Name, oldLeader)).To(Succeed())
-			}
-		}()
+		DeferCleanup(func() {
+			Expect(e2e.RestoreAPIServer(suite.cluster.Name, oldLeader)).To(Succeed())
+		})
 
 		newLeader := suite.waitForDifferentLeader(oldLeader)
 		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
@@ -145,7 +145,6 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 
 		By(withTimestamp(fmt.Sprintf("restoring the API server connection on %q", oldLeader)))
 		Expect(e2e.RestoreAPIServer(suite.cluster.Name, oldLeader)).To(Succeed())
-		blackholeActive = false
 
 		suite.waitForLease()
 		recoveredLeader := suite.waitForLeader()
@@ -341,8 +340,11 @@ func (s *controlPlaneFaultSuite) waitForLeaseHolder(holder string) *coordination
 }
 
 func (s *controlPlaneFaultSuite) waitForMetrics(node string) {
+	if !s.metrics {
+		return
+	}
 	Eventually(func() error {
-		_, err := e2e.ScrapeMetrics(s.cluster.Name, node)
+		_, err := e2e.ScrapeMetrics(s.ctx, s.cluster.Name, node)
 		return err
 	}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
 }
@@ -363,7 +365,11 @@ func (s *controlPlaneFaultSuite) waitForNodeReady(nodeName string) {
 }
 
 func (s *controlPlaneFaultSuite) assertLeaderMetric(leader string) {
+	if !s.metrics {
+		return
+	}
 	e2e.EventuallyMetric(
+		s.ctx,
 		s.cluster.Name,
 		leader,
 		"kube_vip_is_leader",
@@ -375,7 +381,11 @@ func (s *controlPlaneFaultSuite) assertLeaderMetric(leader string) {
 }
 
 func (s *controlPlaneFaultSuite) assertSteadyLeader(leader string) {
+	if !s.metrics {
+		return
+	}
 	e2e.ConsistentlyMetric(
+		s.ctx,
 		s.cluster.Name,
 		leader,
 		"kube_vip_is_leader",
@@ -387,6 +397,9 @@ func (s *controlPlaneFaultSuite) assertSteadyLeader(leader string) {
 }
 
 func (s *controlPlaneFaultSuite) assertOneLeader(skipNodes ...string) {
+	if !s.metrics {
+		return
+	}
 	assertExactlyOneLeaderMetric(s.ctx, s.cluster.Name, s.client, skipNodes...)
 
 	skipped := make(map[string]struct{}, len(skipNodes))
@@ -400,7 +413,7 @@ func (s *controlPlaneFaultSuite) assertOneLeader(skipNodes ...string) {
 			if _, skip := skipped[node]; skip {
 				continue
 			}
-			metrics, err := e2e.ScrapeMetrics(s.cluster.Name, node)
+			metrics, err := e2e.ScrapeMetrics(s.ctx, s.cluster.Name, node)
 			if err != nil {
 				return 0, err
 			}
@@ -421,12 +434,15 @@ func (s *controlPlaneFaultSuite) assertOneLeader(skipNodes ...string) {
 }
 
 func (s *controlPlaneFaultSuite) transitionSnapshot() faultMetricSnapshot {
+	if !s.metrics {
+		return nil
+	}
 	snapshot := make(faultMetricSnapshot, len(s.nodes))
 	for _, node := range s.nodes {
 		var metrics map[string]float64
 		Eventually(func() error {
 			var err error
-			metrics, err = e2e.ScrapeMetrics(s.cluster.Name, node)
+			metrics, err = e2e.ScrapeMetrics(s.ctx, s.cluster.Name, node)
 			return err
 		}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
 		snapshot[node] = metrics
@@ -435,13 +451,16 @@ func (s *controlPlaneFaultSuite) transitionSnapshot() faultMetricSnapshot {
 }
 
 func (s *controlPlaneFaultSuite) assertTransitionCounterStable(before faultMetricSnapshot, fault string) {
+	if !s.metrics {
+		return
+	}
 	labels := map[string]string{"lease_name": faultLeaseName}
 	stableValues := make(map[string]float64)
 	totalDelta := 0.0
 	observed := 0
 
 	for _, node := range s.nodes {
-		metrics, err := e2e.ScrapeMetrics(s.cluster.Name, node)
+		metrics, err := e2e.ScrapeMetrics(s.ctx, s.cluster.Name, node)
 		Expect(err).NotTo(HaveOccurred())
 		if _, matches := e2e.MetricValue(metrics, faultTransitionMetric, labels); matches == 0 {
 			continue
@@ -450,7 +469,7 @@ func (s *controlPlaneFaultSuite) assertTransitionCounterStable(before faultMetri
 		var stable float64
 		Eventually(func() error {
 			var stableErr error
-			stable, stableErr = e2e.MetricStable(s.cluster.Name, node, faultTransitionMetric, labels, 2, faultMetricGap)
+			stable, stableErr = e2e.MetricStable(s.ctx, s.cluster.Name, node, faultTransitionMetric, labels, 2, faultMetricGap)
 			return stableErr
 		}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
 		stableValues[node] = stable
@@ -474,4 +493,14 @@ func (s *controlPlaneFaultSuite) assertTransitionCounterStable(before faultMetri
 	Expect(observed).To(BeNumerically(">=", 1))
 	By(withTimestamp(fmt.Sprintf("stable transition counters after %s: %v; delta %.0f", fault, stableValues, totalDelta)))
 	Expect(totalDelta).To(BeNumerically("<=", faultTransitionDeltaLimit))
+}
+
+func (s *controlPlaneFaultSuite) metricsAvailable() bool {
+	for _, node := range s.nodes {
+		if _, err := e2e.ScrapeMetrics(s.ctx, s.cluster.Name, node); err != nil {
+			By(withTimestamp(fmt.Sprintf("metrics unavailable on %q; continuing with functional assertions: %v", node, err)))
+			return false
+		}
+	}
+	return true
 }

--- a/testing/e2e/e2e_metric_helpers_test.go
+++ b/testing/e2e/e2e_metric_helpers_test.go
@@ -1,0 +1,59 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseMetricsFixture(t *testing.T) {
+	payload, err := os.ReadFile("testdata/metrics.prom")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	metrics, err := parseMetrics(string(payload))
+	if err != nil {
+		t.Fatalf("parseMetrics() error = %v", err)
+	}
+
+	if value, matches := MetricValue(metrics, "kube_vip_is_leader", map[string]string{"node": "control-plane"}); value != 1 || matches != 1 {
+		t.Fatalf("MetricValue() = (%v, %d), want (1, 1)", value, matches)
+	}
+	if value := SumMetric(metrics, "kube_vip_is_leader", map[string]string{"lease_name": "plndr-cp-lock"}); value != 1 {
+		t.Fatalf("SumMetric() = %v, want 1", value)
+	}
+	if value, found := MaxMetric(metrics, "kube_vip_election_errors_total", map[string]string{"reason": "api\nserver"}); value != 3 || !found {
+		t.Fatalf("MaxMetric() = (%v, %t), want (3, true)", value, found)
+	}
+	if value, matches := MetricValue(metrics, "kube_vip_reconcile_seconds_count", nil); value != 4 || matches != 1 {
+		t.Fatalf("histogram count = (%v, %d), want (4, 1)", value, matches)
+	}
+}
+
+func TestMetricHelpersReportMissingAndAmbiguousSeries(t *testing.T) {
+	metrics := map[string]float64{
+		`metric{node="one"}`: 1,
+		`metric{node="two"}`: 2,
+	}
+
+	if _, matches := MetricValue(metrics, "metric", nil); matches != 2 {
+		t.Fatalf("MetricValue() matches = %d, want 2", matches)
+	}
+	if _, matches := MetricValue(metrics, "missing", nil); matches != 0 {
+		t.Fatalf("MetricValue() matches = %d, want 0", matches)
+	}
+	if _, ok := CounterDelta(metrics, map[string]float64{`metric{node="one"}`: 4}, "metric", nil); ok {
+		t.Fatal("CounterDelta() reported an ambiguous selector as available")
+	}
+	if delta, ok := CounterDelta(metrics, map[string]float64{`metric{node="one"}`: 4}, "metric", map[string]string{"node": "one"}); delta != 3 || !ok {
+		t.Fatalf("CounterDelta() = (%v, %t), want (3, true)", delta, ok)
+	}
+}
+
+func TestParseMetricsRejectsInvalidFixture(t *testing.T) {
+	if _, err := parseMetrics("not valid prometheus text"); err == nil {
+		t.Fatal("parseMetrics() succeeded for invalid input")
+	}
+}

--- a/testing/e2e/e2e_rt_test.go
+++ b/testing/e2e/e2e_rt_test.go
@@ -4,12 +4,10 @@
 package e2e_test
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -194,7 +192,7 @@ var _ = Describe("kube-vip routing table mode", func() {
 				otherContainer := controlPlaneContainerName(clusterName, 1)
 
 				By(fmt.Sprintf("stopping the apiserver on %q", targetContainer))
-				setAPIServerState(targetContainer, false)
+				Expect(e2e.StashPodManifest(clusterName, targetContainer, "kube-apiserver.yaml")).To(Succeed())
 
 				By("verifying the unhealthy node withdraws its VIP and route")
 				Expect(checkIPAddress(cpVIP, targetContainer, false)).To(BeTrue())
@@ -205,7 +203,7 @@ var _ = Describe("kube-vip routing table mode", func() {
 				e2e.CheckRoutePresence(cpVIP, otherContainer, true)
 
 				By(fmt.Sprintf("restoring the apiserver on %q", targetContainer))
-				setAPIServerState(targetContainer, true)
+				Expect(e2e.RestorePodManifest(clusterName, targetContainer, "kube-apiserver.yaml")).To(Succeed())
 
 				By("verifying the recovered node re-adds its VIP and route")
 				// Allow extra time here: the apiserver static pod must be restarted
@@ -333,7 +331,7 @@ var _ = Describe("kube-vip routing table mode", func() {
 				otherContainer := controlPlaneContainerName(clusterName, 1)
 
 				By(fmt.Sprintf("stopping the apiserver on %q", targetContainer))
-				setAPIServerState(targetContainer, false)
+				Expect(e2e.StashPodManifest(clusterName, targetContainer, "kube-apiserver.yaml")).To(Succeed())
 
 				By("verifying the unhealthy node withdraws its VIP and route")
 				Expect(checkIPAddress(cpVIP, targetContainer, false)).To(BeTrue())
@@ -344,7 +342,7 @@ var _ = Describe("kube-vip routing table mode", func() {
 				e2e.CheckRoutePresence(cpVIP, otherContainer, true)
 
 				By(fmt.Sprintf("restoring the apiserver on %q", targetContainer))
-				setAPIServerState(targetContainer, true)
+				Expect(e2e.RestorePodManifest(clusterName, targetContainer, "kube-apiserver.yaml")).To(Succeed())
 
 				By("verifying the recovered node re-adds its VIP and route")
 				// Allow extra time here: the apiserver static pod must be restarted
@@ -1814,24 +1812,4 @@ func controlPlaneContainerName(clusterName string, i int) string {
 		return fmt.Sprintf("%s-control-plane%d", clusterName, i)
 	}
 	return fmt.Sprintf("%s-control-plane", clusterName)
-}
-
-// setAPIServerEnabled stops or starts the static apiserver pod on a control-plane
-// container by moving its manifest in or out of the kubelet manifests directory.
-func setAPIServerState(container string, enabled bool) {
-	const (
-		manifestPath = "/etc/kubernetes/manifests/kube-apiserver.yaml"
-		stashPath    = "/tmp/kube-apiserver.yaml"
-	)
-
-	src, dst := manifestPath, stashPath
-	if enabled {
-		src, dst = stashPath, manifestPath
-	}
-
-	out := new(bytes.Buffer)
-	cmd := exec.Command("docker", "exec", container, "mv", src, dst)
-	cmd.Stdout = out
-	cmd.Stderr = out
-	Expect(cmd.Run()).To(Succeed(), out.String())
 }

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -1241,28 +1241,30 @@ func assertControlPlaneIsRoutable(controlPlaneVIP string, transportTimeout, even
 	assertConnection("https", controlPlaneVIP, "6443", "livez", transportTimeout, eventuallyTimeout)
 }
 
-func assertExactlyOneLeaderMetric(ctx context.Context, clusterName string, client kubernetes.Interface) {
+func assertExactlyOneLeaderMetric(ctx context.Context, clusterName string, client kubernetes.Interface, skipNodes ...string) {
 	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(nodes.Items).NotTo(BeEmpty())
 
 	const leaseName = "plndr-cp-lock"
 	labels := map[string]string{"lease_name": leaseName}
-	leaderName := e2e.GetLeaseHolder(ctx, leaseName, "kube-system", client)
-	e2e.EventuallyMetric(clusterName, leaderName, "kube_vip_is_leader", labels,
-		Equal(float64(1)), 60*time.Second, 2*time.Second)
+	skipped := make(map[string]struct{}, len(skipNodes))
+	for _, node := range skipNodes {
+		skipped[node] = struct{}{}
+	}
 
 	Eventually(func() (float64, error) {
 		var total float64
 		for _, node := range nodes.Items {
+			if _, ok := skipped[node.Name]; ok {
+				continue
+			}
+
 			metrics, err := e2e.ScrapeMetrics(clusterName, node.Name)
 			if err != nil {
 				return 0, err
 			}
-			value, ok := e2e.MetricValue(metrics, "kube_vip_is_leader", labels)
-			if ok {
-				total += value
-			}
+			total += e2e.SumMetric(metrics, "kube_vip_is_leader", labels)
 		}
 		return total, nil
 	}, 60*time.Second, 2*time.Second).Should(Equal(float64(1)))

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -136,6 +136,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 					EnableEndpoints:       "true",
 					EnableNodeLabeling:    "false",
 					EnableServiceSecurity: "true",
+					PrometheusHTTPServer:  ":2112",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -183,6 +184,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 					EnableEndpoints:       "true",
 					EnableNodeLabeling:    "false",
 					EnableServiceSecurity: "true",
+					PrometheusHTTPServer:  ":2112",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -203,7 +205,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 				func(svcName string, currentOffset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv4Family, currentOffset, defaultNetwork)
 					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol}, 1, false, dsNumber, func(node string) {
-						e2e.EventuallyMetric(clusterName, node, "kube_vip_active_services", map[string]string{
+						e2e.EventuallyMetric(ctx, clusterName, node, "kube_vip_active_services", map[string]string{
 							"namespace": dsNamespace,
 						}, BeNumerically(">=", float64(1)), 60*time.Second, 2*time.Second)
 					})
@@ -1260,7 +1262,7 @@ func assertExactlyOneLeaderMetric(ctx context.Context, clusterName string, clien
 				continue
 			}
 
-			metrics, err := e2e.ScrapeMetrics(clusterName, node.Name)
+			metrics, err := e2e.ScrapeMetrics(ctx, clusterName, node.Name)
 			if err != nil {
 				return 0, err
 			}

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -151,7 +151,9 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 			})
 
 			It(clusterName+" provides an IPv4 VIP address for the Kubernetes control plane nodes", func() {
-				testControlPlaneVIPs(ctx, []string{cpVIP}, clusterName, client)
+				testControlPlaneVIPs(ctx, []string{cpVIP}, clusterName, client, func() {
+					assertExactlyOneLeaderMetric(ctx, clusterName, client)
+				})
 			})
 		})
 
@@ -200,7 +202,11 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 			DescribeTable("configures an IPv4 VIP address for service",
 				func(svcName string, currentOffset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv4Family, currentOffset, defaultNetwork)
-					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol}, 1, false, dsNumber)
+					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol}, 1, false, dsNumber, func(node string) {
+						e2e.EventuallyMetric(clusterName, node, "kube_vip_active_services", map[string]string{
+							"namespace": dsNamespace,
+						}, BeNumerically(">=", float64(1)), 60*time.Second, 2*time.Second)
+					})
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -1235,6 +1241,33 @@ func assertControlPlaneIsRoutable(controlPlaneVIP string, transportTimeout, even
 	assertConnection("https", controlPlaneVIP, "6443", "livez", transportTimeout, eventuallyTimeout)
 }
 
+func assertExactlyOneLeaderMetric(ctx context.Context, clusterName string, client kubernetes.Interface) {
+	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(nodes.Items).NotTo(BeEmpty())
+
+	const leaseName = "plndr-cp-lock"
+	labels := map[string]string{"lease_name": leaseName}
+	leaderName := e2e.GetLeaseHolder(ctx, leaseName, "kube-system", client)
+	e2e.EventuallyMetric(clusterName, leaderName, "kube_vip_is_leader", labels,
+		Equal(float64(1)), 60*time.Second, 2*time.Second)
+
+	Eventually(func() (float64, error) {
+		var total float64
+		for _, node := range nodes.Items {
+			metrics, err := e2e.ScrapeMetrics(clusterName, node.Name)
+			if err != nil {
+				return 0, err
+			}
+			value, ok := e2e.MetricValue(metrics, "kube_vip_is_leader", labels)
+			if ok {
+				total += value
+			}
+		}
+		return total, nil
+	}, 60*time.Second, 2*time.Second).Should(Equal(float64(1)))
+}
+
 // Assume connection to the provided address is possible
 func assertConnection(protocol, ip, port, suffix string, transportTimeout, eventuallyTimeout time.Duration) {
 	if strings.Contains(ip, ":") {
@@ -1694,12 +1727,12 @@ func cleanupCluster(clusterName, network string, configMtx *sync.Mutex, logger l
 	}
 }
 
-func testControlPlaneVIPs(ctx context.Context, cpVIPs []string, clusterName string, client kubernetes.Interface) {
-	testControlPlaneVIPsWithTimeout(ctx, cpVIPs, clusterName, client, time.Duration(0), 20*time.Second)
+func testControlPlaneVIPs(ctx context.Context, cpVIPs []string, clusterName string, client kubernetes.Interface, afterVIPConfirmed ...func()) {
+	testControlPlaneVIPsWithTimeout(ctx, cpVIPs, clusterName, client, time.Duration(0), 20*time.Second, afterVIPConfirmed...)
 }
 
 func testControlPlaneVIPsWithTimeout(ctx context.Context, cpVIPs []string, clusterName string, client kubernetes.Interface,
-	transportTimeout, eventuallyTimeout time.Duration) {
+	transportTimeout, eventuallyTimeout time.Duration, afterVIPConfirmed ...func()) {
 	Expect(cpVIPs).ToNot(BeEmpty())
 
 	By(withTimestamp("checking that the Kubernetes control plane nodes are accessible via the assigned VIP"))
@@ -1708,6 +1741,9 @@ func testControlPlaneVIPsWithTimeout(ctx context.Context, cpVIPs []string, clust
 	for _, cpVIP := range cpVIPs {
 		By(withTimestamp(fmt.Sprintf("testing connection to VIP: %s", cpVIP)))
 		assertControlPlaneIsRoutable(cpVIP, transportTimeout, eventuallyTimeout)
+	}
+	if len(afterVIPConfirmed) > 0 && afterVIPConfirmed[0] != nil {
+		afterVIPConfirmed[0]()
 	}
 
 	var leaderName string
@@ -1731,6 +1767,7 @@ func testControlPlaneVIPsWithTimeout(ctx context.Context, cpVIPs []string, clust
 
 func testService(ctx context.Context, svcName, lbAddress, leaseName, leaseNamespace string, trafficPolicy corev1.ServiceExternalTrafficPolicy,
 	client kubernetes.Interface, serviceElection bool, ipFamily []corev1.IPFamily, numberOfServices int, deleteDS bool, dsNumber int,
+	afterVIPConfirmed ...func(string),
 ) {
 	lbAddresses := vip.Split(lbAddress)
 
@@ -1758,6 +1795,9 @@ func testService(ctx context.Context, svcName, lbAddress, leaseName, leaseNamesp
 	}
 
 	container := e2e.GetLeaseHolder(ctx, leases[0], leaseNamespace, client)
+	if len(afterVIPConfirmed) > 0 && afterVIPConfirmed[0] != nil {
+		afterVIPConfirmed[0](container)
+	}
 
 	if deleteDS {
 		removeTestDS(ctx, client, dsNamespace, dsName, dsNumber)

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -1947,21 +1947,33 @@ func testServiceCommonLease(ctx context.Context, svcName, lbAddress, leaseNamesp
 		}
 	}
 
-	container := e2e.GetLeaseHolder(ctx, lease, leaseNamespace, client)
-
 	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	Expect(err).ToNot(HaveOccurred())
 
+	nodeNames := make([]string, 0, len(nodes.Items))
 	for _, node := range nodes.Items {
-		expected := node.Name == container
-		for _, addr := range lbAddresses {
-			Expect(checkIPAddress(addr, node.Name, expected)).To(BeTrue())
-		}
+		nodeNames = append(nodeNames, node.Name)
 	}
 
-	for i := range numberOfServices {
-		expected := i < numberOfServices-1
+	getHolder := func() (string, error) {
+		currentLease, err := client.CoordinationV1().Leases(leaseNamespace).Get(ctx, lease, metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+		if currentLease.Spec.HolderIdentity == nil {
+			return "", nil
+		}
+		return *currentLease.Spec.HolderIdentity, nil
+	}
+	checkOwnership := func() (string, error) {
+		return e2e.CheckCommonLeaseOwnership(getHolder, nodeNames, lbAddresses, func(address, node string) bool {
+			return e2e.CheckIPAddressPresence(address, node, true)
+		})
+	}
 
+	Eventually(checkOwnership, "120s", "1s").ShouldNot(BeEmpty())
+
+	for i := range numberOfServices {
 		By(fmt.Sprintf("deleting service %q", services[i]))
 
 		err := client.CoreV1().Services(dsNamespace).Delete(ctx, services[i], metav1.DeleteOptions{})
@@ -1973,15 +1985,28 @@ func testServiceCommonLease(ctx context.Context, svcName, lbAddress, leaseNamesp
 			return err
 		}).ShouldNot(Succeed())
 
-		for _, addr := range lbAddresses {
-			for _, node := range nodes.Items {
-				if node.Name == container {
-					Expect(checkIPAddress(addr, node.Name, expected)).To(BeTrue())
-				} else {
-					Expect(checkIPAddress(addr, node.Name, false)).To(BeTrue())
+		if i < numberOfServices-1 {
+			Eventually(checkOwnership, "120s", "1s").ShouldNot(BeEmpty())
+			continue
+		}
+
+		Eventually(func() error {
+			_, err := client.CoordinationV1().Leases(leaseNamespace).Get(ctx, lease, metav1.GetOptions{})
+			if err == nil {
+				return fmt.Errorf("common lease %s/%s still exists", leaseNamespace, lease)
+			}
+			if !errors.IsNotFound(err) {
+				return fmt.Errorf("common lease %s/%s still exists: %w", leaseNamespace, lease, err)
+			}
+			for _, node := range nodeNames {
+				for _, addr := range lbAddresses {
+					if e2e.CheckIPAddressPresence(addr, node, false) == false {
+						return fmt.Errorf("address %q is still present on node %q", addr, node)
+					}
 				}
 			}
-		}
+			return nil
+		}, "120s", "1s").Should(Succeed())
 	}
 }
 

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -1991,19 +1991,21 @@ func testServiceCommonLease(ctx context.Context, svcName, lbAddress, leaseNamesp
 		}
 
 		Eventually(func() error {
-			_, err := client.CoordinationV1().Leases(leaseNamespace).Get(ctx, lease, metav1.GetOptions{})
-			if err == nil {
-				return fmt.Errorf("common lease %s/%s still exists", leaseNamespace, lease)
+			currentLease, err := client.CoordinationV1().Leases(leaseNamespace).Get(ctx, lease, metav1.GetOptions{})
+			if err := e2e.CheckCommonLeaseRetired(currentLease, err); err != nil {
+				return fmt.Errorf("common lease %s/%s is not retired: %w", leaseNamespace, lease, err)
 			}
-			if !errors.IsNotFound(err) {
-				return fmt.Errorf("common lease %s/%s still exists: %w", leaseNamespace, lease, err)
-			}
+
+			var presentAddresses []string
 			for _, node := range nodeNames {
 				for _, addr := range lbAddresses {
 					if e2e.CheckIPAddressPresence(addr, node, false) == false {
-						return fmt.Errorf("address %q is still present on node %q", addr, node)
+						presentAddresses = append(presentAddresses, fmt.Sprintf("%q on %q", addr, node))
 					}
 				}
+			}
+			if len(presentAddresses) > 0 {
+				return fmt.Errorf("addresses are still present: %s", strings.Join(presentAddresses, ", "))
 			}
 			return nil
 		}, "120s", "1s").Should(Succeed())

--- a/testing/e2e/faults.go
+++ b/testing/e2e/faults.go
@@ -1,0 +1,284 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"path"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	kindcluster "sigs.k8s.io/kind/pkg/cluster"
+)
+
+const (
+	kindNetworkName        = "kind"
+	manifestDirectory      = "/etc/kubernetes/manifests"
+	manifestStashDirectory = "/tmp"
+	nodeReadyTimeout       = 60 * time.Second
+	nodeReadyPollInterval  = time.Second
+)
+
+// PartitionNode models a node-level network partition by disconnecting the
+// node container from the Kind network. Processes in the node continue to run.
+func PartitionNode(clusterName, node string) error {
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return err
+	}
+
+	return runDocker(clusterName, "network", "disconnect", kindNetworkName, node)
+}
+
+// HealNode models recovery from a node-level network partition by reconnecting
+// the node to the Kind network. It restarts the node if it does not become
+// Ready within the recovery timeout.
+func HealNode(clusterName, node string) error {
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return err
+	}
+
+	if err := runDocker(clusterName, "network", "connect", kindNetworkName, node); err != nil {
+		return err
+	}
+
+	readinessErr := waitForNodeReady(clusterName, node)
+	if readinessErr == nil {
+		return nil
+	}
+
+	if err := runDocker(clusterName, "restart", node); err != nil {
+		return fmt.Errorf("node %q in cluster %q did not become Ready and restart failed: %w (readiness error: %v)", node, clusterName, err, readinessErr)
+	}
+
+	if err := waitForNodeReady(clusterName, node); err != nil {
+		return fmt.Errorf("node %q in cluster %q did not become Ready after restart: %w", node, clusterName, err)
+	}
+
+	return nil
+}
+
+// BlackholeAPIServer models loss of a node's local Kubernetes API connection
+// by dropping its outbound TCP connections to the apiserver port. The node
+// itself remains running and can continue to report as Ready for a while.
+func BlackholeAPIServer(clusterName, node string) error {
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return err
+	}
+
+	return runDocker(clusterName,
+		"exec", node, "iptables", "-I", "OUTPUT", "-p", "tcp", "--dport", "6443", "-j", "DROP",
+	)
+}
+
+// RestoreAPIServer removes the apiserver blackhole installed by
+// BlackholeAPIServer, restoring the node's outbound TCP connections to port
+// 6443.
+func RestoreAPIServer(clusterName, node string) error {
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return err
+	}
+
+	return runDocker(clusterName,
+		"exec", node, "iptables", "-D", "OUTPUT", "-p", "tcp", "--dport", "6443", "-j", "DROP",
+	)
+}
+
+// KillKubeVip models kube-vip process failure inside a node. A graceful fault
+// sends SIGTERM so kube-vip can perform shutdown handling; an abrupt fault
+// sends SIGKILL.
+func KillKubeVip(clusterName, node string, graceful bool) error {
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return err
+	}
+
+	signal := "-KILL"
+	if graceful {
+		signal = "-TERM"
+	}
+
+	return runDocker(clusterName, "exec", node, "pkill", signal, "kube-vip")
+}
+
+// RestartNode models a complete node failure and recovery by restarting its
+// Docker container. The caller can use HealNode when it also needs a Ready
+// check after a network fault.
+func RestartNode(clusterName, node string) error {
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return err
+	}
+
+	return runDocker(clusterName, "restart", node)
+}
+
+// DeleteLease models loss of a Kubernetes coordination lease by deleting it
+// through the coordination API.
+func DeleteLease(ctx context.Context, client kubernetes.Interface, namespace, name string) error {
+	if client == nil {
+		return fmt.Errorf("delete lease %s/%s: client is nil", namespace, name)
+	}
+	if err := client.CoordinationV1().Leases(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("delete lease %s/%s: %w", namespace, name, err)
+	}
+
+	return nil
+}
+
+// StealLease models a competing leader taking ownership of a Kubernetes
+// coordination lease by overwriting its holder identity and renewal time.
+func StealLease(ctx context.Context, client kubernetes.Interface, namespace, name, newHolder string) error {
+	if client == nil {
+		return fmt.Errorf("steal lease %s/%s: client is nil", namespace, name)
+	}
+	if newHolder == "" {
+		return fmt.Errorf("steal lease %s/%s: new holder is empty", namespace, name)
+	}
+
+	leases := client.CoordinationV1().Leases(namespace)
+	lease, err := leases.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("get lease %s/%s before stealing: %w", namespace, name, err)
+	}
+
+	holder := newHolder
+	lease.Spec.HolderIdentity = &holder
+	renewTime := metav1.NowMicro()
+	lease.Spec.RenewTime = &renewTime
+	if _, err := leases.Update(ctx, lease, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update stolen lease %s/%s: %w", namespace, name, err)
+	}
+
+	return nil
+}
+
+// StashPodManifest models a static-pod failure by moving a manifest out of
+// the kubelet manifest directory into /tmp on the selected node.
+func StashPodManifest(clusterName, node, manifestName string) error {
+	src, dst, err := podManifestPaths(manifestName)
+	if err != nil {
+		return fmt.Errorf("stash manifest on node %q in cluster %q: %w", node, clusterName, err)
+	}
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return err
+	}
+
+	return runDocker(clusterName, "exec", node, "mv", src, dst)
+}
+
+// RestorePodManifest models static-pod recovery by moving a stashed manifest
+// back into the kubelet manifest directory on the selected node.
+func RestorePodManifest(clusterName, node, manifestName string) error {
+	src, dst, err := podManifestPaths(manifestName)
+	if err != nil {
+		return fmt.Errorf("restore manifest on node %q in cluster %q: %w", node, clusterName, err)
+	}
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return err
+	}
+
+	return runDocker(clusterName, "exec", node, "mv", dst, src)
+}
+
+func runDocker(clusterName string, args ...string) error {
+	var output bytes.Buffer
+	cmd := exec.Command("docker", args...)
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Run(); err != nil {
+		details := strings.TrimSpace(output.String())
+		if details != "" {
+			return fmt.Errorf("cluster %q: docker %s failed: %w: %s", clusterName, strings.Join(args, " "), err, details)
+		}
+		return fmt.Errorf("cluster %q: docker %s failed: %w", clusterName, strings.Join(args, " "), err)
+	}
+
+	return nil
+}
+
+func validateFaultTarget(clusterName, node string) error {
+	if strings.TrimSpace(clusterName) == "" {
+		return fmt.Errorf("fault target cluster name is empty")
+	}
+	if strings.TrimSpace(node) == "" {
+		return fmt.Errorf("fault target node in cluster %q is empty", clusterName)
+	}
+
+	return nil
+}
+
+func podManifestPaths(manifestName string) (string, string, error) {
+	if manifestName == "" || path.Base(manifestName) != manifestName || manifestName == "." || manifestName == ".." {
+		return "", "", fmt.Errorf("manifest name %q must be a file name", manifestName)
+	}
+
+	manifestPath := path.Join(manifestDirectory, manifestName)
+	stashPath := path.Join(manifestStashDirectory, manifestName)
+	return manifestPath, stashPath, nil
+}
+
+func waitForNodeReady(clusterName, node string) error {
+	client, err := clientForKindCluster(clusterName)
+	if err != nil {
+		return fmt.Errorf("create Kubernetes client for cluster %q: %w", clusterName, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), nodeReadyTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(nodeReadyPollInterval)
+	defer ticker.Stop()
+
+	var lastErr error
+	for {
+		current, err := client.CoreV1().Nodes().Get(ctx, node, metav1.GetOptions{})
+		if err != nil {
+			lastErr = err
+		} else if current == nil {
+			lastErr = fmt.Errorf("Kubernetes returned an empty node object")
+		} else if !nodeIsReady(current) {
+			lastErr = fmt.Errorf("Ready condition is not True")
+		} else {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			if lastErr == nil {
+				lastErr = ctx.Err()
+			}
+			return fmt.Errorf("node %q in cluster %q did not become Ready within %s: %w", node, clusterName, nodeReadyTimeout, lastErr)
+		case <-ticker.C:
+		}
+	}
+}
+
+func clientForKindCluster(clusterName string) (kubernetes.Interface, error) {
+	provider := kindcluster.NewProvider(kindcluster.ProviderWithDocker())
+	kubeconfig, err := provider.KubeConfig(clusterName, false)
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := ClientConfigFromKubeconfig(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return kubernetes.NewForConfig(config)
+}
+
+func nodeIsReady(node *corev1.Node) bool {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+
+	return false
+}

--- a/testing/e2e/faults.go
+++ b/testing/e2e/faults.go
@@ -107,6 +107,64 @@ func KillKubeVip(clusterName, node string, graceful bool) error {
 	return runDocker(clusterName, "exec", node, "pkill", signal, "kube-vip")
 }
 
+// KillAndStashKubeVip atomically removes the static-pod manifest and sends
+// SIGKILL to the process it identified. Removing the manifest first prevents
+// kubelet from restarting kube-vip before a failover can be observed.
+func KillAndStashKubeVip(clusterName, node, manifestName string) (string, error) {
+	src, dst, err := podManifestPaths(manifestName)
+	if err != nil {
+		return "", fmt.Errorf("kill and stash kube-vip on node %q in cluster %q: %w", node, clusterName, err)
+	}
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return "", err
+	}
+
+	script := fmt.Sprintf(`pid="$(pgrep -x kube-vip)" && set -- $pid && test "$#" -eq 1 && mv %s %s && { kill -KILL "$1" && printf '%%s' "$1" || { mv %s %s; exit 1; }; }`, src, dst, dst, src)
+	output, err := runDockerOutput(clusterName, "exec", node, "sh", "-c", script)
+	if err != nil {
+		return "", err
+	}
+
+	return singlePID(output)
+}
+
+// KubeVipPID returns the PID of the single kube-vip process running in a Kind
+// node. Static-pod restarts get a new PID, which lets fault tests distinguish a
+// process restart from a node-container restart.
+func KubeVipPID(clusterName, node string) (string, error) {
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return "", err
+	}
+
+	output, err := runDockerOutput(clusterName, "exec", node, "pgrep", "-x", "kube-vip")
+	if err != nil {
+		return "", err
+	}
+
+	return singlePID(output)
+}
+
+// NodeRunning reports whether the Kind node container is still running.
+func NodeRunning(clusterName, node string) (bool, error) {
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return false, err
+	}
+
+	output, err := runDockerOutput(clusterName, "inspect", "--format={{.State.Running}}", node)
+	if err != nil {
+		return false, err
+	}
+
+	switch strings.TrimSpace(output) {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, fmt.Errorf("node %q in cluster %q returned invalid running state %q", node, clusterName, strings.TrimSpace(output))
+	}
+}
+
 // RestartNode models a complete node failure and recovery by restarting its
 // Docker container. The caller can use HealNode when it also needs a Ready
 // check after a network fault.
@@ -192,6 +250,22 @@ func runDocker(clusterName string, args ...string) error {
 	return runDockerAllow(clusterName, nil, args...)
 }
 
+func runDockerOutput(clusterName string, args ...string) (string, error) {
+	var output bytes.Buffer
+	cmd := exec.Command("docker", args...)
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Run(); err != nil {
+		details := strings.TrimSpace(output.String())
+		if details != "" {
+			return "", fmt.Errorf("cluster %q: docker %s failed: %w: %s", clusterName, strings.Join(args, " "), err, details)
+		}
+		return "", fmt.Errorf("cluster %q: docker %s failed: %w", clusterName, strings.Join(args, " "), err)
+	}
+
+	return strings.TrimSpace(output.String()), nil
+}
+
 func runDockerAllow(clusterName string, allowedErrors []string, args ...string) error {
 	var output bytes.Buffer
 	cmd := exec.Command("docker", args...)
@@ -222,6 +296,14 @@ func validateFaultTarget(clusterName, node string) error {
 	}
 
 	return nil
+}
+
+func singlePID(output string) (string, error) {
+	pids := strings.Fields(output)
+	if len(pids) != 1 {
+		return "", fmt.Errorf("expected one kube-vip process, found %d in %q", len(pids), strings.TrimSpace(output))
+	}
+	return pids[0], nil
 }
 
 func podManifestPaths(manifestName string) (string, string, error) {

--- a/testing/e2e/faults.go
+++ b/testing/e2e/faults.go
@@ -289,9 +289,19 @@ type dockerOutput func(clusterName string, args ...string) (string, error)
 
 func restoreKubelet(clusterName, node string, run dockerRun) error {
 	if err := run(clusterName, "exec", node, "systemctl", "start", "kubelet"); err != nil {
+		if dockerContainerMissing(err) {
+			return nil
+		}
 		return err
 	}
-	return run(clusterName, "exec", node, "systemctl", "is-active", "--quiet", "kubelet")
+	if err := run(clusterName, "exec", node, "systemctl", "is-active", "--quiet", "kubelet"); err != nil && !dockerContainerMissing(err) {
+		return err
+	}
+	return nil
+}
+
+func dockerContainerMissing(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "no such container")
 }
 
 func runDockerOutput(clusterName string, args ...string) (string, error) {

--- a/testing/e2e/faults.go
+++ b/testing/e2e/faults.go
@@ -107,25 +107,59 @@ func KillKubeVip(clusterName, node string, graceful bool) error {
 	return runDocker(clusterName, "exec", node, "pkill", signal, "kube-vip")
 }
 
-// KillAndStashKubeVip atomically removes the static-pod manifest and sends
-// SIGKILL to the process it identified. Removing the manifest first prevents
-// kubelet from restarting kube-vip before a failover can be observed.
-func KillAndStashKubeVip(clusterName, node, manifestName string) (string, error) {
-	src, dst, err := podManifestPaths(manifestName)
-	if err != nil {
-		return "", fmt.Errorf("kill and stash kube-vip on node %q in cluster %q: %w", node, clusterName, err)
-	}
+// KillAndSuppressKubeVip stops kubelet before sending SIGKILL to the single
+// kube-vip process. Kind bind-mounts the static-pod manifest from the host, so
+// moving that file inside the node fails with EBUSY. Stopping kubelet prevents
+// a restart without modifying the test-owned host mount source.
+func KillAndSuppressKubeVip(clusterName, node string) (string, error) {
 	if err := validateFaultTarget(clusterName, node); err != nil {
 		return "", err
 	}
 
-	script := fmt.Sprintf(`pid="$(pgrep -x kube-vip)" && set -- $pid && test "$#" -eq 1 && mv %s %s && { kill -KILL "$1" && printf '%%s' "$1" || { mv %s %s; exit 1; }; }`, src, dst, dst, src)
-	output, err := runDockerOutput(clusterName, "exec", node, "sh", "-c", script)
-	if err != nil {
+	return killAndSuppressKubeVip(clusterName, node, runDocker, runDockerOutput)
+}
+
+func killAndSuppressKubeVip(clusterName, node string, run dockerRun, output dockerOutput) (pid string, err error) {
+	restore := true
+	defer func() {
+		if !restore {
+			return
+		}
+		if restoreErr := restoreKubelet(clusterName, node, run); restoreErr != nil {
+			err = fmt.Errorf("%w; additionally failed to restore kubelet: %v", err, restoreErr)
+		}
+	}()
+	if err := run(clusterName, "exec", node, "systemctl", "stop", "kubelet"); err != nil {
 		return "", err
 	}
 
-	return singlePID(output)
+	if err := run(clusterName, "exec", node, "sh", "-c", "! systemctl is-active --quiet kubelet"); err != nil {
+		return "", fmt.Errorf("verify kubelet stopped on node %q: %w", node, err)
+	}
+	pids, err := output(clusterName, "exec", node, "pgrep", "-x", "kube-vip")
+	if err != nil {
+		return "", err
+	}
+	pid, err = singlePID(pids)
+	if err != nil {
+		return "", err
+	}
+	if err := run(clusterName, "exec", node, "kill", "-KILL", pid); err != nil {
+		return "", err
+	}
+
+	restore = false
+	return pid, nil
+}
+
+// RestoreKubeVip restarts kubelet after KillAndSuppressKubeVip and verifies
+// that static-pod reconciliation is active again.
+func RestoreKubeVip(clusterName, node string) error {
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return err
+	}
+
+	return restoreKubelet(clusterName, node, runDocker)
 }
 
 // KubeVipPID returns the PID of the single kube-vip process running in a Kind
@@ -248,6 +282,16 @@ func RestorePodManifest(clusterName, node, manifestName string) error {
 
 func runDocker(clusterName string, args ...string) error {
 	return runDockerAllow(clusterName, nil, args...)
+}
+
+type dockerRun func(clusterName string, args ...string) error
+type dockerOutput func(clusterName string, args ...string) (string, error)
+
+func restoreKubelet(clusterName, node string, run dockerRun) error {
+	if err := run(clusterName, "exec", node, "systemctl", "start", "kubelet"); err != nil {
+		return err
+	}
+	return run(clusterName, "exec", node, "systemctl", "is-active", "--quiet", "kubelet")
 }
 
 func runDockerOutput(clusterName string, args ...string) (string, error) {

--- a/testing/e2e/faults.go
+++ b/testing/e2e/faults.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	kindcluster "sigs.k8s.io/kind/pkg/cluster"
@@ -33,7 +34,7 @@ func PartitionNode(clusterName, node string) error {
 		return err
 	}
 
-	return runDocker(clusterName, "network", "disconnect", kindNetworkName, node)
+	return runDockerAllow(clusterName, []string{"is not connected"}, "network", "disconnect", kindNetworkName, node)
 }
 
 // HealNode models recovery from a node-level network partition by reconnecting
@@ -44,7 +45,7 @@ func HealNode(clusterName, node string) error {
 		return err
 	}
 
-	if err := runDocker(clusterName, "network", "connect", kindNetworkName, node); err != nil {
+	if err := runDockerAllow(clusterName, []string{"already exists"}, "network", "connect", kindNetworkName, node); err != nil {
 		return err
 	}
 
@@ -72,8 +73,8 @@ func BlackholeAPIServer(clusterName, node string) error {
 		return err
 	}
 
-	return runDocker(clusterName,
-		"exec", node, "iptables", "-I", "OUTPUT", "-p", "tcp", "--dport", "6443", "-j", "DROP",
+	return runDocker(clusterName, "exec", node, "sh", "-c",
+		"iptables -C OUTPUT -p tcp --dport 6443 -j DROP || iptables -I OUTPUT -p tcp --dport 6443 -j DROP",
 	)
 }
 
@@ -85,8 +86,8 @@ func RestoreAPIServer(clusterName, node string) error {
 		return err
 	}
 
-	return runDocker(clusterName,
-		"exec", node, "iptables", "-D", "OUTPUT", "-p", "tcp", "--dport", "6443", "-j", "DROP",
+	return runDocker(clusterName, "exec", node, "sh", "-c",
+		"while iptables -C OUTPUT -p tcp --dport 6443 -j DROP 2>/dev/null; do iptables -D OUTPUT -p tcp --dport 6443 -j DROP; done",
 	)
 }
 
@@ -123,7 +124,7 @@ func DeleteLease(ctx context.Context, client kubernetes.Interface, namespace, na
 	if client == nil {
 		return fmt.Errorf("delete lease %s/%s: client is nil", namespace, name)
 	}
-	if err := client.CoordinationV1().Leases(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+	if err := client.CoordinationV1().Leases(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("delete lease %s/%s: %w", namespace, name, err)
 	}
 
@@ -168,7 +169,8 @@ func StashPodManifest(clusterName, node, manifestName string) error {
 		return err
 	}
 
-	return runDocker(clusterName, "exec", node, "mv", src, dst)
+	return runDocker(clusterName, "exec", node, "sh", "-c",
+		fmt.Sprintf("if [ -e %s ]; then mv %s %s; elif [ ! -e %s ]; then exit 1; fi", src, src, dst, dst))
 }
 
 // RestorePodManifest models static-pod recovery by moving a stashed manifest
@@ -182,16 +184,26 @@ func RestorePodManifest(clusterName, node, manifestName string) error {
 		return err
 	}
 
-	return runDocker(clusterName, "exec", node, "mv", dst, src)
+	return runDocker(clusterName, "exec", node, "sh", "-c",
+		fmt.Sprintf("if [ -e %s ]; then mv %s %s; elif [ ! -e %s ]; then exit 1; fi", dst, dst, src, src))
 }
 
 func runDocker(clusterName string, args ...string) error {
+	return runDockerAllow(clusterName, nil, args...)
+}
+
+func runDockerAllow(clusterName string, allowedErrors []string, args ...string) error {
 	var output bytes.Buffer
 	cmd := exec.Command("docker", args...)
 	cmd.Stdout = &output
 	cmd.Stderr = &output
 	if err := cmd.Run(); err != nil {
 		details := strings.TrimSpace(output.String())
+		for _, allowed := range allowedErrors {
+			if strings.Contains(strings.ToLower(details), strings.ToLower(allowed)) {
+				return nil
+			}
+		}
 		if details != "" {
 			return fmt.Errorf("cluster %q: docker %s failed: %w: %s", clusterName, strings.Join(args, " "), err, details)
 		}

--- a/testing/e2e/faults_test.go
+++ b/testing/e2e/faults_test.go
@@ -3,10 +3,76 @@
 package e2e
 
 import (
+	"errors"
+	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 )
+
+func TestKillAndSuppressKubeVip(t *testing.T) {
+	tests := []struct {
+		name        string
+		failAt      int
+		pidOutput   string
+		wantPID     string
+		wantError   bool
+		wantRestore bool
+	}{
+		{name: "kills exact process after stopping kubelet", pidOutput: "123\n", wantPID: "123"},
+		{name: "restores after stop reports failure", failAt: 1, wantError: true, wantRestore: true},
+		{name: "restores after inactive check fails", failAt: 2, wantError: true, wantRestore: true},
+		{name: "restores after process lookup fails", failAt: 3, wantError: true, wantRestore: true},
+		{name: "restores when multiple processes exist", pidOutput: "123\n456\n", wantError: true, wantRestore: true},
+		{name: "restores after kill fails", failAt: 4, pidOutput: "123\n", wantError: true, wantRestore: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var calls [][]string
+			call := 0
+			run := func(_ string, args ...string) error {
+				call++
+				calls = append(calls, append([]string(nil), args...))
+				if call == test.failAt {
+					return errors.New("injected failure")
+				}
+				return nil
+			}
+			output := func(_ string, args ...string) (string, error) {
+				call++
+				calls = append(calls, append([]string(nil), args...))
+				if call == test.failAt {
+					return "", errors.New("injected failure")
+				}
+				return test.pidOutput, nil
+			}
+
+			pid, err := killAndSuppressKubeVip("cluster", "node", run, output)
+			if (err != nil) != test.wantError {
+				t.Fatalf("killAndSuppressKubeVip() error = %v, wantError %t", err, test.wantError)
+			}
+			if pid != test.wantPID {
+				t.Fatalf("killAndSuppressKubeVip() PID = %q, want %q", pid, test.wantPID)
+			}
+			if !reflect.DeepEqual(calls[0], []string{"exec", "node", "systemctl", "stop", "kubelet"}) {
+				t.Fatalf("first call = %v, want kubelet stop", calls[0])
+			}
+			restored := false
+			for _, got := range calls {
+				if reflect.DeepEqual(got, []string{"exec", "node", "systemctl", "start", "kubelet"}) {
+					restored = true
+				}
+			}
+			if restored != test.wantRestore {
+				t.Fatalf("kubelet restored = %t, want %t; calls: %v", restored, test.wantRestore, calls)
+			}
+			if !test.wantError && !reflect.DeepEqual(calls[len(calls)-1], []string{"exec", "node", "kill", "-KILL", "123"}) {
+				t.Fatalf("last call = %v, want exact PID kill", calls[len(calls)-1])
+			}
+		})
+	}
+}
 
 func TestSinglePID(t *testing.T) {
 	tests := []struct {

--- a/testing/e2e/faults_test.go
+++ b/testing/e2e/faults_test.go
@@ -8,6 +8,31 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+func TestSinglePID(t *testing.T) {
+	tests := []struct {
+		name      string
+		output    string
+		want      string
+		wantError bool
+	}{
+		{name: "one process", output: "123\n", want: "123"},
+		{name: "no process", wantError: true},
+		{name: "multiple processes", output: "123\n456\n", wantError: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := singlePID(test.output)
+			if (err != nil) != test.wantError {
+				t.Fatalf("singlePID() error = %v, wantError %t", err, test.wantError)
+			}
+			if got != test.want {
+				t.Fatalf("singlePID() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestPodManifestPaths(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/testing/e2e/faults_test.go
+++ b/testing/e2e/faults_test.go
@@ -99,6 +99,43 @@ func TestSinglePID(t *testing.T) {
 	}
 }
 
+func TestRestoreKubelet(t *testing.T) {
+	tests := []struct {
+		name      string
+		failAt    int
+		err       error
+		wantError bool
+		wantCalls int
+	}{
+		{name: "starts active kubelet", wantCalls: 2},
+		{name: "already deleted before start", failAt: 1, err: errors.New("docker exec: No such container: node"), wantCalls: 1},
+		{name: "deleted before active check", failAt: 2, err: errors.New("No such container: node"), wantCalls: 2},
+		{name: "start failure", failAt: 1, err: errors.New("injected failure"), wantError: true, wantCalls: 1},
+		{name: "inactive kubelet", failAt: 2, err: errors.New("inactive"), wantError: true, wantCalls: 2},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			calls := 0
+			run := func(_ string, _ ...string) error {
+				calls++
+				if calls == test.failAt {
+					return test.err
+				}
+				return nil
+			}
+
+			err := restoreKubelet("cluster", "node", run)
+			if (err != nil) != test.wantError {
+				t.Fatalf("restoreKubelet() error = %v, wantError %t", err, test.wantError)
+			}
+			if calls != test.wantCalls {
+				t.Fatalf("restoreKubelet() calls = %d, want %d", calls, test.wantCalls)
+			}
+		})
+	}
+}
+
 func TestPodManifestPaths(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/testing/e2e/faults_test.go
+++ b/testing/e2e/faults_test.go
@@ -1,0 +1,44 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestPodManifestPaths(t *testing.T) {
+	tests := []struct {
+		name      string
+		wantSrc   string
+		wantDst   string
+		wantError bool
+	}{
+		{name: "kube-apiserver.yaml", wantSrc: "/etc/kubernetes/manifests/kube-apiserver.yaml", wantDst: "/tmp/kube-apiserver.yaml"},
+		{name: "", wantError: true},
+		{name: "../manifest.yaml", wantError: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			src, dst, err := podManifestPaths(test.name)
+			if (err != nil) != test.wantError {
+				t.Fatalf("podManifestPaths() error = %v, wantError %t", err, test.wantError)
+			}
+			if src != test.wantSrc || dst != test.wantDst {
+				t.Fatalf("podManifestPaths() = (%q, %q), want (%q, %q)", src, dst, test.wantSrc, test.wantDst)
+			}
+		})
+	}
+}
+
+func TestNodeIsReady(t *testing.T) {
+	if nodeIsReady(&corev1.Node{}) {
+		t.Fatal("nodeIsReady() = true without a Ready condition")
+	}
+	node := &corev1.Node{Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}}}}
+	if !nodeIsReady(node) {
+		t.Fatal("nodeIsReady() = false for Ready=True")
+	}
+}

--- a/testing/e2e/kube-vip-bgp-annotations.yaml.tmpl
+++ b/testing/e2e/kube-vip-bgp-annotations.yaml.tmpl
@@ -12,7 +12,7 @@ spec:
     args:
     - manager
     - --prometheusHTTPServer
-    - ""
+    - "{{ .PrometheusHTTPServer }}"
     env:
     - name: vip_loglevel
       value: "-4"

--- a/testing/e2e/kube-vip-hostname.yaml.tmpl
+++ b/testing/e2e/kube-vip-hostname.yaml.tmpl
@@ -12,7 +12,7 @@ spec:
     args:
     - manager
     - --prometheusHTTPServer
-    - ""
+    - "{{ .PrometheusHTTPServer }}"
     env:
     - name: vip_arp
       value: "true"

--- a/testing/e2e/kube-vip-routing-table.yaml.tmpl
+++ b/testing/e2e/kube-vip-routing-table.yaml.tmpl
@@ -12,7 +12,7 @@ spec:
     args:
     - manager
     - --prometheusHTTPServer
-    - ""
+    - "{{ .PrometheusHTTPServer }}"
     env:
     - name: vip_loglevel
       value: "-4"

--- a/testing/e2e/kube-vip.yaml.tmpl
+++ b/testing/e2e/kube-vip.yaml.tmpl
@@ -12,7 +12,7 @@ spec:
     args:
     - manager
     - --prometheusHTTPServer
-    - ""
+    - "{{ .PrometheusHTTPServer }}"
     env:
     - name: vip_loglevel
       value: "-4"
@@ -20,8 +20,6 @@ spec:
     - name: lb_class_legacy_handling
       value: "false"
     - name: lb_class_name
-    - name: prometheus_server
-      value: :2112
     - name: disable_service_updates
       value: "false"
     - name: vip_arp

--- a/testing/e2e/metrics.go
+++ b/testing/e2e/metrics.go
@@ -51,14 +51,53 @@ func ScrapeMetrics(clusterName, nodeName string) (map[string]float64, error) {
 	return metrics, nil
 }
 
-// MetricValue returns a metric whose labels contain all requested labels.
-func MetricValue(metrics map[string]float64, name string, labels map[string]string) (float64, bool) {
+// MetricValue returns a metric whose labels contain all requested labels and
+// the number of matching series. When matches is greater than one, value is
+// the first matching series in sorted key order and must not be used as a
+// single-series value.
+func MetricValue(metrics map[string]float64, name string, labels map[string]string) (float64, int) {
+	values := matchingMetricValues(metrics, name, labels)
+	if len(values) == 0 {
+		return 0, 0
+	}
+	return values[0], len(values)
+}
+
+// SumMetric returns the sum of all series whose labels contain all requested
+// labels. It returns zero when no series matches.
+func SumMetric(metrics map[string]float64, name string, labels map[string]string) float64 {
+	var total float64
+	for _, value := range matchingMetricValues(metrics, name, labels) {
+		total += value
+	}
+	return total
+}
+
+// MaxMetric returns the maximum value among all series whose labels contain
+// all requested labels. The bool is false when no series matches.
+func MaxMetric(metrics map[string]float64, name string, labels map[string]string) (float64, bool) {
+	values := matchingMetricValues(metrics, name, labels)
+	if len(values) == 0 {
+		return 0, false
+	}
+
+	maximum := values[0]
+	for _, value := range values[1:] {
+		if value > maximum {
+			maximum = value
+		}
+	}
+	return maximum, true
+}
+
+func matchingMetricValues(metrics map[string]float64, name string, labels map[string]string) []float64 {
 	keys := make([]string, 0, len(metrics))
 	for key := range metrics {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 
+	values := make([]float64, 0)
 	for _, key := range keys {
 		metricName, metricLabels, ok := parseMetricKey(key)
 		if !ok || metricName != name {
@@ -67,28 +106,29 @@ func MetricValue(metrics map[string]float64, name string, labels map[string]stri
 
 		matches := true
 		for labelName, labelValue := range labels {
-			if metricLabels[labelName] != labelValue {
+			metricLabelValue, exists := metricLabels[labelName]
+			if !exists || metricLabelValue != labelValue {
 				matches = false
 				break
 			}
 		}
 		if matches {
-			return metrics[key], true
+			values = append(values, metrics[key])
 		}
 	}
 
-	return 0, false
+	return values
 }
 
 // CounterDelta returns the difference between two counter samples. Missing
 // samples are treated as unavailable rather than as a counter reset.
-func CounterDelta(before, after map[string]float64, name string, labels map[string]string) float64 {
-	beforeValue, beforeOK := MetricValue(before, name, labels)
-	afterValue, afterOK := MetricValue(after, name, labels)
-	if !beforeOK || !afterOK {
-		return 0
+func CounterDelta(before, after map[string]float64, name string, labels map[string]string) (float64, bool) {
+	beforeValue, beforeMatches := MetricValue(before, name, labels)
+	afterValue, afterMatches := MetricValue(after, name, labels)
+	if beforeMatches != 1 || afterMatches != 1 {
+		return 0, false
 	}
-	return afterValue - beforeValue
+	return afterValue - beforeValue, true
 }
 
 // EventuallyMetric retries a metric scrape until its value satisfies matcher.
@@ -99,31 +139,42 @@ func EventuallyMetric(clusterName, node, name string, labels map[string]string, 
 			return 0, err
 		}
 
-		value, ok := MetricValue(metrics, name, labels)
-		if !ok {
-			return 0, fmt.Errorf("metric %s with labels %v was not found", name, labels)
-		}
-		return value, nil
+		return singleMetricValue(metrics, name, labels)
 	}, timeout, interval).Should(matcher)
 }
 
-// MetricStable returns a metric value after confirming that it is unchanged
-// across samples separated by gap.
-func MetricStable(clusterName, node, name string, labels map[string]string, samples int, gap time.Duration) (float64, error) {
-	if samples < 1 {
-		return 0, fmt.Errorf("samples must be at least 1")
-	}
-
-	var stableValue float64
-	for sample := 0; sample < samples; sample++ {
+// ConsistentlyMetric repeatedly scrapes a metric while its value satisfies
+// matcher.
+func ConsistentlyMetric(clusterName, node, name string, labels map[string]string, matcher types.GomegaMatcher, timeout, interval time.Duration) {
+	Consistently(func() (float64, error) {
 		metrics, err := ScrapeMetrics(clusterName, node)
 		if err != nil {
 			return 0, err
 		}
 
-		value, ok := MetricValue(metrics, name, labels)
-		if !ok {
-			return 0, fmt.Errorf("metric %s with labels %v was not found", name, labels)
+		return singleMetricValue(metrics, name, labels)
+	}, timeout, interval).Should(matcher)
+}
+
+// MetricStable returns a metric value after confirming that it is unchanged
+// across samples separated by gap. The observed window is (samples-1)*gap
+// plus scrape latency. A single transient scrape error is retried once for
+// each sample.
+func MetricStable(clusterName, node, name string, labels map[string]string, samples int, gap time.Duration) (float64, error) {
+	if samples < 2 {
+		return 0, fmt.Errorf("samples must be at least 2")
+	}
+
+	var stableValue float64
+	for sample := 0; sample < samples; sample++ {
+		metrics, err := scrapeMetricsRetryOnce(clusterName, node)
+		if err != nil {
+			return 0, err
+		}
+
+		value, err := singleMetricValue(metrics, name, labels)
+		if err != nil {
+			return 0, err
 		}
 		if sample == 0 {
 			stableValue = value
@@ -137,6 +188,31 @@ func MetricStable(clusterName, node, name string, labels map[string]string, samp
 	}
 
 	return stableValue, nil
+}
+
+func singleMetricValue(metrics map[string]float64, name string, labels map[string]string) (float64, error) {
+	value, matches := MetricValue(metrics, name, labels)
+	switch matches {
+	case 0:
+		return 0, fmt.Errorf("metric %s with labels %v was not found", name, labels)
+	case 1:
+		return value, nil
+	default:
+		return 0, fmt.Errorf("metric %s with labels %v matched %d series", name, labels, matches)
+	}
+}
+
+func scrapeMetricsRetryOnce(clusterName, node string) (map[string]float64, error) {
+	metrics, err := ScrapeMetrics(clusterName, node)
+	if err == nil {
+		return metrics, nil
+	}
+
+	retryMetrics, retryErr := ScrapeMetrics(clusterName, node)
+	if retryErr == nil {
+		return retryMetrics, nil
+	}
+	return nil, fmt.Errorf("scrape metrics from %s failed: %v; retry failed: %w", node, err, retryErr)
 }
 
 func parseMetrics(payload string) (map[string]float64, error) {

--- a/testing/e2e/metrics.go
+++ b/testing/e2e/metrics.go
@@ -1,0 +1,393 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+)
+
+// ScrapeMetrics gets and parses the Prometheus metrics exposed by kube-vip in
+// a Kind node. nodeName may be either a Kind node suffix or its full container
+// name.
+func ScrapeMetrics(clusterName, nodeName string) (map[string]float64, error) {
+	if clusterName == "" {
+		return nil, fmt.Errorf("cluster name is empty")
+	}
+	if nodeName == "" {
+		return nil, fmt.Errorf("node name is empty")
+	}
+
+	containerName := nodeName
+	if !strings.HasPrefix(nodeName, clusterName+"-") {
+		containerName = fmt.Sprintf("%s-%s", clusterName, nodeName)
+	}
+
+	cmd := exec.Command("docker", "exec", containerName, "curl", "-fsS", "http://127.0.0.1:2112/metrics")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	payload, err := cmd.Output()
+	if err != nil {
+		if detail := strings.TrimSpace(stderr.String()); detail != "" {
+			return nil, fmt.Errorf("scrape metrics from %s: %w: %s", containerName, err, detail)
+		}
+		return nil, fmt.Errorf("scrape metrics from %s: %w", containerName, err)
+	}
+
+	metrics, err := parseMetrics(string(payload))
+	if err != nil {
+		return nil, fmt.Errorf("parse metrics from %s: %w", containerName, err)
+	}
+	return metrics, nil
+}
+
+// MetricValue returns a metric whose labels contain all requested labels.
+func MetricValue(metrics map[string]float64, name string, labels map[string]string) (float64, bool) {
+	keys := make([]string, 0, len(metrics))
+	for key := range metrics {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		metricName, metricLabels, ok := parseMetricKey(key)
+		if !ok || metricName != name {
+			continue
+		}
+
+		matches := true
+		for labelName, labelValue := range labels {
+			if metricLabels[labelName] != labelValue {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return metrics[key], true
+		}
+	}
+
+	return 0, false
+}
+
+// CounterDelta returns the difference between two counter samples. Missing
+// samples are treated as unavailable rather than as a counter reset.
+func CounterDelta(before, after map[string]float64, name string, labels map[string]string) float64 {
+	beforeValue, beforeOK := MetricValue(before, name, labels)
+	afterValue, afterOK := MetricValue(after, name, labels)
+	if !beforeOK || !afterOK {
+		return 0
+	}
+	return afterValue - beforeValue
+}
+
+// EventuallyMetric retries a metric scrape until its value satisfies matcher.
+func EventuallyMetric(clusterName, node, name string, labels map[string]string, matcher types.GomegaMatcher, timeout, interval time.Duration) {
+	Eventually(func() (float64, error) {
+		metrics, err := ScrapeMetrics(clusterName, node)
+		if err != nil {
+			return 0, err
+		}
+
+		value, ok := MetricValue(metrics, name, labels)
+		if !ok {
+			return 0, fmt.Errorf("metric %s with labels %v was not found", name, labels)
+		}
+		return value, nil
+	}, timeout, interval).Should(matcher)
+}
+
+// MetricStable returns a metric value after confirming that it is unchanged
+// across samples separated by gap.
+func MetricStable(clusterName, node, name string, labels map[string]string, samples int, gap time.Duration) (float64, error) {
+	if samples < 1 {
+		return 0, fmt.Errorf("samples must be at least 1")
+	}
+
+	var stableValue float64
+	for sample := 0; sample < samples; sample++ {
+		metrics, err := ScrapeMetrics(clusterName, node)
+		if err != nil {
+			return 0, err
+		}
+
+		value, ok := MetricValue(metrics, name, labels)
+		if !ok {
+			return 0, fmt.Errorf("metric %s with labels %v was not found", name, labels)
+		}
+		if sample == 0 {
+			stableValue = value
+		} else if value != stableValue {
+			return 0, fmt.Errorf("metric %s with labels %v changed from %v to %v", name, labels, stableValue, value)
+		}
+
+		if sample+1 < samples {
+			time.Sleep(gap)
+		}
+	}
+
+	return stableValue, nil
+}
+
+func parseMetrics(payload string) (map[string]float64, error) {
+	metrics := make(map[string]float64)
+	scanner := bufio.NewScanner(strings.NewReader(payload))
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		name, labels, value, err := parseMetricSample(line)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", lineNumber, err)
+		}
+		key := canonicalMetricKey(name, labels)
+		if _, exists := metrics[key]; exists {
+			return nil, fmt.Errorf("line %d: duplicate sample %s", lineNumber, key)
+		}
+		metrics[key] = value
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan payload: %w", err)
+	}
+
+	return metrics, nil
+}
+
+func parseMetricSample(line string) (string, map[string]string, float64, error) {
+	nameEnd := 0
+	for nameEnd < len(line) && isMetricNameChar(line[nameEnd], nameEnd == 0) {
+		nameEnd++
+	}
+	if nameEnd == 0 {
+		return "", nil, 0, fmt.Errorf("invalid metric name")
+	}
+
+	name := line[:nameEnd]
+	position := nameEnd
+	labels := map[string]string{}
+	if position < len(line) && line[position] == '{' {
+		labelEnd, err := closingBrace(line, position+1)
+		if err != nil {
+			return "", nil, 0, err
+		}
+		labels, err = parseLabelSet(line[position+1 : labelEnd])
+		if err != nil {
+			return "", nil, 0, err
+		}
+		position = labelEnd + 1
+	}
+
+	if position >= len(line) || !isWhitespace(line[position]) {
+		return "", nil, 0, fmt.Errorf("metric %s is missing a value", name)
+	}
+	for position < len(line) && isWhitespace(line[position]) {
+		position++
+	}
+	valueStart := position
+	for position < len(line) && !isWhitespace(line[position]) {
+		position++
+	}
+	if valueStart == position {
+		return "", nil, 0, fmt.Errorf("metric %s is missing a value", name)
+	}
+
+	value, err := strconv.ParseFloat(line[valueStart:position], 64)
+	if err != nil {
+		return "", nil, 0, fmt.Errorf("invalid value for metric %s: %w", name, err)
+	}
+	return name, labels, value, nil
+}
+
+func parseMetricKey(key string) (string, map[string]string, bool) {
+	brace := strings.IndexByte(key, '{')
+	if brace < 0 {
+		if !validMetricName(key) {
+			return "", nil, false
+		}
+		return key, map[string]string{}, true
+	}
+	if !strings.HasSuffix(key, "}") || brace == 0 {
+		return "", nil, false
+	}
+
+	name := key[:brace]
+	if !validMetricName(name) {
+		return "", nil, false
+	}
+	labels, err := parseLabelSet(key[brace+1 : len(key)-1])
+	if err != nil {
+		return "", nil, false
+	}
+	return name, labels, true
+}
+
+func canonicalMetricKey(name string, labels map[string]string) string {
+	if len(labels) == 0 {
+		return name
+	}
+
+	labelNames := make([]string, 0, len(labels))
+	for labelName := range labels {
+		labelNames = append(labelNames, labelName)
+	}
+	sort.Strings(labelNames)
+
+	var builder strings.Builder
+	builder.WriteString(name)
+	builder.WriteByte('{')
+	for index, labelName := range labelNames {
+		if index > 0 {
+			builder.WriteByte(',')
+		}
+		builder.WriteString(labelName)
+		builder.WriteByte('=')
+		builder.WriteString(strconv.Quote(labels[labelName]))
+	}
+	builder.WriteByte('}')
+	return builder.String()
+}
+
+func closingBrace(line string, start int) (int, error) {
+	inQuotes := false
+	escaped := false
+	for position := start; position < len(line); position++ {
+		character := line[position]
+		if inQuotes {
+			if escaped {
+				escaped = false
+			} else if character == '\\' {
+				escaped = true
+			} else if character == '"' {
+				inQuotes = false
+			}
+			continue
+		}
+
+		switch character {
+		case '"':
+			inQuotes = true
+		case '}':
+			return position, nil
+		}
+	}
+	return 0, fmt.Errorf("unterminated label set")
+}
+
+func parseLabelSet(labelSet string) (map[string]string, error) {
+	labels := make(map[string]string)
+	position := 0
+	for {
+		for position < len(labelSet) && isWhitespace(labelSet[position]) {
+			position++
+		}
+		if position == len(labelSet) {
+			return labels, nil
+		}
+
+		labelStart := position
+		for position < len(labelSet) && isMetricNameChar(labelSet[position], position == labelStart) {
+			position++
+		}
+		if labelStart == position {
+			return nil, fmt.Errorf("invalid label name")
+		}
+		labelName := labelSet[labelStart:position]
+
+		for position < len(labelSet) && isWhitespace(labelSet[position]) {
+			position++
+		}
+		if position == len(labelSet) || labelSet[position] != '=' {
+			return nil, fmt.Errorf("label %s is missing an equals sign", labelName)
+		}
+		position++
+		for position < len(labelSet) && isWhitespace(labelSet[position]) {
+			position++
+		}
+		if position == len(labelSet) || labelSet[position] != '"' {
+			return nil, fmt.Errorf("label %s is missing a quoted value", labelName)
+		}
+
+		valueStart := position
+		position++
+		escaped := false
+		closed := false
+		for position < len(labelSet) {
+			character := labelSet[position]
+			position++
+			if escaped {
+				escaped = false
+				continue
+			}
+			if character == '\\' {
+				escaped = true
+				continue
+			}
+			if character == '"' {
+				closed = true
+				break
+			}
+		}
+		if !closed {
+			return nil, fmt.Errorf("label %s has an unterminated value", labelName)
+		}
+
+		value, err := strconv.Unquote(labelSet[valueStart:position])
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for label %s: %w", labelName, err)
+		}
+		if _, exists := labels[labelName]; exists {
+			return nil, fmt.Errorf("duplicate label %s", labelName)
+		}
+		labels[labelName] = value
+
+		for position < len(labelSet) && isWhitespace(labelSet[position]) {
+			position++
+		}
+		if position == len(labelSet) {
+			return labels, nil
+		}
+		if labelSet[position] != ',' {
+			return nil, fmt.Errorf("expected comma after label %s", labelName)
+		}
+		position++
+	}
+}
+
+func validMetricName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for position := range name {
+		if !isMetricNameChar(name[position], position == 0) {
+			return false
+		}
+	}
+	return true
+}
+
+func isMetricNameChar(character byte, first bool) bool {
+	if character == '_' || character == ':' || character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' {
+		return true
+	}
+	return !first && character >= '0' && character <= '9'
+}
+
+func isWhitespace(character byte) bool {
+	return character == ' ' || character == '\t'
+}

--- a/testing/e2e/metrics.go
+++ b/testing/e2e/metrics.go
@@ -4,8 +4,8 @@
 package e2e
 
 import (
-	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 	"sort"
@@ -15,12 +15,15 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 )
 
 // ScrapeMetrics gets and parses the Prometheus metrics exposed by kube-vip in
 // a Kind node. nodeName may be either a Kind node suffix or its full container
 // name.
-func ScrapeMetrics(clusterName, nodeName string) (map[string]float64, error) {
+func ScrapeMetrics(ctx context.Context, clusterName, nodeName string) (map[string]float64, error) {
 	if clusterName == "" {
 		return nil, fmt.Errorf("cluster name is empty")
 	}
@@ -33,7 +36,7 @@ func ScrapeMetrics(clusterName, nodeName string) (map[string]float64, error) {
 		containerName = fmt.Sprintf("%s-%s", clusterName, nodeName)
 	}
 
-	cmd := exec.Command("docker", "exec", containerName, "curl", "-fsS", "http://127.0.0.1:2112/metrics")
+	cmd := exec.CommandContext(ctx, "docker", "exec", containerName, "curl", "-fsS", "http://127.0.0.1:2112/metrics")
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	payload, err := cmd.Output()
@@ -132,9 +135,9 @@ func CounterDelta(before, after map[string]float64, name string, labels map[stri
 }
 
 // EventuallyMetric retries a metric scrape until its value satisfies matcher.
-func EventuallyMetric(clusterName, node, name string, labels map[string]string, matcher types.GomegaMatcher, timeout, interval time.Duration) {
+func EventuallyMetric(ctx context.Context, clusterName, node, name string, labels map[string]string, matcher types.GomegaMatcher, timeout, interval time.Duration) {
 	Eventually(func() (float64, error) {
-		metrics, err := ScrapeMetrics(clusterName, node)
+		metrics, err := ScrapeMetrics(ctx, clusterName, node)
 		if err != nil {
 			return 0, err
 		}
@@ -145,9 +148,9 @@ func EventuallyMetric(clusterName, node, name string, labels map[string]string, 
 
 // ConsistentlyMetric repeatedly scrapes a metric while its value satisfies
 // matcher.
-func ConsistentlyMetric(clusterName, node, name string, labels map[string]string, matcher types.GomegaMatcher, timeout, interval time.Duration) {
+func ConsistentlyMetric(ctx context.Context, clusterName, node, name string, labels map[string]string, matcher types.GomegaMatcher, timeout, interval time.Duration) {
 	Consistently(func() (float64, error) {
-		metrics, err := ScrapeMetrics(clusterName, node)
+		metrics, err := ScrapeMetrics(ctx, clusterName, node)
 		if err != nil {
 			return 0, err
 		}
@@ -160,14 +163,14 @@ func ConsistentlyMetric(clusterName, node, name string, labels map[string]string
 // across samples separated by gap. The observed window is (samples-1)*gap
 // plus scrape latency. A single transient scrape error is retried once for
 // each sample.
-func MetricStable(clusterName, node, name string, labels map[string]string, samples int, gap time.Duration) (float64, error) {
+func MetricStable(ctx context.Context, clusterName, node, name string, labels map[string]string, samples int, gap time.Duration) (float64, error) {
 	if samples < 2 {
 		return 0, fmt.Errorf("samples must be at least 2")
 	}
 
 	var stableValue float64
 	for sample := 0; sample < samples; sample++ {
-		metrics, err := scrapeMetricsRetryOnce(clusterName, node)
+		metrics, err := scrapeMetricsRetryOnce(ctx, clusterName, node)
 		if err != nil {
 			return 0, err
 		}
@@ -183,7 +186,11 @@ func MetricStable(clusterName, node, name string, labels map[string]string, samp
 		}
 
 		if sample+1 < samples {
-			time.Sleep(gap)
+			select {
+			case <-ctx.Done():
+				return 0, ctx.Err()
+			case <-time.After(gap):
+			}
 		}
 	}
 
@@ -202,13 +209,13 @@ func singleMetricValue(metrics map[string]float64, name string, labels map[strin
 	}
 }
 
-func scrapeMetricsRetryOnce(clusterName, node string) (map[string]float64, error) {
-	metrics, err := ScrapeMetrics(clusterName, node)
+func scrapeMetricsRetryOnce(ctx context.Context, clusterName, node string) (map[string]float64, error) {
+	metrics, err := ScrapeMetrics(ctx, clusterName, node)
 	if err == nil {
 		return metrics, nil
 	}
 
-	retryMetrics, retryErr := ScrapeMetrics(clusterName, node)
+	retryMetrics, retryErr := ScrapeMetrics(ctx, clusterName, node)
 	if retryErr == nil {
 		return retryMetrics, nil
 	}
@@ -216,78 +223,38 @@ func scrapeMetricsRetryOnce(clusterName, node string) (map[string]float64, error
 }
 
 func parseMetrics(payload string) (map[string]float64, error) {
+	parser := expfmt.NewTextParser(model.LegacyValidation)
+	families, err := parser.TextToMetricFamilies(strings.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("parse Prometheus text: %w", err)
+	}
+
+	familyList := make([]*dto.MetricFamily, 0, len(families))
+	for _, family := range families {
+		familyList = append(familyList, family)
+	}
+	samples, err := expfmt.ExtractSamples(&expfmt.DecodeOptions{}, familyList...)
+	if err != nil {
+		return nil, fmt.Errorf("extract Prometheus samples: %w", err)
+	}
+
 	metrics := make(map[string]float64)
-	scanner := bufio.NewScanner(strings.NewReader(payload))
-	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-
-	lineNumber := 0
-	for scanner.Scan() {
-		lineNumber++
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-
-		name, labels, value, err := parseMetricSample(line)
-		if err != nil {
-			return nil, fmt.Errorf("line %d: %w", lineNumber, err)
+	for _, sample := range samples {
+		name := string(sample.Metric[model.MetricNameLabel])
+		labels := make(map[string]string, len(sample.Metric)-1)
+		for label, value := range sample.Metric {
+			if label != model.MetricNameLabel {
+				labels[string(label)] = string(value)
+			}
 		}
 		key := canonicalMetricKey(name, labels)
 		if _, exists := metrics[key]; exists {
-			return nil, fmt.Errorf("line %d: duplicate sample %s", lineNumber, key)
+			return nil, fmt.Errorf("duplicate sample %s", key)
 		}
-		metrics[key] = value
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scan payload: %w", err)
+		metrics[key] = float64(sample.Value)
 	}
 
 	return metrics, nil
-}
-
-func parseMetricSample(line string) (string, map[string]string, float64, error) {
-	nameEnd := 0
-	for nameEnd < len(line) && isMetricNameChar(line[nameEnd], nameEnd == 0) {
-		nameEnd++
-	}
-	if nameEnd == 0 {
-		return "", nil, 0, fmt.Errorf("invalid metric name")
-	}
-
-	name := line[:nameEnd]
-	position := nameEnd
-	labels := map[string]string{}
-	if position < len(line) && line[position] == '{' {
-		labelEnd, err := closingBrace(line, position+1)
-		if err != nil {
-			return "", nil, 0, err
-		}
-		labels, err = parseLabelSet(line[position+1 : labelEnd])
-		if err != nil {
-			return "", nil, 0, err
-		}
-		position = labelEnd + 1
-	}
-
-	if position >= len(line) || !isWhitespace(line[position]) {
-		return "", nil, 0, fmt.Errorf("metric %s is missing a value", name)
-	}
-	for position < len(line) && isWhitespace(line[position]) {
-		position++
-	}
-	valueStart := position
-	for position < len(line) && !isWhitespace(line[position]) {
-		position++
-	}
-	if valueStart == position {
-		return "", nil, 0, fmt.Errorf("metric %s is missing a value", name)
-	}
-
-	value, err := strconv.ParseFloat(line[valueStart:position], 64)
-	if err != nil {
-		return "", nil, 0, fmt.Errorf("invalid value for metric %s: %w", name, err)
-	}
-	return name, labels, value, nil
 }
 
 func parseMetricKey(key string) (string, map[string]string, bool) {
@@ -337,32 +304,6 @@ func canonicalMetricKey(name string, labels map[string]string) string {
 	}
 	builder.WriteByte('}')
 	return builder.String()
-}
-
-func closingBrace(line string, start int) (int, error) {
-	inQuotes := false
-	escaped := false
-	for position := start; position < len(line); position++ {
-		character := line[position]
-		if inQuotes {
-			if escaped {
-				escaped = false
-			} else if character == '\\' {
-				escaped = true
-			} else if character == '"' {
-				inQuotes = false
-			}
-			continue
-		}
-
-		switch character {
-		case '"':
-			inQuotes = true
-		case '}':
-			return position, nil
-		}
-	}
-	return 0, fmt.Errorf("unterminated label set")
 }
 
 func parseLabelSet(labelSet string) (map[string]string, error) {

--- a/testing/e2e/template.go
+++ b/testing/e2e/template.go
@@ -32,6 +32,7 @@ type KubevipManifestValues struct {
 	ControlPlaneHealthCheckCAPath           string
 	EnableServiceSecurity                   string
 	PerServiceElectionOnDemand              string
+	PrometheusHTTPServer                    string
 }
 
 type BGPPeerValues struct {

--- a/testing/e2e/testdata/metrics.prom
+++ b/testing/e2e/testdata/metrics.prom
@@ -1,0 +1,12 @@
+# HELP kube_vip_is_leader Whether this process holds a lease.
+# TYPE kube_vip_is_leader gauge
+kube_vip_is_leader{lease_name="plndr-cp-lock",node="control-plane"} 1
+kube_vip_is_leader{node="control-plane2",lease_name="plndr-cp-lock"} 0
+# HELP kube_vip_election_errors_total Election errors.
+# TYPE kube_vip_election_errors_total counter
+kube_vip_election_errors_total{reason="api\nserver",node="control-plane"} 3
+# TYPE kube_vip_reconcile_seconds histogram
+kube_vip_reconcile_seconds_bucket{le="0.1"} 2
+kube_vip_reconcile_seconds_bucket{le="+Inf"} 4
+kube_vip_reconcile_seconds_sum 0.5
+kube_vip_reconcile_seconds_count 4


### PR DESCRIPTION
## Purpose

Add nightly control-plane election and VIP failover fault coverage.

## Key changes

- Exercises API blackholes, kube-vip process termination, lease deletion or theft, and node restart in ARP and routing-table modes.
- Uses settle-based assertions and remains functional when optional metrics are unavailable.
- Adds the dedicated `faults` label and Make target.

## Validation

E2E-tagged compilation, formatting, vet, and current CI checks pass.

## Stack/Merge order

Merge upstream #1753, then #1754, then this PR. Afterward, `test/pr10-faults-svc`, `test/pr11-matrix` (then `test/pr14d-metric-assertions`), and `test/pr13-scale` can merge; merge `ci/pr12-nightly-wiring` last.

This PR intentionally targets `main` while containing parent stack commits from upstream #1753 and #1754; those parent commits will disappear from this PR diff as the parents merge into `main`.