### PR TITLE
test(e2e): pairwise combination matrix generator and conformance spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ TARGETOS=linux
 LDFLAGS=-ldflags "-s -w -X=main.Version=$(VERSION) -X=main.Build=$(BUILD) -extldflags -static"
 DOCKERTAG ?= $(VERSION)
 REPOSITORY ?= docker.io/plndr
-GO_VERSION := $(word 2,$(shell grep '^go ' go.mod))
+GO_VERSION := 1.26.6
 K8S_VERSION ?= v1.35.0
 GINKGO_ARGS ?=
 GINKGO_PROCS ?=
@@ -24,7 +24,7 @@ GINKGO_PARALLEL := $(if $(GINKGO_PROCS),--procs=$(GINKGO_PROCS),-p)
 TEST_MODE ?= arp
 BUILDX_CACHE_FLAGS ?=
 
-.PHONY: all build clean install uninstall simplify check run e2e-tests e2e-tests-faults unit-tests integration-tests unit-tests-docker integration-tests-docker e2e-tests-etcd
+.PHONY: all build clean install uninstall simplify check run e2e-tests e2e-tests-faults e2e-tests-matrix unit-tests integration-tests unit-tests-docker integration-tests-docker
 
 all: check install
 
@@ -134,7 +134,7 @@ manifest-test:
 	docker run $(REPOSITORY)/$(TARGET):$(DOCKERTAG) manifest daemonset --interface eth0 --vip 192.168.0.1 --image "$(REPOSITORY)/$(TARGET):$(DOCKERTAG)" --bgp --leaderElection --controlplane --services --inCluster
 
 unit-tests:
-	go test -race -coverprofile=coverage.out -covermode=atomic ./...
+	go test -race ./...
 
 unit-tests-docker:
 	docker run --rm -w /kube-vip -v $$(pwd):/kube-vip -v kube-vip-gomod-cache:/go/pkg/mod -v kube-vip-gobuild-cache:/root/.cache/go-build golang:$(GO_VERSION) sh -c "make unit-tests; status=$$?; chmod 666 coverage.out 2>/dev/null || true; exit $$status"
@@ -143,20 +143,20 @@ integration-tests:
 	go test -tags=integration,e2e -v ./pkg/etcd
 
 e2e-tests-arp: get-whoami
-	GOMAXPROCS=4 TEST_MODE=arp K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) --label-filter='!faults && !scale' ./testing/e2e
+	GOMAXPROCS=4 TEST_MODE=arp K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) --label-filter='!faults && !scale && !matrix' ./testing/e2e
 
 e2e-tests-rt: get-whoami
-	GOMAXPROCS=4 TEST_MODE=rt K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) --label-filter='!faults && !scale' ./testing/e2e
+	GOMAXPROCS=4 TEST_MODE=rt K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) --label-filter='!faults && !scale && !matrix' ./testing/e2e
 
 e2e-tests-bgp: get-whoami get-gobgp
-	GOMAXPROCS=4 TEST_MODE=bgp K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) --label-filter='!faults && !scale' ./testing/e2e
+	GOMAXPROCS=4 TEST_MODE=bgp K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) --label-filter='!faults && !scale && !matrix' ./testing/e2e
 
 e2e-tests-faults: get-whoami
 	@test "$(TEST_MODE)" = "arp" -o "$(TEST_MODE)" = "rt" || (echo "fault tests support TEST_MODE=arp or TEST_MODE=rt; BGP is not implemented" >&2; exit 1)
 	GOMAXPROCS=4 TEST_MODE=$(TEST_MODE) K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) --label-filter=faults ./testing/e2e
 
-e2e-tests-etcd: get-whoami
-	GOMAXPROCS=4 K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) ./testing/e2e/etcd
+e2e-tests-matrix: get-whoami get-gobgp
+	GOMAXPROCS=4 TEST_MODE=matrix K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) --label-filter=matrix ./testing/e2e
 
 e2e-tests: e2e-tests-arp e2e-tests-rt e2e-tests-bgp
 

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,10 @@ K8S_VERSION ?= v1.35.0
 GINKGO_ARGS ?=
 GINKGO_PROCS ?=
 GINKGO_PARALLEL := $(if $(GINKGO_PROCS),--procs=$(GINKGO_PROCS),-p)
+TEST_MODE ?= arp
 BUILDX_CACHE_FLAGS ?=
 
-.PHONY: all build clean install uninstall simplify check run e2e-tests unit-tests integration-tests unit-tests-docker integration-tests-docker e2e-tests-etcd
+.PHONY: all build clean install uninstall simplify check run e2e-tests e2e-tests-faults unit-tests integration-tests unit-tests-docker integration-tests-docker e2e-tests-etcd
 
 all: check install
 
@@ -142,13 +143,16 @@ integration-tests:
 	go test -tags=integration,e2e -v ./pkg/etcd
 
 e2e-tests-arp: get-whoami
-	GOMAXPROCS=4 TEST_MODE=arp K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) ./testing/e2e
+	GOMAXPROCS=4 TEST_MODE=arp K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) --label-filter='!faults && !scale' ./testing/e2e
 
 e2e-tests-rt: get-whoami
-	GOMAXPROCS=4 TEST_MODE=rt K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) ./testing/e2e
+	GOMAXPROCS=4 TEST_MODE=rt K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) --label-filter='!faults && !scale' ./testing/e2e
 
 e2e-tests-bgp: get-whoami get-gobgp
-	GOMAXPROCS=4 TEST_MODE=bgp K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) ./testing/e2e
+	GOMAXPROCS=4 TEST_MODE=bgp K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) --label-filter='!faults && !scale' ./testing/e2e
+
+e2e-tests-faults: get-whoami
+	GOMAXPROCS=4 TEST_MODE=$(TEST_MODE) K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) --label-filter=faults ./testing/e2e
 
 e2e-tests-etcd: get-whoami
 	GOMAXPROCS=4 K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) ./testing/e2e/etcd

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,7 @@ e2e-tests-bgp: get-whoami get-gobgp
 	GOMAXPROCS=4 TEST_MODE=bgp K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) --label-filter='!faults && !scale' ./testing/e2e
 
 e2e-tests-faults: get-whoami
+	@test "$(TEST_MODE)" = "arp" -o "$(TEST_MODE)" = "rt" || (echo "fault tests support TEST_MODE=arp or TEST_MODE=rt; BGP is not implemented" >&2; exit 1)
 	GOMAXPROCS=4 TEST_MODE=$(TEST_MODE) K8S_IMAGE_PATH=kindest/node:$(K8S_VERSION) E2E_IMAGE_PATH=$(REPOSITORY)/$(TARGET):$(DOCKERTAG) go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -v $(GINKGO_PARALLEL) $(GINKGO_ARGS) --label-filter=faults ./testing/e2e
 
 e2e-tests-etcd: get-whoami

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	k8s.io/apimachinery v0.36.4
 	k8s.io/client-go v0.36.4
 	k8s.io/klog/v2 v2.140.0
+	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/kind v0.33.0
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -147,7 +148,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,8 @@ require (
 	github.com/osrg/gobgp/v4 v4.9.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.24.1
+	github.com/prometheus/client_model v0.6.2
+	github.com/prometheus/common v0.70.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.12.1
 	github.com/vishvananda/netlink v1.3.1
@@ -107,8 +109,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
 	github.com/segmentio/fasthash v1.0.3 // indirect

--- a/pkg/cluster/clusterLeaderElection.go
+++ b/pkg/cluster/clusterLeaderElection.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/election"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
+	"github.com/kube-vip/kube-vip/pkg/metrics"
 	"github.com/kube-vip/kube-vip/pkg/utils"
 
 	log "log/slog"
@@ -105,11 +106,14 @@ func (cluster *Cluster) StartCluster(ctx context.Context, c *kubevip.Config,
 		LeaseAnnotations: c.LeaseAnnotations,
 		Mgr:              em,
 		OnStartedLeading: func(context.Context) { //nolint TODO: potential clean code
+			metrics.LeaderTransitionsTotal.WithLabelValues(leaseID.Name()).Inc()
+			metrics.IsLeader.WithLabelValues(c.NodeName, leaseID.Name()).Set(1)
 			cluster.OnStartedLeading(c, objLease, em, bgpServer, killFunc, false)
 		},
 		OnStoppedLeading: func() {
 			objLease.Elected.Store(false)
 			cluster.OnStoppedLeading(c, objLease, bgpServer)
+			metrics.IsLeader.WithLabelValues(c.NodeName, leaseID.Name()).Set(0)
 		},
 		OnNewLeader: func(identity string) {
 			cluster.OnNewLeader(identity, c)

--- a/pkg/lease/lease.go
+++ b/pkg/lease/lease.go
@@ -136,6 +136,12 @@ func (l *Lease) Add(name string) bool {
 	return false
 }
 
+// Has reports whether an object is a member of the lease.
+func (l *Lease) Has(name string) bool {
+	_, exists := l.services.Load(name)
+	return exists
+}
+
 // delete removes the service from the lease and decrements the counter
 func (l *Lease) delete(service string) {
 	if _, exists := l.services.Load(service); exists {

--- a/pkg/manager/watch_annotations.go
+++ b/pkg/manager/watch_annotations.go
@@ -209,11 +209,21 @@ func parseBgpAnnotations(bgpConfig kubevip.BGPConfig, node *v1.Node, prefix stri
 	bgpConfig.Peers = make([]kubevip.BGPPeer, 0, len(peerIPs))
 	regexPass := regexp.MustCompile(fmt.Sprintf("^%s/(bgp-peers-0-)?bgp-pass$", prefix))
 	regexMultiHop := regexp.MustCompile(fmt.Sprintf("^%s/(bgp-peers-0-)?peer-multi-hop$", prefix))
+	regexPort := regexp.MustCompile(fmt.Sprintf("^%s/(bgp-peers-0-)?peer-port$", prefix))
 	for _, peerIP := range peerIPs {
 		ipAddr := strings.TrimSpace(peerIP)
 
 		if ipAddr != "" {
 			bgpPeer.Address = ipAddr
+			for k, v := range node.Annotations {
+				if regexPort.MatchString(k) {
+					port, err := strconv.ParseUint(v, 10, 16)
+					if err != nil || port == 0 {
+						return bgpConfig, bgpPeer, fmt.Errorf("invalid %q annotation value: %q", k, v)
+					}
+					bgpPeer.Port = uint16(port)
+				}
+			}
 			// Check if we're also expecting a password for this peer
 			base64BGPPassword := ""
 			for k, v := range node.Annotations {

--- a/pkg/manager/watcher_test.go
+++ b/pkg/manager/watcher_test.go
@@ -29,6 +29,7 @@ func TestParseBgpAnnotations(t *testing.T) {
 		"bgp/peer-asn":       "64000",
 		"bgp/src-ip":         "10.0.0.254",
 		"bgp/peer-ip":        "10.0.0.1",
+		"bgp/peer-port":      "1179",
 		"bgp/peer-multi-hop": "true",
 	}
 
@@ -41,6 +42,7 @@ func TestParseBgpAnnotations(t *testing.T) {
 	assert.Equal(t, uint32(64000), bgpPeer.AS, "bgpPeer.AS parsed incorrectly")
 	assert.Equal(t, "10.0.0.254", bgpConfig.RouterID, "bgpConfig.RouterID parsed incorrectly")
 	assert.Equal(t, true, bgpPeer.MultiHop, "bgpPeer.MultiHop parsed incorrectly")
+	assert.Equal(t, uint16(1179), bgpPeer.Port, "bgpPeer.Port parsed incorrectly")
 	assert.EqualValues(t, 15, bgpConfig.HoldTime, "base bgpConfig.HoldTime should not be overwritten")
 	assert.EqualValues(t, 5, bgpConfig.KeepaliveInterval, "base bgpConfig.KeepaliveInterval should not be overwritten")
 
@@ -49,6 +51,7 @@ func TestParseBgpAnnotations(t *testing.T) {
 		"bgp/peer-asn":       "64000",
 		"bgp/src-ip":         "10.0.0.254",
 		"bgp/peer-ip":        "10.0.0.1,10.0.0.2,10.0.0.3",
+		"bgp/peer-port":      "1179",
 		"bgp/bgp-pass":       "cGFzc3dvcmQ=", // dummy password for the test, gosec linter disabled
 		"bgp/peer-multi-hop": "true",
 	}
@@ -59,9 +62,9 @@ func TestParseBgpAnnotations(t *testing.T) {
 	}
 
 	bgpPeers := []kubevip.BGPPeer{
-		{Address: "10.0.0.1", AS: uint32(64000), Password: "password", MultiHop: true},
-		{Address: "10.0.0.2", AS: uint32(64000), Password: "password", MultiHop: true},
-		{Address: "10.0.0.3", AS: uint32(64000), Password: "password", MultiHop: true},
+		{Address: "10.0.0.1", AS: uint32(64000), Port: 1179, Password: "password", MultiHop: true},
+		{Address: "10.0.0.2", AS: uint32(64000), Port: 1179, Password: "password", MultiHop: true},
+		{Address: "10.0.0.3", AS: uint32(64000), Port: 1179, Password: "password", MultiHop: true},
 	}
 	assert.Equal(t, bgpPeers, bgpConfig.Peers, "bgpConfig.Peers parsed incorrectly")
 	assert.Equal(t, "10.0.0.3", bgpPeer.Address, "bgpPeer.Address parsed incorrectly")
@@ -91,11 +94,12 @@ func TestParseNewBgpAnnotations(t *testing.T) {
 	}
 
 	node.Annotations = map[string]string{ //nolint:gosec
-		"bgp/bgp-peers-0-node-asn": "65000",
-		"bgp/bgp-peers-0-peer-asn": "64000",
-		"bgp/bgp-peers-0-peer-ip":  "10.0.0.1,10.0.0.2,10.0.0.3",
-		"bgp/bgp-peers-0-src-ip":   "10.0.0.254",
-		"bgp/bgp-peers-0-bgp-pass": "cGFzc3dvcmQ=", // dummy password for the test, gosec linter disabled
+		"bgp/bgp-peers-0-node-asn":  "65000",
+		"bgp/bgp-peers-0-peer-asn":  "64000",
+		"bgp/bgp-peers-0-peer-ip":   "10.0.0.1,10.0.0.2,10.0.0.3",
+		"bgp/bgp-peers-0-peer-port": "1179",
+		"bgp/bgp-peers-0-src-ip":    "10.0.0.254",
+		"bgp/bgp-peers-0-bgp-pass":  "cGFzc3dvcmQ=", // dummy password for the test, gosec linter disabled
 	}
 
 	bgpConfig, bgpPeer, err := parseBgpAnnotations(bgpConfigBase, node, "bgp")
@@ -104,9 +108,9 @@ func TestParseNewBgpAnnotations(t *testing.T) {
 	}
 
 	bgpPeers := []kubevip.BGPPeer{
-		{Address: "10.0.0.1", AS: uint32(64000), Password: "password"},
-		{Address: "10.0.0.2", AS: uint32(64000), Password: "password"},
-		{Address: "10.0.0.3", AS: uint32(64000), Password: "password"},
+		{Address: "10.0.0.1", AS: uint32(64000), Port: 1179, Password: "password"},
+		{Address: "10.0.0.2", AS: uint32(64000), Port: 1179, Password: "password"},
+		{Address: "10.0.0.3", AS: uint32(64000), Port: 1179, Password: "password"},
 	}
 	assert.Equal(t, bgpPeers, bgpConfig.Peers, "bgpConfig.Peers parsed incorrectly")
 	assert.Equal(t, "10.0.0.254", bgpConfig.SourceIP, "bgpConfig.SourceIP parsed incorrectly")

--- a/pkg/manager/watcher_test.go
+++ b/pkg/manager/watcher_test.go
@@ -121,6 +121,49 @@ func TestParseNewBgpAnnotations(t *testing.T) {
 	assert.EqualValues(t, 5, bgpConfig.KeepaliveInterval, "base bgpConfig.KeepaliveInterval should not be overwritten")
 }
 
+func TestParseBgpAnnotationPort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		port     string
+		wantPort uint16
+		wantErr  bool
+	}{
+		{name: "present", port: "1179", wantPort: 1179},
+		{name: "default"},
+		{name: "invalid", port: "invalid", wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			annotations := map[string]string{
+				"bgp/bgp-peers-0-node-asn": "65000",
+				"bgp/bgp-peers-0-peer-asn": "64000",
+				"bgp/bgp-peers-0-peer-ip":  "10.0.0.1",
+				"bgp/bgp-peers-0-src-ip":   "10.0.0.254",
+			}
+			if test.port != "" {
+				annotations["bgp/bgp-peers-0-peer-port"] = test.port
+			}
+			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test", Annotations: annotations}}
+
+			config, _, err := parseBgpAnnotations(kubevip.BGPConfig{}, node, "bgp")
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("parseBgpAnnotations() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseBgpAnnotations() error = %v", err)
+			}
+			if got := config.Peers[0].Port; got != test.wantPort {
+				t.Fatalf("peer port = %d, want %d", got, test.wantPort)
+			}
+		})
+	}
+}
+
 func Test_parseBgpAnnotations(t *testing.T) {
 	type args struct {
 		node   *corev1.Node

--- a/pkg/manager/worker/common.go
+++ b/pkg/manager/worker/common.go
@@ -242,9 +242,7 @@ func (c *Common) runGlobalElection(ctx context.Context, a election.Actions, leas
 				objLease.Elected.Store(true)
 				objLease.Unlock()
 				close(objLease.Started)
-				a.OnStartedLeading(ctx)
-				metrics.LeaderTransitionsTotal.WithLabelValues(leaseID.Name()).Inc()
-				metrics.IsLeader.WithLabelValues(config.NodeName, leaseID.Name()).Set(1)
+				onStartedLeading(ctx, a, config.NodeName, leaseID.Name())
 			})
 		},
 		OnStoppedLeading: func() {
@@ -258,4 +256,10 @@ func (c *Common) runGlobalElection(ctx context.Context, a election.Actions, leas
 	if err := election.RunOrDie(ctx, run, config); err != nil {
 		log.Error("leaderelection failed", "err", err, "id", config.NodeName, "name", leaseID.Name())
 	}
+}
+
+func onStartedLeading(ctx context.Context, actions election.Actions, nodeName, leaseName string) {
+	metrics.LeaderTransitionsTotal.WithLabelValues(leaseName).Inc()
+	metrics.IsLeader.WithLabelValues(nodeName, leaseName).Set(1)
+	actions.OnStartedLeading(ctx)
 }

--- a/pkg/manager/worker/common_metrics_test.go
+++ b/pkg/manager/worker/common_metrics_test.go
@@ -1,0 +1,51 @@
+package worker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kube-vip/kube-vip/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+type blockingElectionActions struct {
+	started chan struct{}
+}
+
+func (a *blockingElectionActions) OnStartedLeading(ctx context.Context) {
+	close(a.started)
+	<-ctx.Done()
+}
+
+func (*blockingElectionActions) OnStoppedLeading() {}
+
+func (*blockingElectionActions) OnNewLeader(string) {}
+
+func TestLeaderMetricIsPublishedBeforeActionsRun(t *testing.T) {
+	nodeName := t.Name()
+	leaseName := "test-lease"
+	actions := &blockingElectionActions{started: make(chan struct{})}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		onStartedLeading(ctx, actions, nodeName, leaseName)
+		close(done)
+	}()
+
+	select {
+	case <-actions.started:
+	case <-time.After(time.Second):
+		t.Fatal("leadership actions did not start")
+	}
+	if value := testutil.ToFloat64(metrics.IsLeader.WithLabelValues(nodeName, leaseName)); value != 1 {
+		t.Fatalf("leader metric = %v, want 1 while leadership actions are running", value)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("leadership actions did not stop")
+	}
+}

--- a/pkg/servicecontext/servicecontext.go
+++ b/pkg/servicecontext/servicecontext.go
@@ -10,6 +10,7 @@ type Context struct {
 	Ctx                context.Context
 	Cancel             context.CancelFunc
 	IsWatched          bool
+	watchingStopped    chan struct{}
 	ConfiguredNetworks sync.Map
 	EndpointsReady     chan any
 	mu                 sync.Mutex
@@ -100,7 +101,28 @@ func (ctx *Context) SetWatched(watched bool) {
 	ctx.mu.Lock()
 	defer ctx.mu.Unlock()
 
+	if watched && !ctx.IsWatched {
+		ctx.watchingStopped = make(chan struct{})
+	}
+	if !watched && ctx.IsWatched {
+		close(ctx.watchingStopped)
+	}
 	ctx.IsWatched = watched
+}
+
+func (ctx *Context) StartWatching() bool {
+	ctx.mu.Lock()
+	defer ctx.mu.Unlock()
+	if ctx.Ctx.Err() != nil || ctx.IsWatched {
+		return false
+	}
+	ctx.IsWatched = true
+	ctx.watchingStopped = make(chan struct{})
+	return true
+}
+
+func (ctx *Context) StopWatching() {
+	ctx.SetWatched(false)
 }
 
 func (ctx *Context) IsWatchedLocked() bool {
@@ -108,4 +130,21 @@ func (ctx *Context) IsWatchedLocked() bool {
 	defer ctx.mu.Unlock()
 
 	return ctx.IsWatched
+}
+
+func (ctx *Context) WaitForWatchingStopped(waitCtx context.Context) error {
+	ctx.mu.Lock()
+	if !ctx.IsWatched {
+		ctx.mu.Unlock()
+		return nil
+	}
+	stopped := ctx.watchingStopped
+	ctx.mu.Unlock()
+
+	select {
+	case <-waitCtx.Done():
+		return waitCtx.Err()
+	case <-stopped:
+		return nil
+	}
 }

--- a/pkg/services/callback.go
+++ b/pkg/services/callback.go
@@ -20,5 +20,8 @@ func NewCallback(f func(*servicecontext.Context, *v1.Service, *sync.WaitGroup, b
 }
 
 func (c *Callback) Run(svcCtx *servicecontext.Context, svc *v1.Service, wg *sync.WaitGroup) error {
+	if svcCtx.Ctx.Err() != nil {
+		return nil
+	}
 	return c.Function(svcCtx, svc, wg, c.UsesLeaderElection)
 }

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -126,9 +126,6 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 			log.Error("error on stopped leading", "error", err)
 		}
 
-		// wait for leaderelection to be finished
-		<-svcLease.Ctx.Done()
-
 		return nil
 	}
 

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -185,12 +185,10 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 }
 
 func (p *Processor) onStartedLeading(svcCtx *servicecontext.Context, service *v1.Service, wg *sync.WaitGroup) error {
-	var err error
-	if !p.withActiveService(service.UID, svcCtx, func() {
-		err = p.SyncServices(svcCtx, service, wg, true)
-	}) {
+	if !p.serviceContextCurrent(service.UID, svcCtx) {
 		return nil
 	}
+	err := p.SyncServices(svcCtx, service, wg, true)
 	if err != nil {
 		log.Error("service sync", "uid", service.UID, "err", err)
 		return err
@@ -199,11 +197,14 @@ func (p *Processor) onStartedLeading(svcCtx *servicecontext.Context, service *v1
 }
 
 func (p *Processor) onStoppedLeading(svcCtx *servicecontext.Context, svcLease *lease.Lease, service *v1.Service) error {
+	unlockService := p.lockService(service.UID)
+	defer unlockService()
+
 	currentSvcCtx, err := p.getServiceContext(service.UID)
 	if err != nil {
 		return err
 	}
-	if currentSvcCtx != nil && currentSvcCtx != svcCtx {
+	if currentSvcCtx != svcCtx {
 		log.Debug("skipping cleanup from superseded service context", "service", service.Name, "uid", service.UID)
 		return nil
 	}

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -185,7 +185,12 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 }
 
 func (p *Processor) onStartedLeading(svcCtx *servicecontext.Context, service *v1.Service, wg *sync.WaitGroup) error {
-	err := p.SyncServices(svcCtx, service, wg, true)
+	var err error
+	if !p.withActiveService(svcCtx, func() {
+		err = p.SyncServices(svcCtx, service, wg, true)
+	}) {
+		return nil
+	}
 	if err != nil {
 		log.Error("service sync", "uid", service.UID, "err", err)
 		return err

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -186,7 +186,7 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 
 func (p *Processor) onStartedLeading(svcCtx *servicecontext.Context, service *v1.Service, wg *sync.WaitGroup) error {
 	var err error
-	if !p.withActiveService(svcCtx, func() {
+	if !p.withActiveService(service.UID, svcCtx, func() {
 		err = p.SyncServices(svcCtx, service, wg, true)
 	}) {
 		return nil

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -123,15 +123,21 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 		// A follower must return when the current leader loses the lease so the
 		// restart loop can campaign for the same shared lease. Waiting only for
 		// the service context leaves the follower blocked forever after takeover.
+	wait:
 		for svcLease.Elected.Load() {
+			timer := time.NewTimer(200 * time.Millisecond)
 			select {
 			case <-svcCtx.Ctx.Done():
-				if err := p.onStoppedLeading(svcCtx, svcLease, service); err != nil {
-					log.Error("error on stopped leading", "error", err)
-				}
-				return nil
-			case <-time.After(200 * time.Millisecond):
+				timer.Stop()
+				break wait
+			case <-svcLease.Ctx.Done():
+				timer.Stop()
+				break wait
+			case <-timer.C:
 			}
+		}
+		if err := p.onStoppedLeading(svcCtx, svcLease, service); err != nil {
+			log.Error("error on stopped leading", "error", err)
 		}
 
 		return nil

--- a/pkg/services/leader.go
+++ b/pkg/services/leader.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	log "log/slog"
 
@@ -119,11 +120,18 @@ func (p *Processor) StartServicesLeaderElection(svcCtx *servicecontext.Context, 
 			log.Error("error on started leading", "error", err)
 		}
 
-		// Block until service context is cancelled
-		<-svcCtx.Ctx.Done()
-
-		if err := p.onStoppedLeading(svcCtx, svcLease, service); err != nil {
-			log.Error("error on stopped leading", "error", err)
+		// A follower must return when the current leader loses the lease so the
+		// restart loop can campaign for the same shared lease. Waiting only for
+		// the service context leaves the follower blocked forever after takeover.
+		for svcLease.Elected.Load() {
+			select {
+			case <-svcCtx.Ctx.Done():
+				if err := p.onStoppedLeading(svcCtx, svcLease, service); err != nil {
+					log.Error("error on stopped leading", "error", err)
+				}
+				return nil
+			case <-time.After(200 * time.Millisecond):
+			}
 		}
 
 		return nil

--- a/pkg/services/leader_test.go
+++ b/pkg/services/leader_test.go
@@ -5,12 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kube-vip/kube-vip/pkg/instance"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
 	"github.com/kube-vip/kube-vip/pkg/servicecontext"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 )
 
 // TestStartServicesLeaderElection_ReturnsOnLeaseLossWithoutServiceDeletion is a regression test for
@@ -68,4 +70,139 @@ func TestStartServicesLeaderElection_ReturnsOnLeaseLossWithoutServiceDeletion(t 
 	// The lease-cleanup goroutine should still be running, waiting for the service to be
 	// deleted; confirm it is not left dangling forever by cancelling the service context now.
 	svcCtx.Cancel()
+}
+
+func TestSharedLeaseMemberCancellationDoesNotWaitForLeaseRetirement(t *testing.T) {
+	p := &Processor{
+		config:   &kubevip.Config{},
+		leaseMgr: lease.NewManager(),
+	}
+	newService := func(name string) *v1.Service {
+		return &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				UID:       types.UID(name + "-uid"),
+				Annotations: map[string]string{
+					kubevip.ServiceLease: "shared",
+				},
+			},
+		}
+	}
+
+	leader := newService("leader")
+	follower := newService("follower")
+	leaderCtx := servicecontext.New(context.Background())
+	followerCtx := servicecontext.New(context.Background())
+	p.svcMap.Store(leader.UID, leaderCtx)
+	p.svcMap.Store(follower.UID, followerCtx)
+	p.ServiceInstances = []*instance.Instance{
+		{ServiceSnapshot: leader.DeepCopy(), AddCalled: true},
+		{ServiceSnapshot: follower.DeepCopy(), AddCalled: true},
+	}
+
+	namespace, name := lease.ServiceName(leader)
+	id := lease.NewID(p.config.LeaderElectionType, namespace, name)
+	svcLease := p.leaseMgr.Add(context.Background(), id)
+	svcLease.Add(lease.ServiceNamespacedName(leader))
+	svcLease.Elected.Store(true)
+	close(svcLease.Started)
+
+	if !followerCtx.StartWatching() {
+		t.Fatal("failed to start follower watcher")
+	}
+	followerCtx.SignalReadiness()
+	electionDone := make(chan error, 1)
+	go func() {
+		defer followerCtx.StopWatching()
+		electionDone <- p.StartServicesLeaderElection(followerCtx, follower, nil, true)
+	}()
+
+	deadline := time.After(time.Second)
+	for {
+		if svcLease.Has(lease.ServiceNamespacedName(follower)) {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("follower did not join the shared lease")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	joined := make(chan struct{})
+	go func() {
+		svcLease.Lock()
+		svcLease.Unlock()
+		close(joined)
+	}()
+	select {
+	case <-joined:
+	case <-time.After(time.Second):
+		t.Fatal("follower did not finish joining the active campaign")
+	}
+
+	deleteDone := make(chan error, 1)
+	go func() {
+		deleteDone <- p.Delete(watch.Event{Type: watch.Deleted, Object: follower}, false)
+	}()
+
+	select {
+	case err := <-electionDone:
+		if err != nil {
+			t.Fatalf("StartServicesLeaderElection returned an error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("follower election routine waited for the shared lease to retire")
+	}
+	select {
+	case err := <-deleteDone:
+		if err != nil {
+			t.Fatalf("deleting follower returned an error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("follower watcher did not return")
+	}
+
+	if got := p.leaseMgr.Get(id); got != svcLease {
+		t.Fatal("shared lease was retired while its leader remained")
+	}
+	if svcLease.Ctx.Err() != nil {
+		t.Fatal("shared lease context was cancelled while its leader remained")
+	}
+	if _, ok := p.svcMap.Load(follower.UID); ok {
+		t.Fatal("follower context remained registered")
+	}
+	if len(p.ServiceInstances) != 1 || p.ServiceInstances[0].ServiceSnapshot.UID != leader.UID {
+		t.Fatal("follower instance was not removed without disturbing its sibling")
+	}
+
+	processed := make(chan bool, 1)
+	go func() {
+		processed <- p.withActiveService(leader.UID, leaderCtx, func() {})
+	}()
+	select {
+	case active := <-processed:
+		if !active {
+			t.Fatal("remaining service event was rejected")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("remaining service event processing was blocked")
+	}
+
+	if err := p.Delete(watch.Event{Type: watch.Deleted, Object: leader}, false); err != nil {
+		t.Fatalf("deleting final member returned an error: %v", err)
+	}
+	if p.leaseMgr.Get(id) != nil {
+		t.Fatal("shared lease remained after deleting its final member")
+	}
+	if svcLease.Ctx.Err() == nil {
+		t.Fatal("shared lease context remained live after deleting its final member")
+	}
+	if len(p.ServiceInstances) != 0 {
+		t.Fatalf("service instances remained after final cleanup: %d", len(p.ServiceInstances))
+	}
+	if _, ok := p.svcMap.Load(leader.UID); ok {
+		t.Fatal("final service context remained registered")
+	}
 }

--- a/pkg/services/leader_test.go
+++ b/pkg/services/leader_test.go
@@ -119,10 +119,7 @@ func TestSharedLeaseMemberCancellationDoesNotWaitForLeaseRetirement(t *testing.T
 	}()
 
 	deadline := time.After(time.Second)
-	for {
-		if svcLease.Has(lease.ServiceNamespacedName(follower)) {
-			break
-		}
+	for !svcLease.Has(lease.ServiceNamespacedName(follower)) {
 		select {
 		case <-deadline:
 			t.Fatal("follower did not join the shared lease")
@@ -130,14 +127,18 @@ func TestSharedLeaseMemberCancellationDoesNotWaitForLeaseRetirement(t *testing.T
 			time.Sleep(time.Millisecond)
 		}
 	}
-	joined := make(chan struct{})
+	joined := make(chan bool, 1)
 	go func() {
 		svcLease.Lock()
+		isMember := svcLease.Has(lease.ServiceNamespacedName(follower))
 		svcLease.Unlock()
-		close(joined)
+		joined <- isMember
 	}()
 	select {
-	case <-joined:
+	case isMember := <-joined:
+		if !isMember {
+			t.Fatal("follower membership disappeared during campaign setup")
+		}
 	case <-time.After(time.Second):
 		t.Fatal("follower did not finish joining the active campaign")
 	}

--- a/pkg/services/leader_test.go
+++ b/pkg/services/leader_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kube-vip/kube-vip/pkg/instance"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
+	"github.com/kube-vip/kube-vip/pkg/node/noop"
 	"github.com/kube-vip/kube-vip/pkg/servicecontext"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -205,5 +206,77 @@ func TestSharedLeaseMemberCancellationDoesNotWaitForLeaseRetirement(t *testing.T
 	}
 	if _, ok := p.svcMap.Load(leader.UID); ok {
 		t.Fatal("final service context remained registered")
+	}
+}
+
+func TestSharedLeaseFollowerWithdrawsBeforeTakeover(t *testing.T) {
+	p := &Processor{
+		config:           &kubevip.Config{DisableServiceUpdates: true},
+		leaseMgr:         lease.NewManager(),
+		nodeLabelManager: noop.NewManager(),
+	}
+	newService := func(name string) *v1.Service {
+		return &v1.Service{ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: "default", UID: types.UID(name + "-uid"),
+			Annotations: map[string]string{kubevip.ServiceLease: "shared"},
+		}}
+	}
+	leader := newService("leader")
+	follower := newService("follower")
+	followerCtx := servicecontext.New(context.Background())
+	t.Cleanup(followerCtx.Cancel)
+	p.svcMap.Store(follower.UID, followerCtx)
+	followerInstance := &instance.Instance{ServiceSnapshot: follower.DeepCopy()}
+	p.ServiceInstances = []*instance.Instance{
+		{ServiceSnapshot: leader.DeepCopy(), AddCalled: true},
+		followerInstance,
+	}
+
+	namespace, name := lease.ServiceName(follower)
+	id := lease.NewID(p.config.LeaderElectionType, namespace, name)
+	svcLease := p.leaseMgr.Add(context.Background(), id)
+	svcLease.Add(lease.ServiceNamespacedName(leader))
+	svcLease.Elected.Store(true)
+	close(svcLease.Started)
+	followerCtx.SignalReadiness()
+
+	done := make(chan error, 1)
+	go func() { done <- p.StartServicesLeaderElection(followerCtx, follower, nil, true) }()
+
+	deadline := time.After(time.Second)
+	for {
+		unlock := p.lockService(follower.UID)
+		started := followerInstance.AddCalled
+		unlock()
+		if started {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("follower did not enter the active shared lease campaign")
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	// Local leadership loss must withdraw the follower before the restart loop
+	// campaigns again; the old implementation waited for service deletion.
+	svcLease.Elected.Store(false)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("follower did not return after leader loss: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("follower remained blocked after shared lease leadership was lost")
+	}
+
+	if len(p.ServiceInstances) != 1 || p.ServiceInstances[0].ServiceSnapshot.UID != leader.UID {
+		t.Fatal("follower cleanup removed the sibling service")
+	}
+	if !svcLease.Has(lease.ServiceNamespacedName(leader)) || !svcLease.Has(lease.ServiceNamespacedName(follower)) {
+		t.Fatal("follower cleanup changed shared lease membership")
+	}
+	if svcLease.Ctx.Err() != nil {
+		t.Fatal("follower cleanup retired the shared lease while sibling remained")
 	}
 }

--- a/pkg/services/leader_test.go
+++ b/pkg/services/leader_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -278,5 +279,145 @@ func TestSharedLeaseFollowerWithdrawsBeforeTakeover(t *testing.T) {
 	}
 	if svcLease.Ctx.Err() != nil {
 		t.Fatal("follower cleanup retired the shared lease while sibling remained")
+	}
+}
+
+func TestSharedLeaseOwnerCancellationStopsCampaignBeforeWatcherWait(t *testing.T) {
+	p := &Processor{
+		config:   &kubevip.Config{},
+		leaseMgr: lease.NewManager(),
+	}
+	newService := func(name string) *v1.Service {
+		return &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				UID:       types.UID(name + "-uid"),
+				Annotations: map[string]string{
+					kubevip.ServiceLease: "shared",
+				},
+			},
+		}
+	}
+
+	owner := newService("owner")
+	sibling := newService("sibling")
+	ownerCtx := servicecontext.New(context.Background())
+	siblingCtx := servicecontext.New(context.Background())
+	p.svcMap.Store(owner.UID, ownerCtx)
+	p.svcMap.Store(sibling.UID, siblingCtx)
+	p.ServiceInstances = []*instance.Instance{
+		{ServiceSnapshot: owner.DeepCopy(), AddCalled: true},
+		{ServiceSnapshot: sibling.DeepCopy(), AddCalled: true},
+	}
+
+	namespace, name := lease.ServiceName(owner)
+	id := lease.NewID(p.config.LeaderElectionType, namespace, name)
+	svcLease := p.leaseMgr.Add(context.Background(), id)
+	ownerName := lease.ServiceNamespacedName(owner)
+	siblingName := lease.ServiceNamespacedName(sibling)
+	svcLease.Add(ownerName)
+	svcLease.Add(siblingName)
+	svcLease.Elected.Store(true)
+	close(svcLease.Started)
+
+	if !ownerCtx.StartWatching() {
+		t.Fatal("failed to start owner watcher")
+	}
+	campaignStopped := make(chan struct{})
+	var stopCampaign sync.Once
+	ownerCtx.SetLeaderCancel(func() {
+		stopCampaign.Do(func() {
+			svcLease.Elected.Store(false)
+			svcLease.Started = make(chan any)
+			close(campaignStopped)
+		})
+	})
+	watcherDone := make(chan struct{})
+	go func() {
+		defer close(watcherDone)
+		<-ownerCtx.Ctx.Done()
+		<-campaignStopped
+		ownerCtx.StopWatching()
+	}()
+
+	deleteDone := make(chan error, 1)
+	go func() {
+		deleteDone <- p.Delete(watch.Event{Type: watch.Deleted, Object: owner}, false)
+	}()
+	select {
+	case err := <-deleteDone:
+		if err != nil {
+			t.Fatalf("deleting campaign owner returned an error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("deleting campaign owner waited for its watcher")
+	}
+	<-watcherDone
+	select {
+	case <-campaignStopped:
+	default:
+		t.Fatal("owner campaign was not cancelled before the watcher wait completed")
+	}
+
+	if got := p.leaseMgr.Get(id); got != svcLease {
+		t.Fatal("shared lease was replaced while its sibling remained")
+	}
+	if svcLease.Ctx.Err() != nil {
+		t.Fatal("shared lease was cancelled while its sibling remained")
+	}
+	if svcLease.Has(ownerName) {
+		t.Fatal("campaign owner remained a lease member")
+	}
+	if !svcLease.Has(siblingName) {
+		t.Fatal("sibling membership disappeared with the campaign owner")
+	}
+	if _, ok := p.svcMap.Load(owner.UID); ok {
+		t.Fatal("campaign owner context remained registered")
+	}
+	if len(p.ServiceInstances) != 1 || p.ServiceInstances[0].ServiceSnapshot.UID != sibling.UID {
+		t.Fatal("campaign owner cleanup disturbed its sibling instance")
+	}
+
+	campaigned := make(chan struct{})
+	go func() {
+		svcLease.Lock()
+		if !svcLease.Elected.Load() && svcLease.Has(siblingName) {
+			svcLease.Elected.Store(true)
+			close(svcLease.Started)
+		}
+		svcLease.Unlock()
+		close(campaigned)
+	}()
+	select {
+	case <-campaigned:
+	case <-time.After(time.Second):
+		t.Fatal("sibling could not campaign on the shared lease")
+	}
+	if !svcLease.Elected.Load() {
+		t.Fatal("sibling did not take over the shared lease")
+	}
+
+	if err := p.Delete(watch.Event{Type: watch.Deleted, Object: sibling}, false); err != nil {
+		t.Fatalf("deleting final member returned an error: %v", err)
+	}
+	if p.leaseMgr.Get(id) != nil || svcLease.Ctx.Err() == nil {
+		t.Fatal("final member did not retire the shared lease")
+	}
+	if len(p.ServiceInstances) != 0 {
+		t.Fatalf("service instances remained after final cleanup: %d", len(p.ServiceInstances))
+	}
+	if _, ok := p.svcMap.Load(sibling.UID); ok {
+		t.Fatal("final service context remained registered")
+	}
+
+	replacement := p.leaseMgr.Add(context.Background(), id)
+	replacement.Add(siblingName)
+	if err := p.Delete(watch.Event{Type: watch.Deleted, Object: sibling}, false); err != nil {
+		t.Fatalf("repeating final member deletion returned an error: %v", err)
+	}
+	p.leaseMgr.Delete(id, siblingName, svcLease)
+	if p.leaseMgr.Get(id) != replacement || replacement.Ctx.Err() != nil {
+		t.Fatal("stale final cleanup retired the replacement lease")
 	}
 }

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -40,8 +40,9 @@ type Processor struct {
 	// Keeps track of all running instances
 	ServiceInstances []*instance.Instance
 
-	mutex     sync.Mutex
-	bgpServer *bgp.Server
+	mutex          sync.Mutex
+	lifecycleMutex sync.Mutex
+	bgpServer      *bgp.Server
 
 	clientSet   *kubernetes.Clientset
 	rwClientSet *kubernetes.Clientset
@@ -315,12 +316,20 @@ func (p *Processor) Delete(event watch.Event, forcedOnly bool) error {
 }
 
 func (p *Processor) deleteTrackedService(svc *v1.Service) error {
+	p.lifecycleMutex.Lock()
+	defer p.lifecycleMutex.Unlock()
+
 	svcCtx, err := p.getServiceContext(svc.UID)
 	if err != nil {
 		return fmt.Errorf("(svcs) unable to get context: %w", err)
 	}
 
 	if svcCtx != nil {
+		// Stop every producer before tearing down the tracked instance. Endpoint
+		// reconciliation uses lifecycleMutex too, so no queued event can restore
+		// datapath state after this point.
+		svcCtx.Cancel()
+
 		// If no leader election is enabled, delete routes here
 		if !p.config.EnableLeaderElection && !p.config.EnableServicesElection &&
 			p.config.EnableRoutingTable && svcCtx.HasConfiguredNetworks() {
@@ -329,18 +338,18 @@ func (p *Processor) deleteTrackedService(svc *v1.Service) error {
 			}
 		}
 
-		if !p.config.EnableServicesElection {
-			// If this is an active service then and additional leaderElection will handle stopping
-			err = p.deleteService(svcCtx.Ctx, svc.UID)
-			if err != nil {
-				log.Error(err.Error())
-			}
+		// Delete synchronously even with per-Service election. Waiting for the
+		// election callback leaves a window in which a queued callback can add the
+		// deleted Service again.
+		if err = p.deleteService(context.WithoutCancel(svcCtx.Ctx), svc.UID); err != nil {
+			log.Error(err.Error())
 		}
 
-		// Calls the cancel function of the context
 		log.Warn("(svcs) The load balancer was deleted, cancelling context", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
-		svcCtx.Cancel()
-		p.svcMap.Delete(svc.UID)
+		ns, name := lease.ServiceName(svc)
+		leaseID := lease.NewID(p.config.LeaderElectionType, ns, name)
+		p.leaseMgr.Delete(leaseID, lease.ServiceNamespacedName(svc), nil)
+		p.svcMap.CompareAndDelete(svc.UID, svcCtx)
 		// Drop the per-service election series so a recreated service starts clean.
 		metrics.ServiceElectionLoops.DeleteLabelValues(svc.Namespace, svc.Name)
 		p.updateActiveServicesMetric()
@@ -349,6 +358,16 @@ func (p *Processor) deleteTrackedService(svc *v1.Service) error {
 	}
 
 	return nil
+}
+
+func (p *Processor) withActiveService(svcCtx *servicecontext.Context, reconcile func()) bool {
+	p.lifecycleMutex.Lock()
+	defer p.lifecycleMutex.Unlock()
+	if svcCtx.Ctx.Err() != nil {
+		return false
+	}
+	reconcile()
+	return true
 }
 
 func (p *Processor) Stop() {

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -30,7 +30,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/keymutex"
 )
+
+const concurrentServiceLocks = 128
 
 type Processor struct {
 	config        *kubevip.Config
@@ -40,9 +43,10 @@ type Processor struct {
 	// Keeps track of all running instances
 	ServiceInstances []*instance.Instance
 
-	mutex          sync.Mutex
-	lifecycleMutex sync.Mutex
-	bgpServer      *bgp.Server
+	mutex            sync.Mutex
+	serviceLocks     keymutex.KeyMutex
+	serviceLocksOnce sync.Once
+	bgpServer        *bgp.Server
 
 	clientSet   *kubernetes.Clientset
 	rwClientSet *kubernetes.Clientset
@@ -78,6 +82,7 @@ func NewServicesProcessor(config *kubevip.Config, bgpServer *bgp.Server,
 		config:           config,
 		lbClassFilter:    lbClassFilterFunc,
 		ServiceInstances: []*instance.Instance{},
+		serviceLocks:     keymutex.NewHashed(concurrentServiceLocks),
 		bgpServer:        bgpServer,
 		clientSet:        clientSet,
 		rwClientSet:      rwClientSet,
@@ -142,8 +147,8 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 		svc = s
 	}
 
-	p.lifecycleMutex.Lock()
-	defer p.lifecycleMutex.Unlock()
+	unlockService := p.lockService(svc.UID)
+	defer unlockService()
 
 	svcInstance := instance.FindServiceInstance(svc, p.ServiceInstances)
 
@@ -240,13 +245,7 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 				// start if service is not already watched/handled
 				// signal endpoints goroutine we are ready to start and run service handling function
 				log.Info("(svcs) service function starting", "uid", svc.UID)
-				if serviceFunc.UsesLeaderElection {
-					err = serviceFunc.Run(svcCtx, svc, wg)
-				} else {
-					p.withActiveService(svc.UID, svcCtx, func() {
-						err = serviceFunc.Run(svcCtx, svc, wg)
-					})
-				}
+				err = serviceFunc.Run(svcCtx, svc, wg)
 				if err != nil {
 					log.Error(err.Error())
 					if utils.IsPanicError(err) {
@@ -336,18 +335,18 @@ func (p *Processor) deleteTrackedService(svc *v1.Service) error {
 			}
 		}
 
-		p.lifecycleMutex.Lock()
+		unlockService := p.lockService(svc.UID)
 		currentCtx, err := p.getServiceContext(svc.UID)
 		if err != nil {
-			p.lifecycleMutex.Unlock()
+			unlockService()
 			return fmt.Errorf("(svcs) unable to get context: %w", err)
 		}
 		if currentCtx == svcCtx {
+			defer unlockService()
 			break
 		}
-		p.lifecycleMutex.Unlock()
+		unlockService()
 	}
-	defer p.lifecycleMutex.Unlock()
 
 	if svcCtx != nil {
 		// If no leader election is enabled, delete routes here
@@ -381,8 +380,8 @@ func (p *Processor) deleteTrackedService(svc *v1.Service) error {
 }
 
 func (p *Processor) withActiveService(uid types.UID, svcCtx *servicecontext.Context, reconcile func()) bool {
-	p.lifecycleMutex.Lock()
-	defer p.lifecycleMutex.Unlock()
+	unlockService := p.lockService(uid)
+	defer unlockService()
 	if svcCtx.Ctx.Err() != nil {
 		return false
 	}
@@ -392,6 +391,31 @@ func (p *Processor) withActiveService(uid types.UID, svcCtx *servicecontext.Cont
 	}
 	reconcile()
 	return true
+}
+
+func (p *Processor) serviceContextCurrent(uid types.UID, svcCtx *servicecontext.Context) bool {
+	unlockService := p.lockService(uid)
+	defer unlockService()
+	if svcCtx == nil || svcCtx.Ctx.Err() != nil {
+		return false
+	}
+	current, err := p.getServiceContext(uid)
+	return err == nil && current == svcCtx
+}
+
+func (p *Processor) lockService(uid types.UID) func() {
+	p.serviceLocksOnce.Do(func() {
+		if p.serviceLocks == nil {
+			p.serviceLocks = keymutex.NewHashed(concurrentServiceLocks)
+		}
+	})
+	key := string(uid)
+	p.serviceLocks.LockKey(key)
+	return func() {
+		if err := p.serviceLocks.UnlockKey(key); err != nil {
+			log.Error("failed to unlock service lifecycle", "uid", uid, "err", err)
+		}
+	}
 }
 
 func (p *Processor) Stop() {

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -142,6 +142,9 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 		svc = s
 	}
 
+	p.lifecycleMutex.Lock()
+	defer p.lifecycleMutex.Unlock()
+
 	svcInstance := instance.FindServiceInstance(svc, p.ServiceInstances)
 
 	_, usesCommonLease := svc.Annotations[kubevip.ServiceLease]
@@ -224,20 +227,26 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 	}
 
 	// this goroutine starts service handling function (with or without leaderelection)
-	if !svcCtx.IsWatchedLocked() {
+	if svcCtx.StartWatching() {
 		wg.Go(func() {
 			watchWg := sync.WaitGroup{}
 			defer func() {
 				// wait for the sub-goroutines and tag service as not watched
 				watchWg.Wait()
-				svcCtx.SetWatched(false)
+				svcCtx.StopWatching()
 			}()
 
 			watchWg.Go(func() {
 				// start if service is not already watched/handled
 				// signal endpoints goroutine we are ready to start and run service handling function
 				log.Info("(svcs) service function starting", "uid", svc.UID)
-				err = serviceFunc.Run(svcCtx, svc, wg)
+				if serviceFunc.UsesLeaderElection {
+					err = serviceFunc.Run(svcCtx, svc, wg)
+				} else {
+					p.withActiveService(svc.UID, svcCtx, func() {
+						err = serviceFunc.Run(svcCtx, svc, wg)
+					})
+				}
 				if err != nil {
 					log.Error(err.Error())
 					if utils.IsPanicError(err) {
@@ -267,9 +276,6 @@ func (p *Processor) AddOrModify(ctx context.Context, event watch.Event, serviceF
 			})
 
 		})
-
-		// tag service as watched
-		svcCtx.SetWatched(true)
 	}
 
 	if !p.config.EnableServicesElection {
@@ -316,20 +322,34 @@ func (p *Processor) Delete(event watch.Event, forcedOnly bool) error {
 }
 
 func (p *Processor) deleteTrackedService(svc *v1.Service) error {
-	p.lifecycleMutex.Lock()
+	var svcCtx *servicecontext.Context
+	for {
+		var err error
+		svcCtx, err = p.getServiceContext(svc.UID)
+		if err != nil {
+			return fmt.Errorf("(svcs) unable to get context: %w", err)
+		}
+		if svcCtx != nil {
+			svcCtx.Cancel()
+			if err := svcCtx.WaitForWatchingStopped(context.Background()); err != nil {
+				return fmt.Errorf("wait for service watcher: %w", err)
+			}
+		}
+
+		p.lifecycleMutex.Lock()
+		currentCtx, err := p.getServiceContext(svc.UID)
+		if err != nil {
+			p.lifecycleMutex.Unlock()
+			return fmt.Errorf("(svcs) unable to get context: %w", err)
+		}
+		if currentCtx == svcCtx {
+			break
+		}
+		p.lifecycleMutex.Unlock()
+	}
 	defer p.lifecycleMutex.Unlock()
 
-	svcCtx, err := p.getServiceContext(svc.UID)
-	if err != nil {
-		return fmt.Errorf("(svcs) unable to get context: %w", err)
-	}
-
 	if svcCtx != nil {
-		// Stop every producer before tearing down the tracked instance. Endpoint
-		// reconciliation uses lifecycleMutex too, so no queued event can restore
-		// datapath state after this point.
-		svcCtx.Cancel()
-
 		// If no leader election is enabled, delete routes here
 		if !p.config.EnableLeaderElection && !p.config.EnableServicesElection &&
 			p.config.EnableRoutingTable && svcCtx.HasConfiguredNetworks() {
@@ -341,7 +361,7 @@ func (p *Processor) deleteTrackedService(svc *v1.Service) error {
 		// Delete synchronously even with per-Service election. Waiting for the
 		// election callback leaves a window in which a queued callback can add the
 		// deleted Service again.
-		if err = p.deleteService(context.WithoutCancel(svcCtx.Ctx), svc.UID); err != nil {
+		if err := p.deleteService(context.WithoutCancel(svcCtx.Ctx), svc.UID); err != nil {
 			log.Error(err.Error())
 		}
 
@@ -360,10 +380,14 @@ func (p *Processor) deleteTrackedService(svc *v1.Service) error {
 	return nil
 }
 
-func (p *Processor) withActiveService(svcCtx *servicecontext.Context, reconcile func()) bool {
+func (p *Processor) withActiveService(uid types.UID, svcCtx *servicecontext.Context, reconcile func()) bool {
 	p.lifecycleMutex.Lock()
 	defer p.lifecycleMutex.Unlock()
 	if svcCtx.Ctx.Err() != nil {
+		return false
+	}
+	current, err := p.getServiceContext(uid)
+	if err != nil || current != svcCtx {
 		return false
 	}
 	reconcile()

--- a/pkg/services/processor.go
+++ b/pkg/services/processor.go
@@ -330,6 +330,7 @@ func (p *Processor) deleteTrackedService(svc *v1.Service) error {
 		}
 		if svcCtx != nil {
 			svcCtx.Cancel()
+			svcCtx.CallLeaderCancel()
 			if err := svcCtx.WaitForWatchingStopped(context.Background()); err != nil {
 				return fmt.Errorf("wait for service watcher: %w", err)
 			}

--- a/pkg/services/processor_lease_test.go
+++ b/pkg/services/processor_lease_test.go
@@ -5,6 +5,7 @@ import (
 	log "log/slog"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/kube-vip/kube-vip/pkg/bgp"
 	"github.com/kube-vip/kube-vip/pkg/instance"
@@ -16,6 +17,66 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 )
+
+func TestNonElectionSyncDoesNotBlockEndpointReadiness(t *testing.T) {
+	p := &Processor{config: &kubevip.Config{}}
+	service := &v1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name: "first", Namespace: "default", UID: types.UID("first"),
+	}}
+	svcCtx := servicecontext.New(context.Background())
+	p.svcMap.Store(service.UID, svcCtx)
+	p.ServiceInstances = []*instance.Instance{{ServiceSnapshot: service.DeepCopy(), AddCalled: true}}
+
+	callback := NewCallback(p.SyncServices, false)
+	done := make(chan error, 1)
+	go func() {
+		done <- callback.Run(svcCtx, service, &sync.WaitGroup{})
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("SyncServices returned before endpoint readiness: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	if !p.withActiveService(service.UID, svcCtx, svcCtx.SignalReadiness) {
+		t.Fatal("endpoint reconciliation rejected the current Service context")
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("SyncServices returned an error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SyncServices deadlocked waiting for endpoint readiness")
+	}
+}
+
+func TestServiceLifecycleLocksAreIndependent(t *testing.T) {
+	p := &Processor{}
+	firstUID := types.UID("first")
+	secondUID := types.UID("second")
+	first := servicecontext.New(context.Background())
+	second := servicecontext.New(context.Background())
+	p.svcMap.Store(firstUID, first)
+	p.svcMap.Store(secondUID, second)
+
+	unlockFirst := p.lockService(firstUID)
+	defer unlockFirst()
+	processed := make(chan bool, 1)
+	go func() {
+		processed <- p.withActiveService(secondUID, second, func() {})
+	}()
+
+	select {
+	case active := <-processed:
+		if !active {
+			t.Fatal("second Service was not current")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first Service lifecycle blocked an unrelated Service")
+	}
+}
 
 func TestDeletedSharedVIPServiceRejectsRacingEndpointUpdate(t *testing.T) {
 	p := &Processor{}
@@ -44,7 +105,7 @@ func TestDeletedSharedVIPServiceRejectsRacingEndpointUpdate(t *testing.T) {
 		t.Fatalf("initial AddHost() error = %v", err)
 	}
 
-	p.lifecycleMutex.Lock()
+	unlockService := p.lockService(uid)
 	var wg sync.WaitGroup
 	updated := make(chan bool, 1)
 	wg.Go(func() {
@@ -59,7 +120,7 @@ func TestDeletedSharedVIPServiceRejectsRacingEndpointUpdate(t *testing.T) {
 	if err := server.DelHost(context.WithoutCancel(first.Ctx), route, owner); err != nil {
 		t.Fatalf("DelHost() error = %v", err)
 	}
-	p.lifecycleMutex.Unlock()
+	unlockService()
 	wg.Wait()
 
 	if <-updated {
@@ -265,5 +326,50 @@ func TestOnStoppedLeadingDoesNotDeleteReplacementContext(t *testing.T) {
 	}
 	if len(p.ServiceInstances) != 1 || p.ServiceInstances[0] != replacementInstance {
 		t.Fatal("replacement service instance was removed by superseded cleanup")
+	}
+}
+
+func TestOnStoppedLeadingReplacementDuringLockWaitSurvives(t *testing.T) {
+	p := &Processor{
+		config:   &kubevip.Config{},
+		leaseMgr: lease.NewManager(),
+	}
+	service := &v1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name: "example", Namespace: "default", UID: types.UID("service-uid"),
+	}}
+	oldCtx := servicecontext.New(context.Background())
+	replacementCtx := servicecontext.New(context.Background())
+	oldInstance := &instance.Instance{ServiceSnapshot: service.DeepCopy()}
+	replacementInstance := &instance.Instance{ServiceSnapshot: service.DeepCopy()}
+	p.svcMap.Store(service.UID, oldCtx)
+	p.ServiceInstances = []*instance.Instance{oldInstance}
+
+	leaseNamespace, serviceLease := lease.ServiceName(service)
+	svcLease := p.leaseMgr.Add(context.Background(), lease.NewID(p.config.LeaderElectionType, leaseNamespace, serviceLease))
+	unlockService := p.lockService(service.UID)
+	done := make(chan error, 1)
+	go func() {
+		done <- p.onStoppedLeading(oldCtx, svcLease, service)
+	}()
+
+	p.svcMap.Store(service.UID, replacementCtx)
+	p.mutex.Lock()
+	p.ServiceInstances = []*instance.Instance{replacementInstance}
+	p.mutex.Unlock()
+	unlockService()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("onStoppedLeading returned an error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("leadership-loss cleanup did not finish")
+	}
+	if got, err := p.getServiceContext(service.UID); err != nil || got != replacementCtx {
+		t.Fatalf("replacement context was changed: got %v, err %v", got, err)
+	}
+	if len(p.ServiceInstances) != 1 || p.ServiceInstances[0] != replacementInstance {
+		t.Fatal("replacement service instance was removed")
 	}
 }

--- a/pkg/services/processor_lease_test.go
+++ b/pkg/services/processor_lease_test.go
@@ -2,9 +2,11 @@ package services
 
 import (
 	"context"
+	log "log/slog"
 	"sync"
 	"testing"
 
+	"github.com/kube-vip/kube-vip/pkg/bgp"
 	"github.com/kube-vip/kube-vip/pkg/instance"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	"github.com/kube-vip/kube-vip/pkg/lease"
@@ -18,36 +20,57 @@ import (
 func TestDeletedSharedVIPServiceRejectsRacingEndpointUpdate(t *testing.T) {
 	p := &Processor{}
 	first := servicecontext.New(context.Background())
-	second := servicecontext.New(context.Background())
-	const vip = "192.0.2.10"
-	references := map[string]map[string]bool{
-		vip: {"local-a": true, "local-b": true},
+	uid := types.UID("service-uid")
+	p.svcMap.Store(uid, first)
+	server, err := bgp.NewBGPServer(kubevip.BGPConfig{
+		AS:       64512,
+		RouterID: "192.0.2.1",
+		Peers: []kubevip.BGPPeer{{
+			Address: "192.0.2.2",
+			AS:      64513,
+		}},
+	}, log.LevelError)
+	if err != nil {
+		t.Fatalf("NewBGPServer() error = %v", err)
+	}
+	if err := server.Start(context.Background(), nil); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+
+	const route = "2001:db8::10/128"
+	const owner = "default/example"
+	if err := server.AddHost(context.Background(), route, owner); err != nil {
+		t.Fatalf("initial AddHost() error = %v", err)
 	}
 
-	// Hold deletion's lifecycle section so the endpoint update is queued in
-	// the same state observed in the E2E failure.
 	p.lifecycleMutex.Lock()
 	var wg sync.WaitGroup
 	updated := make(chan bool, 1)
 	wg.Go(func() {
-		updated <- p.withActiveService(first, func() {
-			references[vip]["local-a"] = true
+		updated <- p.withActiveService(uid, first, func() {
+			if err := server.AddHost(first.Ctx, route, owner); err != nil {
+				t.Errorf("stale AddHost() error = %v", err)
+			}
 		})
 	})
 
 	first.Cancel()
-	delete(references[vip], "local-a")
+	if err := server.DelHost(context.WithoutCancel(first.Ctx), route, owner); err != nil {
+		t.Fatalf("DelHost() error = %v", err)
+	}
 	p.lifecycleMutex.Unlock()
 	wg.Wait()
 
 	if <-updated {
 		t.Fatal("endpoint update reconciled after its Service was cancelled")
 	}
-	if references[vip]["local-a"] {
-		t.Fatal("deleted Service restored its shared VIP reference")
+	routes, err := server.ListAdvertisedRoutes(context.Background(), true)
+	if err != nil {
+		t.Fatalf("ListAdvertisedRoutes() error = %v", err)
 	}
-	if !references[vip]["local-b"] || second.Ctx.Err() != nil {
-		t.Fatal("deleting one Local Service disturbed the other shared VIP owner")
+	if len(routes) != 0 {
+		t.Fatalf("stale endpoint reconciliation re-advertised %s", route)
 	}
 }
 

--- a/pkg/services/processor_lease_test.go
+++ b/pkg/services/processor_lease_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/kube-vip/kube-vip/pkg/instance"
@@ -13,6 +14,42 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 )
+
+func TestDeletedSharedVIPServiceRejectsRacingEndpointUpdate(t *testing.T) {
+	p := &Processor{}
+	first := servicecontext.New(context.Background())
+	second := servicecontext.New(context.Background())
+	const vip = "192.0.2.10"
+	references := map[string]map[string]bool{
+		vip: {"local-a": true, "local-b": true},
+	}
+
+	// Hold deletion's lifecycle section so the endpoint update is queued in
+	// the same state observed in the E2E failure.
+	p.lifecycleMutex.Lock()
+	var wg sync.WaitGroup
+	updated := make(chan bool, 1)
+	wg.Go(func() {
+		updated <- p.withActiveService(first, func() {
+			references[vip]["local-a"] = true
+		})
+	})
+
+	first.Cancel()
+	delete(references[vip], "local-a")
+	p.lifecycleMutex.Unlock()
+	wg.Wait()
+
+	if <-updated {
+		t.Fatal("endpoint update reconciled after its Service was cancelled")
+	}
+	if references[vip]["local-a"] {
+		t.Fatal("deleted Service restored its shared VIP reference")
+	}
+	if !references[vip]["local-b"] || second.Ctx.Err() != nil {
+		t.Fatal("deleting one Local Service disturbed the other shared VIP owner")
+	}
+}
 
 func TestAddOrModifyStopsTrackedServiceWhenTypeChanges(t *testing.T) {
 	for _, ignored := range []bool{false, true} {

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -45,6 +45,9 @@ const (
 )
 
 func (p *Processor) SyncServices(ctx *servicecontext.Context, svc *v1.Service, wg *sync.WaitGroup, usesLeaderElection bool) error {
+	if ctx.Ctx.Err() != nil {
+		return nil
+	}
 	log.Debug("[STARTING] Service Sync", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
 
 	// Iterate through the synchronising services
@@ -170,6 +173,9 @@ func (p *Processor) addService(ctx context.Context, inst *instance.Instance, svc
 	// protect against addService while reading
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
+	if ctx.Err() != nil {
+		return nil
+	}
 
 	startTime := time.Now()
 

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -48,6 +48,23 @@ func (p *Processor) SyncServices(ctx *servicecontext.Context, svc *v1.Service, w
 	if ctx.Ctx.Err() != nil {
 		return nil
 	}
+	if !usesLeaderElection {
+		select {
+		case <-ctx.Ctx.Done():
+			return nil
+		case <-ctx.GetEndpointsReady():
+		}
+	}
+
+	unlockService := p.lockService(svc.UID)
+	defer unlockService()
+	current, err := p.getServiceContext(svc.UID)
+	if err != nil {
+		return err
+	}
+	if current != ctx || ctx.Ctx.Err() != nil {
+		return nil
+	}
 	log.Debug("[STARTING] Service Sync", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
 
 	// Iterate through the synchronising services
@@ -62,14 +79,6 @@ func (p *Processor) SyncServices(ctx *servicecontext.Context, svc *v1.Service, w
 		log.Debug("[service] add", "namespace", svc.Namespace, "name", svc.Name, "uid", svc.UID)
 		if instance != nil {
 			instance.AddCalled = true
-		}
-
-		if !usesLeaderElection {
-			select {
-			case <-ctx.Ctx.Done():
-				return nil
-			case <-ctx.GetEndpointsReady():
-			}
 		}
 
 		if err := p.addService(ctx.Ctx, instance, svc, wg); err != nil {

--- a/pkg/services/watch_endpoints.go
+++ b/pkg/services/watch_endpoints.go
@@ -83,8 +83,14 @@ func (p *Processor) watchEndpoint(svcCtx *servicecontext.Context, id string, ser
 				log.Info("[endpoint watcher] endpoint object deleted", "provider", provider.GetLabel(), "service name", service.Name, "namespace", service.Namespace)
 			}
 
-			restart, err := epProcessor.Reconcile(svcCtx, event, &lastKnownGoodEndpoint, service, id,
-				p.StartServicesLeaderElection, &wg, p.clientSet, p.updateEgressConfiguration)
+			var restart bool
+			var err error
+			if !p.withActiveService(svcCtx, func() {
+				restart, err = epProcessor.Reconcile(svcCtx, event, &lastKnownGoodEndpoint, service, id,
+					p.StartServicesLeaderElection, &wg, p.clientSet, p.updateEgressConfiguration)
+			}) {
+				return nil
+			}
 			if restart {
 				continue
 			} else if err != nil {

--- a/pkg/services/watch_endpoints.go
+++ b/pkg/services/watch_endpoints.go
@@ -85,7 +85,7 @@ func (p *Processor) watchEndpoint(svcCtx *servicecontext.Context, id string, ser
 
 			var restart bool
 			var err error
-			if !p.withActiveService(svcCtx, func() {
+			if !p.withActiveService(service.UID, svcCtx, func() {
 				restart, err = epProcessor.Reconcile(svcCtx, event, &lastKnownGoodEndpoint, service, id,
 					p.StartServicesLeaderElection, &wg, p.clientSet, p.updateEgressConfiguration)
 			}) {

--- a/testing/e2e/README.md
+++ b/testing/e2e/README.md
@@ -24,3 +24,24 @@ The E2E tests:
     * This causes leader election to occur
 * Attempts to connect to the control plane using the VIP
     * The new leader will need send ndp advertisements before this can succeed within a timeout
+
+## Prometheus metrics helpers
+
+The E2E build also provides helpers for checking the metrics endpoint from
+inside a kind node. `ScrapeMetrics` executes `curl` against
+`http://127.0.0.1:2112/metrics` and parses the result into a label-aware sample
+map. The helpers are compiled only with the `e2e` build tag and do not change
+the normal test suite.
+
+Use `MetricValue` when a label selector should match one series; its second
+return value is the number of matching series. Use `SumMetric` or `MaxMetric`
+when a selector intentionally matches multiple series. `CounterDelta` compares
+two scrapes of one counter, while `EventuallyMetric` and
+`ConsistentlyMetric` provide Gomega polling assertions. `MetricStable` checks
+that a value remains unchanged across samples separated by a caller-selected
+gap, which is useful for detecting leaked loops after a fault.
+
+The metrics-enabled tests require kube-vip to expose port `2112` in the kind
+node and require `curl` in the node image. Keep metric assertions focused on
+stable behavior and use label selectors instead of depending on the ordering
+of Prometheus samples.

--- a/testing/e2e/README.md
+++ b/testing/e2e/README.md
@@ -30,8 +30,9 @@ The E2E tests:
 The E2E build also provides helpers for checking the metrics endpoint from
 inside a kind node. `ScrapeMetrics` executes `curl` against
 `http://127.0.0.1:2112/metrics` and parses the result into a label-aware sample
-map. The helpers are compiled only with the `e2e` build tag and do not change
-the normal test suite.
+map using Prometheus's `expfmt` parser. The helpers accept a context so callers
+can cancel Docker commands and stability waits. They are compiled only with
+the `e2e` build tag and do not change the normal test suite.
 
 Use `MetricValue` when a label selector should match one series; its second
 return value is the number of matching series. Use `SumMetric` or `MaxMetric`
@@ -41,7 +42,8 @@ two scrapes of one counter, while `EventuallyMetric` and
 that a value remains unchanged across samples separated by a caller-selected
 gap, which is useful for detecting leaked loops after a fault.
 
-The metrics-enabled tests require kube-vip to expose port `2112` in the kind
-node and require `curl` in the node image. Keep metric assertions focused on
-stable behavior and use label selectors instead of depending on the ordering
-of Prometheus samples.
+The metrics-enabled tests set `PrometheusHTTPServer` to `:2112` in their
+manifest values. It remains empty in other specs so parallel kube-vip pods do
+not contend for a host-network port. Metrics tests also require `curl` in the
+node image. Keep metric assertions focused on stable behavior and use label
+selectors instead of depending on the ordering of Prometheus samples.

--- a/testing/e2e/README.md
+++ b/testing/e2e/README.md
@@ -25,6 +25,10 @@ The E2E tests:
 * Attempts to connect to the control plane using the VIP
     * The new leader will need send ndp advertisements before this can succeed within a timeout
 
+Fault recovery helpers are idempotent so they can be registered with `DeferCleanup`
+before a fault is injected. This ensures partial setup failures still reconnect
+nodes, remove API-server firewall rules, and restore static-pod manifests.
+
 ## Prometheus metrics helpers
 
 The E2E build also provides helpers for checking the metrics endpoint from

--- a/testing/e2e/bgp/config.toml.tmpl
+++ b/testing/e2e/bgp/config.toml.tmpl
@@ -1,3 +1,4 @@
 [global.config]
   as = {{ .AS }}
   router-id = "1.1.1.1"
+  port = -1

--- a/testing/e2e/bgp/config.toml.tmpl
+++ b/testing/e2e/bgp/config.toml.tmpl
@@ -1,4 +1,5 @@
 [global.config]
   as = {{ .AS }}
   router-id = "1.1.1.1"
-  port = -1
+  port = {{ .Port }}
+  local-address-list = ["{{ .IPv4 }}", "{{ .IPv6 }}"]

--- a/testing/e2e/bgp/server.go
+++ b/testing/e2e/bgp/server.go
@@ -52,6 +52,7 @@ type Server struct {
 	TempDir   string
 
 	kill chan any
+	done chan error
 }
 
 // NewServer starts a GoBGP daemon and connects a gRPC client.
@@ -87,7 +88,8 @@ func NewServer(tempDir string) *Server {
 	f.Close()
 
 	s.kill = make(chan any)
-	go runGoBGP(configPath, s.kill)
+	s.done, err = runGoBGP(configPath, net.JoinHostPort(s.LocalIPv4, strconv.Itoa(int(GoBGPPort))), s.kill)
+	Expect(err).ToNot(HaveOccurred())
 
 	// Connect gRPC client (default: IPv4)
 	s.Client, err = newGoBGPClient(s.LocalIPv4, GoBGPPort)
@@ -123,6 +125,10 @@ func (s *Server) Stop() {
 	if s.kill != nil {
 		close(s.kill)
 		s.kill = nil
+	}
+	if s.done != nil {
+		Expect(<-s.done).To(Succeed())
+		s.done = nil
 	}
 }
 
@@ -344,11 +350,59 @@ func newGoBGPClient(address string, port uint32) (api.GoBgpServiceClient, error)
 	return api.NewGoBgpServiceClient(conn), nil
 }
 
-func runGoBGP(config string, kill chan any) {
+func runGoBGP(config, address string, kill <-chan any) (chan error, error) {
 	By("starting GoBGP server")
 	cmd := exec.Command("../../bin/gobgpd", "-f", config)
-	go cmd.Run()
-	<-kill
-	By("stopping GoBGP server")
-	_ = cmd.Process.Kill()
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start GoBGP: %w", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	if err := waitForProcessReady(address, done, 15*time.Second); err != nil {
+		_ = cmd.Process.Kill()
+		return nil, fmt.Errorf("start GoBGP on %s: %w", address, err)
+	}
+
+	stopped := make(chan error, 1)
+	go func() {
+		select {
+		case err := <-done:
+			stopped <- fmt.Errorf("GoBGP exited unexpectedly: %w", err)
+		case <-kill:
+			By("stopping GoBGP server")
+			if err := cmd.Process.Kill(); err != nil {
+				stopped <- err
+				return
+			}
+			<-done
+			stopped <- nil
+		}
+	}()
+	return stopped, nil
+}
+
+func waitForProcessReady(address string, exited <-chan error, timeout time.Duration) error {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case err := <-exited:
+			if err == nil {
+				return fmt.Errorf("process exited before becoming ready")
+			}
+			return fmt.Errorf("process exited before becoming ready: %w", err)
+		case <-deadline.C:
+			return fmt.Errorf("timed out waiting for TCP readiness")
+		case <-ticker.C:
+			conn, err := net.DialTimeout("tcp", address, time.Second)
+			if err == nil {
+				_ = conn.Close()
+				return nil
+			}
+		}
+	}
 }

--- a/testing/e2e/bgp/server.go
+++ b/testing/e2e/bgp/server.go
@@ -37,10 +37,18 @@ import (
 )
 
 const (
-	GoBGPAS   uint32 = 65500
-	KubevipAS uint32 = 65501
-	GoBGPPort uint32 = 50051
+	GoBGPAS      uint32 = 65500
+	KubevipAS    uint32 = 65501
+	GoBGPPort    uint16 = 1179
+	GoBGPAPIPort uint32 = 50051
 )
+
+type configValues struct {
+	AS   uint32
+	Port uint16
+	IPv4 string
+	IPv6 string
+}
 
 // ---------------------------------------------------------------------------
 // Server — GoBGP daemon lifecycle + gRPC client
@@ -54,8 +62,10 @@ type Server struct {
 	LocalIPv6 string
 	TempDir   string
 
-	kill chan any
-	done chan error
+	kill   chan any
+	done   chan error
+	stdout *lockedBuffer
+	stderr *lockedBuffer
 }
 
 // NewServer starts a GoBGP daemon and connects a gRPC client.
@@ -75,6 +85,7 @@ func NewServer(tempDir string) *Server {
 	v6addr, _, err := deployment.GetLocalIPv6(networkInterface)
 	Expect(err).ToNot(HaveOccurred())
 	s.LocalIPv6 = v6addr.String()
+	Expect(validateBindAddresses(s.LocalIPv4, s.LocalIPv6)).To(Succeed())
 
 	// Render GoBGP config and start daemon
 	curDir, err := os.Getwd()
@@ -87,15 +98,17 @@ func NewServer(tempDir string) *Server {
 	configPath := filepath.Join(tempDir, "config.toml")
 	f, err := os.OpenFile(configPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
 	Expect(err).ToNot(HaveOccurred())
-	Expect(tmpl.Execute(f, &e2e.BGPPeerValues{AS: GoBGPAS})).To(Succeed())
+	Expect(tmpl.Execute(f, configValues{AS: GoBGPAS, Port: GoBGPPort, IPv4: s.LocalIPv4, IPv6: s.LocalIPv6})).To(Succeed())
 	f.Close()
 
 	s.kill = make(chan any)
-	s.done, err = runGoBGP(configPath, net.JoinHostPort(s.LocalIPv4, strconv.Itoa(int(GoBGPPort))), s.kill)
+	apiAddress := net.JoinHostPort(s.LocalIPv4, strconv.Itoa(int(GoBGPAPIPort)))
+	apiHosts := apiAddress + "," + net.JoinHostPort(s.LocalIPv6, strconv.Itoa(int(GoBGPAPIPort)))
+	s.done, s.stdout, s.stderr, err = runGoBGP(configPath, apiHosts, apiAddress, s.kill)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Connect gRPC client (default: IPv4)
-	s.Client, err = newGoBGPClient(s.LocalIPv4, GoBGPPort)
+	s.Client, err = newGoBGPClient(s.LocalIPv4, GoBGPAPIPort)
 	Expect(err).ToNot(HaveOccurred())
 
 	return s
@@ -111,14 +124,14 @@ func BuildServerFromInfo(ipv4, ipv6, tempDir string) *Server {
 	}
 
 	var err error
-	s.Client, err = newGoBGPClient(ipv4, GoBGPPort)
+	s.Client, err = newGoBGPClient(ipv4, GoBGPAPIPort)
 	Expect(err).ToNot(HaveOccurred())
 	return s
 }
 
 // NewClientIPv6 creates a second gRPC client connection via IPv6.
 func (s *Server) NewClientIPv6() api.GoBgpServiceClient {
-	c, err := newGoBGPClient(s.LocalIPv6, GoBGPPort)
+	c, err := newGoBGPClient(s.LocalIPv6, GoBGPAPIPort)
 	Expect(err).ToNot(HaveOccurred())
 	return c
 }
@@ -167,7 +180,7 @@ func (s *Server) AddClusterPeers(ctx context.Context, clusterNodes []nodes.Node,
 				Peer: &api.Peer{
 					Conf: &api.PeerConf{
 						NeighborAddress: p.IP,
-						PeerAsn:         uint32(p.AS),
+						PeerAsn:         p.AS,
 					},
 					AfiSafis: []*api.AfiSafi{
 						{Config: &api.AfiSafiConfig{Enabled: true, Family: &api.Family{Afi: api.Family_AFI_IP, Safi: api.Family_SAFI_UNICAST}}},
@@ -180,6 +193,58 @@ func (s *Server) AddClusterPeers(ctx context.Context, clusterNodes []nodes.Node,
 	}
 
 	return peers
+}
+
+// WaitForEstablished waits until every requested neighbor is established.
+func (s *Server) WaitForEstablished(ctx context.Context, peers []*e2e.BGPPeerValues) error {
+	deadline := time.Now().Add(120 * time.Second)
+	var state string
+	for time.Now().Before(deadline) {
+		var err error
+		state, err = peerState(ctx, s.Client, peers)
+		if err == nil {
+			return nil
+		}
+		state = err.Error() + "; " + state
+		time.Sleep(time.Second)
+	}
+	return fmt.Errorf("timed out waiting for BGP neighbors: %s%s", state, s.logs())
+}
+
+func peerState(ctx context.Context, client api.GoBgpServiceClient, expected []*e2e.BGPPeerValues) (string, error) {
+	peerCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	stream, err := client.ListPeer(peerCtx, &api.ListPeerRequest{})
+	if err != nil {
+		return "", err
+	}
+	wanted := make(map[string]struct{}, len(expected))
+	for _, peer := range expected {
+		wanted[peer.IP] = struct{}{}
+	}
+	states := make([]string, 0, len(expected))
+	for {
+		peer, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			return strings.Join(states, ", "), recvErr
+		}
+		address := peer.GetPeer().GetConf().GetNeighborAddress()
+		if _, ok := wanted[address]; !ok {
+			continue
+		}
+		state := peer.GetPeer().GetState().GetSessionState()
+		states = append(states, fmt.Sprintf("%s=%s", address, state))
+		if state == api.PeerState_SESSION_STATE_ESTABLISHED {
+			delete(wanted, address)
+		}
+	}
+	if len(wanted) != 0 {
+		return strings.Join(states, ", "), fmt.Errorf("%d/%d neighbors are not established", len(wanted), len(expected))
+	}
+	return strings.Join(states, ", "), nil
 }
 
 // RemovePeers deletes the given peers from GoBGP.
@@ -344,6 +409,17 @@ func joinNonEmpty(ss []string) string {
 	return result
 }
 
+func validateBindAddresses(ipv4, ipv6 string) error {
+	v4, v6 := net.ParseIP(ipv4), net.ParseIP(ipv6)
+	if v4 == nil || v4.To4() == nil || v4.IsUnspecified() {
+		return fmt.Errorf("invalid IPv4 bridge address %q", ipv4)
+	}
+	if v6 == nil || v6.To4() != nil || v6.IsUnspecified() || v6.IsLinkLocalUnicast() {
+		return fmt.Errorf("invalid IPv6 bridge address %q", ipv6)
+	}
+	return nil
+}
+
 func newGoBGPClient(address string, port uint32) (api.GoBgpServiceClient, error) {
 	target := net.JoinHostPort(address, strconv.Itoa(int(port)))
 	conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -353,26 +429,41 @@ func newGoBGPClient(address string, port uint32) (api.GoBgpServiceClient, error)
 	return api.NewGoBgpServiceClient(conn), nil
 }
 
-func runGoBGP(config, address string, kill <-chan any) (chan error, error) {
+func runGoBGP(config, apiHosts, readyAddress string, kill <-chan any) (chan error, *lockedBuffer, *lockedBuffer, error) {
 	By("starting GoBGP server")
-	cmd := exec.Command("../../bin/gobgpd", "--api-hosts", address, "-f", config)
+	cmd := exec.Command("../../bin/gobgpd", "--api-hosts", apiHosts, "-f", config) //nolint:gosec // arguments are generated by the test harness
 	stdout := &lockedBuffer{}
 	stderr := &lockedBuffer{}
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
+	stdoutFile, err := os.Create(filepath.Join(filepath.Dir(config), "gobgpd.stdout"))
+	if err != nil {
+		return nil, stdout, stderr, fmt.Errorf("create GoBGP stdout log: %w", err)
+	}
+	stderrFile, err := os.Create(filepath.Join(filepath.Dir(config), "gobgpd.stderr"))
+	if err != nil {
+		stdoutFile.Close()
+		return nil, stdout, stderr, fmt.Errorf("create GoBGP stderr log: %w", err)
+	}
+	cmd.Stdout = io.MultiWriter(stdout, stdoutFile)
+	cmd.Stderr = io.MultiWriter(stderr, stderrFile)
 	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("start GoBGP: %w", err)
+		stdoutFile.Close()
+		stderrFile.Close()
+		return nil, stdout, stderr, fmt.Errorf("start GoBGP: %w", err)
 	}
 
 	done := make(chan error, 1)
-	go func() { done <- cmd.Wait() }()
-	if err := waitForGoBGPReady(address, done, stdout, stderr, 15*time.Second); err != nil {
+	go func() {
+		done <- cmd.Wait()
+		stdoutFile.Close()
+		stderrFile.Close()
+	}()
+	if err := waitForGoBGPReady(readyAddress, done, stdout, stderr, 15*time.Second); err != nil {
 		_ = cmd.Process.Kill()
 		select {
 		case <-done:
 		default:
 		}
-		return nil, fmt.Errorf("start GoBGP on %s: %w", address, err)
+		return nil, stdout, stderr, fmt.Errorf("start GoBGP API on %s: %w", apiHosts, err)
 	}
 
 	stopped := make(chan error, 1)
@@ -390,7 +481,16 @@ func runGoBGP(config, address string, kill <-chan any) (chan error, error) {
 			stopped <- nil
 		}
 	}()
-	return stopped, nil
+	return stopped, stdout, stderr, nil
+}
+
+func (s *Server) logs() string {
+	if s.stdout != nil && s.stderr != nil {
+		return formatProcessLogs(s.stdout, s.stderr)
+	}
+	stdout, _ := os.ReadFile(filepath.Join(s.TempDir, "gobgpd.stdout"))
+	stderr, _ := os.ReadFile(filepath.Join(s.TempDir, "gobgpd.stderr"))
+	return formatProcessLogs(bytes.NewBuffer(stdout), bytes.NewBuffer(stderr))
 }
 
 func waitForGoBGPReady(address string, exited <-chan error, stdout, stderr fmt.Stringer, timeout time.Duration) error {

--- a/testing/e2e/bgp/server.go
+++ b/testing/e2e/bgp/server.go
@@ -9,6 +9,7 @@
 package bgp
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -17,6 +18,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
+	"sync"
 	"text/template"
 	"time"
 
@@ -352,15 +355,23 @@ func newGoBGPClient(address string, port uint32) (api.GoBgpServiceClient, error)
 
 func runGoBGP(config, address string, kill <-chan any) (chan error, error) {
 	By("starting GoBGP server")
-	cmd := exec.Command("../../bin/gobgpd", "-f", config)
+	cmd := exec.Command("../../bin/gobgpd", "--api-hosts", address, "-f", config)
+	stdout := &lockedBuffer{}
+	stderr := &lockedBuffer{}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("start GoBGP: %w", err)
 	}
 
 	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()
-	if err := waitForProcessReady(address, done, 15*time.Second); err != nil {
+	if err := waitForGoBGPReady(address, done, stdout, stderr, 15*time.Second); err != nil {
 		_ = cmd.Process.Kill()
+		select {
+		case <-done:
+		default:
+		}
 		return nil, fmt.Errorf("start GoBGP on %s: %w", address, err)
 	}
 
@@ -368,7 +379,7 @@ func runGoBGP(config, address string, kill <-chan any) (chan error, error) {
 	go func() {
 		select {
 		case err := <-done:
-			stopped <- fmt.Errorf("GoBGP exited unexpectedly: %w", err)
+			stopped <- fmt.Errorf("GoBGP exited unexpectedly: %w%s", err, formatProcessLogs(stdout, stderr))
 		case <-kill:
 			By("stopping GoBGP server")
 			if err := cmd.Process.Kill(); err != nil {
@@ -382,7 +393,14 @@ func runGoBGP(config, address string, kill <-chan any) (chan error, error) {
 	return stopped, nil
 }
 
-func waitForProcessReady(address string, exited <-chan error, timeout time.Duration) error {
+func waitForGoBGPReady(address string, exited <-chan error, stdout, stderr fmt.Stringer, timeout time.Duration) error {
+	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("create GoBGP API client: %w", err)
+	}
+	defer conn.Close()
+	client := api.NewGoBgpServiceClient(conn)
+
 	deadline := time.NewTimer(timeout)
 	defer deadline.Stop()
 	ticker := time.NewTicker(50 * time.Millisecond)
@@ -392,17 +410,49 @@ func waitForProcessReady(address string, exited <-chan error, timeout time.Durat
 		select {
 		case err := <-exited:
 			if err == nil {
-				return fmt.Errorf("process exited before becoming ready")
+				return fmt.Errorf("process exited before becoming ready%s", formatProcessLogs(stdout, stderr))
 			}
-			return fmt.Errorf("process exited before becoming ready: %w", err)
+			return fmt.Errorf("process exited before becoming ready: %w%s", err, formatProcessLogs(stdout, stderr))
 		case <-deadline.C:
-			return fmt.Errorf("timed out waiting for TCP readiness")
+			return fmt.Errorf("timed out waiting for GoBGP API readiness%s", formatProcessLogs(stdout, stderr))
 		case <-ticker.C:
-			conn, err := net.DialTimeout("tcp", address, time.Second)
-			if err == nil {
-				_ = conn.Close()
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			response, err := client.GetBgp(ctx, &api.GetBgpRequest{})
+			cancel()
+			if err == nil && response.GetGlobal().GetAsn() == GoBGPAS {
 				return nil
 			}
 		}
 	}
+}
+
+type lockedBuffer struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.String()
+}
+
+func formatProcessLogs(stdout, stderr fmt.Stringer) string {
+	var sections []string
+	if output := strings.TrimSpace(stdout.String()); output != "" {
+		sections = append(sections, "stdout:\n"+output)
+	}
+	if output := strings.TrimSpace(stderr.String()); output != "" {
+		sections = append(sections, "stderr:\n"+output)
+	}
+	if len(sections) == 0 {
+		return ""
+	}
+	return "\n" + strings.Join(sections, "\n")
 }

--- a/testing/e2e/bgp/server.go
+++ b/testing/e2e/bgp/server.go
@@ -176,23 +176,22 @@ func (s *Server) AddClusterPeers(ctx context.Context, clusterNodes []nodes.Node,
 	// Register peers with GoBGP
 	for _, p := range peers {
 		Eventually(func() error {
-			_, err := s.Client.AddPeer(ctx, &api.AddPeerRequest{
-				Peer: &api.Peer{
-					Conf: &api.PeerConf{
-						NeighborAddress: p.IP,
-						PeerAsn:         p.AS,
-					},
-					AfiSafis: []*api.AfiSafi{
-						{Config: &api.AfiSafiConfig{Enabled: true, Family: &api.Family{Afi: api.Family_AFI_IP, Safi: api.Family_SAFI_UNICAST}}},
-						{Config: &api.AfiSafiConfig{Enabled: true, Family: &api.Family{Afi: api.Family_AFI_IP6, Safi: api.Family_SAFI_UNICAST}}},
-					},
-				},
-			})
+			_, err := s.Client.AddPeer(ctx, peerRequest(p.IP, p.AS))
 			return err
 		}, "120s", "100ms").Should(Succeed())
 	}
 
 	return peers
+}
+
+func peerRequest(address string, asn uint32) *api.AddPeerRequest {
+	return &api.AddPeerRequest{Peer: &api.Peer{
+		Conf: &api.PeerConf{NeighborAddress: address, PeerAsn: asn},
+		AfiSafis: []*api.AfiSafi{
+			{Config: &api.AfiSafiConfig{Enabled: true, Family: &api.Family{Afi: api.Family_AFI_IP, Safi: api.Family_SAFI_UNICAST}}},
+			{Config: &api.AfiSafiConfig{Enabled: true, Family: &api.Family{Afi: api.Family_AFI_IP6, Safi: api.Family_SAFI_UNICAST}}},
+		},
+	}}
 }
 
 // WaitForEstablished waits until every requested neighbor is established.
@@ -264,7 +263,7 @@ func (s *Server) RemovePeers(ctx context.Context, peers []*e2e.BGPPeerValues) {
 // ResolveVIP queries GoBGP for the current next-hops announcing the given VIP.
 // Returns the node IPs that a real BGP router would forward traffic to.
 func ResolveVIP(ctx context.Context, c api.GoBgpServiceClient, vip string) []string {
-	family := &api.Family{Afi: api.Family_AFI_IP, Safi: api.Family_SAFI_UNICAST}
+	family := routeFamily(vip)
 	dests, err := ListPaths(ctx, c, family, []*api.TableLookupPrefix{{Prefix: vip}})
 	Expect(err).ToNot(HaveOccurred())
 
@@ -277,6 +276,14 @@ func ResolveVIP(ctx context.Context, c api.GoBgpServiceClient, vip string) []str
 		}
 	}
 	return nexthops
+}
+
+func routeFamily(address string) *api.Family {
+	afi := api.Family_AFI_IP
+	if ip := net.ParseIP(address); ip != nil && ip.To4() == nil {
+		afi = api.Family_AFI_IP6
+	}
+	return &api.Family{Afi: afi, Safi: api.Family_SAFI_UNICAST}
 }
 
 // ---------------------------------------------------------------------------

--- a/testing/e2e/bgp/server_test.go
+++ b/testing/e2e/bgp/server_test.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"errors"
 	"net"
-	"os"
 	"strings"
 	"testing"
+	"text/template"
 	"time"
 
 	api "github.com/osrg/gobgp/v4/api"
@@ -24,15 +24,33 @@ func (testGoBGPServer) GetBgp(context.Context, *api.GetBgpRequest) (*api.GetBgpR
 	return &api.GetBgpResponse{Global: &api.Global{Asn: GoBGPAS}}, nil
 }
 
-func TestConfigDisablesBGPListener(t *testing.T) {
+func TestConfigUsesUnprivilegedBGPListener(t *testing.T) {
 	t.Parallel()
 
-	config, err := os.ReadFile("config.toml.tmpl")
+	tmpl, err := template.ParseFiles("config.toml.tmpl")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(config), "port = -1") {
-		t.Fatal("GoBGP test config must disable its privileged BGP listener")
+	var config bytes.Buffer
+	if err := tmpl.Execute(&config, configValues{AS: GoBGPAS, Port: GoBGPPort, IPv4: "172.18.0.1", IPv6: "fd00::1"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []string{"port = 1179", `local-address-list = ["172.18.0.1", "fd00::1"]`} {
+		if !strings.Contains(config.String(), expected) {
+			t.Fatalf("GoBGP test config does not contain %q", expected)
+		}
+	}
+}
+
+func TestValidateBindAddresses(t *testing.T) {
+	t.Parallel()
+	if err := validateBindAddresses("172.18.0.1", "fd00::1"); err != nil {
+		t.Fatalf("validateBindAddresses() error = %v", err)
+	}
+	for _, pair := range [][2]string{{"", "fd00::1"}, {"::1", "fd00::1"}, {"172.18.0.1", "fe80::1"}} {
+		if err := validateBindAddresses(pair[0], pair[1]); err == nil {
+			t.Fatalf("validateBindAddresses(%q, %q) succeeded", pair[0], pair[1])
+		}
 	}
 }
 

--- a/testing/e2e/bgp/server_test.go
+++ b/testing/e2e/bgp/server_test.go
@@ -3,14 +3,40 @@
 package bgp
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"net"
+	"os"
 	"strings"
 	"testing"
 	"time"
+
+	api "github.com/osrg/gobgp/v4/api"
+	"google.golang.org/grpc"
 )
 
-func TestWaitForProcessReady(t *testing.T) {
+type testGoBGPServer struct {
+	api.UnimplementedGoBgpServiceServer
+}
+
+func (testGoBGPServer) GetBgp(context.Context, *api.GetBgpRequest) (*api.GetBgpResponse, error) {
+	return &api.GetBgpResponse{Global: &api.Global{Asn: GoBGPAS}}, nil
+}
+
+func TestConfigDisablesBGPListener(t *testing.T) {
+	t.Parallel()
+
+	config, err := os.ReadFile("config.toml.tmpl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(config), "port = -1") {
+		t.Fatal("GoBGP test config must disable its privileged BGP listener")
+	}
+}
+
+func TestWaitForGoBGPReady(t *testing.T) {
 	t.Parallel()
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -18,25 +44,31 @@ func TestWaitForProcessReady(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer listener.Close()
+	server := grpc.NewServer()
+	api.RegisterGoBgpServiceServer(server, testGoBGPServer{})
+	go func() { _ = server.Serve(listener) }()
+	defer server.Stop()
 
 	tests := []struct {
 		name      string
 		address   string
 		exited    chan error
+		stdout    string
+		stderr    string
 		wantError string
 	}{
 		{name: "ready", address: listener.Addr().String(), exited: make(chan error)},
-		{name: "exited", address: "127.0.0.1:0", exited: bufferedError(errors.New("boom")), wantError: "boom"},
-		{name: "timeout", address: "127.0.0.1:0", exited: make(chan error), wantError: "timed out"},
+		{name: "exited", address: "127.0.0.1:0", exited: bufferedError(errors.New("boom")), stdout: "started", stderr: "bind: permission denied", wantError: "stdout:\nstarted\nstderr:\nbind: permission denied"},
+		{name: "timeout", address: "127.0.0.1:0", exited: make(chan error), stderr: "still starting", wantError: "timed out waiting for GoBGP API readiness\nstderr:\nstill starting"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := waitForProcessReady(test.address, test.exited, 100*time.Millisecond)
+			err := waitForGoBGPReady(test.address, test.exited, bytes.NewBufferString(test.stdout), bytes.NewBufferString(test.stderr), 100*time.Millisecond)
 			if test.wantError == "" && err != nil {
-				t.Fatalf("waitForProcessReady() error = %v", err)
+				t.Fatalf("waitForGoBGPReady() error = %v", err)
 			}
 			if test.wantError != "" && (err == nil || !strings.Contains(err.Error(), test.wantError)) {
-				t.Fatalf("waitForProcessReady() error = %v, want substring %q", err, test.wantError)
+				t.Fatalf("waitForGoBGPReady() error = %v, want substring %q", err, test.wantError)
 			}
 		})
 	}

--- a/testing/e2e/bgp/server_test.go
+++ b/testing/e2e/bgp/server_test.go
@@ -54,6 +54,42 @@ func TestValidateBindAddresses(t *testing.T) {
 	}
 }
 
+func TestRouteFamily(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		address string
+		want    api.Family_Afi
+	}{
+		{address: "192.0.2.1", want: api.Family_AFI_IP},
+		{address: "2001:db8::1", want: api.Family_AFI_IP6},
+	}
+	for _, test := range tests {
+		t.Run(test.address, func(t *testing.T) {
+			family := routeFamily(test.address)
+			if family.Afi != test.want || family.Safi != api.Family_SAFI_UNICAST {
+				t.Fatalf("routeFamily(%q) = %s/%s, want %s/%s", test.address, family.Afi, family.Safi, test.want, api.Family_SAFI_UNICAST)
+			}
+		})
+	}
+}
+
+func TestPeerRequestEnablesMultiprotocolFamilies(t *testing.T) {
+	t.Parallel()
+	for _, address := range []string{"192.0.2.2", "2001:db8::2"} {
+		t.Run(address, func(t *testing.T) {
+			peer := peerRequest(address, KubevipAS).GetPeer()
+			if peer.GetConf().GetNeighborAddress() != address || peer.GetConf().GetPeerAsn() != KubevipAS {
+				t.Fatalf("peer config = %+v", peer.GetConf())
+			}
+			families := peer.GetAfiSafis()
+			if len(families) != 2 || families[0].GetConfig().GetFamily().GetAfi() != api.Family_AFI_IP ||
+				families[1].GetConfig().GetFamily().GetAfi() != api.Family_AFI_IP6 {
+				t.Fatalf("peer families = %+v, want IPv4 and IPv6 unicast", families)
+			}
+		})
+	}
+}
+
 func TestWaitForGoBGPReady(t *testing.T) {
 	t.Parallel()
 

--- a/testing/e2e/bgp/server_test.go
+++ b/testing/e2e/bgp/server_test.go
@@ -1,0 +1,49 @@
+//go:build e2e
+
+package bgp
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWaitForProcessReady(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	tests := []struct {
+		name      string
+		address   string
+		exited    chan error
+		wantError string
+	}{
+		{name: "ready", address: listener.Addr().String(), exited: make(chan error)},
+		{name: "exited", address: "127.0.0.1:0", exited: bufferedError(errors.New("boom")), wantError: "boom"},
+		{name: "timeout", address: "127.0.0.1:0", exited: make(chan error), wantError: "timed out"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := waitForProcessReady(test.address, test.exited, 100*time.Millisecond)
+			if test.wantError == "" && err != nil {
+				t.Fatalf("waitForProcessReady() error = %v", err)
+			}
+			if test.wantError != "" && (err == nil || !strings.Contains(err.Error(), test.wantError)) {
+				t.Fatalf("waitForProcessReady() error = %v, want substring %q", err, test.wantError)
+			}
+		})
+	}
+}
+
+func bufferedError(err error) chan error {
+	result := make(chan error, 1)
+	result <- err
+	return result
+}

--- a/testing/e2e/cluster.go
+++ b/testing/e2e/cluster.go
@@ -14,11 +14,15 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	kindconfigv1alpha4 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 	kindcluster "sigs.k8s.io/kind/pkg/cluster"
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
+	"sigs.k8s.io/yaml"
 )
 
 // ClusterSpec describes a Kind cluster with kube-vip.
@@ -33,6 +37,9 @@ type ClusterSpec struct {
 	// TemplateName is the kube-vip manifest template filename relative to the
 	// e2e test directory. Defaults to "kube-vip.yaml.tmpl".
 	TemplateName string
+	// UseDaemonSet deploys the rendered kube-vip pod spec as a daemonset rather
+	// than mounting it as a static pod in each Kind node.
+	UseDaemonSet bool
 }
 
 // Cluster holds a running Kind cluster with kube-vip.
@@ -46,7 +53,7 @@ type Cluster struct {
 	ConfigMtx *sync.Mutex
 }
 
-// CreateCluster creates a Kind cluster, renders and mounts the kube-vip
+// CreateCluster creates a Kind cluster, renders and deploys the kube-vip
 // manifest, loads the kube-vip image, and returns the Cluster.
 func CreateCluster(ctx context.Context, spec *ClusterSpec) *Cluster {
 	c := &Cluster{
@@ -119,16 +126,18 @@ func CreateCluster(ctx context.Context, spec *ClusterSpec) *Cluster {
 		KubeadmConfigPatchesJSON6902: spec.KubeadmPatches,
 	}
 	for i := range spec.Nodes {
-		mPath := manifestPath
-		if i == 0 && v129 {
-			mPath = firstNodeManifestPath
-		}
 		node := kindconfigv1alpha4.Node{
 			Role: kindconfigv1alpha4.ControlPlaneRole,
-			ExtraMounts: []kindconfigv1alpha4.Mount{{
+		}
+		if !spec.UseDaemonSet {
+			mPath := manifestPath
+			if i == 0 && v129 {
+				mPath = firstNodeManifestPath
+			}
+			node.ExtraMounts = []kindconfigv1alpha4.Mount{{
 				HostPath:      mPath,
 				ContainerPath: "/etc/kubernetes/manifests/kube-vip.yaml",
-			}},
+			}}
 		}
 		if k8sImage != "" {
 			node.Image = k8sImage
@@ -164,8 +173,61 @@ func CreateCluster(ctx context.Context, spec *ClusterSpec) *Cluster {
 
 	// Load kube-vip image
 	c.LoadImage(spec.KubeVip.ImagePath)
+	if spec.UseDaemonSet {
+		deployDaemonSet(ctx, c, manifestPath)
+	}
 
 	return c
+}
+
+func deployDaemonSet(ctx context.Context, c *Cluster, manifestPath string) {
+	payload, err := os.ReadFile(manifestPath)
+	Expect(err).NotTo(HaveOccurred())
+
+	var pod corev1.Pod
+	Expect(yaml.Unmarshal(payload, &pod)).To(Succeed())
+	labels := map[string]string{"app": "kube-vip"}
+	pod.Spec.RestartPolicy = corev1.RestartPolicyAlways
+	pod.Spec.Tolerations = append(pod.Spec.Tolerations,
+		corev1.Toleration{
+			Key:      "node-role.kubernetes.io/control-plane",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		corev1.Toleration{
+			Key:      "node-role.kubernetes.io/master",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	)
+
+	daemonSet := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-vip",
+			Namespace: "kube-system",
+			Labels:    labels,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec:       pod.Spec,
+			},
+		},
+	}
+
+	_, err = c.Client.AppsV1().DaemonSets("kube-system").Create(ctx, daemonSet, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(func() error {
+		current, getErr := c.Client.AppsV1().DaemonSets("kube-system").Get(ctx, daemonSet.Name, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+		if current.Status.NumberReady != current.Status.DesiredNumberScheduled {
+			return fmt.Errorf("kube-vip daemonset is not ready: %d/%d", current.Status.NumberReady, current.Status.DesiredNumberScheduled)
+		}
+		return nil
+	}, "120s", "2s").Should(Succeed())
 }
 
 // LoadImage loads a Docker image into the Kind cluster.

--- a/testing/e2e/cluster.go
+++ b/testing/e2e/cluster.go
@@ -176,8 +176,37 @@ func CreateCluster(ctx context.Context, spec *ClusterSpec) *Cluster {
 	if spec.UseDaemonSet {
 		deployDaemonSet(ctx, c, manifestPath)
 	}
+	Eventually(func() error {
+		return kubeVipPodsReady(ctx, c.Client, spec.Nodes)
+	}, "120s", "2s").Should(Succeed())
 
 	return c
+}
+
+func kubeVipPodsReady(ctx context.Context, client kubernetes.Interface, expected int) error {
+	pods, err := client.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{LabelSelector: "app=kube-vip"})
+	if err != nil {
+		return err
+	}
+	ready := 0
+	states := make([]string, 0, len(pods.Items))
+	for _, pod := range pods.Items {
+		isReady := false
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+				isReady = true
+				break
+			}
+		}
+		if isReady {
+			ready++
+		}
+		states = append(states, fmt.Sprintf("%s=%s ready=%t", pod.Name, pod.Status.Phase, isReady))
+	}
+	if ready < expected {
+		return fmt.Errorf("kube-vip pods are not ready: %d/%d; states: %v", ready, expected, states)
+	}
+	return nil
 }
 
 func deployDaemonSet(ctx context.Context, c *Cluster, manifestPath string) {

--- a/testing/e2e/cluster_test.go
+++ b/testing/e2e/cluster_test.go
@@ -1,0 +1,29 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestKubeVipPodsReady(t *testing.T) {
+	t.Parallel()
+	ready := corev1.PodCondition{Type: corev1.PodReady, Status: corev1.ConditionTrue}
+	client := fake.NewSimpleClientset(
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "kube-vip-a", Namespace: "kube-system", Labels: map[string]string{"app": "kube-vip"}}, Status: corev1.PodStatus{Phase: corev1.PodRunning, Conditions: []corev1.PodCondition{ready}}},
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "unrelated", Namespace: "kube-system"}, Status: corev1.PodStatus{Phase: corev1.PodRunning, Conditions: []corev1.PodCondition{ready}}},
+	)
+
+	if err := kubeVipPodsReady(context.Background(), client, 1); err != nil {
+		t.Fatalf("kubeVipPodsReady() error = %v", err)
+	}
+	if err := kubeVipPodsReady(context.Background(), client, 2); err == nil || !strings.Contains(err.Error(), "1/2") {
+		t.Fatalf("kubeVipPodsReady() error = %v, want readiness diagnostics", err)
+	}
+}

--- a/testing/e2e/common_lease.go
+++ b/testing/e2e/common_lease.go
@@ -1,6 +1,11 @@
 package e2e
 
-import "fmt"
+import (
+	"fmt"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
 
 // CheckCommonLeaseOwnership verifies a stable lease holder and its exclusive datapath ownership.
 func CheckCommonLeaseOwnership(getHolder func() (string, error), nodes, addresses []string, hasAddress func(string, string) bool) (string, error) {
@@ -30,4 +35,19 @@ func CheckCommonLeaseOwnership(getHolder func() (string, error), nodes, addresse
 	}
 
 	return holder, nil
+}
+
+// CheckCommonLeaseRetired accepts a deleted lease or one without a holder.
+func CheckCommonLeaseRetired(lease *coordinationv1.Lease, err error) error {
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get common lease: %w", err)
+	}
+	if lease.Spec.HolderIdentity != nil && *lease.Spec.HolderIdentity != "" {
+		return fmt.Errorf("common lease is still held by %q", *lease.Spec.HolderIdentity)
+	}
+
+	return nil
 }

--- a/testing/e2e/common_lease.go
+++ b/testing/e2e/common_lease.go
@@ -1,0 +1,33 @@
+package e2e
+
+import "fmt"
+
+// CheckCommonLeaseOwnership verifies a stable lease holder and its exclusive datapath ownership.
+func CheckCommonLeaseOwnership(getHolder func() (string, error), nodes, addresses []string, hasAddress func(string, string) bool) (string, error) {
+	holder, err := getHolder()
+	if err != nil {
+		return "", err
+	}
+	if holder == "" {
+		return "", fmt.Errorf("common lease has no holder")
+	}
+
+	for _, node := range nodes {
+		for _, address := range addresses {
+			expected := node == holder
+			if hasAddress(address, node) != expected {
+				return "", fmt.Errorf("address %q presence on node %q does not match lease holder %q", address, node, holder)
+			}
+		}
+	}
+
+	currentHolder, err := getHolder()
+	if err != nil {
+		return "", err
+	}
+	if currentHolder != holder {
+		return "", fmt.Errorf("common lease holder changed from %q to %q while checking ownership", holder, currentHolder)
+	}
+
+	return holder, nil
+}

--- a/testing/e2e/common_lease_test.go
+++ b/testing/e2e/common_lease_test.go
@@ -1,0 +1,71 @@
+package e2e
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCheckCommonLeaseOwnershipStableHolder(t *testing.T) {
+	present := map[string]string{"192.0.2.10": "node-a", "2001:db8::10": "node-a"}
+	holder, err := CheckCommonLeaseOwnership(
+		func() (string, error) { return "node-a", nil },
+		[]string{"node-a", "node-b"},
+		[]string{"192.0.2.10", "2001:db8::10"},
+		func(address, node string) bool { return present[address] == node },
+	)
+	if err != nil {
+		t.Fatalf("checkCommonLeaseOwnership() error = %v", err)
+	}
+	if holder != "node-a" {
+		t.Fatalf("checkCommonLeaseOwnership() holder = %q, want node-a", holder)
+	}
+}
+
+func TestCheckCommonLeaseOwnershipHolderMigration(t *testing.T) {
+	holderReads := 0
+	getHolder := func() (string, error) {
+		holderReads++
+		if holderReads == 1 {
+			return "node-a", nil
+		}
+		return "node-b", nil
+	}
+	present := map[string]string{"192.0.2.10": "node-a"}
+	hasAddress := func(address, node string) bool { return present[address] == node }
+
+	if _, err := CheckCommonLeaseOwnership(getHolder, []string{"node-a", "node-b"}, []string{"192.0.2.10"}, hasAddress); err == nil {
+		t.Fatal("checkCommonLeaseOwnership() accepted an ownership snapshot while the holder changed")
+	}
+
+	present["192.0.2.10"] = "node-b"
+	holder, err := CheckCommonLeaseOwnership(getHolder, []string{"node-a", "node-b"}, []string{"192.0.2.10"}, hasAddress)
+	if err != nil {
+		t.Fatalf("checkCommonLeaseOwnership() after migration error = %v", err)
+	}
+	if holder != "node-b" {
+		t.Fatalf("checkCommonLeaseOwnership() holder = %q, want node-b", holder)
+	}
+}
+
+func TestCheckCommonLeaseOwnershipRejectsMissingHolder(t *testing.T) {
+	_, err := CheckCommonLeaseOwnership(
+		func() (string, error) { return "", nil },
+		nil,
+		nil,
+		func(string, string) bool { return false },
+	)
+	if err == nil {
+		t.Fatal("checkCommonLeaseOwnership() accepted an empty holder")
+	}
+
+	want := errors.New("get lease")
+	_, err = CheckCommonLeaseOwnership(
+		func() (string, error) { return "", want },
+		nil,
+		nil,
+		func(string, string) bool { return false },
+	)
+	if !errors.Is(err, want) {
+		t.Fatalf("checkCommonLeaseOwnership() error = %v, want %v", err, want)
+	}
+}

--- a/testing/e2e/common_lease_test.go
+++ b/testing/e2e/common_lease_test.go
@@ -3,6 +3,10 @@ package e2e
 import (
 	"errors"
 	"testing"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/ptr"
 )
 
 func TestCheckCommonLeaseOwnershipStableHolder(t *testing.T) {
@@ -67,5 +71,33 @@ func TestCheckCommonLeaseOwnershipRejectsMissingHolder(t *testing.T) {
 	)
 	if !errors.Is(err, want) {
 		t.Fatalf("checkCommonLeaseOwnership() error = %v, want %v", err, want)
+	}
+}
+
+func TestCheckCommonLeaseRetired(t *testing.T) {
+	getError := errors.New("get lease")
+	tests := []struct {
+		name    string
+		lease   *coordinationv1.Lease
+		err     error
+		wantErr bool
+	}{
+		{name: "absent", err: apierrors.NewNotFound(coordinationv1.Resource("leases"), "common-lease")},
+		{name: "nil holder", lease: &coordinationv1.Lease{}},
+		{name: "empty holder", lease: &coordinationv1.Lease{Spec: coordinationv1.LeaseSpec{HolderIdentity: ptr.To("")}}},
+		{name: "nonempty holder", lease: &coordinationv1.Lease{Spec: coordinationv1.LeaseSpec{HolderIdentity: ptr.To("node-a")}}, wantErr: true},
+		{name: "error", err: getError, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckCommonLeaseRetired(tt.lease, tt.err)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("CheckCommonLeaseRetired() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.name == "error" && !errors.Is(err, getError) {
+				t.Fatalf("CheckCommonLeaseRetired() error = %v, want wrapped %v", err, getError)
+			}
+		})
 	}
 }

--- a/testing/e2e/e2e_bgp_healthcheck_test.go
+++ b/testing/e2e/e2e_bgp_healthcheck_test.go
@@ -99,17 +99,13 @@ var _ = Describe("kube-vip BGP ControlPlane health-check", Ordered, func() {
 				node := kindCluster.Nodes[rand.IntN(len(kindCluster.Nodes))]
 
 				By(fmt.Sprintf("stopping the apiserver on node %s", node.String()))
-				e2e.RunInNode(node, "mv",
-					"/etc/kubernetes/manifests/kube-apiserver.yaml",
-					"/tmp/kube-apiserver.yaml")
+				Expect(e2e.StashPodManifest(kindCluster.Name, node.String(), "kube-apiserver.yaml")).To(Succeed())
 
 				bgp.CheckPathCount(ctx, server.Client, cpVIP, len(kindCluster.Nodes)-1, 30*time.Second)
 				assertVIPReachable(ctx, server, cpVIP, httpClient)
 
 				By(fmt.Sprintf("restoring the apiserver on node %s", node.String()))
-				e2e.RunInNode(node, "mv",
-					"/tmp/kube-apiserver.yaml",
-					"/etc/kubernetes/manifests/kube-apiserver.yaml")
+				Expect(e2e.RestorePodManifest(kindCluster.Name, node.String(), "kube-apiserver.yaml")).To(Succeed())
 
 				bgp.CheckPathCount(ctx, server.Client, cpVIP, len(kindCluster.Nodes), 120*time.Second)
 				assertVIPReachable(ctx, server, cpVIP, httpClient)

--- a/testing/e2e/e2e_bgp_healthcheck_test.go
+++ b/testing/e2e/e2e_bgp_healthcheck_test.go
@@ -43,7 +43,7 @@ var _ = Describe("kube-vip BGP ControlPlane health-check", Ordered, func() {
 
 			cpVIP = e2e.GenerateVIP(utils.IPv4Family, SOffset.Get(), defaultNetwork)
 			kvPeers := []*e2e.BGPPeerValues{
-				{IP: server.LocalIPv4, AS: bgp.GoBGPAS, IPFamily: utils.IPv4Family},
+				{IP: server.LocalIPv4, AS: bgp.GoBGPAS, Port: bgp.GoBGPPort, IPFamily: utils.IPv4Family},
 			}
 
 			kindCluster = e2e.CreateCluster(ctx, &e2e.ClusterSpec{

--- a/testing/e2e/e2e_bgp_test.go
+++ b/testing/e2e/e2e_bgp_test.go
@@ -1262,6 +1262,7 @@ func annotateNodes(ctx context.Context, pref string, client kubernetes.Interface
 		annotations[pref+"src-ip"] = addr
 		annotations[pref+"peer-asn"] = strconv.Itoa(int(peer.AS))
 		annotations[pref+"peer-ip"] = peer.IP
+		annotations[pref+"peer-port"] = strconv.Itoa(int(peer.Port))
 
 		patch, err := json.Marshal(map[string]any{
 			"metadata": map[string]any{

--- a/testing/e2e/e2e_bgp_test.go
+++ b/testing/e2e/e2e_bgp_test.go
@@ -931,6 +931,7 @@ var _ = Describe("kube-vip BGP mode", func() {
 				kvPeer := e2e.BGPPeerValues{
 					IP:       server.LocalIPv4,
 					AS:       bgp.GoBGPAS,
+					Port:     bgp.GoBGPPort,
 					IPFamily: utils.IPv4Family,
 				}
 				Expect(annotateNodes(ctx, "test", kindCluster.Client, kvPeer, bgp.KubevipAS)).To(Succeed())
@@ -1019,10 +1020,10 @@ func setupEnv(ctx context.Context, cpVIP *string,
 
 	kvPeers := []*e2e.BGPPeerValues{}
 	if slices.Contains(peerAddrFamily, utils.IPv4Family) {
-		kvPeers = append(kvPeers, &e2e.BGPPeerValues{IP: server.LocalIPv4, AS: bgp.GoBGPAS, IPFamily: utils.IPv4Family})
+		kvPeers = append(kvPeers, &e2e.BGPPeerValues{IP: server.LocalIPv4, AS: bgp.GoBGPAS, Port: bgp.GoBGPPort, IPFamily: utils.IPv4Family})
 	}
 	if slices.Contains(peerAddrFamily, utils.IPv6Family) {
-		kvPeers = append(kvPeers, &e2e.BGPPeerValues{IP: server.LocalIPv6, AS: bgp.GoBGPAS, IPFamily: utils.IPv6Family})
+		kvPeers = append(kvPeers, &e2e.BGPPeerValues{IP: server.LocalIPv6, AS: bgp.GoBGPAS, Port: bgp.GoBGPPort, IPFamily: utils.IPv6Family})
 	}
 
 	fixedV4Nexthop := defaultFixedNexthopv4

--- a/testing/e2e/e2e_faults_cp_helpers_test.go
+++ b/testing/e2e/e2e_faults_cp_helpers_test.go
@@ -1,0 +1,48 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestControlPlaneElectionMode(t *testing.T) {
+	arp := controlPlaneElectionMode(ModeARP)
+	if !arp.enabled || arp.leaseName != faultLeaseName {
+		t.Fatalf("ARP election = %+v, want enabled lease %q", arp, faultLeaseName)
+	}
+
+	rt := controlPlaneElectionMode(ModeRT)
+	if rt.enabled || rt.leaseName != "" {
+		t.Fatalf("RT election = %+v, want disabled", rt)
+	}
+}
+
+func TestValidateARPFailover(t *testing.T) {
+	tests := []struct {
+		name      string
+		oldLeader string
+		newLeader string
+		owners    []string
+		wantError string
+	}{
+		{name: "complete", oldLeader: "node-a", newLeader: "node-b", owners: []string{"node-b"}},
+		{name: "same leader recovered", oldLeader: "node-a", newLeader: "node-a", owners: []string{"node-a"}},
+		{name: "stale old owner", oldLeader: "node-a", newLeader: "node-b", owners: []string{"node-a", "node-b"}, wantError: "stale VIP ownership"},
+		{name: "VIP missing", oldLeader: "node-a", newLeader: "node-b", wantError: "has no owner"},
+		{name: "wrong owner", oldLeader: "node-a", newLeader: "node-b", owners: []string{"node-c"}, wantError: "does not own VIP"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateARPFailover(test.oldLeader, test.newLeader, test.owners)
+			if test.wantError == "" && err != nil {
+				t.Fatalf("validateARPFailover() error = %v", err)
+			}
+			if test.wantError != "" && (err == nil || !strings.Contains(err.Error(), test.wantError)) {
+				t.Fatalf("validateARPFailover() error = %v, want substring %q", err, test.wantError)
+			}
+		})
+	}
+}

--- a/testing/e2e/e2e_faults_cp_helpers_test.go
+++ b/testing/e2e/e2e_faults_cp_helpers_test.go
@@ -46,3 +46,29 @@ func TestValidateARPFailover(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateARPTransfer(t *testing.T) {
+	tests := []struct {
+		name      string
+		newLeader string
+		owners    []string
+		wantError string
+	}{
+		{name: "sole replacement owner", newLeader: "node-b", owners: []string{"node-b"}},
+		{name: "stale former owner allowed while kubelet stopped", newLeader: "node-b", owners: []string{"node-a", "node-b"}},
+		{name: "replacement missing", newLeader: "node-b", owners: []string{"node-a"}, wantError: "does not own VIP"},
+		{name: "VIP missing", newLeader: "node-b", wantError: "does not own VIP"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateARPTransfer(test.newLeader, test.owners)
+			if test.wantError == "" && err != nil {
+				t.Fatalf("validateARPTransfer() error = %v", err)
+			}
+			if test.wantError != "" && (err == nil || !strings.Contains(err.Error(), test.wantError)) {
+				t.Fatalf("validateARPTransfer() error = %v, want substring %q", err, test.wantError)
+			}
+		})
+	}
+}

--- a/testing/e2e/e2e_faults_cp_test.go
+++ b/testing/e2e/e2e_faults_cp_test.go
@@ -1,0 +1,477 @@
+//go:build e2e
+// +build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	kindconfigv1alpha4 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kube-vip/kube-vip/pkg/utils"
+	"github.com/kube-vip/kube-vip/testing/e2e"
+)
+
+const (
+	faultClusterNodeCount      = 3
+	faultLeaseNamespace        = "kube-system"
+	faultLeaseName             = "plndr-cp-lock"
+	faultTransitionMetric      = "kube_vip_leader_election_transitions_total"
+	faultPollInterval          = time.Second
+	faultMetricGap             = time.Second
+	faultConvergenceTimeout    = 120 * time.Second
+	faultLeaseObservationLimit = 15 * time.Second
+	faultSteadyStateWindow     = 5 * time.Second
+	faultTransitionDeltaLimit  = 4.0
+)
+
+type controlPlaneFaultSuite struct {
+	ctx     context.Context
+	cancel  context.CancelFunc
+	cluster *e2e.Cluster
+	client  kubernetes.Interface
+	vip     string
+	nodes   []string
+	tempDir string
+}
+
+type faultMetricSnapshot map[string]map[string]float64
+
+var _ = Describe("kube-vip control-plane election and VIP failover faults", Label("faults"), Serial, Ordered, func() {
+	if Mode != ModeARP && Mode != ModeRT {
+		return
+	}
+
+	suite := &controlPlaneFaultSuite{}
+
+	BeforeAll(func() {
+		suite.ctx, suite.cancel = context.WithCancel(context.Background())
+		var err error
+		suite.tempDir, err = os.MkdirTemp("", fmt.Sprintf("kube-vip-faults-%s-", Mode))
+		Expect(err).NotTo(HaveOccurred())
+
+		offset := SOffset.Get()
+		suite.vip = e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
+
+		templateName := "kube-vip.yaml.tmpl"
+		manifestValues := e2e.KubevipManifestValues{
+			ControlPlaneVIP:       suite.vip,
+			ImagePath:             os.Getenv("E2E_IMAGE_PATH"),
+			ConfigPath:            os.Getenv("CONFIG_PATH"),
+			ControlPlaneEnable:    "true",
+			SvcEnable:             "false",
+			SvcElectionEnable:     "false",
+			EnableEndpoints:       "true",
+			EnableNodeLabeling:    "false",
+			EnableServiceSecurity: "true",
+		}
+		networking := kindconfigv1alpha4.Networking{
+			IPFamily: kindconfigv1alpha4.IPv4Family,
+		}
+		if Mode == ModeRT {
+			templateName = "kube-vip-routing-table.yaml.tmpl"
+			manifestValues.VipElectionEnable = "true"
+		}
+
+		suite.cluster = e2e.CreateCluster(suite.ctx, &e2e.ClusterSpec{
+			Name:         fmt.Sprintf("kube-vip-faults-%s-%d", Mode, offset),
+			Nodes:        faultClusterNodeCount,
+			Networking:   networking,
+			KubeVip:      manifestValues,
+			Logger:       e2e.TestLogger{},
+			ConfigMtx:    ConfigMtx,
+			TemplateName: templateName,
+		})
+		suite.client = buildFaultClient(suite.cluster.RestCfg)
+		suite.cluster.Client = suite.client
+
+		for _, node := range suite.cluster.Nodes {
+			suite.nodes = append(suite.nodes, node.String())
+		}
+		Expect(suite.nodes).To(HaveLen(faultClusterNodeCount))
+
+		By(withTimestamp("waiting for the control-plane VIP to become routable"))
+		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
+		leader := suite.waitForLeader()
+		suite.waitForLease()
+		suite.assertLeaderMetric(leader)
+		suite.assertOneLeader()
+		suite.assertSteadyLeader(leader)
+	})
+
+	AfterAll(func() {
+		if suite.cluster != nil {
+			suite.cluster.SaveLogs(suite.ctx, suite.tempDir)
+			suite.cluster.Delete()
+		}
+		if suite.cancel != nil {
+			suite.cancel()
+		}
+		if suite.tempDir != "" && os.Getenv("E2E_KEEP_LOGS") != "true" {
+			Expect(os.RemoveAll(suite.tempDir)).To(Succeed())
+		}
+	})
+
+	It("keeps the VIP available while the leader loses API access and recovers", func() {
+		before := suite.transitionSnapshot()
+		oldLeader := suite.waitForLeader()
+
+		By(withTimestamp(fmt.Sprintf("blackholing the API server from leader %q", oldLeader)))
+		Expect(e2e.BlackholeAPIServer(suite.cluster.Name, oldLeader)).To(Succeed())
+		blackholeActive := true
+		defer func() {
+			if blackholeActive {
+				Expect(e2e.RestoreAPIServer(suite.cluster.Name, oldLeader)).To(Succeed())
+			}
+		}()
+
+		newLeader := suite.waitForDifferentLeader(oldLeader)
+		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
+		lease := suite.waitForLease(oldLeader)
+		By(withTimestamp(fmt.Sprintf("lease %s/%s is held by remaining node %q while %q is blackholed", faultLeaseNamespace, faultLeaseName, *lease.Spec.HolderIdentity, oldLeader)))
+		suite.assertLeaderMetric(newLeader)
+		suite.assertOneLeader(oldLeader)
+
+		By(withTimestamp(fmt.Sprintf("restoring the API server connection on %q", oldLeader)))
+		Expect(e2e.RestoreAPIServer(suite.cluster.Name, oldLeader)).To(Succeed())
+		blackholeActive = false
+
+		suite.waitForLease()
+		recoveredLeader := suite.waitForLeader()
+		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
+		suite.assertLeaderMetric(recoveredLeader)
+		suite.assertOneLeader()
+		suite.assertSteadyLeader(recoveredLeader)
+		suite.assertTransitionCounterStable(before, "API server blackhole and recovery")
+	})
+
+	It("recovers after SIGKILL of the kube-vip leader", func() {
+		before := suite.transitionSnapshot()
+		oldLeader := suite.waitForLeader()
+
+		By(withTimestamp(fmt.Sprintf("sending SIGKILL to kube-vip on leader %q", oldLeader)))
+		Expect(e2e.KillKubeVip(suite.cluster.Name, oldLeader, false)).To(Succeed())
+
+		newLeader := suite.waitForDifferentLeader(oldLeader)
+		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
+		suite.waitForLease(oldLeader)
+		suite.assertLeaderMetric(newLeader)
+
+		By(withTimestamp(fmt.Sprintf("waiting for kube-vip metrics to return on restarted node %q", oldLeader)))
+		suite.waitForMetrics(oldLeader)
+		recoveredLeader := suite.waitForLeader()
+		suite.assertLeaderMetric(recoveredLeader)
+		suite.assertOneLeader()
+		suite.assertSteadyLeader(recoveredLeader)
+		suite.assertTransitionCounterStable(before, "SIGKILL and kube-vip restart")
+	})
+
+	It("reacquires the lease after deletion and lease stealing", func() {
+		beforeDelete := suite.transitionSnapshot()
+		oldLease := suite.getLease()
+		oldUID := string(oldLease.UID)
+
+		By(withTimestamp(fmt.Sprintf("deleting lease %s/%s", faultLeaseNamespace, faultLeaseName)))
+		Expect(e2e.DeleteLease(suite.ctx, suite.client, faultLeaseNamespace, faultLeaseName)).To(Succeed())
+		recreatedLease := suite.waitForLease()
+		Expect(string(recreatedLease.UID)).NotTo(Equal(oldUID))
+		leader := suite.waitForLeader()
+		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
+		suite.assertLeaderMetric(leader)
+		suite.assertOneLeader()
+		suite.assertSteadyLeader(leader)
+		suite.assertTransitionCounterStable(beforeDelete, "lease deletion")
+
+		beforeSteal := suite.transitionSnapshot()
+		const stolenHolder = "fault-injector"
+		By(withTimestamp(fmt.Sprintf("overwriting lease %s/%s with holder %q", faultLeaseNamespace, faultLeaseName, stolenHolder)))
+		Eventually(func() error {
+			return e2e.StealLease(suite.ctx, suite.client, faultLeaseNamespace, faultLeaseName, stolenHolder)
+		}, faultLeaseObservationLimit, faultPollInterval).Should(Succeed())
+		suite.waitForLeaseHolder(stolenHolder)
+		suite.waitForLease(stolenHolder)
+		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
+		suite.assertLeaderMetric(suite.waitForLeader())
+		suite.assertOneLeader()
+		stableLeader := suite.waitForLeader()
+		suite.assertSteadyLeader(stableLeader)
+		suite.assertTransitionCounterStable(beforeSteal, "lease stealing")
+	})
+
+	It("fully recovers after restarting the leader node", func() {
+		before := suite.transitionSnapshot()
+		oldLeader := suite.waitForLeader()
+
+		By(withTimestamp(fmt.Sprintf("restarting leader node %q", oldLeader)))
+		Expect(e2e.RestartNode(suite.cluster.Name, oldLeader)).To(Succeed())
+		suite.waitForNodeReady(oldLeader)
+		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
+
+		By(withTimestamp(fmt.Sprintf("waiting for kube-vip metrics to return on restarted node %q", oldLeader)))
+		suite.waitForMetrics(oldLeader)
+		leader := suite.waitForLeader()
+		suite.waitForLease()
+		suite.assertLeaderMetric(leader)
+		suite.assertOneLeader()
+		suite.assertSteadyLeader(leader)
+		suite.assertTransitionCounterStable(before, "control-plane node restart")
+	})
+})
+
+func buildFaultClient(config *rest.Config) kubernetes.Interface {
+	// Fault polling is deliberately more generous than client-go defaults.
+	config.QPS = 50
+	config.Burst = 100
+	config.Timeout = 10 * time.Second
+
+	client, err := kubernetes.NewForConfig(config)
+	Expect(err).NotTo(HaveOccurred())
+	return client
+}
+
+func (s *controlPlaneFaultSuite) waitForLeader() string {
+	// RT mode keeps the VIP in a route instead of an interface address, so the
+	// existing Docker IP lookup used by ARP mode cannot identify its leader.
+	if Mode == ModeRT {
+		lease := s.waitForLease()
+		return *lease.Spec.HolderIdentity
+	}
+
+	var leader string
+	Eventually(func() (string, error) {
+		leader = findLeader(s.vip, s.cluster.Name)
+		if leader == "" {
+			return "", fmt.Errorf("VIP %s has no leader", s.vip)
+		}
+		return leader, nil
+	}, faultConvergenceTimeout, faultPollInterval).ShouldNot(BeEmpty())
+	return leader
+}
+
+func (s *controlPlaneFaultSuite) waitForDifferentLeader(oldLeader string) string {
+	if Mode == ModeRT {
+		var leader string
+		Eventually(func() (string, error) {
+			lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, faultLeaseName, metav1.GetOptions{})
+			if err != nil {
+				return "", err
+			}
+			if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity == "" {
+				return "", fmt.Errorf("lease %s/%s has no holder", faultLeaseNamespace, faultLeaseName)
+			}
+			if *lease.Spec.HolderIdentity == oldLeader {
+				return "", fmt.Errorf("lease %s/%s is still held by %s", faultLeaseNamespace, faultLeaseName, oldLeader)
+			}
+			leader = *lease.Spec.HolderIdentity
+			return leader, nil
+		}, faultConvergenceTimeout, faultPollInterval).ShouldNot(BeEmpty())
+		return leader
+	}
+
+	var leader string
+	Eventually(func() (string, error) {
+		candidate := findLeader(s.vip, s.cluster.Name)
+		if candidate == "" {
+			return "", fmt.Errorf("VIP %s has no leader", s.vip)
+		}
+		if candidate == oldLeader {
+			return "", fmt.Errorf("VIP %s is still held by %s", s.vip, oldLeader)
+		}
+		leader = candidate
+		return leader, nil
+	}, faultConvergenceTimeout, faultPollInterval).ShouldNot(BeEmpty())
+	return leader
+}
+
+func (s *controlPlaneFaultSuite) getLease() *coordinationv1.Lease {
+	lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, faultLeaseName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	return lease
+}
+
+func (s *controlPlaneFaultSuite) waitForLease(excludedHolders ...string) *coordinationv1.Lease {
+	excluded := make(map[string]struct{}, len(excludedHolders))
+	for _, holder := range excludedHolders {
+		excluded[holder] = struct{}{}
+	}
+
+	var current *coordinationv1.Lease
+	Eventually(func() error {
+		lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, faultLeaseName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity == "" {
+			return fmt.Errorf("lease %s/%s has no holder", faultLeaseNamespace, faultLeaseName)
+		}
+		if _, skip := excluded[*lease.Spec.HolderIdentity]; skip {
+			return fmt.Errorf("lease %s/%s is still held by excluded node %q", faultLeaseNamespace, faultLeaseName, *lease.Spec.HolderIdentity)
+		}
+		current = lease
+		return nil
+	}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
+	return current
+}
+
+func (s *controlPlaneFaultSuite) waitForLeaseHolder(holder string) *coordinationv1.Lease {
+	var current *coordinationv1.Lease
+	Eventually(func() error {
+		lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, faultLeaseName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity != holder {
+			return fmt.Errorf("lease %s/%s is not held by %q", faultLeaseNamespace, faultLeaseName, holder)
+		}
+		current = lease
+		return nil
+	}, faultLeaseObservationLimit, faultPollInterval).Should(Succeed())
+	return current
+}
+
+func (s *controlPlaneFaultSuite) waitForMetrics(node string) {
+	Eventually(func() error {
+		_, err := e2e.ScrapeMetrics(s.cluster.Name, node)
+		return err
+	}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
+}
+
+func (s *controlPlaneFaultSuite) waitForNodeReady(nodeName string) {
+	Eventually(func() error {
+		node, err := s.client.CoreV1().Nodes().Get(s.ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+				return nil
+			}
+		}
+		return fmt.Errorf("node %q is not Ready", nodeName)
+	}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
+}
+
+func (s *controlPlaneFaultSuite) assertLeaderMetric(leader string) {
+	e2e.EventuallyMetric(
+		s.cluster.Name,
+		leader,
+		"kube_vip_is_leader",
+		map[string]string{"node": leader, "lease_name": faultLeaseName},
+		Equal(float64(1)),
+		faultConvergenceTimeout,
+		faultPollInterval,
+	)
+}
+
+func (s *controlPlaneFaultSuite) assertSteadyLeader(leader string) {
+	e2e.ConsistentlyMetric(
+		s.cluster.Name,
+		leader,
+		"kube_vip_is_leader",
+		map[string]string{"node": leader, "lease_name": faultLeaseName},
+		Equal(float64(1)),
+		faultSteadyStateWindow,
+		faultPollInterval,
+	)
+}
+
+func (s *controlPlaneFaultSuite) assertOneLeader(skipNodes ...string) {
+	assertExactlyOneLeaderMetric(s.ctx, s.cluster.Name, s.client, skipNodes...)
+
+	skipped := make(map[string]struct{}, len(skipNodes))
+	for _, node := range skipNodes {
+		skipped[node] = struct{}{}
+	}
+	Eventually(func() (float64, error) {
+		maximum := 0.0
+		found := false
+		for _, node := range s.nodes {
+			if _, skip := skipped[node]; skip {
+				continue
+			}
+			metrics, err := e2e.ScrapeMetrics(s.cluster.Name, node)
+			if err != nil {
+				return 0, err
+			}
+			value, ok := e2e.MaxMetric(metrics, "kube_vip_is_leader", map[string]string{"lease_name": faultLeaseName})
+			if !ok {
+				continue
+			}
+			found = true
+			if value > maximum {
+				maximum = value
+			}
+		}
+		if !found {
+			return 0, fmt.Errorf("no leader metric found")
+		}
+		return maximum, nil
+	}, faultConvergenceTimeout, faultPollInterval).Should(BeNumerically("<=", float64(1)))
+}
+
+func (s *controlPlaneFaultSuite) transitionSnapshot() faultMetricSnapshot {
+	snapshot := make(faultMetricSnapshot, len(s.nodes))
+	for _, node := range s.nodes {
+		var metrics map[string]float64
+		Eventually(func() error {
+			var err error
+			metrics, err = e2e.ScrapeMetrics(s.cluster.Name, node)
+			return err
+		}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
+		snapshot[node] = metrics
+	}
+	return snapshot
+}
+
+func (s *controlPlaneFaultSuite) assertTransitionCounterStable(before faultMetricSnapshot, fault string) {
+	labels := map[string]string{"lease_name": faultLeaseName}
+	stableValues := make(map[string]float64)
+	totalDelta := 0.0
+	observed := 0
+
+	for _, node := range s.nodes {
+		metrics, err := e2e.ScrapeMetrics(s.cluster.Name, node)
+		Expect(err).NotTo(HaveOccurred())
+		if _, matches := e2e.MetricValue(metrics, faultTransitionMetric, labels); matches == 0 {
+			continue
+		}
+
+		var stable float64
+		Eventually(func() error {
+			var stableErr error
+			stable, stableErr = e2e.MetricStable(s.cluster.Name, node, faultTransitionMetric, labels, 2, faultMetricGap)
+			return stableErr
+		}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
+		stableValues[node] = stable
+		observed++
+
+		beforeValue, beforeMatches := e2e.MetricValue(before[node], faultTransitionMetric, labels)
+		stableDelta := stable
+		if beforeMatches == 1 {
+			rawDelta, ok := e2e.CounterDelta(before[node], metrics, faultTransitionMetric, labels)
+			Expect(ok).To(BeTrue())
+			By(withTimestamp(fmt.Sprintf("transition counter on %q changed by %.0f during %s before settling", node, rawDelta, fault)))
+			stableDelta = stable - beforeValue
+			if stableDelta < 0 {
+				stableDelta = stable
+			}
+		}
+		Expect(stableDelta).To(BeNumerically(">=", float64(0)))
+		totalDelta += stableDelta
+	}
+
+	Expect(observed).To(BeNumerically(">=", 1))
+	By(withTimestamp(fmt.Sprintf("stable transition counters after %s: %v; delta %.0f", fault, stableValues, totalDelta)))
+	Expect(totalDelta).To(BeNumerically("<=", faultTransitionDeltaLimit))
+}

--- a/testing/e2e/e2e_faults_cp_test.go
+++ b/testing/e2e/e2e_faults_cp_test.go
@@ -41,15 +41,16 @@ const (
 )
 
 type controlPlaneFaultSuite struct {
-	ctx      context.Context
-	cancel   context.CancelFunc
-	cluster  *e2e.Cluster
-	client   kubernetes.Interface
-	vip      string
-	nodes    []string
-	tempDir  string
-	metrics  bool
-	election faultElectionMode
+	ctx            context.Context
+	cancel         context.CancelFunc
+	cluster        *e2e.Cluster
+	client         kubernetes.Interface
+	vip            string
+	nodes          []string
+	tempDir        string
+	metrics        bool
+	election       faultElectionMode
+	suppressedNode string
 }
 
 type faultElectionMode struct {
@@ -81,6 +82,15 @@ func validateARPFailover(oldLeader, newLeader string, owners []string) error {
 		return fmt.Errorf("elected leader %q does not own VIP; owners are %v", newLeader, owners)
 	}
 	return nil
+}
+
+func validateARPTransfer(newLeader string, owners []string) error {
+	for _, owner := range owners {
+		if owner == newLeader {
+			return nil
+		}
+	}
+	return fmt.Errorf("replacement leader %q does not own VIP; owners are %v (a stale owner is expected until the stopped kubelet restarts)", newLeader, owners)
 }
 
 var _ = Describe("kube-vip control-plane election and VIP failover faults", Label("faults"), Serial, Ordered, func() {
@@ -169,6 +179,15 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 		}
 	})
 
+	AfterEach(func() {
+		if suite.suppressedNode == "" || suite.cluster == nil {
+			return
+		}
+		By(withTimestamp(fmt.Sprintf("restoring kubelet on %q before fault-suite teardown", suite.suppressedNode)))
+		Expect(e2e.RestoreKubeVip(suite.cluster.Name, suite.suppressedNode)).To(Succeed())
+		suite.suppressedNode = ""
+	})
+
 	It("keeps the VIP available while the leader loses API access and recovers", func() {
 		if !suite.election.enabled {
 			node := suite.nodes[0]
@@ -231,21 +250,25 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 		By(withTimestamp(fmt.Sprintf("stopping kubelet and sending SIGKILL to kube-vip on elected leader %q", oldLeader)))
 		oldPID, err := e2e.KillAndSuppressKubeVip(suite.cluster.Name, oldLeader)
 		Expect(err).NotTo(HaveOccurred())
-		DeferCleanup(func() {
-			Expect(e2e.RestoreKubeVip(suite.cluster.Name, oldLeader)).To(Succeed())
-		})
+		suite.suppressedNode = oldLeader
 		By(withTimestamp(fmt.Sprintf("sent SIGKILL to kube-vip PID %s on elected leader %q", oldPID, oldLeader)))
 		suite.assertNodeRunning(oldLeader)
 
 		newLeader := suite.waitForDifferentLeader(oldLeader)
-		suite.waitForARPFailover(oldLeader, newLeader)
+		suite.waitForARPTransfer(newLeader)
 		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
 		suite.assertLeaderMetric(newLeader)
+		owners, err := suite.vipOwners()
+		Expect(err).NotTo(HaveOccurred())
+		By(withTimestamp(fmt.Sprintf("lease and reachability transferred to %q while kubelet is stopped on %q; current VIP owners: %v", newLeader, oldLeader, owners)))
 
 		By(withTimestamp(fmt.Sprintf("restarting kubelet to restore kube-vip on %q", oldLeader)))
 		Expect(e2e.RestoreKubeVip(suite.cluster.Name, oldLeader)).To(Succeed())
+		suite.suppressedNode = ""
+		suite.waitForKubeVipRestart(oldLeader, oldPID)
+		suite.waitForNonLeader(oldLeader, newLeader)
+		suite.waitForARPFailover(oldLeader, newLeader)
 		By(withTimestamp(fmt.Sprintf("waiting for kube-vip metrics to return on restarted node %q", oldLeader)))
-		suite.waitForKubeVip(oldLeader)
 		suite.waitForMetrics(oldLeader)
 		recoveredLeader := suite.waitForLeader()
 		suite.assertLeaderMetric(recoveredLeader)
@@ -359,6 +382,40 @@ func (s *controlPlaneFaultSuite) waitForARPFailover(oldLeader, newLeader string)
 		return validateARPFailover(oldLeader, newLeader, owners)
 	}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
 	By(withTimestamp(fmt.Sprintf("election and sole VIP ownership transferred from %q to %q", oldLeader, newLeader)))
+}
+
+func (s *controlPlaneFaultSuite) waitForARPTransfer(newLeader string) {
+	Eventually(func() error {
+		lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, s.election.leaseName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("observe election transfer while kubelet is stopped: %w", err)
+		}
+		if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity != newLeader {
+			return fmt.Errorf("lease %s/%s is not held by replacement leader %q", faultLeaseNamespace, s.election.leaseName, newLeader)
+		}
+		owners, err := s.vipOwners()
+		if err != nil {
+			return err
+		}
+		return validateARPTransfer(newLeader, owners)
+	}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
+}
+
+func (s *controlPlaneFaultSuite) waitForNonLeader(node, leader string) {
+	Eventually(func() error {
+		lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, s.election.leaseName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if lease.Spec.HolderIdentity == nil {
+			return fmt.Errorf("replacement kube-vip on %q is not confirmed as a nonleader: lease %s/%s has no holder", node, faultLeaseNamespace, s.election.leaseName)
+		}
+		if *lease.Spec.HolderIdentity != leader {
+			return fmt.Errorf("replacement kube-vip on %q is not a nonleader: lease %s/%s holder is %q, want %q", node, faultLeaseNamespace, s.election.leaseName, *lease.Spec.HolderIdentity, leader)
+		}
+		return nil
+	}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
+	By(withTimestamp(fmt.Sprintf("replacement kube-vip on %q started as nonleader behind %q", node, leader)))
 }
 
 func (s *controlPlaneFaultSuite) waitForVIPOwner(want string) {

--- a/testing/e2e/e2e_faults_cp_test.go
+++ b/testing/e2e/e2e_faults_cp_test.go
@@ -38,7 +38,6 @@ const (
 	faultLeaseObservationLimit = 15 * time.Second
 	faultSteadyStateWindow     = 5 * time.Second
 	faultTransitionDeltaLimit  = 4.0
-	faultKubeVipManifest       = "kube-vip.yaml"
 )
 
 type controlPlaneFaultSuite struct {
@@ -229,11 +228,11 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 		oldLeader := *oldLease.Spec.HolderIdentity
 		suite.waitForVIPOwner(oldLeader)
 
-		By(withTimestamp(fmt.Sprintf("removing the static-pod manifest and sending SIGKILL to kube-vip on elected leader %q", oldLeader)))
-		oldPID, err := e2e.KillAndStashKubeVip(suite.cluster.Name, oldLeader, faultKubeVipManifest)
+		By(withTimestamp(fmt.Sprintf("stopping kubelet and sending SIGKILL to kube-vip on elected leader %q", oldLeader)))
+		oldPID, err := e2e.KillAndSuppressKubeVip(suite.cluster.Name, oldLeader)
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
-			Expect(e2e.RestorePodManifest(suite.cluster.Name, oldLeader, faultKubeVipManifest)).To(Succeed())
+			Expect(e2e.RestoreKubeVip(suite.cluster.Name, oldLeader)).To(Succeed())
 		})
 		By(withTimestamp(fmt.Sprintf("sent SIGKILL to kube-vip PID %s on elected leader %q", oldPID, oldLeader)))
 		suite.assertNodeRunning(oldLeader)
@@ -243,8 +242,8 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
 		suite.assertLeaderMetric(newLeader)
 
-		By(withTimestamp(fmt.Sprintf("restoring the kube-vip static-pod manifest on %q", oldLeader)))
-		Expect(e2e.RestorePodManifest(suite.cluster.Name, oldLeader, faultKubeVipManifest)).To(Succeed())
+		By(withTimestamp(fmt.Sprintf("restarting kubelet to restore kube-vip on %q", oldLeader)))
+		Expect(e2e.RestoreKubeVip(suite.cluster.Name, oldLeader)).To(Succeed())
 		By(withTimestamp(fmt.Sprintf("waiting for kube-vip metrics to return on restarted node %q", oldLeader)))
 		suite.waitForKubeVip(oldLeader)
 		suite.waitForMetrics(oldLeader)

--- a/testing/e2e/e2e_faults_cp_test.go
+++ b/testing/e2e/e2e_faults_cp_test.go
@@ -4,13 +4,17 @@
 package e2e_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 	"time"
 
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -34,20 +38,51 @@ const (
 	faultLeaseObservationLimit = 15 * time.Second
 	faultSteadyStateWindow     = 5 * time.Second
 	faultTransitionDeltaLimit  = 4.0
+	faultKubeVipManifest       = "kube-vip.yaml"
 )
 
 type controlPlaneFaultSuite struct {
-	ctx     context.Context
-	cancel  context.CancelFunc
-	cluster *e2e.Cluster
-	client  kubernetes.Interface
-	vip     string
-	nodes   []string
-	tempDir string
-	metrics bool
+	ctx      context.Context
+	cancel   context.CancelFunc
+	cluster  *e2e.Cluster
+	client   kubernetes.Interface
+	vip      string
+	nodes    []string
+	tempDir  string
+	metrics  bool
+	election faultElectionMode
+}
+
+type faultElectionMode struct {
+	enabled   bool
+	leaseName string
 }
 
 type faultMetricSnapshot map[string]map[string]float64
+
+func controlPlaneElectionMode(mode string) faultElectionMode {
+	if mode == ModeARP {
+		return faultElectionMode{enabled: true, leaseName: faultLeaseName}
+	}
+	return faultElectionMode{}
+}
+
+func validateARPFailover(oldLeader, newLeader string, owners []string) error {
+	if len(owners) == 0 {
+		return fmt.Errorf("VIP has no owner while lease is held by %q", newLeader)
+	}
+	if newLeader != oldLeader {
+		for _, owner := range owners {
+			if owner == oldLeader {
+				return fmt.Errorf("stale VIP ownership remains on former leader %q", oldLeader)
+			}
+		}
+	}
+	if len(owners) != 1 || owners[0] != newLeader {
+		return fmt.Errorf("elected leader %q does not own VIP; owners are %v", newLeader, owners)
+	}
+	return nil
+}
 
 var _ = Describe("kube-vip control-plane election and VIP failover faults", Label("faults"), Serial, Ordered, func() {
 	if Mode != ModeARP && Mode != ModeRT {
@@ -59,8 +94,9 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 	BeforeAll(func() {
 		suite.ctx, suite.cancel = context.WithCancel(context.Background())
 		var err error
-		suite.tempDir, err = os.MkdirTemp("", fmt.Sprintf("kube-vip-faults-%s-", Mode))
+		suite.tempDir, err = os.MkdirTemp("", fmt.Sprintf("kube-vip-test-faults-%s-", Mode))
 		Expect(err).NotTo(HaveOccurred())
+		suite.election = controlPlaneElectionMode(Mode)
 
 		offset := SOffset.Get()
 		suite.vip = e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
@@ -106,16 +142,24 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 
 		By(withTimestamp("waiting for the control-plane VIP to become routable"))
 		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
-		leader := suite.waitForLeader()
-		suite.waitForLease()
-		suite.assertLeaderMetric(leader)
-		suite.assertOneLeader()
-		suite.assertSteadyLeader(leader)
+		if suite.election.enabled {
+			leader := suite.waitForLeader()
+			suite.waitForVIPOwner(leader)
+			suite.assertLeaderMetric(leader)
+			suite.assertOneLeader()
+			suite.assertSteadyLeader(leader)
+		} else {
+			suite.assertNoElectionLease()
+			By(withTimestamp(fmt.Sprintf("%s mode is configured without control-plane election; validating process and node recovery only", Mode)))
+		}
 	})
 
 	AfterAll(func() {
 		if suite.cluster != nil {
-			suite.cluster.SaveLogs(suite.ctx, suite.tempDir)
+			By(withTimestamp(fmt.Sprintf("saving fault artifacts to %q", suite.tempDir)))
+			if err := e2e.GetLogs(suite.ctx, suite.client, suite.tempDir, suite.cluster.Name); err != nil {
+				By(withTimestamp(fmt.Sprintf("fault artifact collection failed: %v", err)))
+			}
 			suite.cluster.Delete()
 		}
 		if suite.cancel != nil {
@@ -127,6 +171,16 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 	})
 
 	It("keeps the VIP available while the leader loses API access and recovers", func() {
+		if !suite.election.enabled {
+			node := suite.nodes[0]
+			By(withTimestamp(fmt.Sprintf("blackholing the API server from non-electing %s node %q", Mode, node)))
+			Expect(e2e.BlackholeAPIServer(suite.cluster.Name, node)).To(Succeed())
+			DeferCleanup(func() { Expect(e2e.RestoreAPIServer(suite.cluster.Name, node)).To(Succeed()) })
+			assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
+			Expect(e2e.RestoreAPIServer(suite.cluster.Name, node)).To(Succeed())
+			return
+		}
+
 		before := suite.transitionSnapshot()
 		oldLeader := suite.waitForLeader()
 
@@ -139,7 +193,7 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 		newLeader := suite.waitForDifferentLeader(oldLeader)
 		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
 		lease := suite.waitForLease(oldLeader)
-		By(withTimestamp(fmt.Sprintf("lease %s/%s is held by remaining node %q while %q is blackholed", faultLeaseNamespace, faultLeaseName, *lease.Spec.HolderIdentity, oldLeader)))
+		By(withTimestamp(fmt.Sprintf("lease %s/%s is held by remaining node %q while %q is blackholed", faultLeaseNamespace, suite.election.leaseName, *lease.Spec.HolderIdentity, oldLeader)))
 		suite.assertLeaderMetric(newLeader)
 		suite.assertOneLeader(oldLeader)
 
@@ -156,18 +210,43 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 	})
 
 	It("recovers after SIGKILL of the kube-vip leader", func() {
-		before := suite.transitionSnapshot()
-		oldLeader := suite.waitForLeader()
+		if !suite.election.enabled {
+			node := suite.nodes[0]
+			oldPID, err := e2e.KubeVipPID(suite.cluster.Name, node)
+			Expect(err).NotTo(HaveOccurred())
+			By(withTimestamp(fmt.Sprintf("sending SIGKILL to kube-vip PID %s on non-electing %s node %q", oldPID, Mode, node)))
+			killTime := time.Now()
+			Expect(e2e.KillKubeVip(suite.cluster.Name, node, false)).To(Succeed())
+			suite.waitForKubeVipRestart(node, oldPID)
+			By(withTimestamp(fmt.Sprintf("kube-vip restarted on %q after %s", node, time.Since(killTime))))
+			suite.assertNodeRunning(node)
+			assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
+			return
+		}
 
-		By(withTimestamp(fmt.Sprintf("sending SIGKILL to kube-vip on leader %q", oldLeader)))
-		Expect(e2e.KillKubeVip(suite.cluster.Name, oldLeader, false)).To(Succeed())
+		before := suite.transitionSnapshot()
+		oldLease := suite.waitForLease()
+		oldLeader := *oldLease.Spec.HolderIdentity
+		suite.waitForVIPOwner(oldLeader)
+
+		By(withTimestamp(fmt.Sprintf("removing the static-pod manifest and sending SIGKILL to kube-vip on elected leader %q", oldLeader)))
+		oldPID, err := e2e.KillAndStashKubeVip(suite.cluster.Name, oldLeader, faultKubeVipManifest)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			Expect(e2e.RestorePodManifest(suite.cluster.Name, oldLeader, faultKubeVipManifest)).To(Succeed())
+		})
+		By(withTimestamp(fmt.Sprintf("sent SIGKILL to kube-vip PID %s on elected leader %q", oldPID, oldLeader)))
+		suite.assertNodeRunning(oldLeader)
 
 		newLeader := suite.waitForDifferentLeader(oldLeader)
+		suite.waitForARPFailover(oldLeader, newLeader)
 		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
-		suite.waitForLease(oldLeader)
 		suite.assertLeaderMetric(newLeader)
 
+		By(withTimestamp(fmt.Sprintf("restoring the kube-vip static-pod manifest on %q", oldLeader)))
+		Expect(e2e.RestorePodManifest(suite.cluster.Name, oldLeader, faultKubeVipManifest)).To(Succeed())
 		By(withTimestamp(fmt.Sprintf("waiting for kube-vip metrics to return on restarted node %q", oldLeader)))
+		suite.waitForKubeVip(oldLeader)
 		suite.waitForMetrics(oldLeader)
 		recoveredLeader := suite.waitForLeader()
 		suite.assertLeaderMetric(recoveredLeader)
@@ -177,12 +256,16 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 	})
 
 	It("reacquires the lease after deletion and lease stealing", func() {
+		if !suite.election.enabled {
+			Skip(fmt.Sprintf("%s control-plane mode does not use a Kubernetes election lease", Mode))
+		}
+
 		beforeDelete := suite.transitionSnapshot()
 		oldLease := suite.getLease()
 		oldUID := string(oldLease.UID)
 
-		By(withTimestamp(fmt.Sprintf("deleting lease %s/%s", faultLeaseNamespace, faultLeaseName)))
-		Expect(e2e.DeleteLease(suite.ctx, suite.client, faultLeaseNamespace, faultLeaseName)).To(Succeed())
+		By(withTimestamp(fmt.Sprintf("deleting lease %s/%s", faultLeaseNamespace, suite.election.leaseName)))
+		Expect(e2e.DeleteLease(suite.ctx, suite.client, faultLeaseNamespace, suite.election.leaseName)).To(Succeed())
 		recreatedLease := suite.waitForLease()
 		Expect(string(recreatedLease.UID)).NotTo(Equal(oldUID))
 		leader := suite.waitForLeader()
@@ -194,9 +277,9 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 
 		beforeSteal := suite.transitionSnapshot()
 		const stolenHolder = "fault-injector"
-		By(withTimestamp(fmt.Sprintf("overwriting lease %s/%s with holder %q", faultLeaseNamespace, faultLeaseName, stolenHolder)))
+		By(withTimestamp(fmt.Sprintf("overwriting lease %s/%s with holder %q", faultLeaseNamespace, suite.election.leaseName, stolenHolder)))
 		Eventually(func() error {
-			return e2e.StealLease(suite.ctx, suite.client, faultLeaseNamespace, faultLeaseName, stolenHolder)
+			return e2e.StealLease(suite.ctx, suite.client, faultLeaseNamespace, suite.election.leaseName, stolenHolder)
 		}, faultLeaseObservationLimit, faultPollInterval).Should(Succeed())
 		suite.waitForLeaseHolder(stolenHolder)
 		suite.waitForLease(stolenHolder)
@@ -209,6 +292,16 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 	})
 
 	It("fully recovers after restarting the leader node", func() {
+		if !suite.election.enabled {
+			node := suite.nodes[0]
+			By(withTimestamp(fmt.Sprintf("restarting non-electing %s node %q", Mode, node)))
+			Expect(e2e.RestartNode(suite.cluster.Name, node)).To(Succeed())
+			suite.waitForNodeReady(node)
+			suite.waitForKubeVip(node)
+			assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
+			return
+		}
+
 		before := suite.transitionSnapshot()
 		oldLeader := suite.waitForLeader()
 
@@ -240,61 +333,98 @@ func buildFaultClient(config *rest.Config) kubernetes.Interface {
 }
 
 func (s *controlPlaneFaultSuite) waitForLeader() string {
-	// RT mode keeps the VIP in a route instead of an interface address, so the
-	// existing Docker IP lookup used by ARP mode cannot identify its leader.
-	if Mode == ModeRT {
-		lease := s.waitForLease()
-		return *lease.Spec.HolderIdentity
-	}
-
-	var leader string
-	Eventually(func() (string, error) {
-		leader = findLeader(s.vip, s.cluster.Name)
-		if leader == "" {
-			return "", fmt.Errorf("VIP %s has no leader", s.vip)
-		}
-		return leader, nil
-	}, faultConvergenceTimeout, faultPollInterval).ShouldNot(BeEmpty())
-	return leader
+	Expect(s.election.enabled).To(BeTrue(), "%s mode has no control-plane election leader", Mode)
+	return *s.waitForLease().Spec.HolderIdentity
 }
 
 func (s *controlPlaneFaultSuite) waitForDifferentLeader(oldLeader string) string {
-	if Mode == ModeRT {
-		var leader string
-		Eventually(func() (string, error) {
-			lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, faultLeaseName, metav1.GetOptions{})
-			if err != nil {
-				return "", err
-			}
-			if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity == "" {
-				return "", fmt.Errorf("lease %s/%s has no holder", faultLeaseNamespace, faultLeaseName)
-			}
-			if *lease.Spec.HolderIdentity == oldLeader {
-				return "", fmt.Errorf("lease %s/%s is still held by %s", faultLeaseNamespace, faultLeaseName, oldLeader)
-			}
-			leader = *lease.Spec.HolderIdentity
-			return leader, nil
-		}, faultConvergenceTimeout, faultPollInterval).ShouldNot(BeEmpty())
-		return leader
-	}
+	return *s.waitForLease(oldLeader).Spec.HolderIdentity
+}
 
-	var leader string
+func (s *controlPlaneFaultSuite) waitForARPFailover(oldLeader, newLeader string) {
+	Eventually(func() error {
+		lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, s.election.leaseName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("observe election transfer: %w", err)
+		}
+		if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity == "" {
+			return fmt.Errorf("lease %s/%s has no holder", faultLeaseNamespace, s.election.leaseName)
+		}
+		if *lease.Spec.HolderIdentity != newLeader {
+			return fmt.Errorf("lease %s/%s is held by %q, want %q", faultLeaseNamespace, s.election.leaseName, *lease.Spec.HolderIdentity, newLeader)
+		}
+		owners, err := s.vipOwners()
+		if err != nil {
+			return err
+		}
+		return validateARPFailover(oldLeader, newLeader, owners)
+	}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
+	By(withTimestamp(fmt.Sprintf("election and sole VIP ownership transferred from %q to %q", oldLeader, newLeader)))
+}
+
+func (s *controlPlaneFaultSuite) waitForVIPOwner(want string) {
+	Eventually(func() error {
+		owners, err := s.vipOwners()
+		if err != nil {
+			return err
+		}
+		if len(owners) != 1 || owners[0] != want {
+			return fmt.Errorf("VIP %s owners are %v, want only %q", s.vip, owners, want)
+		}
+		return nil
+	}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
+}
+
+func (s *controlPlaneFaultSuite) vipOwners() ([]string, error) {
+	owners := make([]string, 0, len(s.nodes))
+	for _, node := range s.nodes {
+		var output bytes.Buffer
+		cmd := exec.Command("docker", "exec", node, "ip", "-o", "addr", "show", "to", s.vip+"/32")
+		cmd.Stdout = &output
+		cmd.Stderr = &output
+		if err := cmd.Run(); err != nil {
+			return nil, fmt.Errorf("inspect VIP %s on node %q: %w: %s", s.vip, node, err, strings.TrimSpace(output.String()))
+		}
+		if strings.TrimSpace(output.String()) != "" {
+			owners = append(owners, node)
+		}
+	}
+	return owners, nil
+}
+
+func (s *controlPlaneFaultSuite) waitForKubeVipRestart(node, oldPID string) {
 	Eventually(func() (string, error) {
-		candidate := findLeader(s.vip, s.cluster.Name)
-		if candidate == "" {
-			return "", fmt.Errorf("VIP %s has no leader", s.vip)
+		pid, err := e2e.KubeVipPID(s.cluster.Name, node)
+		if err != nil {
+			return "", err
 		}
-		if candidate == oldLeader {
-			return "", fmt.Errorf("VIP %s is still held by %s", s.vip, oldLeader)
+		if pid == oldPID {
+			return "", fmt.Errorf("kube-vip PID %s is still running on %q", oldPID, node)
 		}
-		leader = candidate
-		return leader, nil
+		return pid, nil
 	}, faultConvergenceTimeout, faultPollInterval).ShouldNot(BeEmpty())
-	return leader
+}
+
+func (s *controlPlaneFaultSuite) waitForKubeVip(node string) {
+	Eventually(func() error {
+		_, err := e2e.KubeVipPID(s.cluster.Name, node)
+		return err
+	}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
+}
+
+func (s *controlPlaneFaultSuite) assertNodeRunning(node string) {
+	running, err := e2e.NodeRunning(s.cluster.Name, node)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(running).To(BeTrue(), "SIGKILL must stop kube-vip, not its node container")
+}
+
+func (s *controlPlaneFaultSuite) assertNoElectionLease() {
+	_, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, faultLeaseName, metav1.GetOptions{})
+	Expect(apierrors.IsNotFound(err)).To(BeTrue(), "non-electing %s mode unexpectedly exposed control-plane lease %s/%s: %v", Mode, faultLeaseNamespace, faultLeaseName, err)
 }
 
 func (s *controlPlaneFaultSuite) getLease() *coordinationv1.Lease {
-	lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, faultLeaseName, metav1.GetOptions{})
+	lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, s.election.leaseName, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	return lease
 }
@@ -307,15 +437,15 @@ func (s *controlPlaneFaultSuite) waitForLease(excludedHolders ...string) *coordi
 
 	var current *coordinationv1.Lease
 	Eventually(func() error {
-		lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, faultLeaseName, metav1.GetOptions{})
+		lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, s.election.leaseName, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
 		if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity == "" {
-			return fmt.Errorf("lease %s/%s has no holder", faultLeaseNamespace, faultLeaseName)
+			return fmt.Errorf("lease %s/%s has no holder", faultLeaseNamespace, s.election.leaseName)
 		}
 		if _, skip := excluded[*lease.Spec.HolderIdentity]; skip {
-			return fmt.Errorf("lease %s/%s is still held by excluded node %q", faultLeaseNamespace, faultLeaseName, *lease.Spec.HolderIdentity)
+			return fmt.Errorf("lease %s/%s is still held by excluded node %q", faultLeaseNamespace, s.election.leaseName, *lease.Spec.HolderIdentity)
 		}
 		current = lease
 		return nil
@@ -326,12 +456,12 @@ func (s *controlPlaneFaultSuite) waitForLease(excludedHolders ...string) *coordi
 func (s *controlPlaneFaultSuite) waitForLeaseHolder(holder string) *coordinationv1.Lease {
 	var current *coordinationv1.Lease
 	Eventually(func() error {
-		lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, faultLeaseName, metav1.GetOptions{})
+		lease, err := s.client.CoordinationV1().Leases(faultLeaseNamespace).Get(s.ctx, s.election.leaseName, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
 		if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity != holder {
-			return fmt.Errorf("lease %s/%s is not held by %q", faultLeaseNamespace, faultLeaseName, holder)
+			return fmt.Errorf("lease %s/%s is not held by %q", faultLeaseNamespace, s.election.leaseName, holder)
 		}
 		current = lease
 		return nil
@@ -373,7 +503,7 @@ func (s *controlPlaneFaultSuite) assertLeaderMetric(leader string) {
 		s.cluster.Name,
 		leader,
 		"kube_vip_is_leader",
-		map[string]string{"node": leader, "lease_name": faultLeaseName},
+		map[string]string{"node": leader, "lease_name": s.election.leaseName},
 		Equal(float64(1)),
 		faultConvergenceTimeout,
 		faultPollInterval,
@@ -389,7 +519,7 @@ func (s *controlPlaneFaultSuite) assertSteadyLeader(leader string) {
 		s.cluster.Name,
 		leader,
 		"kube_vip_is_leader",
-		map[string]string{"node": leader, "lease_name": faultLeaseName},
+		map[string]string{"node": leader, "lease_name": s.election.leaseName},
 		Equal(float64(1)),
 		faultSteadyStateWindow,
 		faultPollInterval,
@@ -417,7 +547,7 @@ func (s *controlPlaneFaultSuite) assertOneLeader(skipNodes ...string) {
 			if err != nil {
 				return 0, err
 			}
-			value, ok := e2e.MaxMetric(metrics, "kube_vip_is_leader", map[string]string{"lease_name": faultLeaseName})
+			value, ok := e2e.MaxMetric(metrics, "kube_vip_is_leader", map[string]string{"lease_name": s.election.leaseName})
 			if !ok {
 				continue
 			}
@@ -454,7 +584,7 @@ func (s *controlPlaneFaultSuite) assertTransitionCounterStable(before faultMetri
 	if !s.metrics {
 		return
 	}
-	labels := map[string]string{"lease_name": faultLeaseName}
+	labels := map[string]string{"lease_name": s.election.leaseName}
 	stableValues := make(map[string]float64)
 	totalDelta := 0.0
 	observed := 0

--- a/testing/e2e/e2e_faults_cp_test.go
+++ b/testing/e2e/e2e_faults_cp_test.go
@@ -44,6 +44,7 @@ type controlPlaneFaultSuite struct {
 	vip     string
 	nodes   []string
 	tempDir string
+	metrics bool
 }
 
 type faultMetricSnapshot map[string]map[string]float64
@@ -75,6 +76,7 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 			EnableEndpoints:       "true",
 			EnableNodeLabeling:    "false",
 			EnableServiceSecurity: "true",
+			PrometheusHTTPServer:  ":2112",
 		}
 		networking := kindconfigv1alpha4.Networking{
 			IPFamily: kindconfigv1alpha4.IPv4Family,
@@ -100,6 +102,7 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 			suite.nodes = append(suite.nodes, node.String())
 		}
 		Expect(suite.nodes).To(HaveLen(faultClusterNodeCount))
+		suite.metrics = suite.metricsAvailable()
 
 		By(withTimestamp("waiting for the control-plane VIP to become routable"))
 		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
@@ -129,12 +132,9 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 
 		By(withTimestamp(fmt.Sprintf("blackholing the API server from leader %q", oldLeader)))
 		Expect(e2e.BlackholeAPIServer(suite.cluster.Name, oldLeader)).To(Succeed())
-		blackholeActive := true
-		defer func() {
-			if blackholeActive {
-				Expect(e2e.RestoreAPIServer(suite.cluster.Name, oldLeader)).To(Succeed())
-			}
-		}()
+		DeferCleanup(func() {
+			Expect(e2e.RestoreAPIServer(suite.cluster.Name, oldLeader)).To(Succeed())
+		})
 
 		newLeader := suite.waitForDifferentLeader(oldLeader)
 		assertControlPlaneIsRoutable(suite.vip, 2*time.Second, faultConvergenceTimeout)
@@ -145,7 +145,6 @@ var _ = Describe("kube-vip control-plane election and VIP failover faults", Labe
 
 		By(withTimestamp(fmt.Sprintf("restoring the API server connection on %q", oldLeader)))
 		Expect(e2e.RestoreAPIServer(suite.cluster.Name, oldLeader)).To(Succeed())
-		blackholeActive = false
 
 		suite.waitForLease()
 		recoveredLeader := suite.waitForLeader()
@@ -341,8 +340,11 @@ func (s *controlPlaneFaultSuite) waitForLeaseHolder(holder string) *coordination
 }
 
 func (s *controlPlaneFaultSuite) waitForMetrics(node string) {
+	if !s.metrics {
+		return
+	}
 	Eventually(func() error {
-		_, err := e2e.ScrapeMetrics(s.cluster.Name, node)
+		_, err := e2e.ScrapeMetrics(s.ctx, s.cluster.Name, node)
 		return err
 	}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
 }
@@ -363,7 +365,11 @@ func (s *controlPlaneFaultSuite) waitForNodeReady(nodeName string) {
 }
 
 func (s *controlPlaneFaultSuite) assertLeaderMetric(leader string) {
+	if !s.metrics {
+		return
+	}
 	e2e.EventuallyMetric(
+		s.ctx,
 		s.cluster.Name,
 		leader,
 		"kube_vip_is_leader",
@@ -375,7 +381,11 @@ func (s *controlPlaneFaultSuite) assertLeaderMetric(leader string) {
 }
 
 func (s *controlPlaneFaultSuite) assertSteadyLeader(leader string) {
+	if !s.metrics {
+		return
+	}
 	e2e.ConsistentlyMetric(
+		s.ctx,
 		s.cluster.Name,
 		leader,
 		"kube_vip_is_leader",
@@ -387,6 +397,9 @@ func (s *controlPlaneFaultSuite) assertSteadyLeader(leader string) {
 }
 
 func (s *controlPlaneFaultSuite) assertOneLeader(skipNodes ...string) {
+	if !s.metrics {
+		return
+	}
 	assertExactlyOneLeaderMetric(s.ctx, s.cluster.Name, s.client, skipNodes...)
 
 	skipped := make(map[string]struct{}, len(skipNodes))
@@ -400,7 +413,7 @@ func (s *controlPlaneFaultSuite) assertOneLeader(skipNodes ...string) {
 			if _, skip := skipped[node]; skip {
 				continue
 			}
-			metrics, err := e2e.ScrapeMetrics(s.cluster.Name, node)
+			metrics, err := e2e.ScrapeMetrics(s.ctx, s.cluster.Name, node)
 			if err != nil {
 				return 0, err
 			}
@@ -421,12 +434,15 @@ func (s *controlPlaneFaultSuite) assertOneLeader(skipNodes ...string) {
 }
 
 func (s *controlPlaneFaultSuite) transitionSnapshot() faultMetricSnapshot {
+	if !s.metrics {
+		return nil
+	}
 	snapshot := make(faultMetricSnapshot, len(s.nodes))
 	for _, node := range s.nodes {
 		var metrics map[string]float64
 		Eventually(func() error {
 			var err error
-			metrics, err = e2e.ScrapeMetrics(s.cluster.Name, node)
+			metrics, err = e2e.ScrapeMetrics(s.ctx, s.cluster.Name, node)
 			return err
 		}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
 		snapshot[node] = metrics
@@ -435,13 +451,16 @@ func (s *controlPlaneFaultSuite) transitionSnapshot() faultMetricSnapshot {
 }
 
 func (s *controlPlaneFaultSuite) assertTransitionCounterStable(before faultMetricSnapshot, fault string) {
+	if !s.metrics {
+		return
+	}
 	labels := map[string]string{"lease_name": faultLeaseName}
 	stableValues := make(map[string]float64)
 	totalDelta := 0.0
 	observed := 0
 
 	for _, node := range s.nodes {
-		metrics, err := e2e.ScrapeMetrics(s.cluster.Name, node)
+		metrics, err := e2e.ScrapeMetrics(s.ctx, s.cluster.Name, node)
 		Expect(err).NotTo(HaveOccurred())
 		if _, matches := e2e.MetricValue(metrics, faultTransitionMetric, labels); matches == 0 {
 			continue
@@ -450,7 +469,7 @@ func (s *controlPlaneFaultSuite) assertTransitionCounterStable(before faultMetri
 		var stable float64
 		Eventually(func() error {
 			var stableErr error
-			stable, stableErr = e2e.MetricStable(s.cluster.Name, node, faultTransitionMetric, labels, 2, faultMetricGap)
+			stable, stableErr = e2e.MetricStable(s.ctx, s.cluster.Name, node, faultTransitionMetric, labels, 2, faultMetricGap)
 			return stableErr
 		}, faultConvergenceTimeout, faultPollInterval).Should(Succeed())
 		stableValues[node] = stable
@@ -474,4 +493,14 @@ func (s *controlPlaneFaultSuite) assertTransitionCounterStable(before faultMetri
 	Expect(observed).To(BeNumerically(">=", 1))
 	By(withTimestamp(fmt.Sprintf("stable transition counters after %s: %v; delta %.0f", fault, stableValues, totalDelta)))
 	Expect(totalDelta).To(BeNumerically("<=", faultTransitionDeltaLimit))
+}
+
+func (s *controlPlaneFaultSuite) metricsAvailable() bool {
+	for _, node := range s.nodes {
+		if _, err := e2e.ScrapeMetrics(s.ctx, s.cluster.Name, node); err != nil {
+			By(withTimestamp(fmt.Sprintf("metrics unavailable on %q; continuing with functional assertions: %v", node, err)))
+			return false
+		}
+	}
+	return true
 }

--- a/testing/e2e/e2e_matrix_helpers_test.go
+++ b/testing/e2e/e2e_matrix_helpers_test.go
@@ -4,14 +4,20 @@ package e2e_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"text/template"
 
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/yaml"
 
+	"github.com/kube-vip/kube-vip/pkg/kubevip"
+	"github.com/kube-vip/kube-vip/testing/e2e"
 	"github.com/kube-vip/kube-vip/testing/e2e/matrix"
 )
 
@@ -80,5 +86,60 @@ func TestMatrixBackendsReady(t *testing.T) {
 
 	if err := matrixBackendsReady(context.Background(), fake.NewSimpleClientset(), "default", "missing", matrix.ProviderSlices); err == nil {
 		t.Fatal("matrixBackendsReady() succeeded without EndpointSlices")
+	}
+}
+
+func TestMatrixDualStackServiceConfiguration(t *testing.T) {
+	t.Parallel()
+	service := newTestService("service", "default", "backend", "192.0.2.10,2001:db8::10",
+		corev1.IPFamilyPolicyPreferDualStack, matrixServiceFamilies(matrix.FamilyDual),
+		corev1.ServiceExternalTrafficPolicyCluster, "", 80, false, false)
+	if service.Spec.LoadBalancerIP != "" {
+		t.Fatalf("legacy loadBalancerIP = %q, want empty for dual-stack service", service.Spec.LoadBalancerIP)
+	}
+	if got := service.Annotations[kubevip.LoadbalancerIPAnnotation]; got != "192.0.2.10,2001:db8::10" {
+		t.Fatalf("load-balancer annotation = %q", got)
+	}
+	if service.Spec.IPFamilyPolicy == nil || *service.Spec.IPFamilyPolicy != corev1.IPFamilyPolicyPreferDualStack {
+		t.Fatalf("IPFamilyPolicy = %v, want PreferDualStack", service.Spec.IPFamilyPolicy)
+	}
+	if got := service.Spec.IPFamilies; len(got) != 2 || got[0] != corev1.IPv4Protocol || got[1] != corev1.IPv6Protocol {
+		t.Fatalf("IPFamilies = %v, want [IPv4 IPv6]", got)
+	}
+}
+
+func TestMatrixManifestConfiguresBothServiceMasks(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join("kube-vip.yaml.tmpl")
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestTemplate, err := template.New(filepath.Base(path)).Parse(string(contents))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mode := range []string{"bgp", "arp"} {
+		var rendered strings.Builder
+		values := e2e.KubevipManifestValues{Mode: mode}
+		if mode == "bgp" {
+			values.BGPAS = 65501
+		}
+		if err := manifestTemplate.Execute(&rendered, values); err != nil {
+			t.Fatal(err)
+		}
+		var pod corev1.Pod
+		if err := yaml.Unmarshal([]byte(rendered.String()), &pod); err != nil {
+			t.Fatal(err)
+		}
+		got := ""
+		for _, env := range pod.Spec.Containers[0].Env {
+			if env.Name == "vip_subnet" {
+				got = env.Value
+			}
+		}
+		if got != "32,128" {
+			t.Errorf("%s vip_subnet = %q, want 32,128", mode, got)
+		}
 	}
 }

--- a/testing/e2e/e2e_matrix_helpers_test.go
+++ b/testing/e2e/e2e_matrix_helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"text/template"
@@ -56,6 +57,37 @@ func TestMatrixKubeadmPatches(t *testing.T) {
 	patches := matrixKubeadmPatches("fd00::10", true)
 	if len(patches) != 1 || !strings.Contains(patches[0].Patch, `value: "fd00::10"`) {
 		t.Fatalf("matrixKubeadmPatches() = %#v, want IPv6 certificate SAN", patches)
+	}
+}
+
+func TestAnnotateNodesIncludesPeerPort(t *testing.T) {
+	t.Parallel()
+
+	client := fake.NewSimpleClientset(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1", Annotations: map[string]string{"existing": "value"}},
+		Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
+			{Type: corev1.NodeInternalIP, Address: "192.0.2.10"},
+		}},
+	})
+	peer := e2e.BGPPeerValues{IP: "192.0.2.20", AS: 65500, Port: 1179}
+
+	if err := annotateNodes(context.Background(), "test", client, peer, 65501); err != nil {
+		t.Fatalf("annotateNodes() error = %v", err)
+	}
+	node, err := client.CoreV1().Nodes().Get(context.Background(), "node-1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("getting patched node: %v", err)
+	}
+	want := map[string]string{
+		"existing":                   "value",
+		"test/bgp-peers-0-node-asn":  "65501",
+		"test/bgp-peers-0-src-ip":    "192.0.2.10",
+		"test/bgp-peers-0-peer-asn":  "65500",
+		"test/bgp-peers-0-peer-ip":   "192.0.2.20",
+		"test/bgp-peers-0-peer-port": "1179",
+	}
+	if !reflect.DeepEqual(node.Annotations, want) {
+		t.Fatalf("node annotations = %#v, want %#v", node.Annotations, want)
 	}
 }
 

--- a/testing/e2e/e2e_matrix_helpers_test.go
+++ b/testing/e2e/e2e_matrix_helpers_test.go
@@ -1,0 +1,72 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/kube-vip/kube-vip/testing/e2e/matrix"
+)
+
+func TestMatrixLeaderCapability(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		combo matrix.Combo
+		want  bool
+		lease string
+	}{
+		{name: "ARP control plane", combo: matrix.Combo{Mode: matrix.ModeARP, Function: matrix.FunctionCP, Election: matrix.ElectionGlobal}, want: true, lease: "plndr-cp-lock"},
+		{name: "RT control plane has no election", combo: matrix.Combo{Mode: matrix.ModeRT, Function: matrix.FunctionCP, Election: matrix.ElectionNone}},
+		{name: "RT global service", combo: matrix.Combo{Mode: matrix.ModeRT, Function: matrix.FunctionSvc, Election: matrix.ElectionGlobal}, want: true, lease: "plndr-svcs-lock"},
+		{name: "BGP global service", combo: matrix.Combo{Mode: matrix.ModeBGP, Function: matrix.FunctionSvc, Election: matrix.ElectionGlobal}, want: true, lease: "plndr-svcs-lock"},
+		{name: "BGP per-service", combo: matrix.Combo{Mode: matrix.ModeBGP, Function: matrix.FunctionSvc, Election: matrix.ElectionPerService}, want: true, lease: "kubevip-test"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := shouldAssertMatrixLeader(test.combo, test.combo.Function != matrix.FunctionCP); got != test.want {
+				t.Fatalf("shouldAssertMatrixLeader() = %t, want %t", got, test.want)
+			}
+			if test.want && matrixLeaderLease(test.combo, "test") != test.lease {
+				t.Fatalf("matrixLeaderLease() = %q, want %q", matrixLeaderLease(test.combo, "test"), test.lease)
+			}
+		})
+	}
+}
+
+func TestMatrixBackendsReady(t *testing.T) {
+	t.Parallel()
+	ready := true
+	tests := []struct {
+		name     string
+		provider matrix.Provider
+		client   *fake.Clientset
+	}{
+		{
+			name: "endpoints", provider: matrix.ProviderEndpoints,
+			client: fake.NewSimpleClientset(&corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: "default"}, Subsets: []corev1.EndpointSubset{{Addresses: []corev1.EndpointAddress{{IP: "10.0.0.1"}}}}}),
+		},
+		{
+			name: "slices", provider: matrix.ProviderSlices,
+			client: fake.NewSimpleClientset(&discoveryv1.EndpointSlice{ObjectMeta: metav1.ObjectMeta{Name: "service-1", Namespace: "default", Labels: map[string]string{discoveryv1.LabelServiceName: "service"}}, Endpoints: []discoveryv1.Endpoint{{Addresses: []string{"10.0.0.1"}, Conditions: discoveryv1.EndpointConditions{Ready: &ready}}}}),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := matrixBackendsReady(context.Background(), test.client, "default", "service", test.provider); err != nil {
+				t.Fatalf("matrixBackendsReady() error = %v", err)
+			}
+		})
+	}
+
+	if err := matrixBackendsReady(context.Background(), fake.NewSimpleClientset(), "default", "missing", matrix.ProviderSlices); err == nil {
+		t.Fatal("matrixBackendsReady() succeeded without EndpointSlices")
+	}
+}

--- a/testing/e2e/e2e_matrix_helpers_test.go
+++ b/testing/e2e/e2e_matrix_helpers_test.go
@@ -4,6 +4,7 @@ package e2e_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -38,6 +39,17 @@ func TestMatrixLeaderCapability(t *testing.T) {
 				t.Fatalf("matrixLeaderLease() = %q, want %q", matrixLeaderLease(test.combo, "test"), test.lease)
 			}
 		})
+	}
+}
+
+func TestMatrixKubeadmPatches(t *testing.T) {
+	t.Parallel()
+	if patches := matrixKubeadmPatches("fd00::10", false); patches != nil {
+		t.Fatalf("matrixKubeadmPatches() = %#v when control plane is disabled", patches)
+	}
+	patches := matrixKubeadmPatches("fd00::10", true)
+	if len(patches) != 1 || !strings.Contains(patches[0].Patch, `value: "fd00::10"`) {
+		t.Fatalf("matrixKubeadmPatches() = %#v, want IPv6 certificate SAN", patches)
 	}
 }
 

--- a/testing/e2e/e2e_matrix_test.go
+++ b/testing/e2e/e2e_matrix_test.go
@@ -1,0 +1,369 @@
+//go:build e2e
+// +build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	api "github.com/osrg/gobgp/v4/api"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	kindconfigv1alpha4 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kube-vip/kube-vip/pkg/utils"
+	"github.com/kube-vip/kube-vip/testing/e2e"
+	"github.com/kube-vip/kube-vip/testing/e2e/bgp"
+	"github.com/kube-vip/kube-vip/testing/e2e/matrix"
+)
+
+const matrixClusterNodes = 1
+
+type matrixDeployment struct {
+	cluster   *e2e.Cluster
+	cpVIP     string
+	bgpClient api.GoBgpServiceClient
+	bgpPeers  []*e2e.BGPPeerValues
+	bgpServer *bgp.Server
+}
+
+var _ = Describe("kube-vip pairwise combination matrix", Label("matrix"), func() {
+	if Mode != ModeMatrix {
+		return
+	}
+	tableArgs := []any{
+		func(combo matrix.Combo) {
+			runMatrixCombo(combo)
+		},
+	}
+	tableArgs = append(tableArgs, matrixTableEntries()...)
+	DescribeTable("deploys a valid pairwise combination and reaches steady state", tableArgs...)
+})
+
+func matrixTableEntries() []any {
+	combos := matrix.Generate()
+	shardIndex, shardCount := matrixShard()
+	entries := make([]any, 0, len(combos))
+	for i, combo := range combos {
+		if shardCount > 1 && i%shardCount != shardIndex-1 {
+			continue
+		}
+		entries = append(entries, Entry(matrix.FormatValues(
+			string(combo.Mode),
+			string(combo.Function),
+			string(combo.Family),
+			string(combo.Election),
+			string(combo.Shape),
+			string(combo.Provider),
+			string(combo.ETP),
+		), combo))
+	}
+	return entries
+}
+
+func matrixShard() (int, int) {
+	value := strings.TrimSpace(os.Getenv("MATRIX_SHARD"))
+	if value == "" {
+		return 1, 1
+	}
+
+	parts := strings.Split(value, "/")
+	if len(parts) != 2 {
+		panic(fmt.Sprintf("MATRIX_SHARD must have the form i/n, got %q", value))
+	}
+	index, err := strconv.Atoi(parts[0])
+	if err != nil {
+		panic(fmt.Sprintf("MATRIX_SHARD has invalid shard index %q: %v", parts[0], err))
+	}
+	count, err := strconv.Atoi(parts[1])
+	if err != nil {
+		panic(fmt.Sprintf("MATRIX_SHARD has invalid shard count %q: %v", parts[1], err))
+	}
+	if index < 1 || count < 1 || index > count {
+		panic(fmt.Sprintf("MATRIX_SHARD must satisfy 1 <= i <= n, got %q", value))
+	}
+	return index, count
+}
+
+func runMatrixCombo(combo matrix.Combo) {
+	if combo.Mode == matrix.ModeWireGuard {
+		Skip("WireGuard matrix entries are retained for pairwise coverage, but WireGuard has no e2e setup yet")
+	}
+
+	ctx := context.Background()
+	deployment := createMatrixDeployment(ctx, combo)
+	registerMatrixCleanup(ctx, deployment)
+
+	hasCP := combo.Function == matrix.FunctionCP || combo.Function == matrix.FunctionBoth
+	hasService := combo.Function == matrix.FunctionSvc || combo.Function == matrix.FunctionBoth
+	serviceName := ""
+	if hasService {
+		serviceName = fmt.Sprintf("matrix-svc-%d", SOffset.Get())
+		backendName := fmt.Sprintf("matrix-backend-%d", SOffset.Get())
+		createDS(ctx, backendName, dsNamespace, deployment.cluster.Client, 80)
+		serviceVIP := matrixVIP(combo.Family, SOffset.Get())
+		createTestService(ctx, serviceName, dsNamespace, backendName, serviceVIP,
+			deployment.cluster.Client, corev1.IPFamilyPolicyPreferDualStack,
+			matrixServiceFamilies(combo.Family), matrixTrafficPolicy(combo.ETP), "", 80, false,
+			combo.Election == matrix.ElectionOnDemand)
+		assertMatrixServiceVIP(ctx, deployment.cluster.Client, serviceName, serviceVIP)
+		if combo.Mode == matrix.ModeBGP {
+			assertMatrixBGPVIP(ctx, deployment.bgpClient, serviceVIP)
+		}
+	}
+
+	if hasCP {
+		assertMatrixControlPlaneVIP(ctx, deployment, combo)
+	}
+
+	assertMatrixMetrics(ctx, deployment, combo, serviceName)
+}
+
+func createMatrixDeployment(ctx context.Context, combo matrix.Combo) *matrixDeployment {
+	clusterIPFamily, podSubnet, serviceSubnet := matrixClusterFamily(combo.Family)
+	networking := kindconfigv1alpha4.Networking{IPFamily: clusterIPFamily}
+	if podSubnet != "" {
+		networking.PodSubnet = podSubnet
+		networking.ServiceSubnet = serviceSubnet
+	}
+
+	cpVIP := matrixVIP(combo.Family, SOffset.Get())
+	hasCP := combo.Function == matrix.FunctionCP || combo.Function == matrix.FunctionBoth
+	hasService := combo.Function == matrix.FunctionSvc || combo.Function == matrix.FunctionBoth
+	manifestValues := e2e.KubevipManifestValues{
+		ControlPlaneVIP:            cpVIP,
+		ControlPlaneEnable:         strconv.FormatBool(hasCP),
+		SvcEnable:                  strconv.FormatBool(hasService),
+		SvcElectionEnable:          strconv.FormatBool(combo.Election == matrix.ElectionPerService),
+		VipElectionEnable:          strconv.FormatBool(combo.Election == matrix.ElectionGlobal || (hasCP && combo.Election != matrix.ElectionNone)),
+		EnableEndpoints:            strconv.FormatBool(combo.Provider == matrix.ProviderEndpoints),
+		EnableNodeLabeling:         "false",
+		EnableServiceSecurity:      "true",
+		PerServiceElectionOnDemand: strconv.FormatBool(combo.Election == matrix.ElectionOnDemand),
+		Mode:                       string(combo.Mode),
+	}
+
+	deployment := &matrixDeployment{cpVIP: cpVIP}
+	if combo.Mode == matrix.ModeBGP {
+		Expect(sharedBGPServer).NotTo(BeNil(), "matrix BGP combos require the shared GoBGP server")
+		deployment.bgpServer = sharedBGPServer
+		peerFamilies := matrixBGPPeerFamilies(combo.Family)
+		bgpPeers := make([]*e2e.BGPPeerValues, 0, len(peerFamilies))
+		for _, family := range peerFamilies {
+			peerIP := sharedBGPServer.LocalIPv4
+			if family == utils.IPv6Family {
+				peerIP = sharedBGPServer.LocalIPv6
+			}
+			bgpPeers = append(bgpPeers, &e2e.BGPPeerValues{IP: peerIP, AS: bgp.GoBGPAS, IPFamily: family})
+		}
+		manifestValues.BGPAS = bgp.KubevipAS
+		manifestValues.BGPPeers = bgp.PeerStrings(bgpPeers)
+	}
+
+	templateName := ""
+	if combo.Mode == matrix.ModeRT {
+		templateName = "kube-vip-routing-table.yaml.tmpl"
+	}
+	deployment.cluster = e2e.CreateCluster(ctx, &e2e.ClusterSpec{
+		Name:         fmt.Sprintf("matrix-%d-p%d", SOffset.Get(), GinkgoParallelProcess()),
+		Nodes:        matrixClusterNodes,
+		Networking:   networking,
+		KubeVip:      manifestValues,
+		Logger:       e2e.TestLogger{},
+		ConfigMtx:    ConfigMtx,
+		TemplateName: templateName,
+		UseDaemonSet: combo.Shape == matrix.ShapeDaemonSet,
+	})
+
+	if combo.Mode == matrix.ModeBGP {
+		deployment.bgpPeers = sharedBGPServer.AddClusterPeers(ctx, deployment.cluster.Nodes, bgp.KubevipAS, matrixBGPPeerFamilies(combo.Family))
+		deployment.bgpClient = sharedBGPServer.Client
+	}
+	return deployment
+}
+
+func registerMatrixCleanup(ctx context.Context, deployment *matrixDeployment) {
+	DeferCleanup(func() {
+		if deployment.bgpServer != nil {
+			deployment.bgpServer.RemovePeers(ctx, deployment.bgpPeers)
+		}
+
+		logDir, err := os.MkdirTemp("", "kube-vip-matrix-logs")
+		Expect(err).NotTo(HaveOccurred())
+		deployment.cluster.SaveLogs(ctx, logDir)
+		if os.Getenv("E2E_KEEP_LOGS") != "true" {
+			Expect(os.RemoveAll(logDir)).To(Succeed())
+		}
+		deployment.cluster.Delete()
+	})
+}
+
+func assertMatrixControlPlaneVIP(ctx context.Context, deployment *matrixDeployment, combo matrix.Combo) {
+	for _, address := range strings.Split(deployment.cpVIP, ",") {
+		if combo.Mode == matrix.ModeBGP {
+			assertMatrixBGPVIP(ctx, deployment.bgpClient, address)
+			continue
+		}
+		assertControlPlaneIsRoutable(address, 5*time.Second, 120*time.Second)
+	}
+}
+
+func assertMatrixServiceVIP(ctx context.Context, client kubernetes.Interface, name, vipAddress string) {
+	addresses := strings.Split(vipAddress, ",")
+	Eventually(func() error {
+		service, err := client.CoreV1().Services(dsNamespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		for _, address := range addresses {
+			found := false
+			for _, ingress := range service.Status.LoadBalancer.Ingress {
+				if ingress.IP == address || ingress.Hostname == address {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return fmt.Errorf("service %s/%s has not published VIP %s", dsNamespace, name, address)
+			}
+		}
+		return nil
+	}, "120s", "2s").Should(Succeed())
+}
+
+func assertMatrixBGPVIP(ctx context.Context, client api.GoBgpServiceClient, vipAddress string) {
+	if client == nil {
+		return
+	}
+	for _, address := range strings.Split(vipAddress, ",") {
+		family := &api.Family{Afi: api.Family_AFI_IP, Safi: api.Family_SAFI_UNICAST}
+		if parsed := net.ParseIP(address); parsed != nil && parsed.To4() == nil {
+			family.Afi = api.Family_AFI_IP6
+		}
+		paths := bgp.CheckPaths(ctx, client, family, []*api.TableLookupPrefix{{Prefix: address}}, 1)
+		Expect(paths).NotTo(BeEmpty())
+	}
+}
+
+func assertMatrixMetrics(ctx context.Context, deployment *matrixDeployment, combo matrix.Combo, serviceName string) {
+	hasService := serviceName != ""
+	if shouldAssertMatrixLeader(combo, hasService) {
+		leaseName := matrixLeaderLease(combo, serviceName)
+		labels := map[string]string{"lease_name": leaseName}
+		assertMetricValue := func() (float64, error) {
+			var total float64
+			for _, node := range deployment.cluster.Nodes {
+				metrics, err := e2e.ScrapeMetrics(deployment.cluster.Name, node.String())
+				if err != nil {
+					return 0, err
+				}
+				total += e2e.SumMetric(metrics, "kube_vip_is_leader", labels)
+			}
+			return total, nil
+		}
+		Eventually(assertMetricValue, "120s", "2s").Should(Equal(float64(1)))
+		Consistently(assertMetricValue, "10s", "2s").Should(Equal(float64(1)))
+	}
+
+	if hasService {
+		activeServices := func() (float64, error) {
+			var total float64
+			for _, node := range deployment.cluster.Nodes {
+				metrics, err := e2e.ScrapeMetrics(deployment.cluster.Name, node.String())
+				if err != nil {
+					return 0, err
+				}
+				total += e2e.SumMetric(metrics, "kube_vip_active_services", map[string]string{
+					"namespace": dsNamespace,
+				})
+			}
+			return total, nil
+		}
+		Eventually(activeServices, "120s", "2s").Should(BeNumerically(">=", float64(1)))
+		Consistently(activeServices, "10s", "2s").Should(BeNumerically(">=", float64(1)))
+	}
+}
+
+func shouldAssertMatrixLeader(combo matrix.Combo, hasService bool) bool {
+	if combo.Election == matrix.ElectionNone {
+		return false
+	}
+	if combo.Mode == matrix.ModeBGP {
+		return hasService && combo.Election != matrix.ElectionGlobal
+	}
+	if combo.Function == matrix.FunctionCP || combo.Function == matrix.FunctionBoth {
+		return true
+	}
+	return hasService
+}
+
+func matrixLeaderLease(combo matrix.Combo, serviceName string) string {
+	if combo.Mode != matrix.ModeBGP && (combo.Function == matrix.FunctionCP || combo.Function == matrix.FunctionBoth) {
+		return "plndr-cp-lock"
+	}
+	if combo.Election == matrix.ElectionGlobal {
+		return "plndr-svcs-lock"
+	}
+	return "kubevip-" + serviceName
+}
+
+func matrixClusterFamily(family matrix.Family) (kindconfigv1alpha4.ClusterIPFamily, string, string) {
+	switch family {
+	case matrix.FamilyV6:
+		return kindconfigv1alpha4.IPv6Family, "", ""
+	case matrix.FamilyDual:
+		return kindconfigv1alpha4.DualStackFamily, "fd00:10:244::/56,10.244.0.0/16", "fd00:10:96::/112,10.96.0.0/16"
+	default:
+		return kindconfigv1alpha4.IPv4Family, "", ""
+	}
+}
+
+func matrixServiceFamilies(family matrix.Family) []corev1.IPFamily {
+	switch family {
+	case matrix.FamilyV6:
+		return []corev1.IPFamily{corev1.IPv6Protocol}
+	case matrix.FamilyDual:
+		return []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
+	default:
+		return []corev1.IPFamily{corev1.IPv4Protocol}
+	}
+}
+
+func matrixBGPPeerFamilies(family matrix.Family) []string {
+	switch family {
+	case matrix.FamilyV6:
+		return []string{utils.IPv6Family}
+	case matrix.FamilyDual:
+		return []string{utils.IPv4Family, utils.IPv6Family}
+	default:
+		return []string{utils.IPv4Family}
+	}
+}
+
+func matrixTrafficPolicy(etp matrix.ETP) corev1.ServiceExternalTrafficPolicy {
+	if etp == matrix.ETPLocal {
+		return corev1.ServiceExternalTrafficPolicyLocal
+	}
+	return corev1.ServiceExternalTrafficPolicyCluster
+}
+
+func matrixVIP(family matrix.Family, offset uint) string {
+	switch family {
+	case matrix.FamilyV6:
+		return e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
+	case matrix.FamilyDual:
+		return e2e.GenerateDualStackVIP(offset, defaultNetwork)
+	default:
+		return e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
+	}
+}

--- a/testing/e2e/e2e_matrix_test.go
+++ b/testing/e2e/e2e_matrix_test.go
@@ -144,7 +144,7 @@ func createMatrixDeployment(ctx context.Context, combo matrix.Combo) *matrixDepl
 		networking.ServiceSubnet = serviceSubnet
 	}
 
-	cpVIP := matrixVIP(combo.Family, SOffset.Get())
+	cpVIP := matrixControlPlaneVIP(combo.Family, SOffset.Get())
 	hasCP := combo.Function == matrix.FunctionCP || combo.Function == matrix.FunctionBoth
 	hasService := combo.Function == matrix.FunctionSvc || combo.Function == matrix.FunctionBoth
 	manifestValues := e2e.KubevipManifestValues{
@@ -172,7 +172,7 @@ func createMatrixDeployment(ctx context.Context, combo matrix.Combo) *matrixDepl
 			if family == utils.IPv6Family {
 				peerIP = sharedBGPServer.LocalIPv6
 			}
-			bgpPeers = append(bgpPeers, &e2e.BGPPeerValues{IP: peerIP, AS: bgp.GoBGPAS, IPFamily: family})
+			bgpPeers = append(bgpPeers, &e2e.BGPPeerValues{IP: peerIP, AS: bgp.GoBGPAS, Port: bgp.GoBGPPort, IPFamily: family})
 		}
 		manifestValues.BGPAS = bgp.KubevipAS
 		manifestValues.BGPPeers = bgp.PeerStrings(bgpPeers)
@@ -183,19 +183,21 @@ func createMatrixDeployment(ctx context.Context, combo matrix.Combo) *matrixDepl
 		templateName = "kube-vip-routing-table.yaml.tmpl"
 	}
 	deployment.cluster = e2e.CreateCluster(ctx, &e2e.ClusterSpec{
-		Name:         fmt.Sprintf("matrix-%d-p%d", SOffset.Get(), GinkgoParallelProcess()),
-		Nodes:        matrixClusterNodes,
-		Networking:   networking,
-		KubeVip:      manifestValues,
-		Logger:       e2e.TestLogger{},
-		ConfigMtx:    ConfigMtx,
-		TemplateName: templateName,
-		UseDaemonSet: combo.Shape == matrix.ShapeDaemonSet,
+		Name:           fmt.Sprintf("matrix-%d-p%d", SOffset.Get(), GinkgoParallelProcess()),
+		Nodes:          matrixClusterNodes,
+		Networking:     networking,
+		KubeVip:        manifestValues,
+		Logger:         e2e.TestLogger{},
+		ConfigMtx:      ConfigMtx,
+		KubeadmPatches: matrixKubeadmPatches(cpVIP, hasCP),
+		TemplateName:   templateName,
+		UseDaemonSet:   combo.Shape == matrix.ShapeDaemonSet,
 	})
 
 	if combo.Mode == matrix.ModeBGP {
 		deployment.bgpPeers = sharedBGPServer.AddClusterPeers(ctx, deployment.cluster.Nodes, bgp.KubevipAS, matrixBGPPeerFamilies(combo.Family))
 		deployment.bgpClient = sharedBGPServer.Client
+		Expect(sharedBGPServer.WaitForEstablished(ctx, deployment.bgpPeers)).To(Succeed())
 	}
 	return deployment
 }
@@ -262,7 +264,9 @@ func assertMatrixBGPConnection(ctx context.Context, client api.GoBgpServiceClien
 func assertMatrixRoutes(deployment *matrixDeployment, addresses string) {
 	for _, node := range deployment.cluster.Nodes {
 		for _, address := range strings.Split(addresses, ",") {
-			Expect(e2e.CheckRoutePresence(address, node.String(), true)).To(BeTrue())
+			present, output, err := e2e.CheckRoutePresence(address, node.String(), true)
+			Expect(err).NotTo(HaveOccurred(), "route output: %s", output)
+			Expect(present).To(BeTrue(), "route output: %s", output)
 		}
 	}
 }
@@ -460,4 +464,23 @@ func matrixVIP(family matrix.Family, offset uint) string {
 	default:
 		return e2e.GenerateVIP(utils.IPv4Family, offset, defaultNetwork)
 	}
+}
+
+func matrixControlPlaneVIP(family matrix.Family, offset uint) string {
+	if family == matrix.FamilyDual {
+		// The dual-stack Kind configuration is IPv6-primary, so kubeadm's API
+		// endpoint and kube-vip must use the IPv6 member of the VIP pair.
+		return e2e.GenerateVIP(utils.IPv6Family, offset, defaultNetwork)
+	}
+	return matrixVIP(family, offset)
+}
+
+func matrixKubeadmPatches(cpVIP string, enabled bool) []kindconfigv1alpha4.PatchJSON6902 {
+	if !enabled {
+		return nil
+	}
+	return []kindconfigv1alpha4.PatchJSON6902{{
+		Group: "kubeadm.k8s.io", Version: "v1beta3", Kind: "ClusterConfiguration",
+		Patch: fmt.Sprintf("- op: add\n  path: /apiServer/certSANs/-\n  value: %q", cpVIP),
+	}}
 }

--- a/testing/e2e/e2e_matrix_test.go
+++ b/testing/e2e/e2e_matrix_test.go
@@ -96,10 +96,6 @@ func matrixShard() (int, int) {
 }
 
 func runMatrixCombo(combo matrix.Combo) {
-	if combo.Mode == matrix.ModeWireGuard {
-		Skip("WireGuard matrix entries are retained for pairwise coverage, but WireGuard has no e2e setup yet")
-	}
-
 	ctx := context.Background()
 	deployment := createMatrixDeployment(ctx, combo)
 	registerMatrixCleanup(ctx, deployment)
@@ -119,6 +115,9 @@ func runMatrixCombo(combo matrix.Combo) {
 		assertMatrixServiceVIP(ctx, deployment.cluster.Client, serviceName, serviceVIP)
 		if combo.Mode == matrix.ModeBGP {
 			assertMatrixBGPVIP(ctx, deployment.bgpClient, serviceVIP)
+		}
+		for _, address := range strings.Split(serviceVIP, ",") {
+			assertConnection("http", address, "80", "", 5*time.Second, 120*time.Second)
 		}
 	}
 
@@ -151,6 +150,7 @@ func createMatrixDeployment(ctx context.Context, combo matrix.Combo) *matrixDepl
 		EnableServiceSecurity:      "true",
 		PerServiceElectionOnDemand: strconv.FormatBool(combo.Election == matrix.ElectionOnDemand),
 		Mode:                       string(combo.Mode),
+		PrometheusHTTPServer:       ":2112",
 	}
 
 	deployment := &matrixDeployment{cpVIP: cpVIP}
@@ -263,7 +263,7 @@ func assertMatrixMetrics(ctx context.Context, deployment *matrixDeployment, comb
 		assertMetricValue := func() (float64, error) {
 			var total float64
 			for _, node := range deployment.cluster.Nodes {
-				metrics, err := e2e.ScrapeMetrics(deployment.cluster.Name, node.String())
+				metrics, err := e2e.ScrapeMetrics(ctx, deployment.cluster.Name, node.String())
 				if err != nil {
 					return 0, err
 				}
@@ -279,7 +279,7 @@ func assertMatrixMetrics(ctx context.Context, deployment *matrixDeployment, comb
 		activeServices := func() (float64, error) {
 			var total float64
 			for _, node := range deployment.cluster.Nodes {
-				metrics, err := e2e.ScrapeMetrics(deployment.cluster.Name, node.String())
+				metrics, err := e2e.ScrapeMetrics(ctx, deployment.cluster.Name, node.String())
 				if err != nil {
 					return 0, err
 				}

--- a/testing/e2e/e2e_matrix_test.go
+++ b/testing/e2e/e2e_matrix_test.go
@@ -8,12 +8,14 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"time"
 
 	api "github.com/osrg/gobgp/v4/api"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	kindconfigv1alpha4 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
@@ -112,12 +114,18 @@ func runMatrixCombo(combo matrix.Combo) {
 			deployment.cluster.Client, corev1.IPFamilyPolicyPreferDualStack,
 			matrixServiceFamilies(combo.Family), matrixTrafficPolicy(combo.ETP), "", 80, false,
 			combo.Election == matrix.ElectionOnDemand)
+		assertMatrixBackendsReady(ctx, deployment.cluster.Client, serviceName, combo.Provider)
 		assertMatrixServiceVIP(ctx, deployment.cluster.Client, serviceName, serviceVIP)
 		if combo.Mode == matrix.ModeBGP {
 			assertMatrixBGPVIP(ctx, deployment.bgpClient, serviceVIP)
+			assertMatrixBGPConnection(ctx, deployment.bgpClient, serviceVIP, "http", "80", "")
 		}
-		for _, address := range strings.Split(serviceVIP, ",") {
-			assertConnection("http", address, "80", "", 5*time.Second, 120*time.Second)
+		if combo.Mode == matrix.ModeARP {
+			for _, address := range strings.Split(serviceVIP, ",") {
+				assertConnection("http", address, "80", "", 5*time.Second, 120*time.Second)
+			}
+		} else if combo.Mode == matrix.ModeRT {
+			assertMatrixRoutes(deployment, serviceVIP)
 		}
 	}
 
@@ -212,10 +220,93 @@ func assertMatrixControlPlaneVIP(ctx context.Context, deployment *matrixDeployme
 	for _, address := range strings.Split(deployment.cpVIP, ",") {
 		if combo.Mode == matrix.ModeBGP {
 			assertMatrixBGPVIP(ctx, deployment.bgpClient, address)
+			assertMatrixBGPConnection(ctx, deployment.bgpClient, address, "https", "6443", "livez")
+			continue
+		}
+		if combo.Mode == matrix.ModeRT {
+			assertMatrixRoutes(deployment, address)
 			continue
 		}
 		assertControlPlaneIsRoutable(address, 5*time.Second, 120*time.Second)
 	}
+}
+
+func assertMatrixBGPConnection(ctx context.Context, client api.GoBgpServiceClient, addresses, protocol, port, suffix string) {
+	for _, address := range strings.Split(addresses, ",") {
+		var nextHops []string
+		Eventually(func() error {
+			nextHops = bgp.ResolveVIP(ctx, client, address)
+			if len(nextHops) == 0 {
+				return fmt.Errorf("BGP has no next hop for VIP %s", address)
+			}
+			return nil
+		}, "120s", "2s").Should(Succeed())
+
+		prefix := address + "/32"
+		familyArg := "-4"
+		if net.ParseIP(address).To4() == nil {
+			prefix = address + "/128"
+			familyArg = "-6"
+		}
+		cmd := exec.Command("sudo", "ip", familyArg, "route", "replace", prefix, "via", nextHops[0])
+		output, err := cmd.CombinedOutput()
+		Expect(err).NotTo(HaveOccurred(), "install route to BGP VIP %s via %s: %s", address, nextHops[0], strings.TrimSpace(string(output)))
+		DeferCleanup(func() {
+			output, err := exec.Command("sudo", "ip", familyArg, "route", "del", prefix).CombinedOutput()
+			Expect(err).NotTo(HaveOccurred(), "remove route to BGP VIP %s: %s", address, strings.TrimSpace(string(output)))
+		})
+		assertConnection(protocol, address, port, suffix, 5*time.Second, 120*time.Second)
+	}
+}
+
+func assertMatrixRoutes(deployment *matrixDeployment, addresses string) {
+	for _, node := range deployment.cluster.Nodes {
+		for _, address := range strings.Split(addresses, ",") {
+			Expect(e2e.CheckRoutePresence(address, node.String(), true)).To(BeTrue())
+		}
+	}
+}
+
+func assertMatrixBackendsReady(ctx context.Context, client kubernetes.Interface, serviceName string, provider matrix.Provider) {
+	Eventually(func() error {
+		return matrixBackendsReady(ctx, client, dsNamespace, serviceName, provider)
+	}, "120s", "2s").Should(Succeed())
+}
+
+func matrixBackendsReady(ctx context.Context, client kubernetes.Interface, namespace, serviceName string, provider matrix.Provider) error {
+	if provider == matrix.ProviderEndpoints {
+		endpoints, err := client.CoreV1().Endpoints(namespace).Get(ctx, serviceName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		ready := 0
+		for _, subset := range endpoints.Subsets {
+			ready += len(subset.Addresses)
+		}
+		if ready == 0 {
+			return fmt.Errorf("endpoints %s/%s have no ready addresses; subsets: %+v", namespace, serviceName, endpoints.Subsets)
+		}
+		return nil
+	}
+
+	slices, err := client.DiscoveryV1().EndpointSlices(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: discoveryv1.LabelServiceName + "=" + serviceName,
+	})
+	if err != nil {
+		return err
+	}
+	ready := 0
+	for _, slice := range slices.Items {
+		for _, endpoint := range slice.Endpoints {
+			if endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready {
+				ready += len(endpoint.Addresses)
+			}
+		}
+	}
+	if ready == 0 {
+		return fmt.Errorf("endpoint slices for %s/%s have no ready addresses; slices: %+v", namespace, serviceName, slices.Items)
+	}
+	return nil
 }
 
 func assertMatrixServiceVIP(ctx context.Context, client kubernetes.Interface, name, vipAddress string) {
@@ -299,7 +390,10 @@ func shouldAssertMatrixLeader(combo matrix.Combo, hasService bool) bool {
 		return false
 	}
 	if combo.Mode == matrix.ModeBGP {
-		return hasService && combo.Election != matrix.ElectionGlobal
+		return hasService
+	}
+	if combo.Mode == matrix.ModeRT {
+		return hasService && combo.Election != matrix.ElectionNone
 	}
 	if combo.Function == matrix.FunctionCP || combo.Function == matrix.FunctionBoth {
 		return true
@@ -308,7 +402,7 @@ func shouldAssertMatrixLeader(combo matrix.Combo, hasService bool) bool {
 }
 
 func matrixLeaderLease(combo matrix.Combo, serviceName string) string {
-	if combo.Mode != matrix.ModeBGP && (combo.Function == matrix.FunctionCP || combo.Function == matrix.FunctionBoth) {
+	if combo.Mode == matrix.ModeARP && (combo.Function == matrix.FunctionCP || combo.Function == matrix.FunctionBoth) {
 		return "plndr-cp-lock"
 	}
 	if combo.Election == matrix.ElectionGlobal {

--- a/testing/e2e/e2e_metric_helpers_test.go
+++ b/testing/e2e/e2e_metric_helpers_test.go
@@ -1,0 +1,59 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseMetricsFixture(t *testing.T) {
+	payload, err := os.ReadFile("testdata/metrics.prom")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	metrics, err := parseMetrics(string(payload))
+	if err != nil {
+		t.Fatalf("parseMetrics() error = %v", err)
+	}
+
+	if value, matches := MetricValue(metrics, "kube_vip_is_leader", map[string]string{"node": "control-plane"}); value != 1 || matches != 1 {
+		t.Fatalf("MetricValue() = (%v, %d), want (1, 1)", value, matches)
+	}
+	if value := SumMetric(metrics, "kube_vip_is_leader", map[string]string{"lease_name": "plndr-cp-lock"}); value != 1 {
+		t.Fatalf("SumMetric() = %v, want 1", value)
+	}
+	if value, found := MaxMetric(metrics, "kube_vip_election_errors_total", map[string]string{"reason": "api\nserver"}); value != 3 || !found {
+		t.Fatalf("MaxMetric() = (%v, %t), want (3, true)", value, found)
+	}
+	if value, matches := MetricValue(metrics, "kube_vip_reconcile_seconds_count", nil); value != 4 || matches != 1 {
+		t.Fatalf("histogram count = (%v, %d), want (4, 1)", value, matches)
+	}
+}
+
+func TestMetricHelpersReportMissingAndAmbiguousSeries(t *testing.T) {
+	metrics := map[string]float64{
+		`metric{node="one"}`: 1,
+		`metric{node="two"}`: 2,
+	}
+
+	if _, matches := MetricValue(metrics, "metric", nil); matches != 2 {
+		t.Fatalf("MetricValue() matches = %d, want 2", matches)
+	}
+	if _, matches := MetricValue(metrics, "missing", nil); matches != 0 {
+		t.Fatalf("MetricValue() matches = %d, want 0", matches)
+	}
+	if _, ok := CounterDelta(metrics, map[string]float64{`metric{node="one"}`: 4}, "metric", nil); ok {
+		t.Fatal("CounterDelta() reported an ambiguous selector as available")
+	}
+	if delta, ok := CounterDelta(metrics, map[string]float64{`metric{node="one"}`: 4}, "metric", map[string]string{"node": "one"}); delta != 3 || !ok {
+		t.Fatalf("CounterDelta() = (%v, %t), want (3, true)", delta, ok)
+	}
+}
+
+func TestParseMetricsRejectsInvalidFixture(t *testing.T) {
+	if _, err := parseMetrics("not valid prometheus text"); err == nil {
+		t.Fatal("parseMetrics() succeeded for invalid input")
+	}
+}

--- a/testing/e2e/e2e_rt_test.go
+++ b/testing/e2e/e2e_rt_test.go
@@ -4,12 +4,10 @@
 package e2e_test
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -194,7 +192,7 @@ var _ = Describe("kube-vip routing table mode", func() {
 				otherContainer := controlPlaneContainerName(clusterName, 1)
 
 				By(fmt.Sprintf("stopping the apiserver on %q", targetContainer))
-				setAPIServerState(targetContainer, false)
+				Expect(e2e.StashPodManifest(clusterName, targetContainer, "kube-apiserver.yaml")).To(Succeed())
 
 				By("verifying the unhealthy node withdraws its VIP and route")
 				Expect(checkIPAddress(cpVIP, targetContainer, false)).To(BeTrue())
@@ -205,7 +203,7 @@ var _ = Describe("kube-vip routing table mode", func() {
 				e2e.CheckRoutePresence(cpVIP, otherContainer, true)
 
 				By(fmt.Sprintf("restoring the apiserver on %q", targetContainer))
-				setAPIServerState(targetContainer, true)
+				Expect(e2e.RestorePodManifest(clusterName, targetContainer, "kube-apiserver.yaml")).To(Succeed())
 
 				By("verifying the recovered node re-adds its VIP and route")
 				// Allow extra time here: the apiserver static pod must be restarted
@@ -333,7 +331,7 @@ var _ = Describe("kube-vip routing table mode", func() {
 				otherContainer := controlPlaneContainerName(clusterName, 1)
 
 				By(fmt.Sprintf("stopping the apiserver on %q", targetContainer))
-				setAPIServerState(targetContainer, false)
+				Expect(e2e.StashPodManifest(clusterName, targetContainer, "kube-apiserver.yaml")).To(Succeed())
 
 				By("verifying the unhealthy node withdraws its VIP and route")
 				Expect(checkIPAddress(cpVIP, targetContainer, false)).To(BeTrue())
@@ -344,7 +342,7 @@ var _ = Describe("kube-vip routing table mode", func() {
 				e2e.CheckRoutePresence(cpVIP, otherContainer, true)
 
 				By(fmt.Sprintf("restoring the apiserver on %q", targetContainer))
-				setAPIServerState(targetContainer, true)
+				Expect(e2e.RestorePodManifest(clusterName, targetContainer, "kube-apiserver.yaml")).To(Succeed())
 
 				By("verifying the recovered node re-adds its VIP and route")
 				// Allow extra time here: the apiserver static pod must be restarted
@@ -1814,24 +1812,4 @@ func controlPlaneContainerName(clusterName string, i int) string {
 		return fmt.Sprintf("%s-control-plane%d", clusterName, i)
 	}
 	return fmt.Sprintf("%s-control-plane", clusterName)
-}
-
-// setAPIServerEnabled stops or starts the static apiserver pod on a control-plane
-// container by moving its manifest in or out of the kubelet manifests directory.
-func setAPIServerState(container string, enabled bool) {
-	const (
-		manifestPath = "/etc/kubernetes/manifests/kube-apiserver.yaml"
-		stashPath    = "/tmp/kube-apiserver.yaml"
-	)
-
-	src, dst := manifestPath, stashPath
-	if enabled {
-		src, dst = stashPath, manifestPath
-	}
-
-	out := new(bytes.Buffer)
-	cmd := exec.Command("docker", "exec", container, "mv", src, dst)
-	cmd.Stdout = out
-	cmd.Stderr = out
-	Expect(cmd.Run()).To(Succeed(), out.String())
 }

--- a/testing/e2e/e2e_suite_test.go
+++ b/testing/e2e/e2e_suite_test.go
@@ -18,10 +18,11 @@ import (
 )
 
 const (
-	ModeEnv = "TEST_MODE"
-	ModeARP = "arp"
-	ModeRT  = "rt"
-	ModeBGP = "bgp"
+	ModeEnv    = "TEST_MODE"
+	ModeARP    = "arp"
+	ModeRT     = "rt"
+	ModeBGP    = "bgp"
+	ModeMatrix = "matrix"
 
 	parallelOffsetStride = 1000
 )
@@ -45,7 +46,7 @@ func TestE2E(t *testing.T) {
 	mode := os.Getenv(ModeEnv)
 	if mode == "" {
 		Mode = ModeARP
-	} else if mode != ModeARP && mode != ModeRT && mode != ModeBGP {
+	} else if mode != ModeARP && mode != ModeRT && mode != ModeBGP && mode != ModeMatrix {
 		log.Fatal("invalid", "mode", mode)
 		os.Exit(1)
 	} else {
@@ -69,7 +70,7 @@ var _ = SynchronizedBeforeSuite(
 	func() []byte {
 		e2e.EnsureKindNetwork()
 
-		if Mode != ModeBGP {
+		if Mode != ModeBGP && Mode != ModeMatrix {
 			return nil
 		}
 
@@ -89,7 +90,7 @@ var _ = SynchronizedBeforeSuite(
 	},
 	// All processes: connect to the shared GoBGP server.
 	func(data []byte) {
-		if Mode != ModeBGP || len(data) == 0 {
+		if (Mode != ModeBGP && Mode != ModeMatrix) || len(data) == 0 {
 			return
 		}
 

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -1241,28 +1241,30 @@ func assertControlPlaneIsRoutable(controlPlaneVIP string, transportTimeout, even
 	assertConnection("https", controlPlaneVIP, "6443", "livez", transportTimeout, eventuallyTimeout)
 }
 
-func assertExactlyOneLeaderMetric(ctx context.Context, clusterName string, client kubernetes.Interface) {
+func assertExactlyOneLeaderMetric(ctx context.Context, clusterName string, client kubernetes.Interface, skipNodes ...string) {
 	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(nodes.Items).NotTo(BeEmpty())
 
 	const leaseName = "plndr-cp-lock"
 	labels := map[string]string{"lease_name": leaseName}
-	leaderName := e2e.GetLeaseHolder(ctx, leaseName, "kube-system", client)
-	e2e.EventuallyMetric(clusterName, leaderName, "kube_vip_is_leader", labels,
-		Equal(float64(1)), 60*time.Second, 2*time.Second)
+	skipped := make(map[string]struct{}, len(skipNodes))
+	for _, node := range skipNodes {
+		skipped[node] = struct{}{}
+	}
 
 	Eventually(func() (float64, error) {
 		var total float64
 		for _, node := range nodes.Items {
+			if _, ok := skipped[node.Name]; ok {
+				continue
+			}
+
 			metrics, err := e2e.ScrapeMetrics(clusterName, node.Name)
 			if err != nil {
 				return 0, err
 			}
-			value, ok := e2e.MetricValue(metrics, "kube_vip_is_leader", labels)
-			if ok {
-				total += value
-			}
+			total += e2e.SumMetric(metrics, "kube_vip_is_leader", labels)
 		}
 		return total, nil
 	}, 60*time.Second, 2*time.Second).Should(Equal(float64(1)))

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -136,6 +136,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 					EnableEndpoints:       "true",
 					EnableNodeLabeling:    "false",
 					EnableServiceSecurity: "true",
+					PrometheusHTTPServer:  ":2112",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -183,6 +184,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 					EnableEndpoints:       "true",
 					EnableNodeLabeling:    "false",
 					EnableServiceSecurity: "true",
+					PrometheusHTTPServer:  ":2112",
 				}
 
 				tempDirPath = MustMkdirTemp(tempDirPathRoot, testDirPrefix)
@@ -203,7 +205,7 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 				func(svcName string, currentOffset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv4Family, currentOffset, defaultNetwork)
 					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol}, 1, false, dsNumber, func(node string) {
-						e2e.EventuallyMetric(clusterName, node, "kube_vip_active_services", map[string]string{
+						e2e.EventuallyMetric(ctx, clusterName, node, "kube_vip_active_services", map[string]string{
 							"namespace": dsNamespace,
 						}, BeNumerically(">=", float64(1)), 60*time.Second, 2*time.Second)
 					})
@@ -1260,7 +1262,7 @@ func assertExactlyOneLeaderMetric(ctx context.Context, clusterName string, clien
 				continue
 			}
 
-			metrics, err := e2e.ScrapeMetrics(clusterName, node.Name)
+			metrics, err := e2e.ScrapeMetrics(ctx, clusterName, node.Name)
 			if err != nil {
 				return 0, err
 			}

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -151,7 +151,9 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 			})
 
 			It(clusterName+" provides an IPv4 VIP address for the Kubernetes control plane nodes", func() {
-				testControlPlaneVIPs(ctx, []string{cpVIP}, clusterName, client)
+				testControlPlaneVIPs(ctx, []string{cpVIP}, clusterName, client, func() {
+					assertExactlyOneLeaderMetric(ctx, clusterName, client)
+				})
 			})
 		})
 
@@ -200,7 +202,11 @@ var _ = Describe("kube-vip ARP/NDP broadcast neighbor", func() {
 			DescribeTable("configures an IPv4 VIP address for service",
 				func(svcName string, currentOffset uint, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 					lbAddress := e2e.GenerateVIP(utils.IPv4Family, currentOffset, defaultNetwork)
-					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol}, 1, false, dsNumber)
+					testService(ctx, svcName, lbAddress, "plndr-svcs-lock", "kube-system", trafficPolicy, client, false, []corev1.IPFamily{corev1.IPv4Protocol}, 1, false, dsNumber, func(node string) {
+						e2e.EventuallyMetric(clusterName, node, "kube_vip_active_services", map[string]string{
+							"namespace": dsNamespace,
+						}, BeNumerically(">=", float64(1)), 60*time.Second, 2*time.Second)
+					})
 				},
 				Entry("with external traffic policy - cluster", "test-svc-cluster", SOffset.Get(), corev1.ServiceExternalTrafficPolicyCluster),
 				Entry("with external traffic policy - local", "test-svc-local", SOffset.Get(), corev1.ServiceExternalTrafficPolicyLocal),
@@ -1235,6 +1241,33 @@ func assertControlPlaneIsRoutable(controlPlaneVIP string, transportTimeout, even
 	assertConnection("https", controlPlaneVIP, "6443", "livez", transportTimeout, eventuallyTimeout)
 }
 
+func assertExactlyOneLeaderMetric(ctx context.Context, clusterName string, client kubernetes.Interface) {
+	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(nodes.Items).NotTo(BeEmpty())
+
+	const leaseName = "plndr-cp-lock"
+	labels := map[string]string{"lease_name": leaseName}
+	leaderName := e2e.GetLeaseHolder(ctx, leaseName, "kube-system", client)
+	e2e.EventuallyMetric(clusterName, leaderName, "kube_vip_is_leader", labels,
+		Equal(float64(1)), 60*time.Second, 2*time.Second)
+
+	Eventually(func() (float64, error) {
+		var total float64
+		for _, node := range nodes.Items {
+			metrics, err := e2e.ScrapeMetrics(clusterName, node.Name)
+			if err != nil {
+				return 0, err
+			}
+			value, ok := e2e.MetricValue(metrics, "kube_vip_is_leader", labels)
+			if ok {
+				total += value
+			}
+		}
+		return total, nil
+	}, 60*time.Second, 2*time.Second).Should(Equal(float64(1)))
+}
+
 // Assume connection to the provided address is possible
 func assertConnection(protocol, ip, port, suffix string, transportTimeout, eventuallyTimeout time.Duration) {
 	if strings.Contains(ip, ":") {
@@ -1694,12 +1727,12 @@ func cleanupCluster(clusterName, network string, configMtx *sync.Mutex, logger l
 	}
 }
 
-func testControlPlaneVIPs(ctx context.Context, cpVIPs []string, clusterName string, client kubernetes.Interface) {
-	testControlPlaneVIPsWithTimeout(ctx, cpVIPs, clusterName, client, time.Duration(0), 20*time.Second)
+func testControlPlaneVIPs(ctx context.Context, cpVIPs []string, clusterName string, client kubernetes.Interface, afterVIPConfirmed ...func()) {
+	testControlPlaneVIPsWithTimeout(ctx, cpVIPs, clusterName, client, time.Duration(0), 20*time.Second, afterVIPConfirmed...)
 }
 
 func testControlPlaneVIPsWithTimeout(ctx context.Context, cpVIPs []string, clusterName string, client kubernetes.Interface,
-	transportTimeout, eventuallyTimeout time.Duration) {
+	transportTimeout, eventuallyTimeout time.Duration, afterVIPConfirmed ...func()) {
 	Expect(cpVIPs).ToNot(BeEmpty())
 
 	By(withTimestamp("checking that the Kubernetes control plane nodes are accessible via the assigned VIP"))
@@ -1708,6 +1741,9 @@ func testControlPlaneVIPsWithTimeout(ctx context.Context, cpVIPs []string, clust
 	for _, cpVIP := range cpVIPs {
 		By(withTimestamp(fmt.Sprintf("testing connection to VIP: %s", cpVIP)))
 		assertControlPlaneIsRoutable(cpVIP, transportTimeout, eventuallyTimeout)
+	}
+	if len(afterVIPConfirmed) > 0 && afterVIPConfirmed[0] != nil {
+		afterVIPConfirmed[0]()
 	}
 
 	var leaderName string
@@ -1731,6 +1767,7 @@ func testControlPlaneVIPsWithTimeout(ctx context.Context, cpVIPs []string, clust
 
 func testService(ctx context.Context, svcName, lbAddress, leaseName, leaseNamespace string, trafficPolicy corev1.ServiceExternalTrafficPolicy,
 	client kubernetes.Interface, serviceElection bool, ipFamily []corev1.IPFamily, numberOfServices int, deleteDS bool, dsNumber int,
+	afterVIPConfirmed ...func(string),
 ) {
 	lbAddresses := vip.Split(lbAddress)
 
@@ -1758,6 +1795,9 @@ func testService(ctx context.Context, svcName, lbAddress, leaseName, leaseNamesp
 	}
 
 	container := e2e.GetLeaseHolder(ctx, leases[0], leaseNamespace, client)
+	if len(afterVIPConfirmed) > 0 && afterVIPConfirmed[0] != nil {
+		afterVIPConfirmed[0](container)
+	}
 
 	if deleteDS {
 		removeTestDS(ctx, client, dsNamespace, dsName, dsNumber)

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -1507,6 +1507,26 @@ func removePod(ctx context.Context, name, namespace string, client kubernetes.In
 func createTestService(ctx context.Context, name, namespace, target, lbAddress string, client kubernetes.Interface, ipfPolicy corev1.IPFamilyPolicy,
 	ipFamiles []corev1.IPFamily, externalPolicy corev1.ServiceExternalTrafficPolicy, leaseName string, port int, dhcpBroadcast bool, forceElection bool,
 ) {
+	s := newTestService(name, namespace, target, lbAddress, ipfPolicy, ipFamiles, externalPolicy, leaseName, port, dhcpBroadcast, forceElection)
+
+	By(withTimestamp(fmt.Sprintf("creating service %s/%s", namespace, name)))
+
+	Eventually(func() error {
+		_, err := client.CoreV1().Services(namespace).Create(ctx, s, metav1.CreateOptions{})
+		return err
+	}, time.Second*60, time.Second).Should(Succeed())
+	By(withTimestamp(fmt.Sprintf("service %s/%s created", namespace, name)))
+
+	Eventually(func() error {
+		By(withTimestamp(fmt.Sprintf("getting service %s/%s\n", namespace, name)))
+		_, err := client.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
+		return err
+	}, time.Second*60, time.Second).Should(Succeed())
+}
+
+func newTestService(name, namespace, target, lbAddress string, ipfPolicy corev1.IPFamilyPolicy,
+	ipFamilies []corev1.IPFamily, externalPolicy corev1.ServiceExternalTrafficPolicy, leaseName string, port int, dhcpBroadcast bool, forceElection bool,
+) *corev1.Service {
 	svcAnnotations := make(map[string]string)
 	svcAnnotations[kubevip.LoadbalancerIPAnnotation] = lbAddress
 	if leaseName != "" {
@@ -1523,9 +1543,7 @@ func createTestService(ctx context.Context, name, namespace, target, lbAddress s
 	labels := make(map[string]string)
 	labels["app"] = target
 
-	By(withTimestamp(fmt.Sprintf("creating service %s/%s", namespace, name)))
-
-	s := corev1.Service{
+	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   namespace,
@@ -1533,7 +1551,7 @@ func createTestService(ctx context.Context, name, namespace, target, lbAddress s
 			Annotations: svcAnnotations,
 		},
 		Spec: corev1.ServiceSpec{
-			IPFamilies:            ipFamiles,
+			IPFamilies:            ipFamilies,
 			IPFamilyPolicy:        &ipfPolicy,
 			Type:                  corev1.ServiceTypeLoadBalancer,
 			ExternalTrafficPolicy: externalPolicy,
@@ -1546,18 +1564,6 @@ func createTestService(ctx context.Context, name, namespace, target, lbAddress s
 			Selector: labels,
 		},
 	}
-
-	Eventually(func() error {
-		_, err := client.CoreV1().Services(namespace).Create(ctx, &s, metav1.CreateOptions{})
-		return err
-	}, time.Second*60, time.Second).Should(Succeed())
-	By(withTimestamp(fmt.Sprintf("service %s/%s created", namespace, name)))
-
-	Eventually(func() error {
-		By(withTimestamp(fmt.Sprintf("getting service %s/%s\n", namespace, name)))
-		_, err := client.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
-		return err
-	}, time.Second*60, time.Second).Should(Succeed())
 }
 
 func checkIPAddress(lbAddress, container string, expected bool) bool {

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -1947,21 +1947,33 @@ func testServiceCommonLease(ctx context.Context, svcName, lbAddress, leaseNamesp
 		}
 	}
 
-	container := e2e.GetLeaseHolder(ctx, lease, leaseNamespace, client)
-
 	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	Expect(err).ToNot(HaveOccurred())
 
+	nodeNames := make([]string, 0, len(nodes.Items))
 	for _, node := range nodes.Items {
-		expected := node.Name == container
-		for _, addr := range lbAddresses {
-			Expect(checkIPAddress(addr, node.Name, expected)).To(BeTrue())
-		}
+		nodeNames = append(nodeNames, node.Name)
 	}
 
-	for i := range numberOfServices {
-		expected := i < numberOfServices-1
+	getHolder := func() (string, error) {
+		currentLease, err := client.CoordinationV1().Leases(leaseNamespace).Get(ctx, lease, metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+		if currentLease.Spec.HolderIdentity == nil {
+			return "", nil
+		}
+		return *currentLease.Spec.HolderIdentity, nil
+	}
+	checkOwnership := func() (string, error) {
+		return e2e.CheckCommonLeaseOwnership(getHolder, nodeNames, lbAddresses, func(address, node string) bool {
+			return e2e.CheckIPAddressPresence(address, node, true)
+		})
+	}
 
+	Eventually(checkOwnership, "120s", "1s").ShouldNot(BeEmpty())
+
+	for i := range numberOfServices {
 		By(fmt.Sprintf("deleting service %q", services[i]))
 
 		err := client.CoreV1().Services(dsNamespace).Delete(ctx, services[i], metav1.DeleteOptions{})
@@ -1973,15 +1985,28 @@ func testServiceCommonLease(ctx context.Context, svcName, lbAddress, leaseNamesp
 			return err
 		}).ShouldNot(Succeed())
 
-		for _, addr := range lbAddresses {
-			for _, node := range nodes.Items {
-				if node.Name == container {
-					Expect(checkIPAddress(addr, node.Name, expected)).To(BeTrue())
-				} else {
-					Expect(checkIPAddress(addr, node.Name, false)).To(BeTrue())
+		if i < numberOfServices-1 {
+			Eventually(checkOwnership, "120s", "1s").ShouldNot(BeEmpty())
+			continue
+		}
+
+		Eventually(func() error {
+			_, err := client.CoordinationV1().Leases(leaseNamespace).Get(ctx, lease, metav1.GetOptions{})
+			if err == nil {
+				return fmt.Errorf("common lease %s/%s still exists", leaseNamespace, lease)
+			}
+			if !errors.IsNotFound(err) {
+				return fmt.Errorf("common lease %s/%s still exists: %w", leaseNamespace, lease, err)
+			}
+			for _, node := range nodeNames {
+				for _, addr := range lbAddresses {
+					if e2e.CheckIPAddressPresence(addr, node, false) == false {
+						return fmt.Errorf("address %q is still present on node %q", addr, node)
+					}
 				}
 			}
-		}
+			return nil
+		}, "120s", "1s").Should(Succeed())
 	}
 }
 

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -1991,19 +1991,21 @@ func testServiceCommonLease(ctx context.Context, svcName, lbAddress, leaseNamesp
 		}
 
 		Eventually(func() error {
-			_, err := client.CoordinationV1().Leases(leaseNamespace).Get(ctx, lease, metav1.GetOptions{})
-			if err == nil {
-				return fmt.Errorf("common lease %s/%s still exists", leaseNamespace, lease)
+			currentLease, err := client.CoordinationV1().Leases(leaseNamespace).Get(ctx, lease, metav1.GetOptions{})
+			if err := e2e.CheckCommonLeaseRetired(currentLease, err); err != nil {
+				return fmt.Errorf("common lease %s/%s is not retired: %w", leaseNamespace, lease, err)
 			}
-			if !errors.IsNotFound(err) {
-				return fmt.Errorf("common lease %s/%s still exists: %w", leaseNamespace, lease, err)
-			}
+
+			var presentAddresses []string
 			for _, node := range nodeNames {
 				for _, addr := range lbAddresses {
 					if e2e.CheckIPAddressPresence(addr, node, false) == false {
-						return fmt.Errorf("address %q is still present on node %q", addr, node)
+						presentAddresses = append(presentAddresses, fmt.Sprintf("%q on %q", addr, node))
 					}
 				}
+			}
+			if len(presentAddresses) > 0 {
+				return fmt.Errorf("addresses are still present: %s", strings.Join(presentAddresses, ", "))
 			}
 			return nil
 		}, "120s", "1s").Should(Succeed())

--- a/testing/e2e/faults.go
+++ b/testing/e2e/faults.go
@@ -1,0 +1,284 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"path"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	kindcluster "sigs.k8s.io/kind/pkg/cluster"
+)
+
+const (
+	kindNetworkName        = "kind"
+	manifestDirectory      = "/etc/kubernetes/manifests"
+	manifestStashDirectory = "/tmp"
+	nodeReadyTimeout       = 60 * time.Second
+	nodeReadyPollInterval  = time.Second
+)
+
+// PartitionNode models a node-level network partition by disconnecting the
+// node container from the Kind network. Processes in the node continue to run.
+func PartitionNode(clusterName, node string) error {
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return err
+	}
+
+	return runDocker(clusterName, "network", "disconnect", kindNetworkName, node)
+}
+
+// HealNode models recovery from a node-level network partition by reconnecting
+// the node to the Kind network. It restarts the node if it does not become
+// Ready within the recovery timeout.
+func HealNode(clusterName, node string) error {
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return err
+	}
+
+	if err := runDocker(clusterName, "network", "connect", kindNetworkName, node); err != nil {
+		return err
+	}
+
+	readinessErr := waitForNodeReady(clusterName, node)
+	if readinessErr == nil {
+		return nil
+	}
+
+	if err := runDocker(clusterName, "restart", node); err != nil {
+		return fmt.Errorf("node %q in cluster %q did not become Ready and restart failed: %w (readiness error: %v)", node, clusterName, err, readinessErr)
+	}
+
+	if err := waitForNodeReady(clusterName, node); err != nil {
+		return fmt.Errorf("node %q in cluster %q did not become Ready after restart: %w", node, clusterName, err)
+	}
+
+	return nil
+}
+
+// BlackholeAPIServer models loss of a node's local Kubernetes API connection
+// by dropping its outbound TCP connections to the apiserver port. The node
+// itself remains running and can continue to report as Ready for a while.
+func BlackholeAPIServer(clusterName, node string) error {
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return err
+	}
+
+	return runDocker(clusterName,
+		"exec", node, "iptables", "-I", "OUTPUT", "-p", "tcp", "--dport", "6443", "-j", "DROP",
+	)
+}
+
+// RestoreAPIServer removes the apiserver blackhole installed by
+// BlackholeAPIServer, restoring the node's outbound TCP connections to port
+// 6443.
+func RestoreAPIServer(clusterName, node string) error {
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return err
+	}
+
+	return runDocker(clusterName,
+		"exec", node, "iptables", "-D", "OUTPUT", "-p", "tcp", "--dport", "6443", "-j", "DROP",
+	)
+}
+
+// KillKubeVip models kube-vip process failure inside a node. A graceful fault
+// sends SIGTERM so kube-vip can perform shutdown handling; an abrupt fault
+// sends SIGKILL.
+func KillKubeVip(clusterName, node string, graceful bool) error {
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return err
+	}
+
+	signal := "-KILL"
+	if graceful {
+		signal = "-TERM"
+	}
+
+	return runDocker(clusterName, "exec", node, "pkill", signal, "kube-vip")
+}
+
+// RestartNode models a complete node failure and recovery by restarting its
+// Docker container. The caller can use HealNode when it also needs a Ready
+// check after a network fault.
+func RestartNode(clusterName, node string) error {
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return err
+	}
+
+	return runDocker(clusterName, "restart", node)
+}
+
+// DeleteLease models loss of a Kubernetes coordination lease by deleting it
+// through the coordination API.
+func DeleteLease(ctx context.Context, client kubernetes.Interface, namespace, name string) error {
+	if client == nil {
+		return fmt.Errorf("delete lease %s/%s: client is nil", namespace, name)
+	}
+	if err := client.CoordinationV1().Leases(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("delete lease %s/%s: %w", namespace, name, err)
+	}
+
+	return nil
+}
+
+// StealLease models a competing leader taking ownership of a Kubernetes
+// coordination lease by overwriting its holder identity and renewal time.
+func StealLease(ctx context.Context, client kubernetes.Interface, namespace, name, newHolder string) error {
+	if client == nil {
+		return fmt.Errorf("steal lease %s/%s: client is nil", namespace, name)
+	}
+	if newHolder == "" {
+		return fmt.Errorf("steal lease %s/%s: new holder is empty", namespace, name)
+	}
+
+	leases := client.CoordinationV1().Leases(namespace)
+	lease, err := leases.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("get lease %s/%s before stealing: %w", namespace, name, err)
+	}
+
+	holder := newHolder
+	lease.Spec.HolderIdentity = &holder
+	renewTime := metav1.NowMicro()
+	lease.Spec.RenewTime = &renewTime
+	if _, err := leases.Update(ctx, lease, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update stolen lease %s/%s: %w", namespace, name, err)
+	}
+
+	return nil
+}
+
+// StashPodManifest models a static-pod failure by moving a manifest out of
+// the kubelet manifest directory into /tmp on the selected node.
+func StashPodManifest(clusterName, node, manifestName string) error {
+	src, dst, err := podManifestPaths(manifestName)
+	if err != nil {
+		return fmt.Errorf("stash manifest on node %q in cluster %q: %w", node, clusterName, err)
+	}
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return err
+	}
+
+	return runDocker(clusterName, "exec", node, "mv", src, dst)
+}
+
+// RestorePodManifest models static-pod recovery by moving a stashed manifest
+// back into the kubelet manifest directory on the selected node.
+func RestorePodManifest(clusterName, node, manifestName string) error {
+	src, dst, err := podManifestPaths(manifestName)
+	if err != nil {
+		return fmt.Errorf("restore manifest on node %q in cluster %q: %w", node, clusterName, err)
+	}
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return err
+	}
+
+	return runDocker(clusterName, "exec", node, "mv", dst, src)
+}
+
+func runDocker(clusterName string, args ...string) error {
+	var output bytes.Buffer
+	cmd := exec.Command("docker", args...)
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Run(); err != nil {
+		details := strings.TrimSpace(output.String())
+		if details != "" {
+			return fmt.Errorf("cluster %q: docker %s failed: %w: %s", clusterName, strings.Join(args, " "), err, details)
+		}
+		return fmt.Errorf("cluster %q: docker %s failed: %w", clusterName, strings.Join(args, " "), err)
+	}
+
+	return nil
+}
+
+func validateFaultTarget(clusterName, node string) error {
+	if strings.TrimSpace(clusterName) == "" {
+		return fmt.Errorf("fault target cluster name is empty")
+	}
+	if strings.TrimSpace(node) == "" {
+		return fmt.Errorf("fault target node in cluster %q is empty", clusterName)
+	}
+
+	return nil
+}
+
+func podManifestPaths(manifestName string) (string, string, error) {
+	if manifestName == "" || path.Base(manifestName) != manifestName || manifestName == "." || manifestName == ".." {
+		return "", "", fmt.Errorf("manifest name %q must be a file name", manifestName)
+	}
+
+	manifestPath := path.Join(manifestDirectory, manifestName)
+	stashPath := path.Join(manifestStashDirectory, manifestName)
+	return manifestPath, stashPath, nil
+}
+
+func waitForNodeReady(clusterName, node string) error {
+	client, err := clientForKindCluster(clusterName)
+	if err != nil {
+		return fmt.Errorf("create Kubernetes client for cluster %q: %w", clusterName, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), nodeReadyTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(nodeReadyPollInterval)
+	defer ticker.Stop()
+
+	var lastErr error
+	for {
+		current, err := client.CoreV1().Nodes().Get(ctx, node, metav1.GetOptions{})
+		if err != nil {
+			lastErr = err
+		} else if current == nil {
+			lastErr = fmt.Errorf("Kubernetes returned an empty node object")
+		} else if !nodeIsReady(current) {
+			lastErr = fmt.Errorf("Ready condition is not True")
+		} else {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			if lastErr == nil {
+				lastErr = ctx.Err()
+			}
+			return fmt.Errorf("node %q in cluster %q did not become Ready within %s: %w", node, clusterName, nodeReadyTimeout, lastErr)
+		case <-ticker.C:
+		}
+	}
+}
+
+func clientForKindCluster(clusterName string) (kubernetes.Interface, error) {
+	provider := kindcluster.NewProvider(kindcluster.ProviderWithDocker())
+	kubeconfig, err := provider.KubeConfig(clusterName, false)
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := ClientConfigFromKubeconfig(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return kubernetes.NewForConfig(config)
+}
+
+func nodeIsReady(node *corev1.Node) bool {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+
+	return false
+}

--- a/testing/e2e/faults.go
+++ b/testing/e2e/faults.go
@@ -107,6 +107,64 @@ func KillKubeVip(clusterName, node string, graceful bool) error {
 	return runDocker(clusterName, "exec", node, "pkill", signal, "kube-vip")
 }
 
+// KillAndStashKubeVip atomically removes the static-pod manifest and sends
+// SIGKILL to the process it identified. Removing the manifest first prevents
+// kubelet from restarting kube-vip before a failover can be observed.
+func KillAndStashKubeVip(clusterName, node, manifestName string) (string, error) {
+	src, dst, err := podManifestPaths(manifestName)
+	if err != nil {
+		return "", fmt.Errorf("kill and stash kube-vip on node %q in cluster %q: %w", node, clusterName, err)
+	}
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return "", err
+	}
+
+	script := fmt.Sprintf(`pid="$(pgrep -x kube-vip)" && set -- $pid && test "$#" -eq 1 && mv %s %s && { kill -KILL "$1" && printf '%%s' "$1" || { mv %s %s; exit 1; }; }`, src, dst, dst, src)
+	output, err := runDockerOutput(clusterName, "exec", node, "sh", "-c", script)
+	if err != nil {
+		return "", err
+	}
+
+	return singlePID(output)
+}
+
+// KubeVipPID returns the PID of the single kube-vip process running in a Kind
+// node. Static-pod restarts get a new PID, which lets fault tests distinguish a
+// process restart from a node-container restart.
+func KubeVipPID(clusterName, node string) (string, error) {
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return "", err
+	}
+
+	output, err := runDockerOutput(clusterName, "exec", node, "pgrep", "-x", "kube-vip")
+	if err != nil {
+		return "", err
+	}
+
+	return singlePID(output)
+}
+
+// NodeRunning reports whether the Kind node container is still running.
+func NodeRunning(clusterName, node string) (bool, error) {
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return false, err
+	}
+
+	output, err := runDockerOutput(clusterName, "inspect", "--format={{.State.Running}}", node)
+	if err != nil {
+		return false, err
+	}
+
+	switch strings.TrimSpace(output) {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, fmt.Errorf("node %q in cluster %q returned invalid running state %q", node, clusterName, strings.TrimSpace(output))
+	}
+}
+
 // RestartNode models a complete node failure and recovery by restarting its
 // Docker container. The caller can use HealNode when it also needs a Ready
 // check after a network fault.
@@ -192,6 +250,22 @@ func runDocker(clusterName string, args ...string) error {
 	return runDockerAllow(clusterName, nil, args...)
 }
 
+func runDockerOutput(clusterName string, args ...string) (string, error) {
+	var output bytes.Buffer
+	cmd := exec.Command("docker", args...)
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Run(); err != nil {
+		details := strings.TrimSpace(output.String())
+		if details != "" {
+			return "", fmt.Errorf("cluster %q: docker %s failed: %w: %s", clusterName, strings.Join(args, " "), err, details)
+		}
+		return "", fmt.Errorf("cluster %q: docker %s failed: %w", clusterName, strings.Join(args, " "), err)
+	}
+
+	return strings.TrimSpace(output.String()), nil
+}
+
 func runDockerAllow(clusterName string, allowedErrors []string, args ...string) error {
 	var output bytes.Buffer
 	cmd := exec.Command("docker", args...)
@@ -222,6 +296,14 @@ func validateFaultTarget(clusterName, node string) error {
 	}
 
 	return nil
+}
+
+func singlePID(output string) (string, error) {
+	pids := strings.Fields(output)
+	if len(pids) != 1 {
+		return "", fmt.Errorf("expected one kube-vip process, found %d in %q", len(pids), strings.TrimSpace(output))
+	}
+	return pids[0], nil
 }
 
 func podManifestPaths(manifestName string) (string, string, error) {

--- a/testing/e2e/faults.go
+++ b/testing/e2e/faults.go
@@ -289,9 +289,19 @@ type dockerOutput func(clusterName string, args ...string) (string, error)
 
 func restoreKubelet(clusterName, node string, run dockerRun) error {
 	if err := run(clusterName, "exec", node, "systemctl", "start", "kubelet"); err != nil {
+		if dockerContainerMissing(err) {
+			return nil
+		}
 		return err
 	}
-	return run(clusterName, "exec", node, "systemctl", "is-active", "--quiet", "kubelet")
+	if err := run(clusterName, "exec", node, "systemctl", "is-active", "--quiet", "kubelet"); err != nil && !dockerContainerMissing(err) {
+		return err
+	}
+	return nil
+}
+
+func dockerContainerMissing(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "no such container")
 }
 
 func runDockerOutput(clusterName string, args ...string) (string, error) {

--- a/testing/e2e/faults.go
+++ b/testing/e2e/faults.go
@@ -107,25 +107,59 @@ func KillKubeVip(clusterName, node string, graceful bool) error {
 	return runDocker(clusterName, "exec", node, "pkill", signal, "kube-vip")
 }
 
-// KillAndStashKubeVip atomically removes the static-pod manifest and sends
-// SIGKILL to the process it identified. Removing the manifest first prevents
-// kubelet from restarting kube-vip before a failover can be observed.
-func KillAndStashKubeVip(clusterName, node, manifestName string) (string, error) {
-	src, dst, err := podManifestPaths(manifestName)
-	if err != nil {
-		return "", fmt.Errorf("kill and stash kube-vip on node %q in cluster %q: %w", node, clusterName, err)
-	}
+// KillAndSuppressKubeVip stops kubelet before sending SIGKILL to the single
+// kube-vip process. Kind bind-mounts the static-pod manifest from the host, so
+// moving that file inside the node fails with EBUSY. Stopping kubelet prevents
+// a restart without modifying the test-owned host mount source.
+func KillAndSuppressKubeVip(clusterName, node string) (string, error) {
 	if err := validateFaultTarget(clusterName, node); err != nil {
 		return "", err
 	}
 
-	script := fmt.Sprintf(`pid="$(pgrep -x kube-vip)" && set -- $pid && test "$#" -eq 1 && mv %s %s && { kill -KILL "$1" && printf '%%s' "$1" || { mv %s %s; exit 1; }; }`, src, dst, dst, src)
-	output, err := runDockerOutput(clusterName, "exec", node, "sh", "-c", script)
-	if err != nil {
+	return killAndSuppressKubeVip(clusterName, node, runDocker, runDockerOutput)
+}
+
+func killAndSuppressKubeVip(clusterName, node string, run dockerRun, output dockerOutput) (pid string, err error) {
+	restore := true
+	defer func() {
+		if !restore {
+			return
+		}
+		if restoreErr := restoreKubelet(clusterName, node, run); restoreErr != nil {
+			err = fmt.Errorf("%w; additionally failed to restore kubelet: %v", err, restoreErr)
+		}
+	}()
+	if err := run(clusterName, "exec", node, "systemctl", "stop", "kubelet"); err != nil {
 		return "", err
 	}
 
-	return singlePID(output)
+	if err := run(clusterName, "exec", node, "sh", "-c", "! systemctl is-active --quiet kubelet"); err != nil {
+		return "", fmt.Errorf("verify kubelet stopped on node %q: %w", node, err)
+	}
+	pids, err := output(clusterName, "exec", node, "pgrep", "-x", "kube-vip")
+	if err != nil {
+		return "", err
+	}
+	pid, err = singlePID(pids)
+	if err != nil {
+		return "", err
+	}
+	if err := run(clusterName, "exec", node, "kill", "-KILL", pid); err != nil {
+		return "", err
+	}
+
+	restore = false
+	return pid, nil
+}
+
+// RestoreKubeVip restarts kubelet after KillAndSuppressKubeVip and verifies
+// that static-pod reconciliation is active again.
+func RestoreKubeVip(clusterName, node string) error {
+	if err := validateFaultTarget(clusterName, node); err != nil {
+		return err
+	}
+
+	return restoreKubelet(clusterName, node, runDocker)
 }
 
 // KubeVipPID returns the PID of the single kube-vip process running in a Kind
@@ -248,6 +282,16 @@ func RestorePodManifest(clusterName, node, manifestName string) error {
 
 func runDocker(clusterName string, args ...string) error {
 	return runDockerAllow(clusterName, nil, args...)
+}
+
+type dockerRun func(clusterName string, args ...string) error
+type dockerOutput func(clusterName string, args ...string) (string, error)
+
+func restoreKubelet(clusterName, node string, run dockerRun) error {
+	if err := run(clusterName, "exec", node, "systemctl", "start", "kubelet"); err != nil {
+		return err
+	}
+	return run(clusterName, "exec", node, "systemctl", "is-active", "--quiet", "kubelet")
 }
 
 func runDockerOutput(clusterName string, args ...string) (string, error) {

--- a/testing/e2e/faults.go
+++ b/testing/e2e/faults.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	kindcluster "sigs.k8s.io/kind/pkg/cluster"
@@ -33,7 +34,7 @@ func PartitionNode(clusterName, node string) error {
 		return err
 	}
 
-	return runDocker(clusterName, "network", "disconnect", kindNetworkName, node)
+	return runDockerAllow(clusterName, []string{"is not connected"}, "network", "disconnect", kindNetworkName, node)
 }
 
 // HealNode models recovery from a node-level network partition by reconnecting
@@ -44,7 +45,7 @@ func HealNode(clusterName, node string) error {
 		return err
 	}
 
-	if err := runDocker(clusterName, "network", "connect", kindNetworkName, node); err != nil {
+	if err := runDockerAllow(clusterName, []string{"already exists"}, "network", "connect", kindNetworkName, node); err != nil {
 		return err
 	}
 
@@ -72,8 +73,8 @@ func BlackholeAPIServer(clusterName, node string) error {
 		return err
 	}
 
-	return runDocker(clusterName,
-		"exec", node, "iptables", "-I", "OUTPUT", "-p", "tcp", "--dport", "6443", "-j", "DROP",
+	return runDocker(clusterName, "exec", node, "sh", "-c",
+		"iptables -C OUTPUT -p tcp --dport 6443 -j DROP || iptables -I OUTPUT -p tcp --dport 6443 -j DROP",
 	)
 }
 
@@ -85,8 +86,8 @@ func RestoreAPIServer(clusterName, node string) error {
 		return err
 	}
 
-	return runDocker(clusterName,
-		"exec", node, "iptables", "-D", "OUTPUT", "-p", "tcp", "--dport", "6443", "-j", "DROP",
+	return runDocker(clusterName, "exec", node, "sh", "-c",
+		"while iptables -C OUTPUT -p tcp --dport 6443 -j DROP 2>/dev/null; do iptables -D OUTPUT -p tcp --dport 6443 -j DROP; done",
 	)
 }
 
@@ -123,7 +124,7 @@ func DeleteLease(ctx context.Context, client kubernetes.Interface, namespace, na
 	if client == nil {
 		return fmt.Errorf("delete lease %s/%s: client is nil", namespace, name)
 	}
-	if err := client.CoordinationV1().Leases(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+	if err := client.CoordinationV1().Leases(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("delete lease %s/%s: %w", namespace, name, err)
 	}
 
@@ -168,7 +169,8 @@ func StashPodManifest(clusterName, node, manifestName string) error {
 		return err
 	}
 
-	return runDocker(clusterName, "exec", node, "mv", src, dst)
+	return runDocker(clusterName, "exec", node, "sh", "-c",
+		fmt.Sprintf("if [ -e %s ]; then mv %s %s; elif [ ! -e %s ]; then exit 1; fi", src, src, dst, dst))
 }
 
 // RestorePodManifest models static-pod recovery by moving a stashed manifest
@@ -182,16 +184,26 @@ func RestorePodManifest(clusterName, node, manifestName string) error {
 		return err
 	}
 
-	return runDocker(clusterName, "exec", node, "mv", dst, src)
+	return runDocker(clusterName, "exec", node, "sh", "-c",
+		fmt.Sprintf("if [ -e %s ]; then mv %s %s; elif [ ! -e %s ]; then exit 1; fi", dst, dst, src, src))
 }
 
 func runDocker(clusterName string, args ...string) error {
+	return runDockerAllow(clusterName, nil, args...)
+}
+
+func runDockerAllow(clusterName string, allowedErrors []string, args ...string) error {
 	var output bytes.Buffer
 	cmd := exec.Command("docker", args...)
 	cmd.Stdout = &output
 	cmd.Stderr = &output
 	if err := cmd.Run(); err != nil {
 		details := strings.TrimSpace(output.String())
+		for _, allowed := range allowedErrors {
+			if strings.Contains(strings.ToLower(details), strings.ToLower(allowed)) {
+				return nil
+			}
+		}
 		if details != "" {
 			return fmt.Errorf("cluster %q: docker %s failed: %w: %s", clusterName, strings.Join(args, " "), err, details)
 		}

--- a/testing/e2e/faults_test.go
+++ b/testing/e2e/faults_test.go
@@ -3,10 +3,76 @@
 package e2e
 
 import (
+	"errors"
+	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 )
+
+func TestKillAndSuppressKubeVip(t *testing.T) {
+	tests := []struct {
+		name        string
+		failAt      int
+		pidOutput   string
+		wantPID     string
+		wantError   bool
+		wantRestore bool
+	}{
+		{name: "kills exact process after stopping kubelet", pidOutput: "123\n", wantPID: "123"},
+		{name: "restores after stop reports failure", failAt: 1, wantError: true, wantRestore: true},
+		{name: "restores after inactive check fails", failAt: 2, wantError: true, wantRestore: true},
+		{name: "restores after process lookup fails", failAt: 3, wantError: true, wantRestore: true},
+		{name: "restores when multiple processes exist", pidOutput: "123\n456\n", wantError: true, wantRestore: true},
+		{name: "restores after kill fails", failAt: 4, pidOutput: "123\n", wantError: true, wantRestore: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var calls [][]string
+			call := 0
+			run := func(_ string, args ...string) error {
+				call++
+				calls = append(calls, append([]string(nil), args...))
+				if call == test.failAt {
+					return errors.New("injected failure")
+				}
+				return nil
+			}
+			output := func(_ string, args ...string) (string, error) {
+				call++
+				calls = append(calls, append([]string(nil), args...))
+				if call == test.failAt {
+					return "", errors.New("injected failure")
+				}
+				return test.pidOutput, nil
+			}
+
+			pid, err := killAndSuppressKubeVip("cluster", "node", run, output)
+			if (err != nil) != test.wantError {
+				t.Fatalf("killAndSuppressKubeVip() error = %v, wantError %t", err, test.wantError)
+			}
+			if pid != test.wantPID {
+				t.Fatalf("killAndSuppressKubeVip() PID = %q, want %q", pid, test.wantPID)
+			}
+			if !reflect.DeepEqual(calls[0], []string{"exec", "node", "systemctl", "stop", "kubelet"}) {
+				t.Fatalf("first call = %v, want kubelet stop", calls[0])
+			}
+			restored := false
+			for _, got := range calls {
+				if reflect.DeepEqual(got, []string{"exec", "node", "systemctl", "start", "kubelet"}) {
+					restored = true
+				}
+			}
+			if restored != test.wantRestore {
+				t.Fatalf("kubelet restored = %t, want %t; calls: %v", restored, test.wantRestore, calls)
+			}
+			if !test.wantError && !reflect.DeepEqual(calls[len(calls)-1], []string{"exec", "node", "kill", "-KILL", "123"}) {
+				t.Fatalf("last call = %v, want exact PID kill", calls[len(calls)-1])
+			}
+		})
+	}
+}
 
 func TestSinglePID(t *testing.T) {
 	tests := []struct {

--- a/testing/e2e/faults_test.go
+++ b/testing/e2e/faults_test.go
@@ -8,6 +8,31 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+func TestSinglePID(t *testing.T) {
+	tests := []struct {
+		name      string
+		output    string
+		want      string
+		wantError bool
+	}{
+		{name: "one process", output: "123\n", want: "123"},
+		{name: "no process", wantError: true},
+		{name: "multiple processes", output: "123\n456\n", wantError: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := singlePID(test.output)
+			if (err != nil) != test.wantError {
+				t.Fatalf("singlePID() error = %v, wantError %t", err, test.wantError)
+			}
+			if got != test.want {
+				t.Fatalf("singlePID() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestPodManifestPaths(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/testing/e2e/faults_test.go
+++ b/testing/e2e/faults_test.go
@@ -99,6 +99,43 @@ func TestSinglePID(t *testing.T) {
 	}
 }
 
+func TestRestoreKubelet(t *testing.T) {
+	tests := []struct {
+		name      string
+		failAt    int
+		err       error
+		wantError bool
+		wantCalls int
+	}{
+		{name: "starts active kubelet", wantCalls: 2},
+		{name: "already deleted before start", failAt: 1, err: errors.New("docker exec: No such container: node"), wantCalls: 1},
+		{name: "deleted before active check", failAt: 2, err: errors.New("No such container: node"), wantCalls: 2},
+		{name: "start failure", failAt: 1, err: errors.New("injected failure"), wantError: true, wantCalls: 1},
+		{name: "inactive kubelet", failAt: 2, err: errors.New("inactive"), wantError: true, wantCalls: 2},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			calls := 0
+			run := func(_ string, _ ...string) error {
+				calls++
+				if calls == test.failAt {
+					return test.err
+				}
+				return nil
+			}
+
+			err := restoreKubelet("cluster", "node", run)
+			if (err != nil) != test.wantError {
+				t.Fatalf("restoreKubelet() error = %v, wantError %t", err, test.wantError)
+			}
+			if calls != test.wantCalls {
+				t.Fatalf("restoreKubelet() calls = %d, want %d", calls, test.wantCalls)
+			}
+		})
+	}
+}
+
 func TestPodManifestPaths(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/testing/e2e/faults_test.go
+++ b/testing/e2e/faults_test.go
@@ -1,0 +1,44 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestPodManifestPaths(t *testing.T) {
+	tests := []struct {
+		name      string
+		wantSrc   string
+		wantDst   string
+		wantError bool
+	}{
+		{name: "kube-apiserver.yaml", wantSrc: "/etc/kubernetes/manifests/kube-apiserver.yaml", wantDst: "/tmp/kube-apiserver.yaml"},
+		{name: "", wantError: true},
+		{name: "../manifest.yaml", wantError: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			src, dst, err := podManifestPaths(test.name)
+			if (err != nil) != test.wantError {
+				t.Fatalf("podManifestPaths() error = %v, wantError %t", err, test.wantError)
+			}
+			if src != test.wantSrc || dst != test.wantDst {
+				t.Fatalf("podManifestPaths() = (%q, %q), want (%q, %q)", src, dst, test.wantSrc, test.wantDst)
+			}
+		})
+	}
+}
+
+func TestNodeIsReady(t *testing.T) {
+	if nodeIsReady(&corev1.Node{}) {
+		t.Fatal("nodeIsReady() = true without a Ready condition")
+	}
+	node := &corev1.Node{Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}}}}
+	if !nodeIsReady(node) {
+		t.Fatal("nodeIsReady() = false for Ready=True")
+	}
+}

--- a/testing/e2e/ip.go
+++ b/testing/e2e/ip.go
@@ -170,33 +170,44 @@ func CheckIPAddressPresenceByLease(ctx context.Context, name, namespace, ip stri
 	return CheckIPAddressPresence(ip, container, expected)
 }
 
-func CheckRoutePresence(ip string, container string, expected bool) bool {
+func CheckRoutePresence(ip string, container string, expected bool) (bool, string, error) {
 	family := "-4"
 	if utils.IsIPv6(ip) {
 		family = "-6"
 	}
 
 	result := false
+	var output string
+	var commandErr error
 	Eventually(func() bool {
 		cmdOut := new(bytes.Buffer)
 		cmdErr := new(bytes.Buffer)
 
+		prefix := ip + "/32"
+		if family == "-6" {
+			prefix = ip + "/128"
+		}
 		cmd := exec.Command(
-			"docker", "exec", container, "ip", family, "route", "show", "table", "198",
+			"docker", "exec", container, "ip", family, "route", "show", "table", "198", "exact", prefix,
 		)
 
 		cmd.Stdout = cmdOut
 		cmd.Stderr = cmdErr
-		cmd.Run()
+		commandErr = cmd.Run()
+		output = strings.TrimSpace(cmdOut.String())
+		if commandErr != nil {
+			commandErr = fmt.Errorf("inspect %s routes in container %q: %w: %s", family, container, commandErr, strings.TrimSpace(cmdErr.String()))
+			return false
+		}
 
 		By("Routes: " + cmdOut.String())
 
-		result = strings.Contains(cmdOut.String(), ip) == expected
+		result = (output != "") == expected
 
 		return result
-	}, "120s", "1s").Should(BeTrue())
+	}, "120s", "1s").Should(BeTrue(), "route output: %q; error: %v", output, commandErr)
 
-	return result
+	return result, output, commandErr
 }
 
 func CheckLeasePresence(ctx context.Context, name, namespace string, client kubernetes.Interface, expected bool) *coordinationv1.Lease {

--- a/testing/e2e/kube-vip-bgp-annotations.yaml.tmpl
+++ b/testing/e2e/kube-vip-bgp-annotations.yaml.tmpl
@@ -12,7 +12,7 @@ spec:
     args:
     - manager
     - --prometheusHTTPServer
-    - ""
+    - "{{ .PrometheusHTTPServer }}"
     env:
     - name: vip_loglevel
       value: "-4"

--- a/testing/e2e/kube-vip-hostname.yaml.tmpl
+++ b/testing/e2e/kube-vip-hostname.yaml.tmpl
@@ -12,7 +12,7 @@ spec:
     args:
     - manager
     - --prometheusHTTPServer
-    - ""
+    - "{{ .PrometheusHTTPServer }}"
     env:
     - name: vip_arp
       value: "true"

--- a/testing/e2e/kube-vip-routing-table.yaml.tmpl
+++ b/testing/e2e/kube-vip-routing-table.yaml.tmpl
@@ -12,7 +12,7 @@ spec:
     args:
     - manager
     - --prometheusHTTPServer
-    - ""
+    - "{{ .PrometheusHTTPServer }}"
     env:
     - name: vip_loglevel
       value: "-4"

--- a/testing/e2e/kube-vip.yaml.tmpl
+++ b/testing/e2e/kube-vip.yaml.tmpl
@@ -26,8 +26,8 @@ spec:
       value: "false"
     - name: port
       value: "6443"
-    - name: vip_cidr
-      value: "32"
+    - name: vip_subnet
+      value: "32,128"
     - name: vip_leaderelection
       value: "{{ if .VipElectionEnable }}{{ .VipElectionEnable }}{{ else }}false{{ end }}"
     - name: vip_interface
@@ -57,6 +57,8 @@ spec:
 {{- else }}
     - name: vip_arp
       value: "true"
+    - name: vip_subnet
+      value: "32,128"
     - name: vip_interface
       value: eth0
     - name: vip_leaderelection

--- a/testing/e2e/kube-vip.yaml.tmpl
+++ b/testing/e2e/kube-vip.yaml.tmpl
@@ -60,7 +60,7 @@ spec:
     - name: vip_interface
       value: eth0
     - name: vip_leaderelection
-      value: "true"
+      value: "{{ if .VipElectionEnable }}{{ .VipElectionEnable }}{{ else }}true{{ end }}"
     - name: vip_leaseduration
       value: "5"
     - name: vip_renewdeadline

--- a/testing/e2e/kube-vip.yaml.tmpl
+++ b/testing/e2e/kube-vip.yaml.tmpl
@@ -12,7 +12,7 @@ spec:
     args:
     - manager
     - --prometheusHTTPServer
-    - ""
+    - "{{ .PrometheusHTTPServer }}"
     env:
     - name: vip_loglevel
       value: "-4"
@@ -20,8 +20,6 @@ spec:
     - name: lb_class_legacy_handling
       value: "false"
     - name: lb_class_name
-    - name: prometheus_server
-      value: :2112
     - name: disable_service_updates
       value: "false"
     - name: vip_arp

--- a/testing/e2e/kube-vip.yaml.tmpl
+++ b/testing/e2e/kube-vip.yaml.tmpl
@@ -29,7 +29,7 @@ spec:
     - name: vip_cidr
       value: "32"
     - name: vip_leaderelection
-      value: "false"
+      value: "{{ if .VipElectionEnable }}{{ .VipElectionEnable }}{{ else }}false{{ end }}"
     - name: vip_interface
       value: lo
     - name: bgp_enable

--- a/testing/e2e/matrix/matrix.go
+++ b/testing/e2e/matrix/matrix.go
@@ -1,0 +1,342 @@
+// Package matrix defines the pairwise e2e configuration matrix.
+package matrix
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Mode selects the mechanism used to advertise a VIP.
+type Mode string
+
+const (
+	ModeARP       Mode = "arp"
+	ModeBGP       Mode = "bgp"
+	ModeRT        Mode = "rt"
+	ModeWireGuard Mode = "wireguard"
+)
+
+// Function selects which kube-vip function a combo exercises.
+type Function string
+
+const (
+	FunctionCP   Function = "cp"
+	FunctionSvc  Function = "svc"
+	FunctionBoth Function = "both"
+)
+
+// Family selects the Kubernetes and VIP address families.
+type Family string
+
+const (
+	FamilyV4   Family = "v4"
+	FamilyV6   Family = "v6"
+	FamilyDual Family = "dual"
+)
+
+// Election selects the leader-election arrangement for a combo.
+type Election string
+
+const (
+	ElectionGlobal     Election = "global"
+	ElectionPerService Election = "per-service"
+	ElectionOnDemand   Election = "on-demand"
+	ElectionNone       Election = "none"
+)
+
+// Shape selects whether kube-vip runs as a static pod or a daemonset.
+type Shape string
+
+const (
+	ShapeStaticPod Shape = "static-pod"
+	ShapeDaemonSet Shape = "daemonset"
+)
+
+// Provider selects the Kubernetes endpoint resource watched by kube-vip.
+type Provider string
+
+const (
+	ProviderSlices    Provider = "slices"
+	ProviderEndpoints Provider = "endpoints"
+)
+
+// ETP selects the Service external traffic policy.
+type ETP string
+
+const (
+	ETPCluster ETP = "Cluster"
+	ETPLocal   ETP = "Local"
+)
+
+// Combo is one complete configuration in the matrix.
+type Combo struct {
+	Mode     Mode
+	Function Function
+	Family   Family
+	Election Election
+	Shape    Shape
+	Provider Provider
+	ETP      ETP
+}
+
+// String returns the stable name used in test output and generated ordering.
+func (c Combo) String() string {
+	return fmt.Sprintf("mode=%s,function=%s,family=%s,election=%s,shape=%s,provider=%s,etp=%s",
+		c.Mode, c.Function, c.Family, c.Election, c.Shape, c.Provider, c.ETP)
+}
+
+// Key is an alias for String, useful when a combo is used as a map key.
+func (c Combo) Key() string {
+	return c.String()
+}
+
+// Axis describes one named matrix axis. Values are returned as strings so the
+// complete axis table can be inspected without exposing mutable package state.
+type Axis struct {
+	Name   string
+	Values []string
+}
+
+var axisTable = []Axis{
+	{Name: "mode", Values: []string{string(ModeARP), string(ModeBGP), string(ModeRT), string(ModeWireGuard)}},
+	{Name: "function", Values: []string{string(FunctionCP), string(FunctionSvc), string(FunctionBoth)}},
+	{Name: "family", Values: []string{string(FamilyV4), string(FamilyV6), string(FamilyDual)}},
+	{Name: "election", Values: []string{string(ElectionGlobal), string(ElectionPerService), string(ElectionOnDemand), string(ElectionNone)}},
+	{Name: "shape", Values: []string{string(ShapeStaticPod), string(ShapeDaemonSet)}},
+	{Name: "provider", Values: []string{string(ProviderSlices), string(ProviderEndpoints)}},
+	{Name: "etp", Values: []string{string(ETPCluster), string(ETPLocal)}},
+}
+
+// Axes returns the ordered axes and a copy of every value list.
+func Axes() []Axis {
+	axes := make([]Axis, len(axisTable))
+	for i, axis := range axisTable {
+		axes[i] = Axis{Name: axis.Name, Values: append([]string(nil), axis.Values...)}
+	}
+	return axes
+}
+
+// FullCrossProductCount returns the number of combinations before exclusions
+// and pairwise reduction are applied.
+func FullCrossProductCount() int {
+	count := 1
+	for _, axis := range axisTable {
+		count *= len(axis.Values)
+	}
+	return count
+}
+
+// CrossProductCount is kept as a descriptive alias for callers reporting the
+// unreduced matrix size.
+func CrossProductCount() int {
+	return FullCrossProductCount()
+}
+
+// ValidCrossProductCount returns the number of allowed combinations before
+// pairwise reduction is applied.
+func ValidCrossProductCount() int {
+	return len(validCrossProduct())
+}
+
+type exclusionRule struct {
+	name  string
+	match func(Combo) bool
+}
+
+// exclusions are deliberately explicit. They document product limitations
+// next to the generator instead of hiding them in the greedy selector.
+var exclusions = []exclusionRule{
+	{
+		name: "bgp does not use the no-election service arrangement",
+		match: func(c Combo) bool {
+			return c.Mode == ModeBGP && c.Election == ElectionNone
+		},
+	},
+	{
+		name: "wireguard currently covers services, not control-plane-only or hybrid combos",
+		match: func(c Combo) bool {
+			return c.Mode == ModeWireGuard && c.Function != FunctionSvc
+		},
+	},
+	{
+		name: "routing-table and BGP service elections require a service function",
+		match: func(c Combo) bool {
+			return (c.Mode == ModeRT || c.Mode == ModeBGP) && c.Function == FunctionCP &&
+				(c.Election == ElectionPerService || c.Election == ElectionOnDemand)
+		},
+	},
+	{
+		name: "per-service election requires a service function",
+		match: func(c Combo) bool {
+			return c.Mode != ModeRT && c.Mode != ModeBGP && c.Function == FunctionCP &&
+				(c.Election == ElectionPerService || c.Election == ElectionOnDemand)
+		},
+	},
+}
+
+// ExclusionReason returns the first matching exclusion description, or an
+// empty string when the combo is allowed.
+func ExclusionReason(c Combo) string {
+	for _, rule := range exclusions {
+		if rule.match(c) {
+			return rule.name
+		}
+	}
+	return ""
+}
+
+// IsExcluded reports whether a combo is intentionally omitted from the
+// matrix. The exclusions include the RT and BGP service-election constraint:
+// those election modes are only meaningful when a service is present.
+func IsExcluded(c Combo) bool {
+	return ExclusionReason(c) != ""
+}
+
+// Valid reports whether a combo is emitted by the generator.
+func Valid(c Combo) bool {
+	return !IsExcluded(c)
+}
+
+// Generate emits a deterministic, pairwise-complete set of valid combos.
+//
+// It first enumerates the allowed cross-product in axis order. It then uses a
+// deterministic greedy set-cover pass: at each step, select the first
+// remaining combo that covers the most uncovered value pairs. Pair
+// requirements that cannot exist because of an exclusion are not requested;
+// every feasible value pair is still covered.
+func Generate() []Combo {
+	all := validCrossProduct()
+	remaining := requiredPairs(all)
+	selected := make([]Combo, 0)
+	used := make([]bool, len(all))
+
+	for len(remaining) > 0 {
+		bestIndex := -1
+		bestScore := -1
+		for i, combo := range all {
+			if used[i] {
+				continue
+			}
+
+			score := 0
+			for pair := range comboPairs(combo) {
+				if _, ok := remaining[pair]; ok {
+					score++
+				}
+			}
+			if score > bestScore {
+				bestIndex = i
+				bestScore = score
+			}
+		}
+
+		if bestIndex < 0 || bestScore == 0 {
+			panic("matrix: pairwise requirements cannot be covered")
+		}
+
+		used[bestIndex] = true
+		combo := all[bestIndex]
+		selected = append(selected, combo)
+		for pair := range comboPairs(combo) {
+			delete(remaining, pair)
+		}
+	}
+
+	return selected
+}
+
+// Combos is a descriptive alias for Generate.
+func Combos() []Combo {
+	return Generate()
+}
+
+type valuePair struct {
+	firstAxis  int
+	secondAxis int
+	first      string
+	second     string
+}
+
+func validCrossProduct() []Combo {
+	combos := make([]Combo, 0, FullCrossProductCount())
+	for _, mode := range []Mode{ModeARP, ModeBGP, ModeRT, ModeWireGuard} {
+		for _, function := range []Function{FunctionCP, FunctionSvc, FunctionBoth} {
+			for _, family := range []Family{FamilyV4, FamilyV6, FamilyDual} {
+				for _, election := range []Election{ElectionGlobal, ElectionPerService, ElectionOnDemand, ElectionNone} {
+					for _, shape := range []Shape{ShapeStaticPod, ShapeDaemonSet} {
+						for _, provider := range []Provider{ProviderSlices, ProviderEndpoints} {
+							for _, etp := range []ETP{ETPCluster, ETPLocal} {
+								combo := Combo{
+									Mode:     mode,
+									Function: function,
+									Family:   family,
+									Election: election,
+									Shape:    shape,
+									Provider: provider,
+									ETP:      etp,
+								}
+								if Valid(combo) {
+									combos = append(combos, combo)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return combos
+}
+
+func comboValues(combo Combo) []string {
+	return []string{
+		string(combo.Mode),
+		string(combo.Function),
+		string(combo.Family),
+		string(combo.Election),
+		string(combo.Shape),
+		string(combo.Provider),
+		string(combo.ETP),
+	}
+}
+
+func comboPairs(combo Combo) map[valuePair]struct{} {
+	values := comboValues(combo)
+	pairs := make(map[valuePair]struct{})
+	for firstAxis := 0; firstAxis < len(values); firstAxis++ {
+		for secondAxis := firstAxis + 1; secondAxis < len(values); secondAxis++ {
+			pairs[valuePair{
+				firstAxis:  firstAxis,
+				secondAxis: secondAxis,
+				first:      values[firstAxis],
+				second:     values[secondAxis],
+			}] = struct{}{}
+		}
+	}
+	return pairs
+}
+
+func requiredPairs(combos []Combo) map[valuePair]struct{} {
+	allPairs := make(map[valuePair]struct{})
+	for _, combo := range combos {
+		for pair := range comboPairs(combo) {
+			allPairs[pair] = struct{}{}
+		}
+	}
+	return allPairs
+}
+
+// FormatValues is useful to produce compact, stable table entry names.
+func FormatValues(values ...string) string {
+	cleaned := make([]string, 0, len(values))
+	for _, value := range values {
+		cleaned = append(cleaned, strings.ReplaceAll(value, " ", "-"))
+	}
+	return strings.Join(cleaned, "-")
+}
+
+// ShardName returns a stable one-based shard label for human-readable output.
+func ShardName(index, count int) string {
+	return "shard-" + strconv.Itoa(index) + "-of-" + strconv.Itoa(count)
+}

--- a/testing/e2e/matrix/matrix.go
+++ b/testing/e2e/matrix/matrix.go
@@ -99,7 +99,7 @@ type Axis struct {
 }
 
 var axisTable = []Axis{
-	{Name: "mode", Values: []string{string(ModeARP), string(ModeBGP), string(ModeRT), string(ModeWireGuard)}},
+	{Name: "mode", Values: []string{string(ModeARP), string(ModeBGP), string(ModeRT)}},
 	{Name: "function", Values: []string{string(FunctionCP), string(FunctionSvc), string(FunctionBoth)}},
 	{Name: "family", Values: []string{string(FamilyV4), string(FamilyV6), string(FamilyDual)}},
 	{Name: "election", Values: []string{string(ElectionGlobal), string(ElectionPerService), string(ElectionOnDemand), string(ElectionNone)}},
@@ -154,10 +154,8 @@ var exclusions = []exclusionRule{
 		},
 	},
 	{
-		name: "wireguard currently covers services, not control-plane-only or hybrid combos",
-		match: func(c Combo) bool {
-			return c.Mode == ModeWireGuard && c.Function != FunctionSvc
-		},
+		name:  "wireguard has no runnable e2e deployment",
+		match: func(c Combo) bool { return c.Mode == ModeWireGuard },
 	},
 	{
 		name: "routing-table and BGP service elections require a service function",
@@ -260,7 +258,7 @@ type valuePair struct {
 
 func validCrossProduct() []Combo {
 	combos := make([]Combo, 0, FullCrossProductCount())
-	for _, mode := range []Mode{ModeARP, ModeBGP, ModeRT, ModeWireGuard} {
+	for _, mode := range []Mode{ModeARP, ModeBGP, ModeRT} {
 		for _, function := range []Function{FunctionCP, FunctionSvc, FunctionBoth} {
 			for _, family := range []Family{FamilyV4, FamilyV6, FamilyDual} {
 				for _, election := range []Election{ElectionGlobal, ElectionPerService, ElectionOnDemand, ElectionNone} {

--- a/testing/e2e/matrix/matrix.go
+++ b/testing/e2e/matrix/matrix.go
@@ -148,28 +148,20 @@ type exclusionRule struct {
 // next to the generator instead of hiding them in the greedy selector.
 var exclusions = []exclusionRule{
 	{
-		name: "bgp does not use the no-election service arrangement",
+		name: "control-plane-only mode requires its supported election arrangement",
 		match: func(c Combo) bool {
-			return c.Mode == ModeBGP && c.Election == ElectionNone
+			if c.Function != FunctionCP {
+				return false
+			}
+			if c.Mode == ModeARP {
+				return c.Election != ElectionGlobal
+			}
+			return c.Election != ElectionNone
 		},
 	},
 	{
 		name:  "wireguard has no runnable e2e deployment",
 		match: func(c Combo) bool { return c.Mode == ModeWireGuard },
-	},
-	{
-		name: "routing-table and BGP service elections require a service function",
-		match: func(c Combo) bool {
-			return (c.Mode == ModeRT || c.Mode == ModeBGP) && c.Function == FunctionCP &&
-				(c.Election == ElectionPerService || c.Election == ElectionOnDemand)
-		},
-	},
-	{
-		name: "per-service election requires a service function",
-		match: func(c Combo) bool {
-			return c.Mode != ModeRT && c.Mode != ModeBGP && c.Function == FunctionCP &&
-				(c.Election == ElectionPerService || c.Election == ElectionOnDemand)
-		},
 	},
 }
 
@@ -185,8 +177,7 @@ func ExclusionReason(c Combo) string {
 }
 
 // IsExcluded reports whether a combo is intentionally omitted from the
-// matrix. The exclusions include the RT and BGP service-election constraint:
-// those election modes are only meaningful when a service is present.
+// matrix.
 func IsExcluded(c Combo) bool {
 	return ExclusionReason(c) != ""
 }

--- a/testing/e2e/matrix/matrix_test.go
+++ b/testing/e2e/matrix/matrix_test.go
@@ -1,0 +1,87 @@
+package matrix
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGenerateIsPairwiseComplete(t *testing.T) {
+	t.Parallel()
+
+	combos := Generate()
+	if len(combos) == 0 {
+		t.Fatal("Generate returned no combos")
+	}
+	t.Logf("generated %d combos from %d valid combinations and full cross-product of %d", len(combos), ValidCrossProductCount(), FullCrossProductCount())
+
+	seenCombos := make(map[string]struct{}, len(combos))
+	for _, combo := range combos {
+		if IsExcluded(combo) {
+			t.Fatalf("excluded combo was emitted: %s (%s)", combo, ExclusionReason(combo))
+		}
+		if _, exists := seenCombos[combo.Key()]; exists {
+			t.Fatalf("duplicate combo emitted: %s", combo)
+		}
+		seenCombos[combo.Key()] = struct{}{}
+	}
+
+	valid := validCrossProduct()
+	required := requiredPairs(valid)
+	covered := make(map[valuePair]struct{})
+	for _, combo := range combos {
+		for pair := range comboPairs(combo) {
+			covered[pair] = struct{}{}
+		}
+	}
+
+	for pair := range required {
+		if _, exists := covered[pair]; !exists {
+			t.Fatalf("pair is not covered: axes %d/%d values %q/%q",
+				pair.firstAxis, pair.secondAxis, pair.first, pair.second)
+		}
+	}
+}
+
+func TestGenerateIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	first := Generate()
+	second := Generate()
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("Generate returned different output on repeated calls")
+	}
+}
+
+func TestGenerateRespectsKnownExclusions(t *testing.T) {
+	t.Parallel()
+
+	cases := []Combo{
+		{Mode: ModeBGP, Function: FunctionSvc, Family: FamilyV4, Election: ElectionNone, Shape: ShapeStaticPod, Provider: ProviderSlices, ETP: ETPCluster},
+		{Mode: ModeWireGuard, Function: FunctionCP, Family: FamilyV4, Election: ElectionGlobal, Shape: ShapeStaticPod, Provider: ProviderSlices, ETP: ETPCluster},
+		{Mode: ModeARP, Function: FunctionCP, Family: FamilyV4, Election: ElectionPerService, Shape: ShapeStaticPod, Provider: ProviderSlices, ETP: ETPCluster},
+		{Mode: ModeRT, Function: FunctionCP, Family: FamilyV4, Election: ElectionOnDemand, Shape: ShapeStaticPod, Provider: ProviderSlices, ETP: ETPCluster},
+	}
+	for _, combo := range cases {
+		if !IsExcluded(combo) {
+			t.Errorf("expected combo to be excluded: %s", combo)
+		}
+	}
+
+	if IsExcluded(Combo{
+		Mode:     ModeRT,
+		Function: FunctionBoth,
+		Family:   FamilyDual,
+		Election: ElectionPerService,
+		Shape:    ShapeDaemonSet,
+		Provider: ProviderEndpoints,
+		ETP:      ETPLocal,
+	}) {
+		t.Error("valid RT service-election combo was excluded")
+	}
+}
+
+func TestFullCrossProductCount(t *testing.T) {
+	if got, want := FullCrossProductCount(), 1152; got != want {
+		t.Fatalf("FullCrossProductCount() = %d, want %d", got, want)
+	}
+}

--- a/testing/e2e/matrix/matrix_test.go
+++ b/testing/e2e/matrix/matrix_test.go
@@ -59,7 +59,7 @@ func TestGenerateRespectsKnownExclusions(t *testing.T) {
 	t.Parallel()
 
 	cases := []Combo{
-		{Mode: ModeBGP, Function: FunctionSvc, Family: FamilyV4, Election: ElectionNone, Shape: ShapeStaticPod, Provider: ProviderSlices, ETP: ETPCluster},
+		{Mode: ModeBGP, Function: FunctionCP, Family: FamilyV4, Election: ElectionGlobal, Shape: ShapeStaticPod, Provider: ProviderSlices, ETP: ETPCluster},
 		{Mode: ModeWireGuard, Function: FunctionCP, Family: FamilyV4, Election: ElectionGlobal, Shape: ShapeStaticPod, Provider: ProviderSlices, ETP: ETPCluster},
 		{Mode: ModeARP, Function: FunctionCP, Family: FamilyV4, Election: ElectionPerService, Shape: ShapeStaticPod, Provider: ProviderSlices, ETP: ETPCluster},
 		{Mode: ModeRT, Function: FunctionCP, Family: FamilyV4, Election: ElectionOnDemand, Shape: ShapeStaticPod, Provider: ProviderSlices, ETP: ETPCluster},
@@ -80,6 +80,26 @@ func TestGenerateRespectsKnownExclusions(t *testing.T) {
 		ETP:      ETPLocal,
 	}) {
 		t.Error("valid RT service-election combo was excluded")
+	}
+}
+
+func TestGeneratedCombosHaveRunnableConfiguration(t *testing.T) {
+	t.Parallel()
+
+	for _, combo := range Generate() {
+		hasService := combo.Function == FunctionSvc || combo.Function == FunctionBoth
+		if !hasService && (combo.Election == ElectionPerService || combo.Election == ElectionOnDemand) {
+			t.Errorf("generated service election without service function: %s", combo)
+		}
+		if combo.Function == FunctionCP {
+			wantElection := ElectionNone
+			if combo.Mode == ModeARP {
+				wantElection = ElectionGlobal
+			}
+			if combo.Election != wantElection {
+				t.Errorf("generated unsupported control-plane election: %s", combo)
+			}
+		}
 	}
 }
 

--- a/testing/e2e/matrix/matrix_test.go
+++ b/testing/e2e/matrix/matrix_test.go
@@ -16,6 +16,9 @@ func TestGenerateIsPairwiseComplete(t *testing.T) {
 
 	seenCombos := make(map[string]struct{}, len(combos))
 	for _, combo := range combos {
+		if combo.Mode == ModeWireGuard {
+			t.Fatalf("unrunnable WireGuard combo was emitted: %s", combo)
+		}
 		if IsExcluded(combo) {
 			t.Fatalf("excluded combo was emitted: %s (%s)", combo, ExclusionReason(combo))
 		}
@@ -81,7 +84,7 @@ func TestGenerateRespectsKnownExclusions(t *testing.T) {
 }
 
 func TestFullCrossProductCount(t *testing.T) {
-	if got, want := FullCrossProductCount(), 1152; got != want {
+	if got, want := FullCrossProductCount(), 864; got != want {
 		t.Fatalf("FullCrossProductCount() = %d, want %d", got, want)
 	}
 }

--- a/testing/e2e/metrics.go
+++ b/testing/e2e/metrics.go
@@ -51,14 +51,53 @@ func ScrapeMetrics(clusterName, nodeName string) (map[string]float64, error) {
 	return metrics, nil
 }
 
-// MetricValue returns a metric whose labels contain all requested labels.
-func MetricValue(metrics map[string]float64, name string, labels map[string]string) (float64, bool) {
+// MetricValue returns a metric whose labels contain all requested labels and
+// the number of matching series. When matches is greater than one, value is
+// the first matching series in sorted key order and must not be used as a
+// single-series value.
+func MetricValue(metrics map[string]float64, name string, labels map[string]string) (float64, int) {
+	values := matchingMetricValues(metrics, name, labels)
+	if len(values) == 0 {
+		return 0, 0
+	}
+	return values[0], len(values)
+}
+
+// SumMetric returns the sum of all series whose labels contain all requested
+// labels. It returns zero when no series matches.
+func SumMetric(metrics map[string]float64, name string, labels map[string]string) float64 {
+	var total float64
+	for _, value := range matchingMetricValues(metrics, name, labels) {
+		total += value
+	}
+	return total
+}
+
+// MaxMetric returns the maximum value among all series whose labels contain
+// all requested labels. The bool is false when no series matches.
+func MaxMetric(metrics map[string]float64, name string, labels map[string]string) (float64, bool) {
+	values := matchingMetricValues(metrics, name, labels)
+	if len(values) == 0 {
+		return 0, false
+	}
+
+	maximum := values[0]
+	for _, value := range values[1:] {
+		if value > maximum {
+			maximum = value
+		}
+	}
+	return maximum, true
+}
+
+func matchingMetricValues(metrics map[string]float64, name string, labels map[string]string) []float64 {
 	keys := make([]string, 0, len(metrics))
 	for key := range metrics {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 
+	values := make([]float64, 0)
 	for _, key := range keys {
 		metricName, metricLabels, ok := parseMetricKey(key)
 		if !ok || metricName != name {
@@ -67,28 +106,29 @@ func MetricValue(metrics map[string]float64, name string, labels map[string]stri
 
 		matches := true
 		for labelName, labelValue := range labels {
-			if metricLabels[labelName] != labelValue {
+			metricLabelValue, exists := metricLabels[labelName]
+			if !exists || metricLabelValue != labelValue {
 				matches = false
 				break
 			}
 		}
 		if matches {
-			return metrics[key], true
+			values = append(values, metrics[key])
 		}
 	}
 
-	return 0, false
+	return values
 }
 
 // CounterDelta returns the difference between two counter samples. Missing
 // samples are treated as unavailable rather than as a counter reset.
-func CounterDelta(before, after map[string]float64, name string, labels map[string]string) float64 {
-	beforeValue, beforeOK := MetricValue(before, name, labels)
-	afterValue, afterOK := MetricValue(after, name, labels)
-	if !beforeOK || !afterOK {
-		return 0
+func CounterDelta(before, after map[string]float64, name string, labels map[string]string) (float64, bool) {
+	beforeValue, beforeMatches := MetricValue(before, name, labels)
+	afterValue, afterMatches := MetricValue(after, name, labels)
+	if beforeMatches != 1 || afterMatches != 1 {
+		return 0, false
 	}
-	return afterValue - beforeValue
+	return afterValue - beforeValue, true
 }
 
 // EventuallyMetric retries a metric scrape until its value satisfies matcher.
@@ -99,31 +139,42 @@ func EventuallyMetric(clusterName, node, name string, labels map[string]string, 
 			return 0, err
 		}
 
-		value, ok := MetricValue(metrics, name, labels)
-		if !ok {
-			return 0, fmt.Errorf("metric %s with labels %v was not found", name, labels)
-		}
-		return value, nil
+		return singleMetricValue(metrics, name, labels)
 	}, timeout, interval).Should(matcher)
 }
 
-// MetricStable returns a metric value after confirming that it is unchanged
-// across samples separated by gap.
-func MetricStable(clusterName, node, name string, labels map[string]string, samples int, gap time.Duration) (float64, error) {
-	if samples < 1 {
-		return 0, fmt.Errorf("samples must be at least 1")
-	}
-
-	var stableValue float64
-	for sample := 0; sample < samples; sample++ {
+// ConsistentlyMetric repeatedly scrapes a metric while its value satisfies
+// matcher.
+func ConsistentlyMetric(clusterName, node, name string, labels map[string]string, matcher types.GomegaMatcher, timeout, interval time.Duration) {
+	Consistently(func() (float64, error) {
 		metrics, err := ScrapeMetrics(clusterName, node)
 		if err != nil {
 			return 0, err
 		}
 
-		value, ok := MetricValue(metrics, name, labels)
-		if !ok {
-			return 0, fmt.Errorf("metric %s with labels %v was not found", name, labels)
+		return singleMetricValue(metrics, name, labels)
+	}, timeout, interval).Should(matcher)
+}
+
+// MetricStable returns a metric value after confirming that it is unchanged
+// across samples separated by gap. The observed window is (samples-1)*gap
+// plus scrape latency. A single transient scrape error is retried once for
+// each sample.
+func MetricStable(clusterName, node, name string, labels map[string]string, samples int, gap time.Duration) (float64, error) {
+	if samples < 2 {
+		return 0, fmt.Errorf("samples must be at least 2")
+	}
+
+	var stableValue float64
+	for sample := 0; sample < samples; sample++ {
+		metrics, err := scrapeMetricsRetryOnce(clusterName, node)
+		if err != nil {
+			return 0, err
+		}
+
+		value, err := singleMetricValue(metrics, name, labels)
+		if err != nil {
+			return 0, err
 		}
 		if sample == 0 {
 			stableValue = value
@@ -137,6 +188,31 @@ func MetricStable(clusterName, node, name string, labels map[string]string, samp
 	}
 
 	return stableValue, nil
+}
+
+func singleMetricValue(metrics map[string]float64, name string, labels map[string]string) (float64, error) {
+	value, matches := MetricValue(metrics, name, labels)
+	switch matches {
+	case 0:
+		return 0, fmt.Errorf("metric %s with labels %v was not found", name, labels)
+	case 1:
+		return value, nil
+	default:
+		return 0, fmt.Errorf("metric %s with labels %v matched %d series", name, labels, matches)
+	}
+}
+
+func scrapeMetricsRetryOnce(clusterName, node string) (map[string]float64, error) {
+	metrics, err := ScrapeMetrics(clusterName, node)
+	if err == nil {
+		return metrics, nil
+	}
+
+	retryMetrics, retryErr := ScrapeMetrics(clusterName, node)
+	if retryErr == nil {
+		return retryMetrics, nil
+	}
+	return nil, fmt.Errorf("scrape metrics from %s failed: %v; retry failed: %w", node, err, retryErr)
 }
 
 func parseMetrics(payload string) (map[string]float64, error) {

--- a/testing/e2e/metrics.go
+++ b/testing/e2e/metrics.go
@@ -1,0 +1,393 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+)
+
+// ScrapeMetrics gets and parses the Prometheus metrics exposed by kube-vip in
+// a Kind node. nodeName may be either a Kind node suffix or its full container
+// name.
+func ScrapeMetrics(clusterName, nodeName string) (map[string]float64, error) {
+	if clusterName == "" {
+		return nil, fmt.Errorf("cluster name is empty")
+	}
+	if nodeName == "" {
+		return nil, fmt.Errorf("node name is empty")
+	}
+
+	containerName := nodeName
+	if !strings.HasPrefix(nodeName, clusterName+"-") {
+		containerName = fmt.Sprintf("%s-%s", clusterName, nodeName)
+	}
+
+	cmd := exec.Command("docker", "exec", containerName, "curl", "-fsS", "http://127.0.0.1:2112/metrics")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	payload, err := cmd.Output()
+	if err != nil {
+		if detail := strings.TrimSpace(stderr.String()); detail != "" {
+			return nil, fmt.Errorf("scrape metrics from %s: %w: %s", containerName, err, detail)
+		}
+		return nil, fmt.Errorf("scrape metrics from %s: %w", containerName, err)
+	}
+
+	metrics, err := parseMetrics(string(payload))
+	if err != nil {
+		return nil, fmt.Errorf("parse metrics from %s: %w", containerName, err)
+	}
+	return metrics, nil
+}
+
+// MetricValue returns a metric whose labels contain all requested labels.
+func MetricValue(metrics map[string]float64, name string, labels map[string]string) (float64, bool) {
+	keys := make([]string, 0, len(metrics))
+	for key := range metrics {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		metricName, metricLabels, ok := parseMetricKey(key)
+		if !ok || metricName != name {
+			continue
+		}
+
+		matches := true
+		for labelName, labelValue := range labels {
+			if metricLabels[labelName] != labelValue {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return metrics[key], true
+		}
+	}
+
+	return 0, false
+}
+
+// CounterDelta returns the difference between two counter samples. Missing
+// samples are treated as unavailable rather than as a counter reset.
+func CounterDelta(before, after map[string]float64, name string, labels map[string]string) float64 {
+	beforeValue, beforeOK := MetricValue(before, name, labels)
+	afterValue, afterOK := MetricValue(after, name, labels)
+	if !beforeOK || !afterOK {
+		return 0
+	}
+	return afterValue - beforeValue
+}
+
+// EventuallyMetric retries a metric scrape until its value satisfies matcher.
+func EventuallyMetric(clusterName, node, name string, labels map[string]string, matcher types.GomegaMatcher, timeout, interval time.Duration) {
+	Eventually(func() (float64, error) {
+		metrics, err := ScrapeMetrics(clusterName, node)
+		if err != nil {
+			return 0, err
+		}
+
+		value, ok := MetricValue(metrics, name, labels)
+		if !ok {
+			return 0, fmt.Errorf("metric %s with labels %v was not found", name, labels)
+		}
+		return value, nil
+	}, timeout, interval).Should(matcher)
+}
+
+// MetricStable returns a metric value after confirming that it is unchanged
+// across samples separated by gap.
+func MetricStable(clusterName, node, name string, labels map[string]string, samples int, gap time.Duration) (float64, error) {
+	if samples < 1 {
+		return 0, fmt.Errorf("samples must be at least 1")
+	}
+
+	var stableValue float64
+	for sample := 0; sample < samples; sample++ {
+		metrics, err := ScrapeMetrics(clusterName, node)
+		if err != nil {
+			return 0, err
+		}
+
+		value, ok := MetricValue(metrics, name, labels)
+		if !ok {
+			return 0, fmt.Errorf("metric %s with labels %v was not found", name, labels)
+		}
+		if sample == 0 {
+			stableValue = value
+		} else if value != stableValue {
+			return 0, fmt.Errorf("metric %s with labels %v changed from %v to %v", name, labels, stableValue, value)
+		}
+
+		if sample+1 < samples {
+			time.Sleep(gap)
+		}
+	}
+
+	return stableValue, nil
+}
+
+func parseMetrics(payload string) (map[string]float64, error) {
+	metrics := make(map[string]float64)
+	scanner := bufio.NewScanner(strings.NewReader(payload))
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		name, labels, value, err := parseMetricSample(line)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", lineNumber, err)
+		}
+		key := canonicalMetricKey(name, labels)
+		if _, exists := metrics[key]; exists {
+			return nil, fmt.Errorf("line %d: duplicate sample %s", lineNumber, key)
+		}
+		metrics[key] = value
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan payload: %w", err)
+	}
+
+	return metrics, nil
+}
+
+func parseMetricSample(line string) (string, map[string]string, float64, error) {
+	nameEnd := 0
+	for nameEnd < len(line) && isMetricNameChar(line[nameEnd], nameEnd == 0) {
+		nameEnd++
+	}
+	if nameEnd == 0 {
+		return "", nil, 0, fmt.Errorf("invalid metric name")
+	}
+
+	name := line[:nameEnd]
+	position := nameEnd
+	labels := map[string]string{}
+	if position < len(line) && line[position] == '{' {
+		labelEnd, err := closingBrace(line, position+1)
+		if err != nil {
+			return "", nil, 0, err
+		}
+		labels, err = parseLabelSet(line[position+1 : labelEnd])
+		if err != nil {
+			return "", nil, 0, err
+		}
+		position = labelEnd + 1
+	}
+
+	if position >= len(line) || !isWhitespace(line[position]) {
+		return "", nil, 0, fmt.Errorf("metric %s is missing a value", name)
+	}
+	for position < len(line) && isWhitespace(line[position]) {
+		position++
+	}
+	valueStart := position
+	for position < len(line) && !isWhitespace(line[position]) {
+		position++
+	}
+	if valueStart == position {
+		return "", nil, 0, fmt.Errorf("metric %s is missing a value", name)
+	}
+
+	value, err := strconv.ParseFloat(line[valueStart:position], 64)
+	if err != nil {
+		return "", nil, 0, fmt.Errorf("invalid value for metric %s: %w", name, err)
+	}
+	return name, labels, value, nil
+}
+
+func parseMetricKey(key string) (string, map[string]string, bool) {
+	brace := strings.IndexByte(key, '{')
+	if brace < 0 {
+		if !validMetricName(key) {
+			return "", nil, false
+		}
+		return key, map[string]string{}, true
+	}
+	if !strings.HasSuffix(key, "}") || brace == 0 {
+		return "", nil, false
+	}
+
+	name := key[:brace]
+	if !validMetricName(name) {
+		return "", nil, false
+	}
+	labels, err := parseLabelSet(key[brace+1 : len(key)-1])
+	if err != nil {
+		return "", nil, false
+	}
+	return name, labels, true
+}
+
+func canonicalMetricKey(name string, labels map[string]string) string {
+	if len(labels) == 0 {
+		return name
+	}
+
+	labelNames := make([]string, 0, len(labels))
+	for labelName := range labels {
+		labelNames = append(labelNames, labelName)
+	}
+	sort.Strings(labelNames)
+
+	var builder strings.Builder
+	builder.WriteString(name)
+	builder.WriteByte('{')
+	for index, labelName := range labelNames {
+		if index > 0 {
+			builder.WriteByte(',')
+		}
+		builder.WriteString(labelName)
+		builder.WriteByte('=')
+		builder.WriteString(strconv.Quote(labels[labelName]))
+	}
+	builder.WriteByte('}')
+	return builder.String()
+}
+
+func closingBrace(line string, start int) (int, error) {
+	inQuotes := false
+	escaped := false
+	for position := start; position < len(line); position++ {
+		character := line[position]
+		if inQuotes {
+			if escaped {
+				escaped = false
+			} else if character == '\\' {
+				escaped = true
+			} else if character == '"' {
+				inQuotes = false
+			}
+			continue
+		}
+
+		switch character {
+		case '"':
+			inQuotes = true
+		case '}':
+			return position, nil
+		}
+	}
+	return 0, fmt.Errorf("unterminated label set")
+}
+
+func parseLabelSet(labelSet string) (map[string]string, error) {
+	labels := make(map[string]string)
+	position := 0
+	for {
+		for position < len(labelSet) && isWhitespace(labelSet[position]) {
+			position++
+		}
+		if position == len(labelSet) {
+			return labels, nil
+		}
+
+		labelStart := position
+		for position < len(labelSet) && isMetricNameChar(labelSet[position], position == labelStart) {
+			position++
+		}
+		if labelStart == position {
+			return nil, fmt.Errorf("invalid label name")
+		}
+		labelName := labelSet[labelStart:position]
+
+		for position < len(labelSet) && isWhitespace(labelSet[position]) {
+			position++
+		}
+		if position == len(labelSet) || labelSet[position] != '=' {
+			return nil, fmt.Errorf("label %s is missing an equals sign", labelName)
+		}
+		position++
+		for position < len(labelSet) && isWhitespace(labelSet[position]) {
+			position++
+		}
+		if position == len(labelSet) || labelSet[position] != '"' {
+			return nil, fmt.Errorf("label %s is missing a quoted value", labelName)
+		}
+
+		valueStart := position
+		position++
+		escaped := false
+		closed := false
+		for position < len(labelSet) {
+			character := labelSet[position]
+			position++
+			if escaped {
+				escaped = false
+				continue
+			}
+			if character == '\\' {
+				escaped = true
+				continue
+			}
+			if character == '"' {
+				closed = true
+				break
+			}
+		}
+		if !closed {
+			return nil, fmt.Errorf("label %s has an unterminated value", labelName)
+		}
+
+		value, err := strconv.Unquote(labelSet[valueStart:position])
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for label %s: %w", labelName, err)
+		}
+		if _, exists := labels[labelName]; exists {
+			return nil, fmt.Errorf("duplicate label %s", labelName)
+		}
+		labels[labelName] = value
+
+		for position < len(labelSet) && isWhitespace(labelSet[position]) {
+			position++
+		}
+		if position == len(labelSet) {
+			return labels, nil
+		}
+		if labelSet[position] != ',' {
+			return nil, fmt.Errorf("expected comma after label %s", labelName)
+		}
+		position++
+	}
+}
+
+func validMetricName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for position := range name {
+		if !isMetricNameChar(name[position], position == 0) {
+			return false
+		}
+	}
+	return true
+}
+
+func isMetricNameChar(character byte, first bool) bool {
+	if character == '_' || character == ':' || character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' {
+		return true
+	}
+	return !first && character >= '0' && character <= '9'
+}
+
+func isWhitespace(character byte) bool {
+	return character == ' ' || character == '\t'
+}

--- a/testing/e2e/metrics.go
+++ b/testing/e2e/metrics.go
@@ -4,8 +4,8 @@
 package e2e
 
 import (
-	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 	"sort"
@@ -15,12 +15,15 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 )
 
 // ScrapeMetrics gets and parses the Prometheus metrics exposed by kube-vip in
 // a Kind node. nodeName may be either a Kind node suffix or its full container
 // name.
-func ScrapeMetrics(clusterName, nodeName string) (map[string]float64, error) {
+func ScrapeMetrics(ctx context.Context, clusterName, nodeName string) (map[string]float64, error) {
 	if clusterName == "" {
 		return nil, fmt.Errorf("cluster name is empty")
 	}
@@ -33,7 +36,7 @@ func ScrapeMetrics(clusterName, nodeName string) (map[string]float64, error) {
 		containerName = fmt.Sprintf("%s-%s", clusterName, nodeName)
 	}
 
-	cmd := exec.Command("docker", "exec", containerName, "curl", "-fsS", "http://127.0.0.1:2112/metrics")
+	cmd := exec.CommandContext(ctx, "docker", "exec", containerName, "curl", "-fsS", "http://127.0.0.1:2112/metrics")
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	payload, err := cmd.Output()
@@ -132,9 +135,9 @@ func CounterDelta(before, after map[string]float64, name string, labels map[stri
 }
 
 // EventuallyMetric retries a metric scrape until its value satisfies matcher.
-func EventuallyMetric(clusterName, node, name string, labels map[string]string, matcher types.GomegaMatcher, timeout, interval time.Duration) {
+func EventuallyMetric(ctx context.Context, clusterName, node, name string, labels map[string]string, matcher types.GomegaMatcher, timeout, interval time.Duration) {
 	Eventually(func() (float64, error) {
-		metrics, err := ScrapeMetrics(clusterName, node)
+		metrics, err := ScrapeMetrics(ctx, clusterName, node)
 		if err != nil {
 			return 0, err
 		}
@@ -145,9 +148,9 @@ func EventuallyMetric(clusterName, node, name string, labels map[string]string, 
 
 // ConsistentlyMetric repeatedly scrapes a metric while its value satisfies
 // matcher.
-func ConsistentlyMetric(clusterName, node, name string, labels map[string]string, matcher types.GomegaMatcher, timeout, interval time.Duration) {
+func ConsistentlyMetric(ctx context.Context, clusterName, node, name string, labels map[string]string, matcher types.GomegaMatcher, timeout, interval time.Duration) {
 	Consistently(func() (float64, error) {
-		metrics, err := ScrapeMetrics(clusterName, node)
+		metrics, err := ScrapeMetrics(ctx, clusterName, node)
 		if err != nil {
 			return 0, err
 		}
@@ -160,14 +163,14 @@ func ConsistentlyMetric(clusterName, node, name string, labels map[string]string
 // across samples separated by gap. The observed window is (samples-1)*gap
 // plus scrape latency. A single transient scrape error is retried once for
 // each sample.
-func MetricStable(clusterName, node, name string, labels map[string]string, samples int, gap time.Duration) (float64, error) {
+func MetricStable(ctx context.Context, clusterName, node, name string, labels map[string]string, samples int, gap time.Duration) (float64, error) {
 	if samples < 2 {
 		return 0, fmt.Errorf("samples must be at least 2")
 	}
 
 	var stableValue float64
 	for sample := 0; sample < samples; sample++ {
-		metrics, err := scrapeMetricsRetryOnce(clusterName, node)
+		metrics, err := scrapeMetricsRetryOnce(ctx, clusterName, node)
 		if err != nil {
 			return 0, err
 		}
@@ -183,7 +186,11 @@ func MetricStable(clusterName, node, name string, labels map[string]string, samp
 		}
 
 		if sample+1 < samples {
-			time.Sleep(gap)
+			select {
+			case <-ctx.Done():
+				return 0, ctx.Err()
+			case <-time.After(gap):
+			}
 		}
 	}
 
@@ -202,13 +209,13 @@ func singleMetricValue(metrics map[string]float64, name string, labels map[strin
 	}
 }
 
-func scrapeMetricsRetryOnce(clusterName, node string) (map[string]float64, error) {
-	metrics, err := ScrapeMetrics(clusterName, node)
+func scrapeMetricsRetryOnce(ctx context.Context, clusterName, node string) (map[string]float64, error) {
+	metrics, err := ScrapeMetrics(ctx, clusterName, node)
 	if err == nil {
 		return metrics, nil
 	}
 
-	retryMetrics, retryErr := ScrapeMetrics(clusterName, node)
+	retryMetrics, retryErr := ScrapeMetrics(ctx, clusterName, node)
 	if retryErr == nil {
 		return retryMetrics, nil
 	}
@@ -216,78 +223,38 @@ func scrapeMetricsRetryOnce(clusterName, node string) (map[string]float64, error
 }
 
 func parseMetrics(payload string) (map[string]float64, error) {
+	parser := expfmt.NewTextParser(model.LegacyValidation)
+	families, err := parser.TextToMetricFamilies(strings.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("parse Prometheus text: %w", err)
+	}
+
+	familyList := make([]*dto.MetricFamily, 0, len(families))
+	for _, family := range families {
+		familyList = append(familyList, family)
+	}
+	samples, err := expfmt.ExtractSamples(&expfmt.DecodeOptions{}, familyList...)
+	if err != nil {
+		return nil, fmt.Errorf("extract Prometheus samples: %w", err)
+	}
+
 	metrics := make(map[string]float64)
-	scanner := bufio.NewScanner(strings.NewReader(payload))
-	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-
-	lineNumber := 0
-	for scanner.Scan() {
-		lineNumber++
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-
-		name, labels, value, err := parseMetricSample(line)
-		if err != nil {
-			return nil, fmt.Errorf("line %d: %w", lineNumber, err)
+	for _, sample := range samples {
+		name := string(sample.Metric[model.MetricNameLabel])
+		labels := make(map[string]string, len(sample.Metric)-1)
+		for label, value := range sample.Metric {
+			if label != model.MetricNameLabel {
+				labels[string(label)] = string(value)
+			}
 		}
 		key := canonicalMetricKey(name, labels)
 		if _, exists := metrics[key]; exists {
-			return nil, fmt.Errorf("line %d: duplicate sample %s", lineNumber, key)
+			return nil, fmt.Errorf("duplicate sample %s", key)
 		}
-		metrics[key] = value
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scan payload: %w", err)
+		metrics[key] = float64(sample.Value)
 	}
 
 	return metrics, nil
-}
-
-func parseMetricSample(line string) (string, map[string]string, float64, error) {
-	nameEnd := 0
-	for nameEnd < len(line) && isMetricNameChar(line[nameEnd], nameEnd == 0) {
-		nameEnd++
-	}
-	if nameEnd == 0 {
-		return "", nil, 0, fmt.Errorf("invalid metric name")
-	}
-
-	name := line[:nameEnd]
-	position := nameEnd
-	labels := map[string]string{}
-	if position < len(line) && line[position] == '{' {
-		labelEnd, err := closingBrace(line, position+1)
-		if err != nil {
-			return "", nil, 0, err
-		}
-		labels, err = parseLabelSet(line[position+1 : labelEnd])
-		if err != nil {
-			return "", nil, 0, err
-		}
-		position = labelEnd + 1
-	}
-
-	if position >= len(line) || !isWhitespace(line[position]) {
-		return "", nil, 0, fmt.Errorf("metric %s is missing a value", name)
-	}
-	for position < len(line) && isWhitespace(line[position]) {
-		position++
-	}
-	valueStart := position
-	for position < len(line) && !isWhitespace(line[position]) {
-		position++
-	}
-	if valueStart == position {
-		return "", nil, 0, fmt.Errorf("metric %s is missing a value", name)
-	}
-
-	value, err := strconv.ParseFloat(line[valueStart:position], 64)
-	if err != nil {
-		return "", nil, 0, fmt.Errorf("invalid value for metric %s: %w", name, err)
-	}
-	return name, labels, value, nil
 }
 
 func parseMetricKey(key string) (string, map[string]string, bool) {
@@ -337,32 +304,6 @@ func canonicalMetricKey(name string, labels map[string]string) string {
 	}
 	builder.WriteByte('}')
 	return builder.String()
-}
-
-func closingBrace(line string, start int) (int, error) {
-	inQuotes := false
-	escaped := false
-	for position := start; position < len(line); position++ {
-		character := line[position]
-		if inQuotes {
-			if escaped {
-				escaped = false
-			} else if character == '\\' {
-				escaped = true
-			} else if character == '"' {
-				inQuotes = false
-			}
-			continue
-		}
-
-		switch character {
-		case '"':
-			inQuotes = true
-		case '}':
-			return position, nil
-		}
-	}
-	return 0, fmt.Errorf("unterminated label set")
 }
 
 func parseLabelSet(labelSet string) (map[string]string, error) {

--- a/testing/e2e/template.go
+++ b/testing/e2e/template.go
@@ -38,6 +38,7 @@ type KubevipManifestValues struct {
 type BGPPeerValues struct {
 	IP       string
 	AS       uint32
+	Port     uint16
 	MPBGP    string
 	IPFamily string
 }
@@ -53,9 +54,14 @@ func (pv *BGPPeerValues) String() string {
 		tmpIP = fmt.Sprintf("[%s]", tmpIP)
 	}
 
-	if pv.MPBGP != "" {
-		return fmt.Sprintf("%s:%d::false/mpbgp_nexthop=%s", tmpIP, pv.AS, pv.MPBGP)
+	port := pv.Port
+	if port == 0 {
+		port = 179
 	}
 
-	return fmt.Sprintf("%s:%d::false", tmpIP, pv.AS)
+	if pv.MPBGP != "" {
+		return fmt.Sprintf("%s:%d::false:%d:mpbgp_nexthop=%s", tmpIP, pv.AS, port, pv.MPBGP)
+	}
+
+	return fmt.Sprintf("%s:%d::false:%d", tmpIP, pv.AS, port)
 }

--- a/testing/e2e/template.go
+++ b/testing/e2e/template.go
@@ -32,6 +32,7 @@ type KubevipManifestValues struct {
 	ControlPlaneHealthCheckCAPath           string
 	EnableServiceSecurity                   string
 	PerServiceElectionOnDemand              string
+	PrometheusHTTPServer                    string
 }
 
 type BGPPeerValues struct {

--- a/testing/e2e/template_test.go
+++ b/testing/e2e/template_test.go
@@ -1,0 +1,26 @@
+//go:build e2e
+
+package e2e
+
+import "testing"
+
+func TestBGPPeerValuesString(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		peer BGPPeerValues
+		want string
+	}{
+		{name: "IPv4 explicit port", peer: BGPPeerValues{IP: "192.0.2.1", AS: 65000, Port: 1179}, want: "192.0.2.1:65000::false:1179"},
+		{name: "IPv6 explicit port", peer: BGPPeerValues{IP: "2001:db8::1", AS: 65000, Port: 1179}, want: "[2001:db8::1]:65000::false:1179"},
+		{name: "default port", peer: BGPPeerValues{IP: "192.0.2.1", AS: 65000}, want: "192.0.2.1:65000::false:179"},
+		{name: "MP-BGP", peer: BGPPeerValues{IP: "192.0.2.1", AS: 65000, Port: 1179, MPBGP: "fixed"}, want: "192.0.2.1:65000::false:1179:mpbgp_nexthop=fixed"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.peer.String(); got != test.want {
+				t.Fatalf("String() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/testing/e2e/testdata/metrics.prom
+++ b/testing/e2e/testdata/metrics.prom
@@ -1,0 +1,12 @@
+# HELP kube_vip_is_leader Whether this process holds a lease.
+# TYPE kube_vip_is_leader gauge
+kube_vip_is_leader{lease_name="plndr-cp-lock",node="control-plane"} 1
+kube_vip_is_leader{node="control-plane2",lease_name="plndr-cp-lock"} 0
+# HELP kube_vip_election_errors_total Election errors.
+# TYPE kube_vip_election_errors_total counter
+kube_vip_election_errors_total{reason="api\nserver",node="control-plane"} 3
+# TYPE kube_vip_reconcile_seconds histogram
+kube_vip_reconcile_seconds_bucket{le="0.1"} 2
+kube_vip_reconcile_seconds_bucket{le="+Inf"} 4
+kube_vip_reconcile_seconds_sum 0.5
+kube_vip_reconcile_seconds_count 4


### PR DESCRIPTION
## Purpose

Add a deterministic pairwise E2E matrix across supported kube-vip configurations.

## Key changes

- Generates valid combinations across mode, function, family, election, topology, provider, and traffic policy.
- Proves pairwise completeness and deterministic output in unit tests.
- Adds sharded matrix execution and functional steady-state checks.

## Validation

Matrix unit tests, E2E-tagged compilation, formatting, vet, and current CI checks pass.

## Stack/Merge order

Merge upstream #1753, #1754, and #1755 in that order before this PR. Then merge `test/pr14d-metric-assertions`; merge `ci/pr12-nightly-wiring` after the feature-suite PRs it integrates.

This PR intentionally targets `main` while containing parent stack commits from upstream #1753 through #1755; those parent commits will disappear from this PR diff as the parents merge into `main`.